### PR TITLE
Make all caching lambdas static

### DIFF
--- a/Sources/AngouriMath/Core/Entity/Entity.Definition.cs
+++ b/Sources/AngouriMath/Core/Entity/Entity.Definition.cs
@@ -89,7 +89,7 @@ namespace AngouriMath
         /// <summary>
         /// Represents all direct children of a node
         /// </summary>
-        public IReadOnlyList<Entity> DirectChildren => directChildren.GetValue(@this => @this.InitDirectChildren(), this);
+        public IReadOnlyList<Entity> DirectChildren => directChildren.GetValue(static @this => @this.InitDirectChildren(), this);
         private FieldCache<IReadOnlyList<Entity>> directChildren;
 
         /// <remarks>A depth-first enumeration is required by
@@ -107,7 +107,7 @@ namespace AngouriMath
         /// a + b / 2 ^ 3, a, b / 2 ^ 3, b, 2 ^ 3, 2, 3
         /// </code>
         /// </example>
-        public IEnumerable<Entity> Nodes => nodes.GetValue(@this => @this.DirectChildren.SelectMany(c => c.Nodes).Prepend(@this), this);
+        public IEnumerable<Entity> Nodes => nodes.GetValue(static @this => @this.DirectChildren.SelectMany(c => c.Nodes).Prepend(@this), this);
         private FieldCache<IEnumerable<Entity>> nodes;
 
         /// <summary>
@@ -164,7 +164,7 @@ namespace AngouriMath
         /// Whether both parts of the complex number are finite
         /// meaning that it could be safely used for calculations
         /// </value>
-        public bool IsFinite => isFinite.GetValue(@this => @this.ThisIsFinite && @this.DirectChildren.All(x => x.IsFinite), this);
+        public bool IsFinite => isFinite.GetValue(static @this => @this.ThisIsFinite && @this.DirectChildren.All(x => x.IsFinite), this);
         private FieldCache<bool> isFinite;
         /// <summary>
         /// Not NaN and not infinity
@@ -172,7 +172,7 @@ namespace AngouriMath
         protected virtual bool ThisIsFinite => true;       
 
         /// <value>Number of nodes in tree</value>
-        public int Complexity => complexity.GetValue(@this => 1 + @this.DirectChildren.Sum(x => x.Complexity), this);
+        public int Complexity => complexity.GetValue(static @this => 1 + @this.DirectChildren.Sum(x => x.Complexity), this);
         private FieldCache<int> complexity;
 
         /// <summary>
@@ -183,7 +183,7 @@ namespace AngouriMath
         /// Set of unique variables excluding mathematical constants
         /// such as <see cref="MathS.pi"/> and <see cref="MathS.e"/>
         /// </returns>
-        public IEnumerable<Variable> Vars => vars.GetValue(@this => @this.VarsAndConsts.Where(x => !x.IsConstant), this);
+        public IEnumerable<Variable> Vars => vars.GetValue(static @this => @this.VarsAndConsts.Where(x => !x.IsConstant), this);
         private FieldCache<IEnumerable<Variable>> vars;
 
         /// <summary>
@@ -195,7 +195,7 @@ namespace AngouriMath
         /// such as <see cref="MathS.pi"/> and <see cref="MathS.e"/>
         /// </returns>
         public IReadOnlyCollection<Variable> VarsAndConsts => varsAndConsts.GetValue(
-            @this => new HashSet<Variable>(@this is Variable v ? new[] { v } : @this.DirectChildren.SelectMany(x => x.VarsAndConsts)), this);
+            static @this => new HashSet<Variable>(@this is Variable v ? new[] { v } : @this.DirectChildren.SelectMany(x => x.VarsAndConsts)), this);
         private FieldCache<IReadOnlyCollection<Variable>> varsAndConsts;
 
         /// <summary>Checks if <paramref name="x"/> is a subnode inside this <see cref="Entity"/> tree.

--- a/Sources/AngouriMath/Core/Entity/Omni/Entity.Omni.Classes.cs
+++ b/Sources/AngouriMath/Core/Entity/Omni/Entity.Omni.Classes.cs
@@ -155,8 +155,8 @@ namespace AngouriMath
 
                 /// <inheritdoc/>
                 public override int GetHashCode()
