### PR TITLE
Force user to use ^ symbol to power a number

### DIFF
--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -888,7 +888,12 @@ namespace AngouriMath
         /// </summary>
         public static partial class Settings
         {
-
+            [ConstantField]
+            private static bool explicitParsingOnly=false;
+            /// <summary>
+            /// Determine if it should only parse if it is explicit
+            /// </summary>
+            public static bool ExplicitParsingOnly { get => explicitParsingOnly;}
             /// <summary>
             /// That is how we perform newton solving when no analytical solution was found
             /// in <see cref="Entity.Solve(Variable)"/> and <see cref="Entity.SolveEquation(Variable)"/>
@@ -1057,7 +1062,20 @@ namespace AngouriMath
             /// </summary>
             public static Setting<EContext> DecimalPrecisionContext =>
                 decimalPrecisionContext ??= new EContext(100, ERounding.HalfUp, -100, 1000, false);
+
+           
+
             [ThreadStatic] private static Setting<EContext>? decimalPrecisionContext;
+
+            /// <summary>
+            /// When value is set to true , user must use The caret symbol (^) to power a number 
+            /// ExplicitParsingOnly is set to False by default
+            /// </summary>
+            /// <param name="value"></param>
+            public static void SetExplicitParsingOnly(bool value)
+            {
+                explicitParsingOnly = value;
+            }
         }
 
         /// <summary>Returns an <see cref="Entity"/> in polynomial order if possible</summary>

--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -1062,20 +1062,7 @@ namespace AngouriMath
             /// </summary>
             public static Setting<EContext> DecimalPrecisionContext =>
                 decimalPrecisionContext ??= new EContext(100, ERounding.HalfUp, -100, 1000, false);
-
-           
-
-            [ThreadStatic] private static Setting<EContext>? decimalPrecisionContext;
-
-            /// <summary>
-            /// When value is set to true , user must use The caret symbol (^) to power a number 
-            /// ExplicitParsingOnly is set to False by default
-            /// </summary>
-            /// <param name="value"></param>
-            public static void SetExplicitParsingOnly(bool value)
-            {
-                explicitParsingOnly = value;
-            }
+            [ThreadStatic] private static Setting<EContext>? decimalPrecisionContext;           
         }
 
         /// <summary>Returns an <see cref="Entity"/> in polynomial order if possible</summary>

