### PR TITLE
Improvements to operations with collections and indexables

### DIFF
--- a/Sources/AngouriMath/AngouriMath/Convenience/SettingClass.cs
+++ b/Sources/AngouriMath/AngouriMath/Convenience/SettingClass.cs
@@ -158,7 +158,7 @@ namespace AngouriMath.Convenience
     {
         private readonly List<(TKey key, TValue value)> list = new();
 
-        internal TValue Peek() => list[list.Count - 1].value;
+        internal TValue Peek() => list[^1].value;
 
         internal bool Remove(TKey key)
         {

--- a/Sources/AngouriMath/AngouriMath/Functions/Boolean/TableSolver.cs
+++ b/Sources/AngouriMath/AngouriMath/Functions/Boolean/TableSolver.cs
@@ -46,7 +46,7 @@ namespace AngouriMath.Functions.Boolean
         /// <exception cref="WrongNumberOfArgumentsException"/>
         internal static Matrix? SolveTable(Entity expr, Variable[] variables)
         {
-            var count = expr.Vars.Count();
+            var count = expr.Vars.Count;
             // TODO: we probably also should verify the uniqueness of the given variables
             if (count != variables.Length)
                 throw new WrongNumberOfArgumentsException("Number of variables must equal number of variables in the expression");
@@ -67,7 +67,7 @@ namespace AngouriMath.Functions.Boolean
 
         internal static Matrix? BuildTruthTable(Entity expr, Variable[] variables)
         {
-            var count = expr.Vars.Count();
+            var count = expr.Vars.Count;
             // TODO: we probably also should verify the uniqueness of the given variables
             if (count != variables.Length)
                 throw new WrongNumberOfArgumentsException("Number of variables must equal number of variables in the expression");

--- a/Sources/AngouriMath/AngouriMath/Functions/Compilation/IntoLinq/CompilationProtocol.cs
+++ b/Sources/AngouriMath/AngouriMath/Functions/Compilation/IntoLinq/CompilationProtocol.cs
@@ -258,8 +258,8 @@ namespace AngouriMath.Core.Compilation.IntoLinq
             }
             
             // last case
-            var expression = children[children.Length - 2];
-            var predicate = children[children.Length - 1];
+            var expression = children[^2];
+            var predicate = children[^1];
             var nan = ConvertNaN(maxType);
             
             (expression, nan) = EqualizeTypesIfAble(expression, nan);

--- a/Sources/AngouriMath/AngouriMath/Functions/Continuous/Solvers/EquationSolver.cs
+++ b/Sources/AngouriMath/AngouriMath/Functions/Continuous/Solvers/EquationSolver.cs
@@ -26,7 +26,7 @@ namespace AngouriMath.Functions.Algebra
 
             static Entity simplifier(Entity entity) => entity.InnerSimplified;
             static Entity evaluator(Entity entity) => entity.Evaled;
-            var factorizer = equation.Vars.Count() == 1 ? (Func<Entity, Entity>)evaluator : simplifier;
+            var factorizer = equation.Vars.Count == 1 ? (Func<Entity, Entity>)evaluator : simplifier;
 
 
             if (solutions is FiniteSet finiteSet)
@@ -75,7 +75,7 @@ namespace AngouriMath.Functions.Algebra
         /// </param>
         internal static List<List<Entity>> InSolveSystem(List<Entity> equations, ReadOnlySpan<Variable> vars)
         {
-            var var = vars[vars.Length - 1];
+            var var = vars[^1];
             if (equations.Count == 1)
                 return equations[0].InnerSimplified.SolveEquation(var) is FiniteSet els 
                        ? els.Select(sol => new List<Entity> { sol }).ToList()

--- a/Sources/AngouriMath/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
+++ b/Sources/AngouriMath/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
@@ -209,7 +209,7 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
             // https://mathoverflow.net/a/28977
 
             // if nothing has been found so far
-            if (MathS.Settings.AllowNewton && expr.Vars.Count() == 1)
+            if (MathS.Settings.AllowNewton && expr.Vars.Count == 1)
                 return expr.SolveNt(x).Select(ent => TryDowncast(expr, x, ent)).ToSet();
 
             return Enumerable.Empty<Entity>().ToSet();

--- a/Sources/AngouriMath/AngouriMath/Functions/NumberTheory/Primes.cs
+++ b/Sources/AngouriMath/AngouriMath/Functions/NumberTheory/Primes.cs
@@ -58,7 +58,7 @@ namespace AngouriMath.Functions
 
             static void AddPrimeC()
             {
-                var n = (primes[primes.Count - 1].cache + 2) ?? throw new AngouriBugException("It was supposed to be not null");
+                var n = (primes[^1].cache + 2) ?? throw new AngouriBugException("It was supposed to be not null");
                 while (!IsPrimeC(n))
                     n += 2;
                 primes.Add((n, n));
@@ -66,7 +66,7 @@ namespace AngouriMath.Functions
 
             static void AddPrimeI()
             {
-                var n = (primes[primes.Count - 1].actual + 2) ?? throw new AngouriBugException("It was supposed to be not null");
+                var n = (primes[^1].actual + 2) ?? throw new AngouriBugException("It was supposed to be not null");
                 while (!IsPrimeI(n))
                     n += 2;
                 primes.Add((n, null));

--- a/Sources/Tests/UnitTests/Convenience/FromStringTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/FromStringTest.cs
@@ -318,7 +318,7 @@ namespace AngouriMath.Tests.Convenience
         public void TestUnicodeVariablesParser(string exprRaw, string expectedName)
         {
             Entity actual = exprRaw;
-            var any = actual.Vars.First();
+            var any = actual.Vars[0];
             Assert.Equal(expectedName, any.Name);
         }
         


### PR DESCRIPTION
- When appropriate, `Count` property is used instead of call to `Count()` method
- When the intent was to index an array from the end, the negative indexing operator (think `[^1]`) was used