### PR TITLE
Use the highest version for prereleases instead of the lowest

### DIFF
--- a/.github/workflows/Nuget.yml
+++ b/.github/workflows/Nuget.yml
@@ -26,7 +26,7 @@ jobs:
           currtime=$(date +%s)
           echo "commit hash is $commithash"
           echo "time is $currtime"
-          name=0.0.0-master-$currtime-$commithash
+          name=10.0.0-master-$currtime-$commithash
           echo "name is $name"
           
           # AngouriMath


### PR DESCRIPTION
That way you can add myget as source and update immediately. 