### PR TITLE
Interactive Plot.polar draft implementation (#544)

### DIFF
--- a/Sources/Wrappers/AngouriMath.Interactive/Plot.fs
+++ b/Sources/Wrappers/AngouriMath.Interactive/Plot.fs
@@ -33,6 +33,18 @@ let private prepareLinearData (range : 'T seq) (func : obj) =
     let yData = List.map compiled xData
     (xData, yData)
 
+let private preparePolarData (range: 'T seq) (func : obj) =
+    let (phiData, rData) = prepareLinearData range func
+    let polar = List.zip phiData rData
+    let getX = parsed "r * cos(phi)"
+    let (phix, rx) = getOnlyTwoVariables getX
+    let compiledX = compiled2In<double, 'T, double> rx phix getX
+    let getY = parsed "r * sin(phi)"
+    let (phiy, ry) = getOnlyTwoVariables getY
+    let compiledY = compiled2In<double, 'T, double> ry phiy getY
+    let xData = List.map (fun (phi, r) -> compiledX r phi) polar
+    let yData = List.map (fun (phi, r) -> compiledY r phi) polar
+    (xData, yData)
 
 let private prepareSurface3DData (xRange : 'T1 seq) (yRange : 'T2 seq) (func : obj) =
     let entity = parsed func
@@ -65,6 +77,12 @@ let linear (range : 'T seq) (func : obj) =
     let (xData, yData) = prepareLinearData range func
     Chart.Line (xData, yData)
     |> withTransparency
+
+let polar (range : 'T seq) (func : obj) =
+    let (xData, yData) = preparePolarData range func
+    Chart.Line (xData, yData)
+    |> withTransparency
+    
 
 let scatter2D (range : 'T seq) (func : obj) =
     let (xData, yData) = prepareLinearData range func

--- a/Sources/Wrappers/AngouriMath.Interactive/Plot.fs
+++ b/Sources/Wrappers/AngouriMath.Interactive/Plot.fs
@@ -37,13 +37,12 @@ let private preparePolarData (range: 'T seq) (func : obj) =
     let (phiData, rData) = prepareLinearData range func
     let polar = List.zip phiData rData
     let getX = parsed "r * cos(phi)"
-    let (phix, rx) = getOnlyTwoVariables getX
-    let compiledX = compiled2In<double, 'T, double> rx phix getX
     let getY = parsed "r * sin(phi)"
-    let (phiy, ry) = getOnlyTwoVariables getY
-    let compiledY = compiled2In<double, 'T, double> ry phiy getY
-    let xData = List.map (fun (phi, r) -> compiledX r phi) polar
-    let yData = List.map (fun (phi, r) -> compiledY r phi) polar
+    let (phi, r) = (symbol "phi", symbol "r")
+    let compiledX = compiled2In<'T, double, double> phi r getX
+    let compiledY = compiled2In<'T, double, double> phi r getY
+    let xData = List.map (fun (phi, r) -> compiledX phi r) polar
+    let yData = List.map (fun (phi, r) -> compiledY phi r) polar
     (xData, yData)
 
 let private prepareSurface3DData (xRange : 'T1 seq) (yRange : 'T2 seq) (func : obj) =
@@ -78,7 +77,7 @@ let linear (range : 'T seq) (func : obj) =
     Chart.Line (xData, yData)
     |> withTransparency
 
-let polar (range : 'T seq) (func : obj) =
+let polarLinear (range : 'T seq) (func : obj) =
     let (xData, yData) = preparePolarData range func
     Chart.Line (xData, yData)
     |> withTransparency


### PR DESCRIPTION
I'm not very familiar with either .NET ecosystem or F#, so I have no idea whether the workaround I used here is an acceptable (besides the fact that at least compiler is satisfied with it, since the types don't get narrowed as they would if one uses mere `fun (r, phi) -> r * sin(phi)`).