### PR TITLE
Added a simplify pattern for XOR that reduces A xor 0 to A.

### DIFF
--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Common.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Common.cs
@@ -227,6 +227,10 @@ namespace AngouriMath.Functions
             Mulf(Rational(var mOne, var den), var any1) when mOne == -1 && den != 1 => -(any1 / den),
             Mulf(var any1, Rational(var mOne, var den)) when mOne == -1 && den != 1 => -(any1 / den),
 
+            // a xor 0 = a
+            Xorf(var any1, Integer(0)) => any1,
+            Xorf(Integer(0), var any1) => any1,
+
             _ => x
         };
     }

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Common.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Common.cs
@@ -227,9 +227,15 @@ namespace AngouriMath.Functions
             Mulf(Rational(var mOne, var den), var any1) when mOne == -1 && den != 1 => -(any1 / den),
             Mulf(var any1, Rational(var mOne, var den)) when mOne == -1 && den != 1 => -(any1 / den),
 
-            // a xor 0 = a
-            Xorf(var any1, Integer(0)) => any1,
-            Xorf(Integer(0), var any1) => any1,
+            // a xor false = a
+            Xorf(var any1, Entity.Boolean any2) when any2 == false => any1,
+            Xorf(var any2, var any1) when any2 == false => any1,
+            Xorf(var any1, Integer any2) when any2 == 0 => any1,
+            Xorf(Integer any2, var any1) when any2 == 0 => any1,
+
+            // a xor true = not a
+            Xorf(var any1, var any2) when any2 == true => new Notf(any1),
+            Xorf(var any2, var any1) when any2 == true => new Notf(any1),
 
             _ => x
         };

--- a/Sources/Tests/UnitTests/PatternsTest/SimplifyTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/SimplifyTest.cs
@@ -97,6 +97,10 @@ namespace UnitTests.PatternsTest
         [Fact] public void Divide3() => AssertSimplifyToString("(x2 + 2 x y + y2 + 1) / (x + y)", "x + 1 / (x + y) + y");
         [Fact] public void Xor1() => AssertSimplify(new Entity.Xorf(x, 0), x);
         [Fact] public void Xor2() => AssertSimplify(new Entity.Xorf(0, x), x);
+        [Fact] public void Xor3() => AssertSimplify(new Entity.Xorf(false, x), x);
+        [Fact] public void Xor4() => AssertSimplify(new Entity.Xorf(x, false), x);
+        [Fact] public void Xor5() => AssertSimplify(new Entity.Xorf(x, true), new Entity.Notf(x));
+        [Fact] public void Xor6() => AssertSimplify(new Entity.Xorf(true, x), new Entity.Notf(x));
 
         [Fact] public void BigSimple1() => AssertSimplifyToString(
             "1+2x*-1+2x*2+x^2+2x+2x*-4+2x*4+2x*2x*-1+2x*2x*2+2x*x^2+x^2+x^2*-4+x^2*4+x^2*2*x*-1+x^2*2x*2+x^2*x^2",

--- a/Sources/Tests/UnitTests/PatternsTest/SimplifyTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/SimplifyTest.cs
@@ -95,6 +95,8 @@ namespace UnitTests.PatternsTest
         // TODO: Smart factorizer
         [Fact] public void Divide2() => AssertSimplifyToString("(x3 + 3 x 2 y + 3 x y 2 + y3) / (x + y)", "x ^ 2 + 2 * x * y + y ^ 2");
         [Fact] public void Divide3() => AssertSimplifyToString("(x2 + 2 x y + y2 + 1) / (x + y)", "x + 1 / (x + y) + y");
+        [Fact] public void Xor1() => AssertSimplify(new Entity.Xorf(x, 0), x);
+        [Fact] public void Xor2() => AssertSimplify(new Entity.Xorf(0, x), x);
 
         [Fact] public void BigSimple1() => AssertSimplifyToString(
             "1+2x*-1+2x*2+x^2+2x+2x*-4+2x*4+2x*2x*-1+2x*2x*2+2x*x^2+x^2+x^2*-4+x^2*4+x^2*2*x*-1+x^2*2x*2+x^2*x^2",


### PR DESCRIPTION
This is a small PR that adds a rule regarding XOR to the common simplifier patterns:

`X ⊕ 0 = X`

Our group encounters this kind of pattern occasionally, so we would like to see this added to the canonical `Simplify()` method. All of the unit tests pass with this new rule in place, and we have added some unit tests to cover this new behavior.