### PR TITLE
Expose OperatorSet construction where Eval() is not called automatically to match Entity operator behaviour

### DIFF
--- a/AngouriMath/Core/Sys/Sets/SetNode.cs
+++ b/AngouriMath/Core/Sys/Sets/SetNode.cs
@@ -48,16 +48,16 @@ namespace AngouriMath.Core
         public abstract bool Contains(Entity piece);
 
         public static SetNode operator &(SetNode A, SetNode B)
-            => OperatorSet.And(A, B);
+            => OperatorSet.And(A, B).Eval();
 
         public static SetNode operator |(SetNode A, SetNode B)
-            => OperatorSet.Or(A, B);
+            => OperatorSet.Or(A, B).Eval();
 
         public static SetNode operator -(SetNode A, SetNode B)
-            => OperatorSet.Minus(A, B);
+            => OperatorSet.Minus(A, B).Eval();
 
         public static SetNode operator !(SetNode A)
-            => OperatorSet.Inverse(A);
+            => OperatorSet.Inverse(A).Eval();
 
         public SetNode Eval()
         {
@@ -119,16 +119,16 @@ namespace AngouriMath.Core
         public override bool Contains(Entity entity)
             => Contains(new OneElementPiece(entity));
 
-        internal static SetNode And(SetNode A, SetNode B)
+        public static SetNode And(SetNode A, SetNode B)
         => new OperatorSet(OperatorSet.OperatorType.INTERSECTION, A, B);
 
-        internal static SetNode Or(SetNode A, SetNode B)
+        public static SetNode Or(SetNode A, SetNode B)
             => new OperatorSet(OperatorSet.OperatorType.UNION, A, B);
 
-        internal static SetNode Minus(SetNode A, SetNode B)
+        public static SetNode Minus(SetNode A, SetNode B)
         => new OperatorSet(OperatorSet.OperatorType.COMPLEMENT, A, B);
 
-        internal static SetNode Inverse(SetNode A)
+        public static SetNode Inverse(SetNode A)
         => new OperatorSet(OperatorSet.OperatorType.INVERSION, A);
     }
 

--- a/AngouriMath/Core/Sys/Sets/SetNode.cs
+++ b/AngouriMath/Core/Sys/Sets/SetNode.cs
@@ -48,16 +48,16 @@ namespace AngouriMath.Core
         public abstract bool Contains(Entity piece);
 
         public static SetNode operator &(SetNode A, SetNode B)
-            => OperatorSet.And(A, B).Eval();
+            => OperatorSet.And(A, B);
 
         public static SetNode operator |(SetNode A, SetNode B)
-            => OperatorSet.Or(A, B).Eval();
+            => OperatorSet.Or(A, B);
 
         public static SetNode operator -(SetNode A, SetNode B)
-            => OperatorSet.Minus(A, B).Eval();
+            => OperatorSet.Minus(A, B);
 
         public static SetNode operator !(SetNode A)
-            => OperatorSet.Inverse(A).Eval();
+            => OperatorSet.Inverse(A);
 
         public SetNode Eval()
         {

--- a/AngouriMath/Core/Sys/Sets/SetNode.cs
+++ b/AngouriMath/Core/Sys/Sets/SetNode.cs
@@ -70,13 +70,13 @@ namespace AngouriMath.Core
                     return op.ConnectionType switch
                     {
                         OperatorSet.OperatorType.UNION =>
-                            SetFunctions.Unite(op.Children[0], op.Children[1]),
+                            SetFunctions.Unite(op.Children[0].Eval(), op.Children[1].Eval()),
                         OperatorSet.OperatorType.INTERSECTION =>
-                            SetFunctions.Intersect(op.Children[0], op.Children[1]),
+                            SetFunctions.Intersect(op.Children[0].Eval(), op.Children[1].Eval()),
                         OperatorSet.OperatorType.COMPLEMENT =>
-                            SetFunctions.Subtract(op.Children[0], op.Children[1]),
+                            SetFunctions.Subtract(op.Children[0].Eval(), op.Children[1].Eval()),
                         OperatorSet.OperatorType.INVERSION =>
-                            SetFunctions.Invert(op.Children[0])
+                            SetFunctions.Invert(op.Children[0].Eval())
                     };
             }
 


### PR DESCRIPTION
Eval() can be called once only on the final result.