### PR TITLE
`.deb` package for the terminal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ TestResults
 /Sources/Tests/DotnetBenchmark/Properties/launchSettings.json
 **/.ionide/**
 Sources/msbuild.binlog
+
+**/native-out/**
+**/deb-output/**
+*.deb

--- a/Sources/Terminal/AngouriMath.Terminal/ship/build-linux-x64.sh
+++ b/Sources/Terminal/AngouriMath.Terminal/ship/build-linux-x64.sh
@@ -1,0 +1,6 @@
+cd ..
+dotnet publish \
+-r linux-x64 \
+-c release \
+-o ./native-out \
+-p:SelfContained=true

--- a/Sources/Terminal/AngouriMath.Terminal/ship/pack-deb.sh
+++ b/Sources/Terminal/AngouriMath.Terminal/ship/pack-deb.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+echo 'Packing for deb'
+
+version='0.1-alpha'
+name='angourimath-cli'
+folder="${name}_${version}_amd64"
+
+rm -r deb-output
+mkdir deb-output
+cd deb-output
+mkdir "$folder"
+cd "$folder"
+
+mkdir DEBIAN
+cd DEBIAN
+printf "Package: $name\n" > control
+printf "Version: $version\n" >> control
+printf 'Architecture: amd64\n' >> control
+printf 'Maintainer: WhiteBlackGoose <wbg@angouri.org>\n' >> control
+printf 'Description: terminal for AngouriMath.CLI\n' >> control
+
+cd ..
+mkdir -p usr/local/bin
+cp ../../start-cli.sh ./usr/local/bin/angourimath-cli
+chmod +x ./usr/local/bin/angourimath-cli
+
+cp -r ../../../native-out ./usr/local/bin/amcli-data
+
+cd ..
+dpkg-deb --build --root-owner-group "$folder"

--- a/Sources/Terminal/AngouriMath.Terminal/ship/start-cli.sh
+++ b/Sources/Terminal/AngouriMath.Terminal/ship/start-cli.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/local/bin/amcli-data/AngouriMath.Terminal


### PR DESCRIPTION
Who would've thought you need as many as 1 braincell to pack a package for debian-based distro. To pack:
```
./build-linux-x64.sh
./pack-deb.sh
```

![image](https://user-images.githubusercontent.com/31178401/185767021-4b5df648-48e2-416e-8f94-98a4f4f41de9.png)