--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -888,12 +888,12 @@ namespace AngouriMath
         /// </summary>
         public static partial class Settings
         {
-            [ConstantField]
-            private static bool explicitParsingOnly=false;
+
             /// <summary>
             /// Determine if it should only parse if it is explicit
             /// </summary>
-            public static bool ExplicitParsingOnly { get => explicitParsingOnly;}
+            public static Setting<bool> ExplicitParsingOnly => explicitParsingOnly ??= false;
+            [ThreadStatic] private static Setting<bool>? explicitParsingOnly;
             /// <summary>
             /// That is how we perform newton solving when no analytical solution was found
             /// in <see cref="Entity.Solve(Variable)"/> and <see cref="Entity.SolveEquation(Variable)"/>

--- a/Sources/AngouriMath/Core/Parser.cs
+++ b/Sources/AngouriMath/Core/Parser.cs
@@ -34,7 +34,7 @@ namespace AngouriMath.Core
         }
         public static Entity Parse(string source)
         {
-            AngouriMathTextWriter angouriMathTextWriter = new AngouriMathTextWriter();
+            var angouriMathTextWriter = new AngouriMathTextWriter();
             var lexer = new AngouriMathLexer(new AntlrInputStream(source), null, angouriMathTextWriter);
             var tokenStream = new CommonTokenStream(lexer);
             tokenStream.Fill();
@@ -54,15 +54,12 @@ namespace AngouriMath.Core
             {
                 if (MathS.Settings.ExplicitParsingOnly && tokenType == VARIABLE)
                 {
-                    angouriMathTextWriter.WriteLine("Cannot power a number without '^' When SetExplicitParsingOnly(true)  has been called"+ $"\n"+ 
-                        "If you want to power a number without '^' Dont call SetExplicitParsingOnly(true) ");
+                    throw new InvalidArgumentParseException("Cannot power a number without '^' When  MathS.Settings.ExplicitParsingOnly.Set(true)  has been called" + $"\n" +
+                        "If you want to power a number without '^' Don't call MathS.Settings.ExplicitParsingOnly.Set(true)");
                 }
                 return lexer.Power;
             }
-            CommonToken GetMultiplyToken(AngouriMathLexer lexer )
-            {
-                return lexer.Multiply;
-            }
+      
             if (tokenList.Count == 0)
                 throw new AngouriBugException($"{nameof(ParseException)} should have been thrown");
             int i = 0;
@@ -80,9 +77,7 @@ namespace AngouriMath.Core
                     // 2x -> 2 * x       2sqrt -> 2 * sqrt       2( -> 2 * (
                     // x y -> x * y      x sqrt -> x * sqrt      x( -> x * (
                     // )x -> ) * x       )sqrt -> ) * sqrt       )( -> ) * (
-                    (NUMBER or VARIABLE or PARENTHESIS_CLOSE, VARIABLE or FUNCTION_OPEN or PARENTHESIS_OPEN) =>
-                        GetMultiplyToken(lexer),
-
+                    (NUMBER or VARIABLE or PARENTHESIS_CLOSE, VARIABLE or FUNCTION_OPEN or PARENTHESIS_OPEN) => lexer.Multiply,
                     // 3 2 -> 3 ^ 2                 )2 -> ) ^ 2
                     (NUMBER or PARENTHESIS_CLOSE, NUMBER) => GetPowerToken(lexer,NUMBER),
                     //x2 ->x ^ 2

--- a/Sources/AngouriMath/Core/Parser.cs
+++ b/Sources/AngouriMath/Core/Parser.cs
@@ -36,7 +36,7 @@ namespace AngouriMath.Core
             var tokenStream = new CommonTokenStream(lexer);
             tokenStream.Fill();
             var tokenList = tokenStream.GetTokens();
-
+        
             const string NUMBER = nameof(NUMBER);
             const string VARIABLE = nameof(VARIABLE);
             const string PARENTHESIS_OPEN = "'('";
@@ -65,8 +65,8 @@ namespace AngouriMath.Core
                     // )x -> ) * x       )sqrt -> ) * sqrt       )( -> ) * (
                     (NUMBER or VARIABLE or PARENTHESIS_CLOSE, VARIABLE or FUNCTION_OPEN or PARENTHESIS_OPEN) =>
                         lexer.Multiply,
-                    // 3 2 -> 3 ^ 2      x2 -> x ^ 2             )2 -> ) ^ 2
-                    (NUMBER or VARIABLE or PARENTHESIS_CLOSE, NUMBER) => lexer.Power,
+                    // 3 2 -> 3 ^ 2                 )2 -> ) ^ 2
+                    (NUMBER or PARENTHESIS_CLOSE, NUMBER) => lexer.Power,
                     _ => null
                 } is { } insertToken)
                     // Insert at j because we need to keep the first one behind

--- a/Sources/Tests/UnitTests/Core/Settings.cs
+++ b/Sources/Tests/UnitTests/Core/Settings.cs
@@ -61,27 +61,14 @@ namespace UnitTests.Core
             Assert.Equal(67, MaxExpansionTermCount.Value);
         }
 
-        [Fact]
-        public void AssertErrorWhenPoweringNumberAccordingToSetting1()
+        [Theory]
+        [InlineData("x2=16")]
+        [InlineData("x2 + 4x +4 = 0")]
+        public void AssertErrorWhenPoweringNumberAccordingToSetting(string expr)
         {
             using var _ = ExplicitParsingOnly.Set(true);
 
-            Assert.Throws<InvalidArgumentParseException>(() => {
-                Entity expr1 = "x2=16";
-                expr1.Solve("x");
-            });
-
-        }
-
-        [Fact]
-        public void AssertErrorWhenPoweringNumberAccordingToSetting2()
-        {
-            using var _ = ExplicitParsingOnly.Set(true);
-      
-            Assert.Throws<InvalidArgumentParseException>(() => {
-                Entity expr1 = "x2 + 4x +4 = 0";
-                expr1.Solve("x");
-            });
+            Assert.Throws<InvalidArgumentParseException>(() => MathS.FromString(expr));
 
         }
     }

--- a/Sources/Tests/UnitTests/Core/Settings.cs
+++ b/Sources/Tests/UnitTests/Core/Settings.cs
@@ -64,8 +64,8 @@ namespace UnitTests.Core
         [Theory]
         [InlineData("x2=16")]
         [InlineData("x2 + 4x +4 = 0")]
