### PR TITLE
Issue 619 Bug: Solving a system of equations...

### DIFF
--- a/Sources/AngouriMath/AngouriMath/Functions/Continuous/Solvers/EquationSolver.cs
+++ b/Sources/AngouriMath/AngouriMath/Functions/Continuous/Solvers/EquationSolver.cs
@@ -77,7 +77,7 @@ namespace AngouriMath.Functions.Algebra
         {
             var var = vars[^1];
             if (equations.Count == 1)
-                return equations[0].InnerSimplified.SolveEquation(var) is FiniteSet els 
+                return equations[0].InnerSimplified.SolveEquation(var).InnerSimplified is FiniteSet els 
                        ? els.Select(sol => new List<Entity> { sol }).ToList()
                        : new();
             var result = new List<List<Entity>>();

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/SolveSystem.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/SolveSystem.cs
@@ -102,5 +102,24 @@ namespace AngouriMath.Tests.Algebra
             "x2 + y",
             "y - x - 3"
         }, new Entity.Variable[] { "x", "y" }, 2);
+
+
+        [Fact]
+        public void SystemWithZero() => AssertSystemSolvable(new Entity[] {
+            "x - y - 1000",
+            "y - 0"
+        }, new Entity.Variable[] { "x", "y" }, 1);
+
+        [Fact]
+        public void SystemWithZero2() => AssertSystemSolvable(new Entity[] {
+            "y - 0",
+            "x - y - 1000"            
+        }, new Entity.Variable[] { "x", "y" }, 1);
+
+        [Fact]
+        public void SystemWithZero3() => AssertSystemSolvable(new Entity[] {
+            "y - 0",
+            "x - y"
+        }, new Entity.Variable[] { "x", "y" }, 1);
     }
 }


### PR DESCRIPTION
#619 

I added tests with the inputs described in the issue to the SolveSystem tests.

During debugging, I found that `AnalyticalEquationSolver.Solve( "{-(x + -1000) / (-1)}", "{x}" )` 
was returning `"{{  } \/ { 1000 } \ {  }}"`

That value wasn't fitting the FiniteSet type in the ternary within EquationSolver.InSolveSystem.
I tried simply getting InnerSimplified of the solution, and that worked for the new test cases and didn't break the old ones.

Maybe this isn't the right place to simplify, or FiniteSet should accept the value as is.