### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ Console.WriteLine(solutions);
 
 Find derivatives:
 ```cs
-var func = "x2 + ln(cos(x) + 3) + 4x";
-var derivative = func.Differentiate("x");
+Entity func = "x2 + ln(cos(x) + 3) + 4x";
+Entity derivative = func.Differentiate("x");
 Console.WriteLine(derivative.Simplify());
 ```
 <img src="https://render.githubusercontent.com/render/math?math=4%2B\frac{\sin\left(x\right)}{{\ln\left(\cos\left(x\right)%2B3\right)}^{2}\times \left(\cos\left(x\right)%2B3\right)}%2B2\times x">


### PR DESCRIPTION
The calculus example in the readme gives error:
"'string' does not contain a definition for 'Differentiate' and no accessible extension method 'Differentiate' accepting a first argument of type 'string' could be found (are you missing a using directive or an assembly reference?)"

Fixed this issue by Changing var to Entity when declaring the variable