### PR TITLE
Moved F# matrix operations to Functions.Matricies

### DIFF
--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -437,14 +437,14 @@ namespace AngouriMath
             /// <param name="exprToPolyVars">
             /// Takes the place of the expression variable, polynomial variable, and the differentiation point for each variable.
             /// </param>
-            /// <param name="termCount">
-            /// The number of terms you want to get
+            /// <param name="degree">
+            /// The degree of the taylor polynomial desired.
             /// </param>
             /// <returns>
             /// An expression in the polynomial form over the poly variables given in <paramref name="exprToPolyVars"/>
             /// </returns>
-            public static Entity MultivariableTaylorExpansion(Entity expr, int termCount, params (Variable exprVariable, Variable polyVariable, Entity value)[] exprToPolyVars)
-                => Functions.Series.MultivariableTaylorExpansion(expr, termCount, exprToPolyVars);
+            public static Entity MultivariableTaylorExpansion(Entity expr, int degree, params (Variable exprVariable, Variable polyVariable, Entity value)[] exprToPolyVars)
+                => Functions.Series.MultivariableTaylorExpansion(expr, degree, exprToPolyVars);
 
         }
 

--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -413,7 +413,7 @@ namespace AngouriMath
             /// 
             /// Do NOT call ToArray() or anything like this on the result of this method. It is 
             /// infinite iterator. To get a finite result as in a sum of finite number of terms,
-            /// call TaylorExpansion
+            /// call MultivariableTaylorExpansion
             /// </summary>
             /// <param name="expr">
             /// The function, to find Taylor expansion of
@@ -441,7 +441,7 @@ namespace AngouriMath
             /// The number of terms you want to get
             /// </param>
             /// <returns>
-            /// An infinite iterator over the terms of Taylor series of the given expression.
+            /// An expression in the polynomial form over the poly variables given in <paramref name="exprToPolyVars"/>
             /// </returns>
             public static Entity MultivariableTaylorExpansion(Entity expr, (Variable exprVariable, Variable polyVariable, Entity value)[] exprToPolyVars, int termCount)
                 => Functions.Series.MultivariableTaylorExpansion(expr, exprToPolyVars, termCount);

--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -406,6 +406,46 @@ namespace AngouriMath
             /// </returns>
             public static Entity TaylorExpansion(Entity expr, Variable exprVariable, Variable polyVariable, Entity point, int termCount)
                 => Functions.Series.TaylorExpansion(expr, exprVariable, polyVariable, point, termCount);
+
+            /// <summary>
+            /// Finds the symbolic expression of terms of the Taylor expansion of the given function with multiple variables.
+            /// https://en.wikipedia.org/wiki/Taylor_series#Taylor_series_in_several_variables
+            /// 
+            /// Do NOT call ToArray() or anything like this on the result of this method. It is 
+            /// infinite iterator. To get a finite result as in a sum of finite number of terms,
+            /// call TaylorExpansion
+            /// </summary>
+            /// <param name="expr">
+            /// The function, to find Taylor expansion of
+            /// </param>
+            /// <param name="exprToPolyVars">
+            /// Takes the place of the expression variable, polynomial variable, and the differentiation point for each variable.
+            /// </param>
+            /// <returns>
+            /// An infinite iterator over the terms of Taylor series of the given expression.
+            /// </returns>
+            public static IEnumerable<Entity> MultivariableTaylorExpansionTerms(Entity expr, (Variable exprVariable, Variable polyVariable, Entity value)[] exprToPolyVars)
+                => Functions.Series.MultivariableTaylorExpansionTerms(expr, exprToPolyVars);
+
+            /// <summary>
+            /// Finds the symbolic expression of terms of the Taylor expansion of the given function with multiple variables.
+            /// https://en.wikipedia.org/wiki/Taylor_series#Taylor_series_in_several_variables
+            /// </summary>
+            /// <param name="expr">
+            /// The function, to find Taylor expansion of
+            /// </param>
+            /// <param name="exprToPolyVars">
+            /// Takes the place of the expression variable, polynomial variable, and the differentiation point for each variable.
+            /// </param>
+            /// <param name="termCount">
+            /// The number of terms you want to get
+            /// </param>
+            /// <returns>
+            /// An infinite iterator over the terms of Taylor series of the given expression.
+            /// </returns>
+            public static Entity MultivariableTaylorExpansion(Entity expr, (Variable exprVariable, Variable polyVariable, Entity value)[] exprToPolyVars, int termCount)
+                => Functions.Series.MultivariableTaylorExpansion(expr, exprToPolyVars, termCount);
+
         }
 
 

--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -424,7 +424,7 @@ namespace AngouriMath
             /// <returns>
             /// An infinite iterator over the terms of Taylor series of the given expression.
             /// </returns>
-            public static IEnumerable<Entity> MultivariableTaylorExpansionTerms(Entity expr, (Variable exprVariable, Variable polyVariable, Entity value)[] exprToPolyVars)
+            public static IEnumerable<Entity> MultivariableTaylorExpansionTerms(Entity expr, params (Variable exprVariable, Variable polyVariable, Entity value)[] exprToPolyVars)
                 => Functions.Series.MultivariableTaylorExpansionTerms(expr, exprToPolyVars);
 
             /// <summary>
@@ -443,8 +443,8 @@ namespace AngouriMath
             /// <returns>
             /// An expression in the polynomial form over the poly variables given in <paramref name="exprToPolyVars"/>
             /// </returns>
-            public static Entity MultivariableTaylorExpansion(Entity expr, (Variable exprVariable, Variable polyVariable, Entity value)[] exprToPolyVars, int termCount)
-                => Functions.Series.MultivariableTaylorExpansion(expr, exprToPolyVars, termCount);
+            public static Entity MultivariableTaylorExpansion(Entity expr, int termCount, params (Variable exprVariable, Variable polyVariable, Entity value)[] exprToPolyVars)
+                => Functions.Series.MultivariableTaylorExpansion(expr, termCount, exprToPolyVars);
 
         }
 

