### PR TITLE
Infinite recursion in integral fix

### DIFF
--- a/Sources/AngouriMath/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
+++ b/Sources/AngouriMath/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
@@ -80,6 +80,7 @@ namespace AngouriMath
                         // TODO: consider Derivative for negative cases
                         (var expr, Variable var, int asInt)
                             when SequentialIntegrating(expr, var, asInt) is var res and not Integralf
+                            && !res.Nodes.Any(n => n is Integralf)
                             => res.Evaled,
                         _ => null
                     },
@@ -96,6 +97,7 @@ namespace AngouriMath
                         // TODO: should we apply InnerSimplified?
                         (var expr, Variable var, int asInt)
                             when SequentialIntegrating(expr, var, asInt) is var res and not Integralf
+                            && !res.Nodes.Any(n => n is Integralf)
                             => res.InnerSimplified,
                         _ => null
                     },

--- a/Sources/Tests/UnitTests/Calculus/IntegrationTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/IntegrationTest.cs
@@ -28,7 +28,6 @@ namespace AngouriMath.Tests.Calculus
         [InlineData("a ^ x", "a ^ x / ln(a)")]
         [InlineData("sec(a x + b)", "1/2 * ln((1 + sin(a x + b)) / (1 - sin(a x + b))) / a")]
         [InlineData("csc(a x + b)", "ln(tan(1/2(a x + b))) / a")]
-        [InlineData("integral((4x^2+5x-4)/((5x-2)(4x^2+2)), x)", "integral((4x^2+5x-4)/((5x-2)(4x^2+2)), x)")]
         public void TestIndefinite(string initial, string expected)
         {
             Assert.Equal(expected.ToEntity().Simplify(), initial.Integrate("x").Simplify());

--- a/Sources/Tests/UnitTests/Calculus/IntegrationTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/IntegrationTest.cs
@@ -28,6 +28,7 @@ namespace AngouriMath.Tests.Calculus
         [InlineData("a ^ x", "a ^ x / ln(a)")]
         [InlineData("sec(a x + b)", "1/2 * ln((1 + sin(a x + b)) / (1 - sin(a x + b))) / a")]
         [InlineData("csc(a x + b)", "ln(tan(1/2(a x + b))) / a")]
+        [InlineData("integral((4x^2+5x-4)/((5x-2)(4x^2+2)), x)", "integral((4x^2+5x-4)/((5x-2)(4x^2+2)), x)")]
         public void TestIndefinite(string initial, string expected)
         {
             Assert.Equal(expected.ToEntity().Simplify(), initial.Integrate("x").Simplify());

--- a/Sources/Tests/UnitTests/Common/InnerSimplifyTest.cs
+++ b/Sources/Tests/UnitTests/Common/InnerSimplifyTest.cs
@@ -19,6 +19,7 @@ namespace AngouriMath.Tests.Common
         [InlineData("3 ^ 100")]
         [InlineData("(-3) ^ 100")]
         [InlineData("0.01 ^ 100")]
+        [InlineData("integral((4x^2+5x-4)/((5x-2)(4x^2+2)), x)")]
         public void ShouldNotChangeTest(string expr)
         {
             var expected = expr.ToEntity();


### PR DESCRIPTION
Whenever you do `InnerSimplified` against an integral node, it would try to evaluate the integral. If it stays an integral, we do not evaluate again.

However, in certain cases it would not return an integral - but it would return something like a sum of integrals. In that case, we don't want to evaluate anymore either