-        [InlineData("x2 3")]
-        [InlineData("x2 0.5")]
+        [InlineData("2 3")]
+        [InlineData(") 2")]
         [InlineData("integral(x3)")]
         [InlineData("derivative(x2)")]
         public void AssertErrorWhenPoweringNumberAccordingToSetting(string expr)

--- a/Sources/Tests/UnitTests/Core/Settings.cs
+++ b/Sources/Tests/UnitTests/Core/Settings.cs
@@ -64,10 +64,8 @@ namespace UnitTests.Core
         [Theory]
         [InlineData("x2=16")]
         [InlineData("x2 + 4x +4 = 0")]
-        [InlineData("(x2+5)(x2+5)")]
-        [InlineData("3(x2+5)")]
-        [InlineData("integral(x3)")]
-        [InlineData("derivative(x2)")]
+        [InlineData("(a + 2) 2")]
+        [InlineData("3 2")]
         public void AssertErrorWhenPoweringNumberAccordingToSetting(string expr)
         {
             using var _ = ExplicitParsingOnly.Set(true);

--- a/Sources/Tests/UnitTests/Core/Settings.cs
+++ b/Sources/Tests/UnitTests/Core/Settings.cs
@@ -1,4 +1,6 @@
-﻿using Xunit;
+﻿using AngouriMath;
+using AngouriMath.Core.Exceptions;
+using Xunit;
 using static AngouriMath.MathS.Settings;
 
 namespace UnitTests.Core
@@ -49,7 +51,7 @@ namespace UnitTests.Core
                 using var d2 = MaxExpansionTermCount.Set(87);
 
                 // normally, it is called after d2.Dispose(), but what if we call it here...
-                d1.Dispose(); 
+                d1.Dispose();
 
                 // d1 was disposed, but d2 was not.
                 // Since it was the last one, 
@@ -57,6 +59,30 @@ namespace UnitTests.Core
                 Assert.Equal(87, MaxExpansionTermCount.Value);
             }
             Assert.Equal(67, MaxExpansionTermCount.Value);
+        }
+
+        [Fact]
+        public void AssertErrorWhenPoweringNumberAccordingToSetting1()
+        {
+            using var _ = ExplicitParsingOnly.Set(true);
+
+            Assert.Throws<InvalidArgumentParseException>(() => {
+                Entity expr1 = "x2=16";
+                expr1.Solve("x");
+            });
+
+        }
+
+        [Fact]
+        public void AssertErrorWhenPoweringNumberAccordingToSetting2()
+        {
+            using var _ = ExplicitParsingOnly.Set(true);
+      
+            Assert.Throws<InvalidArgumentParseException>(() => {
+                Entity expr1 = "x2 + 4x +4 = 0";
+                expr1.Solve("x");
+            });
+
         }
     }
 }

--- a/Sources/Tests/UnitTests/Core/Settings.cs
+++ b/Sources/Tests/UnitTests/Core/Settings.cs
@@ -64,8 +64,8 @@ namespace UnitTests.Core
         [Theory]
         [InlineData("x2=16")]
         [InlineData("x2 + 4x +4 = 0")]
-        [InlineData("2 3")]
-        [InlineData(") 2")]
+        [InlineData("(x2+5)(x2+5)")]
+        [InlineData("3(x2+5)")]
         [InlineData("integral(x3)")]
         [InlineData("derivative(x2)")]
         public void AssertErrorWhenPoweringNumberAccordingToSetting(string expr)

--- a/Sources/Tests/UnitTests/Core/Settings.cs
+++ b/Sources/Tests/UnitTests/Core/Settings.cs
@@ -60,10 +60,14 @@ namespace UnitTests.Core
             }
             Assert.Equal(67, MaxExpansionTermCount.Value);
         }
-
+        
         [Theory]
         [InlineData("x2=16")]
         [InlineData("x2 + 4x +4 = 0")]
+        [InlineData("x2 3")]
+        [InlineData("x2 0.5")]
+        [InlineData("integral(x3)")]
+        [InlineData("derivative(x2)")]
         public void AssertErrorWhenPoweringNumberAccordingToSetting(string expr)
         {
             using var _ = ExplicitParsingOnly.Set(true);


### PR DESCRIPTION
The caret symbol (^)  is a conventional way to power a number rather than squaring x with x2 it is better to square it using x^2 because x2 may be interpreted as 2x