--- a/Sources/AngouriMath/Functions/Series.cs
+++ b/Sources/AngouriMath/Functions/Series.cs
@@ -50,7 +50,7 @@ namespace AngouriMath.Functions
         {
             // This structure is just a deconstruction of the terms that are added together in a multi taylor polynomial.
             // Like n (x - a)^s (y - b)^t f'(x,y), where n is the coefficient, s and t are pointCoefficientDegrees, and then the partialDerivative
-            // See https://en.wikipedia.org/wiki/Taylor_series#Taylor_series_in_several_variables for the formula used here.
+            // Many of these need to be computed and added together per computed expansion term.
             var lastTerms = new List<(int coefficient, int[] pointCoefficientDegrees, Entity partialDerivative)>();
             var order = 0;
             var variables = exprToPolyVars.Length;
@@ -59,38 +59,44 @@ namespace AngouriMath.Functions
             {
                 var newTerms = new List<(int coefficient, int[] pointCoefficientDegrees, Entity partialDerivative)>();
 
-                // Take a bunch of partial derivatives
-                if (order == 0) newTerms.Add((1, new int[variables], expr));
-                else {
-
+                // Base case: initial term is just the given expression.
+                if (order == 0) 
+                    newTerms.Add((1, new int[variables], expr));
+                else 
+                {
+                    // Iterative step: take the partial derivative of each of the previous terms with respect to each of the variables.
                     foreach (var lastTerm in lastTerms)
                     {
-                        // with respect to each variable 
                         for (int variableIndex = 0; variableIndex < exprToPolyVars.Length; variableIndex++)
                         {
-                            var triple = exprToPolyVars[variableIndex];
+                            // Compute first what our point coefficient degrees will be, so that we don't repeat the computation of
+                            // any partial derivatives, like f_xy vs f_yx.
+                            var variable = exprToPolyVars[variableIndex];
                             var newPointCoeffs = new int[variables];
+                            // The new degree is the same as the parent term's, times an extra (x - a) or whichever variable.
                             lastTerm.pointCoefficientDegrees.CopyTo(newPointCoeffs,0);
                             newPointCoeffs[variableIndex] += 1;
 
+                            // The term is a repeat if it's coefficients match one previously computed.
                             bool foundRepeatFlag = false;
-
                             for (int newTermIndex = 0; newTermIndex < newTerms.Count; newTermIndex++)
                             {
                                 var newTerm = newTerms[newTermIndex];
 
-                                if (Enumerable.SequenceEqual(newTerm.pointCoefficientDegrees, newPointCoeffs))
+                                if (Enumerable.SequenceEqual(newPointCoeffs, newTerm.pointCoefficientDegrees))
                                 {
+                                    // If the match is found, instead of creating a whole new repeat term, we just add
+                                    // to the match's coefficient. This ends up making a neat binomial coefficient pattern.
                                     newTerm.coefficient += lastTerm.coefficient;
                                     foundRepeatFlag = true;
                                     break;
                                 }
                             }
 
-                            // If the partial derivative has already been computed, we just add to it's coefficient instead of duplicating it.
+                            // If no match is found, we add it to the new term list.
                             if (!foundRepeatFlag)
                             {
-                                var newPartialDerivative = lastTerm.partialDerivative.Differentiate(triple.exprVariable);
+                                var newPartialDerivative = lastTerm.partialDerivative.Differentiate(variable.exprVariable);
                                 newTerms.Add((lastTerm.coefficient, newPointCoeffs, newPartialDerivative));
                             }
                            
@@ -99,11 +105,12 @@ namespace AngouriMath.Functions
 
                 }
 
-                Entity fullExpr = 0;
 
-                // Put together the full term
-                foreach (var newTerm in newTerms) {
-                    
+                // From the list of deconstructed terms, we put assemble the term and sum them all up.
+                var fullExpressionTerms = new List<Entity>();
+                foreach (var newTerm in newTerms) 
+                {
+                    // pointCoefficients are transformed into their proper (x - a)^t... forms.
                     Entity pointCoefficients = 1;
                     for (int variableIndex = 0; variableIndex < exprToPolyVars.Length; variableIndex++)
                     {
@@ -111,12 +118,15 @@ namespace AngouriMath.Functions
                         pointCoefficients *= (triple.polyVariable - triple.point).Pow(newTerm.pointCoefficientDegrees[variableIndex]);
                     }
 
-                    fullExpr += newTerm.partialDerivative * newTerm.coefficient * pointCoefficients;
+                    fullExpressionTerms.Add( newTerm.partialDerivative * newTerm.coefficient * pointCoefficients );
                 }
+                Entity fullExpr = TreeAnalyzer.MultiHangBinary(fullExpressionTerms, (a, b) => a + b);
 
+                // then solve for the given point and simplify,
                 foreach (var variable in exprToPolyVars)
                     fullExpr = fullExpr.Substitute(variable.exprVariable, variable.point).InnerSimplified;
 
+                // and divide that all by the proper factorial.
                 if (order > 1)
                     fullExpr /= ((Entity)order).Factorial();
 

--- a/Sources/AngouriMath/Functions/Series.cs
+++ b/Sources/AngouriMath/Functions/Series.cs
@@ -44,5 +44,82 @@ namespace AngouriMath.Functions
             }
             throw new AngouriBugException($"We cannot get here, as {nameof(TaylorExpansionTerms)} is supposed to be endless");
         }
+
+        internal static IEnumerable<Entity> MultivariableTaylorExpansionTerms(Entity expr, (Variable exprVariable, Variable polyVariable, Entity point)[] exprToPolyVars)
+        {
+            // pointCoefficient is the sequence of (x-a)(x-b)...
+            var lastTerms = new List<(int coefficient, Entity pointCoefficients, Entity partialDerivative)>();
+            var i = 0;
+
+            while (true)
+            {
+                var newTerms = new List<(int coefficient, Entity pointCoefficients, Entity partialDerivative)>();
+                var factorialCoeff = i > 1 ? 1 / ((Entity)i).Factorial() : 1;
+
+                if (i > 0) {
+
+                    foreach (var lastTerm in lastTerms)
+                    {
+                        // Splits into a version for every variable
+                        foreach (var triple in exprToPolyVars)
+                        {
+                            var newPointCoeffs = (lastTerm.pointCoefficients * (triple.polyVariable - triple.point)).InnerSimplified;
+                            bool foundRepeatFlag = false;
+
+                            for (int j = 0; j < newTerms.Count; j++)
+                            {
+                                var newTerm = newTerms[j];
+
+                                if (newTerm.pointCoefficients.Equals(newPointCoeffs))
+                                {
+                                    newTerm.coefficient += lastTerm.coefficient;
+                                    foundRepeatFlag = true;
+                                    break;
+                                }
+                            }
+
+                            // If the partial derivative has already been computed, we just add to it's coefficient and skip this.
+                            if (!foundRepeatFlag)
+                            {
+                                var newPartialDerivative = lastTerm.partialDerivative.Differentiate(triple.exprVariable);
+                                newTerms.Add((lastTerm.coefficient, newPointCoeffs, newPartialDerivative));
+                            }
+                           
+                        }
+                    }
+
+                }
+                else newTerms.Add((1, 1, expr));
+
+                Entity fullExpr = 0;
+
+                foreach (var newPartialDerivative in newTerms)
+                    fullExpr += newPartialDerivative.coefficient * newPartialDerivative.pointCoefficients * newPartialDerivative.partialDerivative;
+
+                fullExpr *= factorialCoeff;
+
+                foreach (var triples in exprToPolyVars)
+                    fullExpr = fullExpr.Substitute(triples.exprVariable, triples.point).InnerSimplified;
+
+                yield return fullExpr.InnerSimplified;
+
+                lastTerms = newTerms;
+                i++;
+            }
+        }
+
+        internal static Entity MultivariableTaylorExpansion(Entity expr, (Variable exprVariable, Variable polyVariable, Entity point)[] exprToPolyVars, int termCount)
+        {
+            if (termCount < 0)
+                throw new InvalidNumberException($"{nameof(termCount)} is supposed to be at least 0");
+            var terms = new List<Entity>();
+            foreach (var term in MultivariableTaylorExpansionTerms(expr, exprToPolyVars))
+            {
+                if (terms.Count >= termCount)
+                    return TreeAnalyzer.MultiHangBinary(terms, (a, b) => a + b);
+                terms.Add(term);
+            }
+            throw new AngouriBugException($"We cannot get here, as {nameof(TaylorExpansionTerms)} is supposed to be endless");
+        }
     }
 }

--- a/Sources/AngouriMath/Functions/Series.cs
+++ b/Sources/AngouriMath/Functions/Series.cs
@@ -50,6 +50,7 @@ namespace AngouriMath.Functions
         {
             // This structure is just a deconstruction of the terms that are added together in a multi taylor polynomial.
             // Like n (x - a)^s (y - b)^t f'(x,y), where n is the coefficient, s and t are pointCoefficientDegrees, and then the partialDerivative
+            // See https://en.wikipedia.org/wiki/Taylor_series#Taylor_series_in_several_variables for the formula used here.
             var lastTerms = new List<(int coefficient, int[] pointCoefficientDegrees, Entity partialDerivative)>();
             var order = 0;
             var variables = exprToPolyVars.Length;
@@ -58,11 +59,13 @@ namespace AngouriMath.Functions
             {
                 var newTerms = new List<(int coefficient, int[] pointCoefficientDegrees, Entity partialDerivative)>();
 
-                if (order > 0) {
+                // Take a bunch of partial derivatives
+                if (order == 0) newTerms.Add((1, new int[variables], expr));
+                else {
 
                     foreach (var lastTerm in lastTerms)
                     {
-                        // We must take the partial derivative with respect to each component.
+                        // with respect to each variable 
                         for (int variableIndex = 0; variableIndex < exprToPolyVars.Length; variableIndex++)
                         {
                             var triple = exprToPolyVars[variableIndex];
@@ -84,7 +87,7 @@ namespace AngouriMath.Functions
                                 }
                             }
 
-                            // If the partial derivative has already been computed, we just add to it's coefficient and skip this.
+                            // If the partial derivative has already been computed, we just add to it's coefficient instead of duplicating it.
                             if (!foundRepeatFlag)
                             {
                                 var newPartialDerivative = lastTerm.partialDerivative.Differentiate(triple.exprVariable);
@@ -95,10 +98,10 @@ namespace AngouriMath.Functions
                     }
 
                 }
-                else newTerms.Add((1, new int[variables], expr));
 
                 Entity fullExpr = 0;
 
+                // Put together the full term
                 foreach (var newTerm in newTerms) {
                     
                     Entity pointCoefficients = 1;

--- a/Sources/AngouriMath/Functions/Series.cs
+++ b/Sources/AngouriMath/Functions/Series.cs
@@ -46,7 +46,7 @@ namespace AngouriMath.Functions
             throw new AngouriBugException($"We cannot get here, as {nameof(TaylorExpansionTerms)} is supposed to be endless");
         }
 
-        internal static IEnumerable<Entity> MultivariableTaylorExpansionTerms(Entity expr, (Variable exprVariable, Variable polyVariable, Entity point)[] exprToPolyVars)
+        internal static IEnumerable<Entity> MultivariableTaylorExpansionTerms(Entity expr, params (Variable exprVariable, Variable polyVariable, Entity point)[] exprToPolyVars)
         {
             // This structure is just a deconstruction of the terms that are added together in a multi taylor polynomial.
             // Like n (x - a)^s (y - b)^t f'(x,y), where n is the coefficient, s and t are pointCoefficientDegrees, and then the partialDerivative
@@ -137,7 +137,7 @@ namespace AngouriMath.Functions
             }
         }
 
-        internal static Entity MultivariableTaylorExpansion(Entity expr, (Variable exprVariable, Variable polyVariable, Entity point)[] exprToPolyVars, int termCount)
+        internal static Entity MultivariableTaylorExpansion(Entity expr, int termCount, params (Variable exprVariable, Variable polyVariable, Entity point)[] exprToPolyVars )
         {
             if (termCount < 0)
                 throw new InvalidNumberException($"{nameof(termCount)} is supposed to be at least 0");

--- a/Sources/AngouriMath/Functions/Series.cs
+++ b/Sources/AngouriMath/Functions/Series.cs
@@ -119,13 +119,19 @@ namespace AngouriMath.Functions
                         pointCoefficients *= (variable.polyVariable - variable.point).Pow(newTerm.pointCoefficientDegrees[variableIndex]);
                     }
 
-                    fullExpressionTerms.Add( newTerm.partialDerivative * newTerm.coefficient * pointCoefficients );
-                }
-                Entity fullExpr = TreeAnalyzer.MultiHangBinary(fullExpressionTerms, (a, b) => a + b);
+                    // Solve the partial derivative at the given point,
+                    var solvedPartialDerivative = newTerm.partialDerivative;
+                    foreach (var variable in exprToPolyVars)
+                        solvedPartialDerivative = solvedPartialDerivative.Substitute(variable.exprVariable, variable.point);
 
-                // then solve for the given point and simplify,
-                foreach (var variable in exprToPolyVars)
-                    fullExpr = fullExpr.Substitute(variable.exprVariable, variable.point).InnerSimplified;
+                    var fullTerm = solvedPartialDerivative * newTerm.coefficient * pointCoefficients;
+
+                    // tack on the coefficient information,
+                    fullExpressionTerms.Add(fullTerm);
+                }
+
+                Entity fullExpr = TreeAnalyzer.MultiHangBinary(fullExpressionTerms, (a, b) => a + b);
+                fullExpr = fullExpr.InnerSimplified;
 
                 if (fullExpr.Equals(Number.Integer.Zero))
                     yield return Number.Integer.Zero;

--- a/Sources/AngouriMath/Functions/Series.cs
+++ b/Sources/AngouriMath/Functions/Series.cs
@@ -88,6 +88,7 @@ namespace AngouriMath.Functions
                                     // If the match is found, instead of creating a whole new repeat term, we just add
                                     // to the match's coefficient. This ends up making a neat binomial coefficient pattern.
                                     newTerm.coefficient += lastTerm.coefficient;
+                                    newTerms[newTermIndex] = newTerm;
                                     foundRepeatFlag = true;
                                     break;
                                 }
@@ -114,8 +115,8 @@ namespace AngouriMath.Functions
                     Entity pointCoefficients = 1;
                     for (int variableIndex = 0; variableIndex < exprToPolyVars.Length; variableIndex++)
                     {
-                        var triple = exprToPolyVars[variableIndex];
-                        pointCoefficients *= (triple.polyVariable - triple.point).Pow(newTerm.pointCoefficientDegrees[variableIndex]);
+                        var variable = exprToPolyVars[variableIndex];
+                        pointCoefficients *= (variable.polyVariable - variable.point).Pow(newTerm.pointCoefficientDegrees[variableIndex]);
                     }
 
                     fullExpressionTerms.Add( newTerm.partialDerivative * newTerm.coefficient * pointCoefficients );
@@ -126,11 +127,16 @@ namespace AngouriMath.Functions
                 foreach (var variable in exprToPolyVars)
                     fullExpr = fullExpr.Substitute(variable.exprVariable, variable.point).InnerSimplified;
 
-                // and divide that all by the proper factorial.
-                if (order > 1)
-                    fullExpr /= ((Entity)order).Factorial();
+                if (fullExpr.Equals(Number.Integer.Zero))
+                    yield return Number.Integer.Zero;
+                else
+                {
+                    // and divide that all by the proper factorial.
+                    if (order > 1)
+                        fullExpr /= ((Entity)order).Factorial();
 
-                yield return fullExpr;
+                    yield return fullExpr;
+                }
 
                 lastTerms = newTerms;
                 order++;

--- a/Sources/Tests/FSharpWrapperUnitTests/Functions.Matrices.fs
+++ b/Sources/Tests/FSharpWrapperUnitTests/Functions.Matrices.fs
@@ -1,7 +1,7 @@
 ﻿module ReturnValues.FunctionsMatricesTest
 
 open AngouriMath.FSharp.Core
-open AngouriMath.FSharp.Functions
+open AngouriMath.FSharp.Matrices
 open Utils
 open Xunit
 
@@ -23,10 +23,6 @@ let ``Tensor product 2`` () = Assert.Equal(parsed "[a b]", (asMatrix "a") *** (a
 let ``Tensor power 1`` () = Assert.Equal(parsed "[a2, a b, b a, b2]", (asMatrix "[a, b]") **** 2)
 [<Fact>]
 let ``Tensor power 2`` () = Assert.Equal(parsed "[a2 * a]", (asMatrix "a") **** 3)
-
-
-open AngouriMath.FSharp.Matrices
-
 [<Fact>]
 let ``matrix 2x2 func`` () = testEqual (parsed "[[a, b], [c, d]]", matrix2x2 "a" "b" "c" "d")
 [<Fact>]

--- a/Sources/Tests/FSharpWrapperUnitTests/MatricesTest.fs
+++ b/Sources/Tests/FSharpWrapperUnitTests/MatricesTest.fs
@@ -1,7 +1,6 @@
 ﻿module MatricesTest
 
 open AngouriMath
-open AngouriMath.FSharp.Functions
 open AngouriMath.FSharp.Matrices
 open Xunit
 

--- a/Sources/Tests/UnitTests/Calculus/SeriesTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/SeriesTest.cs
@@ -22,23 +22,21 @@ namespace UnitTests.Calculus
         }
 
         [Theory]
-        [InlineData("a t3 + b t2 + c t + d", "((d) + ((c) * (x))) + (((((2) * (b)) * ((x) ^ (2))) / ((2)!)) + ((((6) * (a)) * ((x) ^ (3))) / ((3)!)))", 4)]
-        [InlineData("(e^t)ln(1+s)", "(0) + ((y) + ((((2) * ((x) * (y))) + ((-1) * ((y) ^ (2)))) / ((2)!)))", 3)]
-        [InlineData("sin(t)+cos(s)+tan(u)", "((1) + ((x) + (z)))", 2)]
+        [InlineData("sin(t)", "(((0) + (x)) + ((0) + ((((-1) * ((x) ^ (3))) / ((3)!)) + (0)))) + (((((x) ^ (5)) / ((5)!)) + (0)) + ((((-1) * ((x) ^ (7))) / ((7)!)) + ((0) + (((x) ^ (9)) / ((9)!)))))", 10)]
+        [InlineData("cos(t)", "(((1) + (0)) + ((((-1) * ((x) ^ (2))) / ((2)!)) + ((0) + (((x) ^ (4)) / ((4)!))))) + (((0) + (((-1) * ((x) ^ (6))) / ((6)!))) + ((0) + ((((x) ^ (8)) / ((8)!)) + (0))))", 10)]
+        [InlineData("tan(t)", "((0) + ((x) + (0))) + ((((2) * ((x) ^ (3))) / ((3)!)) + ((0) + (((16) * ((x) ^ (5))) / ((5)!))))", 6)]
+        [InlineData("cotan(1 - t)", "(cotan(1)) + (((((-1) / ((sin(1)) ^ (2))) * (-1)) * (x)) + ((((((-1) * ((((2) * (sin(1))) * ((cos(1)) * (-1))) * (-1))) / (((sin(1)) ^ (2)) ^ (2))) * (-1)) * ((x) ^ (2))) / ((2)!)))", 3)]
+        [InlineData("a t3 + b s2 + c u + d", "((d) + ((c) * (z))) + (((((2) * (b)) * ((y) ^ (2))) / ((2)!)) + ((((6) * (a)) * ((x) ^ (3))) / ((3)!)))", 4)]
+        [InlineData("(e^t)ln(1 + s)", "(0) + ((y) + ((((2) * ((x) * (y))) + ((-1) * ((y) ^ (2)))) / ((2)!)))", 3)]
+        [InlineData("sin(t) + cos(s) + tan(u)", "((1) + ((x) + (z)))", 2)]
         [InlineData("cos(t)sin(s)", "((0) + (y)) + ((0) + ((((-3) * (((x) ^ (2)) * (y))) + ((-1) * ((y) ^ (3)))) / ((3)!)))", 4)]
         [InlineData("sin(t)sin(s)sin(u)sin(v)", "((0) + (0)) + ((0) + ((0) + (((24) * ((((x) * (y)) * (z)) * (w))) / ((4)!))))", 5)]
         public void MultivariableTaylorDirect(string funcOverTRaw, string expectedRaw, int termCount)
         {
             Entity funcOverT = funcOverTRaw;
             Entity expected = expectedRaw;
-            var vars = new (Variable exprVariable, Variable polyVariable, Entity value)[]
-            {
-                ("t", "x", "0"),
-                ("s", "y", "0"),
-                ("u", "z", "0"),
-                ("v", "w", "0")
-            };
-            Entity actual = MathS.Series.MultivariableTaylorExpansion(funcOverT, termCount, vars);
+            Entity actual = MathS.Series.MultivariableTaylorExpansion(funcOverT, termCount,
+                ("t", "x", "0"), ("s", "y", "0"), ("u", "z", "0"), ("v", "w", "0"));
             actual.ShouldBe(expected);
         }
 
@@ -78,19 +76,16 @@ namespace UnitTests.Calculus
 
         [Theory]
         [InlineData(new double[3] { 0, 0, 0 }, 4, "sin(x) + cos(y) + tan(z)", new double[3] { 0.5, -0.5, 0.1 })]
+        [InlineData(new double[3] { 0, 0, 0 }, 6, "tanh(z)", new double[3] { 99, 99, 0.2 })]
         [InlineData(new double[3] { 0, 0, 0 }, 4, "sqrt(x - 1) / e ^ (y - 1) + sin(z)", new double[3] { 0.1, 0.1, 0.1 })]
+        [InlineData(new double[3] { -5, 5, 10 }, 4, "e^((x)(y)(z))", new double[3] { -5.5, 5.5, 9 })]
         [InlineData(new double[3] { 1, 1, 1 }, 6, "(e^x)ln(1 + y)z", new double[3] { 0.5, 0.5, 0.5 })]
+        [InlineData(new double[3] { 3, 2, 1 }, 6, "((x)(y^2)(z^3)) / (1 + y)", new double[3] { 3, 1.5, 1.5 })]
         public void CheckMultivariableCorrectness(double[] point, int termCount, string func, double[] pointToCheckAt)
         {
-            var vars = new (Variable exprVariable, Variable polyVariable, Entity value)[]
-            {
-                ("x", "x", point[0]),
-                ("y", "y", point[1]),
-                ("z", "z", point[2])
-            };
-
             Entity expr = func;
-            var taylor = MathS.Series.MultivariableTaylorExpansion(expr, termCount, vars);
+            var taylor = MathS.Series.MultivariableTaylorExpansion(expr, termCount,
+                ("x", "x", point[0]), ("y", "y", point[1]), ("z", "z", point[2]) );
 
             var expected = expr.Substitute("x", pointToCheckAt[0]).Substitute("y", pointToCheckAt[1]).Substitute("z", pointToCheckAt[2]).EvalNumerical();
             var actual = taylor.Substitute("x", pointToCheckAt[0]).Substitute("y", pointToCheckAt[1]).Substitute("z", pointToCheckAt[2]).EvalNumerical();

--- a/Sources/Tests/UnitTests/Calculus/SeriesTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/SeriesTest.cs
@@ -23,6 +23,7 @@ namespace UnitTests.Calculus
         [Theory]
         [InlineData("a t3 + b t2 + c t + d", "((d) + ((c) * (x))) + (((((2) * (b)) * ((x) ^ (2))) / ((2)!)) + ((((6) * (a)) * ((x) ^ (3))) / ((3)!)))", 4)]
         [InlineData("(e^t)ln(1+s)", "((0) + ((y) + ((((x) * (y)) + -((y) ^ (2))) / ((2)!))))", 3)]
+        [InlineData("sin(t)+cos(s)+tan(u)", "((1) + ((x) + (z)))", 2)]
         public void MultivariableTaylorDirect(string funcOverTRaw, string expectedRaw, int termCount)
         {
             Entity funcOverT = funcOverTRaw;
@@ -30,7 +31,8 @@ namespace UnitTests.Calculus
             var vars = new (Variable exprVariable, Variable polyVariable, Entity value)[]
             {
                 ("t", "x", "0"),
-                ("s", "y", "0")
+                ("s", "y", "0"),
+                ("u", "z", "0")
             };
             Entity actual = MathS.Series.MultivariableTaylorExpansion(funcOverT, vars, termCount);
             actual.ShouldBe(expected);

--- a/Sources/Tests/UnitTests/Calculus/SeriesTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/SeriesTest.cs
@@ -34,7 +34,7 @@ namespace UnitTests.Calculus
                 ("s", "y", "0"),
                 ("u", "z", "0")
             };
-            Entity actual = MathS.Series.MultivariableTaylorExpansion(funcOverT, vars, termCount);
+            Entity actual = MathS.Series.MultivariableTaylorExpansion(funcOverT, termCount, vars);
             actual.ShouldBe(expected);
         }
 

--- a/Sources/Tests/UnitTests/Calculus/SeriesTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/SeriesTest.cs
@@ -22,7 +22,7 @@ namespace UnitTests.Calculus
 
         [Theory]
         [InlineData("a t3 + b t2 + c t + d", "((d) + ((c) * (x))) + (((((2) * (b)) * ((x) ^ (2))) / ((2)!)) + ((((6) * (a)) * ((x) ^ (3))) / ((3)!)))", 4)]
-        [InlineData("(e^t)ln(1+s)", "((0) + (y) + ((((x) * (y)) + -((y) ^ (2))) / ((2)!)))", 3)]
+        [InlineData("(e^t)ln(1+s)", "((0) + ((y) + ((((x) * (y)) + -((y) ^ (2))) / ((2)!))))", 3)]
         public void MultivariableTaylorDirect(string funcOverTRaw, string expectedRaw, int termCount)
         {
             Entity funcOverT = funcOverTRaw;
@@ -33,7 +33,7 @@ namespace UnitTests.Calculus
                 ("s", "y", "0")
             };
             Entity actual = MathS.Series.MultivariableTaylorExpansion(funcOverT, vars, termCount);
-            Assert.Equal(expected, actual);
+            actual.ShouldBe(expected);
         }
 
         [Theory]

--- a/Sources/Tests/UnitTests/Calculus/SeriesTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/SeriesTest.cs
@@ -22,7 +22,7 @@ namespace UnitTests.Calculus
 
         [Theory]
         [InlineData("a t3 + b t2 + c t + d", "((d) + ((c) * (x))) + (((((2) * (b)) * ((x) ^ (2))) / ((2)!)) + ((((6) * (a)) * ((x) ^ (3))) / ((3)!)))", 4)]
-        [InlineData("(e^t)ln(1+s)", "y + xy - (y^2)/2", 3)]
+        [InlineData("(e^t)ln(1+s)", "((0) + (y) + ((((x) * (y)) + -((y) ^ (2))) / ((2)!)))", 3)]
         public void MultivariableTaylorDirect(string funcOverTRaw, string expectedRaw, int termCount)
         {
             Entity funcOverT = funcOverTRaw;

--- a/Sources/Tests/UnitTests/Calculus/SeriesTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/SeriesTest.cs
@@ -22,8 +22,10 @@ namespace UnitTests.Calculus
 
         [Theory]
         [InlineData("a t3 + b t2 + c t + d", "((d) + ((c) * (x))) + (((((2) * (b)) * ((x) ^ (2))) / ((2)!)) + ((((6) * (a)) * ((x) ^ (3))) / ((3)!)))", 4)]
-        [InlineData("(e^t)ln(1+s)", "((0) + ((y) + ((((x) * (y)) + -((y) ^ (2))) / ((2)!))))", 3)]
+        [InlineData("(e^t)ln(1+s)", "(0) + ((y) + ((((2) * ((x) * (y))) + ((-1) * ((y) ^ (2)))) / ((2)!)))", 3)]
         [InlineData("sin(t)+cos(s)+tan(u)", "((1) + ((x) + (z)))", 2)]
+        [InlineData("cos(t)sin(s)", "((0) + (y)) + ((0) + ((((-3) * (((x) ^ (2)) * (y))) + ((-1) * ((y) ^ (3)))) / ((3)!)))", 4)]
+        [InlineData("sin(t)sin(s)sin(u)sin(v)", "((0) + (0)) + ((0) + ((0) + (((24) * ((((x) * (y)) * (z)) * (w))) / ((4)!))))", 5)]
         public void MultivariableTaylorDirect(string funcOverTRaw, string expectedRaw, int termCount)
         {
             Entity funcOverT = funcOverTRaw;
@@ -32,7 +34,8 @@ namespace UnitTests.Calculus
             {
                 ("t", "x", "0"),
                 ("s", "y", "0"),
-                ("u", "z", "0")
+                ("u", "z", "0"),
+                ("v", "w", "0")
             };
             Entity actual = MathS.Series.MultivariableTaylorExpansion(funcOverT, termCount, vars);
             actual.ShouldBe(expected);

--- a/Sources/Tests/UnitTests/Calculus/SeriesTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/SeriesTest.cs
@@ -1,5 +1,6 @@
 ﻿using AngouriMath;
 using Xunit;
+using static AngouriMath.Entity;
 
 namespace UnitTests.Calculus
 {
@@ -16,6 +17,22 @@ namespace UnitTests.Calculus
             Entity funcOverT = funcOverTRaw;
             Entity expected = expectedRaw;
             Entity actual = MathS.Series.TaylorExpansion(funcOverT, "t", "x", "0", termCount);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("a t3 + b t2 + c t + d", "((d) + ((c) * (x))) + (((((2) * (b)) * ((x) ^ (2))) / ((2)!)) + ((((6) * (a)) * ((x) ^ (3))) / ((3)!)))", 4)]
+        [InlineData("(e^t)ln(1+s)", "y + xy - (y^2)/2", 3)]
+        public void MultivariableTaylorDirect(string funcOverTRaw, string expectedRaw, int termCount)
+        {
+            Entity funcOverT = funcOverTRaw;
+            Entity expected = expectedRaw;
+            var vars = new (Variable exprVariable, Variable polyVariable, Entity value)[]
+            {
+                ("t", "x", "0"),
+                ("s", "y", "0")
+            };
+            Entity actual = MathS.Series.MultivariableTaylorExpansion(funcOverT, vars, termCount);
             Assert.Equal(expected, actual);
         }
 

--- a/Sources/Tests/UnitTests/Calculus/SeriesTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/SeriesTest.cs
@@ -1,4 +1,5 @@
 ﻿using AngouriMath;
+using System.Collections.Generic;
 using Xunit;
 using static AngouriMath.Entity;
 
@@ -62,13 +63,37 @@ namespace UnitTests.Calculus
         [InlineData(6,  4, "tanh(x)", 6.2)]
         [InlineData(0,  4, "sqrt(x - 1) / e ^ (x - 1) + sin(x)", 0.1)]
         [InlineData(0,  6, "1 + x", 1)]
-        public void CheckTheCorrectness(double point, int termCount, string func, int pointToCheckAt)
+        public void CheckTheCorrectness(double point, int termCount, string func, double pointToCheckAt)
         {
             Entity expr = func;
             var taylor = MathS.Series.TaylorExpansion(expr, "x", "x", point, termCount);
 
             var expected = expr.Substitute("x", pointToCheckAt).EvalNumerical();
             var actual = taylor.Substitute("x", pointToCheckAt).EvalNumerical();
+
+            var error = (expected - actual).Abs();
+
+            Assert.True(error < 0.05, $"Error is: {error}");
+        }
+
+        [Theory]
+        [InlineData(new double[3] { 0, 0, 0 }, 4, "sin(x) + cos(y) + tan(z)", new double[3] { 0.5, -0.5, 0.1 })]
+        [InlineData(new double[3] { 0, 0, 0 }, 4, "sqrt(x - 1) / e ^ (y - 1) + sin(z)", new double[3] { 0.1, 0.1, 0.1 })]
+        [InlineData(new double[3] { 1, 1, 1 }, 6, "(e^x)ln(1 + y)z", new double[3] { 0.5, 0.5, 0.5 })]
+        public void CheckMultivariableCorrectness(double[] point, int termCount, string func, double[] pointToCheckAt)
+        {
+            var vars = new (Variable exprVariable, Variable polyVariable, Entity value)[]
+            {
+                ("x", "x", point[0]),
+                ("y", "y", point[1]),
+                ("z", "z", point[2])
+            };
+
+            Entity expr = func;
+            var taylor = MathS.Series.MultivariableTaylorExpansion(expr, termCount, vars);
+
+            var expected = expr.Substitute("x", pointToCheckAt[0]).Substitute("y", pointToCheckAt[1]).Substitute("z", pointToCheckAt[2]).EvalNumerical();
+            var actual = taylor.Substitute("x", pointToCheckAt[0]).Substitute("y", pointToCheckAt[1]).Substitute("z", pointToCheckAt[2]).EvalNumerical();
 
             var error = (expected - actual).Abs();
 

--- a/Sources/Wrappers/AngouriMath.FSharp/Functions.fs
+++ b/Sources/Wrappers/AngouriMath.FSharp/Functions.fs
@@ -2,7 +2,6 @@
 
 open Core
 open AngouriMath
-open System.Linq
 
 /// Creates a node of power and inner simplifies it
 let ( ** ) a b =
@@ -33,14 +32,6 @@ let substituted x value expr = (parsed expr).Substitute(parsed x, parsed value)
 
 /// Returns a multiline string representation of matrix
 let printedMatrix (x: AngouriMath.Entity.Matrix) = x.ToString(true)
-
-/// Returns a matrix modified according to the modifier
-let modifiedMatrix (x: AngouriMath.Entity.Matrix) m =
-    x.With(new System.Func<int, int, AngouriMath.Entity, AngouriMath.Entity>(m))
-
-/// Gets the transposed form of a matrix or vector
-let transposed (m: AngouriMath.Entity.Matrix) = m.T
-
 
 /// Returns a conjunction node of two nodes
 let conjunction a b = MathS.Conjunction(parsed a, parsed b)
@@ -274,44 +265,3 @@ type Lengths =
     | Any
     | Invalid
     | Fixed of int
-    
-/// Creates a matrix from a list of lists
-/// of objects (which are parsed into Entities)
-let matrix x = 
-    let rec columnCount (x : 'T list list) =
-        match x with
-        | [] -> Any
-        | hd::tl ->
-            match columnCount tl with
-            | Any -> Fixed(hd.Length)
-            | Invalid -> Invalid
-            | Fixed len -> if len = hd.Length then Fixed(len) else Invalid
-    
-    let parseListOfLists li =
-        [ for row in li do yield [ for el in row do yield (parsed el) ] ]
-    
-    match columnCount x with
-    | Any | Invalid -> raise ParseException
-    | Fixed _ -> MathS.Matrix(array2D (parseListOfLists x))
-    
-    
-/// Creates a column vector from a 1-dimensional list
-let vector li =
-    MathS.Vector([ for el in li do yield parsed el ].ToArray())
-   
-/// If the provided entity is a matrix,
-/// it is returned downcasted. Otherwise,
-/// a 1x1 matrix containing the entity is returned.
-let asMatrix a = 
-    match parsed a with
-    | :? Entity.Matrix as m -> m
-    | other -> vector [other]
-
-/// Finds the tensor product of two given matrices
-let ( *** ) a b =
-    Entity.Matrix.TensorProduct(a, b).InnerSimplified |> asMatrix
-
-/// Finds the tensor power of a given matrix. The
-/// power must be positive/
-let ( **** ) (a: Entity.Matrix) b =
-    a.TensorPower(b).InnerSimplified |> asMatrix

--- a/Sources/Wrappers/AngouriMath.FSharp/Matrices.fs
+++ b/Sources/Wrappers/AngouriMath.FSharp/Matrices.fs
@@ -3,6 +3,70 @@
 open AngouriMath
 open AngouriMath.FSharp.Core
 open AngouriMath.FSharp.Functions
+open System.Linq
+
+/// Creates a matrix from a list of lists
+/// of objects (which are parsed into Entities)
+let matrix x = 
+ let rec columnCount (x : 'T list list) =
+     match x with
+     | [] -> Any
+     | hd::tl ->
+         match columnCount tl with
+         | Any -> Fixed(hd.Length)
+         | Invalid -> Invalid
+         | Fixed len -> if len = hd.Length then Fixed(len) else Invalid
+ 
+ let parseListOfLists li =
+     [ for row in li do yield [ for el in row do yield (parsed el) ] ]
+ 
+ match columnCount x with
+ | Any | Invalid -> raise ParseException
+ | Fixed _ -> MathS.Matrix(array2D (parseListOfLists x))
+ 
+ 
+/// Creates a column vector from a 1-dimensional list
+let vector li =
+ MathS.Vector([ for el in li do yield parsed el ].ToArray())
+
+/// If the provided entity is a matrix,
+/// it is returned downcasted. Otherwise,
+/// a 1x1 matrix containing the entity is returned.
+let asMatrix a = 
+ match parsed a with
+ | :? Entity.Matrix as m -> m
+ | other -> vector [other]
+
+/// Creates a square 2x2 matrix, with four elements
+/// in the following order: left-top, right-top,
+/// left-bottom, right-bottom
+let matrix2x2 leftTop rightTop leftBottom rightBottom = 
+    matrix [[leftTop; rightTop]; [leftBottom; rightBottom]]
+ 
+/// Creates a square 3x3 matrix, going first from left
+/// to right, then from top to bottom (the same way
+/// people in Europe read)
+let matrix3x3 leftTop middleTop rightTop leftMiddle middleMiddle rightMiddle leftBottom middleBottom rightBottom =
+    matrix [[leftTop; middleTop; rightTop]; [leftMiddle; middleMiddle; rightMiddle]; [leftBottom; middleBottom; rightBottom]]
+ 
+/// Creates a vector of two elements
+let vector2 a b = vector [a; b]
+ 
+/// Creates a vector of three elements
+let vector3 a b c = vector [a; b; c]
+ 
+/// Creates a new matrix with each
+/// cell's coordinates mapped to
+/// an element (first comes the number of
+/// the row, then the number of column,
+/// starting from 0)
+let matrixWith rows cols map = MathS.Matrix(rows, cols, new System.Func<int, int, Entity>(map))
+ 
+/// Creates a new vector with
+/// each element mapped from its
+/// position (indexed from 0)
+/// to the value via the map function
+let vectorWith count map = matrixWith count 1 (fun r _ -> map r)
 
 let (|*) a b = (parsed a * parsed b).InnerSimplified |> asMatrix
 
@@ -14,34 +78,18 @@ let (|-) a b = (parsed a - parsed b).InnerSimplified |> asMatrix
 
 let (|/) a b = (parsed a / parsed b).InnerSimplified |> asMatrix
 
+/// Finds the tensor product of two given matrices
+let ( *** ) a b =
+ Entity.Matrix.TensorProduct(a, b).InnerSimplified |> asMatrix
 
-/// Creates a square 2x2 matrix, with four elements
-/// in the following order: left-top, right-top,
-/// left-bottom, right-bottom
-let matrix2x2 leftTop rightTop leftBottom rightBottom = 
-    matrix [[leftTop; rightTop]; [leftBottom; rightBottom]]
+/// Finds the tensor power of a given matrix. The
+/// power must be positive
+let ( **** ) (a: Entity.Matrix) b =
+ a.TensorPower(b).InnerSimplified |> asMatrix
 
-/// Creates a square 3x3 matrix, going first from left
-/// to right, then from top to bottom (the same way
-/// people in Europe read)
-let matrix3x3 leftTop middleTop rightTop leftMiddle middleMiddle rightMiddle leftBottom middleBottom rightBottom =
-    matrix [[leftTop; middleTop; rightTop]; [leftMiddle; middleMiddle; rightMiddle]; [leftBottom; middleBottom; rightBottom]]
+/// Returns a matrix modified according to the modifier
+let modifiedMatrix (x: AngouriMath.Entity.Matrix) m =
+    x.With(new System.Func<int, int, AngouriMath.Entity, AngouriMath.Entity>(m))
 
-/// Creates a vector of two elements
-let vector2 a b = vector [a; b]
-
-/// Creates a vector of three elements
-let vector3 a b c = vector [a; b; c]
-
-/// Creates a new matrix with each
-/// cell's coordinates mapped to
-/// an element (first comes the number of
-/// the row, then the number of column,
-/// starting from 0)
-let matrixWith rows cols map = MathS.Matrix(rows, cols, new System.Func<int, int, Entity>(map))
-
-/// Creates a new vector with
-/// each element mapped from its
-/// position (indexed from 0)
-/// to the value via the map function
-let vectorWith count map = matrixWith count 1 (fun r _ -> map r)
+/// Gets the transposed form of a matrix or vector
+let transposed (m: AngouriMath.Entity.Matrix) = m.T


### PR DESCRIPTION
This solves https://github.com/asc-community/AngouriMath/issues/407, but goes further, moving all methods that create or operate on matricies to Functions.Matricies. Is that okay?