-                    => hashCode.GetValue(@this =>
-                        Elements.OrderBy(el => el.GetHashCode()).HashCodeOfSequence(HashCodeFunctional.HashCodeShifts.FiniteSet), 
+                    => hashCode.GetValue(static @this =>
+                        @this.Elements.OrderBy(el => el.GetHashCode()).HashCodeOfSequence(HashCodeFunctional.HashCodeShifts.FiniteSet), 
                         this);
                 private FieldCache<int> hashCode;
 
@@ -574,12 +574,12 @@ namespace AngouriMath
                 protected override Entity[] InitDirectChildren() => new[] { Left, Right };
 
                 /// <inheritdoc/>
-                public override bool IsSetFinite => isSetFinite.GetValue(@this =>
+                public override bool IsSetFinite => isSetFinite.GetValue(static @this =>
                     @this.Left is FiniteSet finite1 && @this.Right is FiniteSet finite2 && finite1.IsSetFinite && finite2.IsSetFinite, this);
                 private FieldCache<bool> isSetFinite;
 
                 /// <inheritdoc/>
-                public override bool IsSetEmpty => isSetEmpty.GetValue(@this =>
+                public override bool IsSetEmpty => isSetEmpty.GetValue(static @this =>
                     @this.Left is FiniteSet finite1 && @this.Right is FiniteSet finite2 && finite1.IsSetEmpty && finite2.IsSetEmpty, this);
                 private FieldCache<bool> isSetEmpty;
 
@@ -626,13 +626,13 @@ namespace AngouriMath
                 protected override Entity[] InitDirectChildren() => new[] { Left, Right };
 
                 /// <inheritdoc/>
-                public override bool IsSetFinite => isSetFinite.GetValue(@this => 
+                public override bool IsSetFinite => isSetFinite.GetValue(static @this => 
                     @this.Left is FiniteSet finite1 && @this.Right is FiniteSet finite2
                     && (finite1.IsSetFinite || finite2.IsSetFinite), this);
                 private FieldCache<bool> isSetFinite;
 
                 /// <inheritdoc/>
-                public override bool IsSetEmpty => isSetEmpty.GetValue(@this =>
+                public override bool IsSetEmpty => isSetEmpty.GetValue(static @this =>
                     @this.Left is FiniteSet finite1 && @this.Right is FiniteSet finite2
                     && (finite1.IsSetEmpty || finite2.IsSetEmpty), this);
                 private FieldCache<bool> isSetEmpty;
@@ -680,12 +680,12 @@ namespace AngouriMath
                 protected override Entity[] InitDirectChildren() => new[] { Left, Right };
 
                 /// <inheritdoc/>
-                public override bool IsSetFinite => isSetFinite.GetValue(@this =>
+                public override bool IsSetFinite => isSetFinite.GetValue(static @this =>
                     @this.Left is FiniteSet finite1 && @this.Right is FiniteSet && finite1.IsSetFinite, this);
                 private FieldCache<bool> isSetFinite;
 
                 /// <inheritdoc/>
-                public override bool IsSetEmpty => isSetEmpty.GetValue(@this =>
+                public override bool IsSetEmpty => isSetEmpty.GetValue(static @this =>
                     @this.Left is FiniteSet finite1 && @this.Right is FiniteSet finite2
                     && (finite1.IsSetEmpty || finite1 == finite2), this);
                 private FieldCache<bool> isSetEmpty;

--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Definition.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Definition.cs
@@ -28,7 +28,7 @@ namespace AngouriMath
         /// consistency's sake, consider the call of this property
         /// as free as the addressing of a field.
         /// </summary>
-        public Entity InnerSimplified => innerSimplified.GetValue(@this => @this.InnerSimplifyWithCheck(), this);
+        public Entity InnerSimplified => innerSimplified.GetValue(static @this => @this.InnerSimplifyWithCheck(), this);
         private FieldCache<Entity> innerSimplified;
 
 
@@ -121,7 +121,7 @@ namespace AngouriMath
         /// consistency's sake, consider the call of this property
         /// as free as the addressing of a field.
         /// </summary>
-        public Entity Evaled => evaled.GetValue(@this => @this.InnerEvalWithCheck(), this);
+        public Entity Evaled => evaled.GetValue(static @this => @this.InnerEvalWithCheck(), this);
         private FieldCache<Entity> evaled;
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Core/Multithreading/CancelTest.cs
+++ b/Sources/Tests/UnitTests/Core/Multithreading/CancelTest.cs
@@ -21,7 +21,7 @@ namespace UnitTests.Core.Multithreading
         /// this will become false
         /// </summary>
         public static bool MakesSenseToPerformTest => makesSenseToPerformTest.GetValue(
-            @this => !new TimeOutChecker().BeingCompletedForLessThan(
+            static @this => !new TimeOutChecker().BeingCompletedForLessThan(
                 SomeLongLastingTask
                 , ShouldLastAtLeast), someReference);
 

--- a/Sources/Tests/UnitTests/Core/Multithreading/MultithreadingCancel.cs
+++ b/Sources/Tests/UnitTests/Core/Multithreading/MultithreadingCancel.cs
@@ -27,7 +27,7 @@ namespace UnitTests.Core.Multithreading
         /// this will become false
         /// </summary>
         public static bool MakesSenseToPerformTest => makesSenseToPerformTest.GetValue(
-            @this => !new TimeOutChecker().BeingCompletedForLessThan(
+            static @this => !new TimeOutChecker().BeingCompletedForLessThan(
                 SomeLongLastingTask
                 , ShouldLastAtLeast), someReference);
         private static object someReference = new();


### PR DESCRIPTION
Closes #438 and helps to prevent other developers from unintentionally accessing the capturing context and, therefore, creating closures that need to allocate more memory.