### PR TITLE
Use the same isClosed for both real and complex parts

### DIFF
--- a/AngouriMath/Core/Sys/Sets/Piece.cs
+++ b/AngouriMath/Core/Sys/Sets/Piece.cs
@@ -281,7 +281,7 @@ namespace AngouriMath.Core
         /// <param name="isClosed"></param>
         /// <returns></returns>
         public IntervalPiece SetLeftClosed(bool isClosed)
-            => SetLeftClosed(isClosed, true);
+            => SetLeftClosed(isClosed, isClosed);
 
         /// <summary>
         /// Used for real intervals only.
@@ -291,7 +291,7 @@ namespace AngouriMath.Core
         /// <param name="isClosed"></param>
         /// <returns></returns>
         public IntervalPiece SetRightClosed(bool isClosed)
-            => SetRightClosed(isClosed, true);
+            => SetRightClosed(isClosed, isClosed);
 
         /// <summary>
         /// Used for any type of interval


### PR DESCRIPTION
So that the set R can be described as (-Infinity, Infinity) while the set C can be described as (-Infinity-Infinity\*i, Infinity+Infinity\*i), unifying the notations