### PR TITLE
Fix two Simplify hangs, an integration stack overflow, and incomplete factoring (#403, #531, #178, #205)

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -179,6 +179,17 @@ namespace AngouriMath.Functions.Algebra
 
                 // If the result doesn't contain x anymore, we found a valid substitution
                 // and we can integrate with respect to u (treating u as a variable)
+                // Dividing by a derivative that is zero gives NaN, and NaN contains no x,
+                // so it passes the test below and is handed back as the answer. The check
+                // on duDx above catches the cases where that is visible without work;
+                // this catches the rest, where the derivative is only zero after
+                // simplification -- d/dx (sin(x)^2 + cos(x)^2) is written as
+                // 2sin(x)cos(x) - 2cos(x)sin(x), which Evaled cannot reduce with x still
+                // symbolic. That is how the integral of sin(x)^2 + cos(x)^2 came back as
+                // NaN * (sin(x)^2 + cos(x)^2).
+                if (integrandInU.Nodes.Any(node => node == MathS.NaN))
+                    continue;
+
                 if (!integrandInU.ContainsNode(x) && Integration.ComputeIndefiniteIntegral(integrandInU, uSub, integrateByParts) is { } resultInU)
                     // Substitute back: replace u with g(x)
                     return resultInU.Substitute(uSub, u);

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -23,22 +23,22 @@ namespace AngouriMath.Functions.Algebra
             });
         }
 
-        internal static Entity? SolveAsPolynomialTerm(Entity expr, Entity.Variable x) => expr switch
+        internal static Entity? SolveAsPolynomialTerm(Entity expr, Entity.Variable x, bool integrateByParts = true) => expr switch
         {
             Entity.Mulf(var m1, var m2) =>
                 !m1.ContainsNode(x) ?
-                    Integration.ComputeIndefiniteIntegral(m2, x)?.Pipe(i => m1 * i) :
+                    Integration.ComputeIndefiniteIntegral(m2, x, integrateByParts)?.Pipe(i => m1 * i) :
                 !m2.ContainsNode(x) ?
-                    Integration.ComputeIndefiniteIntegral(m1, x)?.Pipe(i => m2 * i) :
+                    Integration.ComputeIndefiniteIntegral(m1, x, integrateByParts)?.Pipe(i => m2 * i) :
                 null,
 
             Entity.Divf(var div, var over) =>
                 !div.ContainsNode(x) ?
                     over is Entity.Powf(var @base, var power) ?
-                        Integration.ComputeIndefiniteIntegral(MathS.Pow(@base, -power), x)?.Pipe(i => div * i) :
-                        Integration.ComputeIndefiniteIntegral(MathS.Pow(over, -1), x)?.Pipe(i => div * i) :
+                        Integration.ComputeIndefiniteIntegral(MathS.Pow(@base, -power), x, integrateByParts)?.Pipe(i => div * i) :
+                        Integration.ComputeIndefiniteIntegral(MathS.Pow(over, -1), x, integrateByParts)?.Pipe(i => div * i) :
                 !over.ContainsNode(x) ?
-                    Integration.ComputeIndefiniteIntegral(div, x)?.Pipe(i => i / over) :
+                    Integration.ComputeIndefiniteIntegral(div, x, integrateByParts)?.Pipe(i => i / over) :
                 null,
 
             Entity.Powf(var @base, var power) =>
@@ -95,6 +95,18 @@ namespace AngouriMath.Functions.Algebra
 
             if (expr is Entity.Mulf(var f, var g))
             {
+                // Case 0: a logarithm times a polynomial. Only one of the two orders
+                // terminates. Differentiating the polynomial, which is what Case 1 does,
+                // leaves the logarithm to be integrated, and the antiderivative of ln(x)
+                // holds an x*ln(x) that puts the original integral back in front of us --
+                // that is how integral(x * ln(x), x) recursed until the stack ran out.
+                // Differentiating the logarithm instead turns it into 1/x, which cancels
+                // against the integrated polynomial and ends. (The L-before-A of LIATE.)
+                if (f is Logf && MathS.TryPolynomial(g, x, out _)
+                    && TryIntegrateByPartsOnce(f, g, x) is { } logFirstF) return logFirstF;
+                if (g is Logf && MathS.TryPolynomial(f, x, out _)
+                    && TryIntegrateByPartsOnce(g, f, x) is { } logFirstG) return logFirstG;
+
                 // Case 1: One term is polynomial - use recursive polynomial integration by parts
                 if (MathS.TryPolynomial(f, x, out var fPoly)) return IntegrateByPartsPolynomial(fPoly, g, x);
                 if (MathS.TryPolynomial(g, x, out var gPoly)) return IntegrateByPartsPolynomial(gPoly, f, x);
@@ -113,23 +125,23 @@ namespace AngouriMath.Functions.Algebra
             return null;
         }
 
-        internal static Entity? SolveLogarithmic(Entity expr, Entity.Variable x) => expr switch
+        internal static Entity? SolveLogarithmic(Entity expr, Entity.Variable x, bool integrateByParts = true) => expr switch
         {
             Entity.Logf(var @base, var arg) =>
                 @base.ContainsNode(x) ?
-                    Integration.ComputeIndefiniteIntegral(MathS.Ln(arg) / MathS.Ln(@base), x) :
+                    Integration.ComputeIndefiniteIntegral(MathS.Ln(arg) / MathS.Ln(@base), x, integrateByParts) :
                 arg is Entity.Powf(var y, var pow) ? // log(b, y^p) = ln(y^p) / ln(b) = ln(p) / ln(b) * ln(y)
-                    Integration.ComputeIndefiniteIntegral(pow / MathS.Ln(@base) * MathS.Ln(y), x) :
+                    Integration.ComputeIndefiniteIntegral(pow / MathS.Ln(@base) * MathS.Ln(y), x, integrateByParts) :
                     null,
 
             _ => null
         };
 
-        internal static Entity? SolveExponential(Entity expr, Entity.Variable x) => expr switch
+        internal static Entity? SolveExponential(Entity expr, Entity.Variable x, bool integrateByParts = true) => expr switch
         {
             Entity.Powf(var @base, var pow) =>
                 @base.ContainsNode(x) ?
-                    Integration.ComputeIndefiniteIntegral(MathS.Pow(MathS.e, MathS.Ln(@base) * pow), x) :
+                    Integration.ComputeIndefiniteIntegral(MathS.Pow(MathS.e, MathS.Ln(@base) * pow), x, integrateByParts) :
                     null,
 
             _ => null
@@ -139,7 +151,7 @@ namespace AngouriMath.Functions.Algebra
         /// Attempts to solve an integral using u-substitution.
         /// Looks for patterns where f(g(x)) * g'(x) can be integrated as F(g(x)).
         /// </summary>
-        internal static Entity? SolveBySubstitution(Entity expr, Entity.Variable x)
+        internal static Entity? SolveBySubstitution(Entity expr, Entity.Variable x, bool integrateByParts = true)
         {
             // Try to find a suitable substitution u = g(x)
             // We need to identify a composite function and check if du/dx appears in the integrand
@@ -147,6 +159,14 @@ namespace AngouriMath.Functions.Algebra
             foreach (var u in candidates)
             {
                 var duDx = u.Differentiate(x).InnerSimplified;
+
+                // A candidate that does not vary with x is no substitution at all, and its
+                // derivative is zero: dividing the integrand by it gives NaN, which then
+                // contains no x and so passes the test below and is returned as the answer.
+                // `ln(e)`, picked up as a logarithm anywhere in the integrand, was enough --
+                // it is how the antiderivative of x * ln(x) came back holding a NaN.
+                if (!u.ContainsNode(x) || duDx.Evaled == 0)
+                    continue;
 
                 // Try to express expr as h(u) * du/dx
                 // If successful, integral becomes ∫h(u)du
@@ -159,7 +179,7 @@ namespace AngouriMath.Functions.Algebra
 
                 // If the result doesn't contain x anymore, we found a valid substitution
                 // and we can integrate with respect to u (treating u as a variable)
-                if (!integrandInU.ContainsNode(x) && Integration.ComputeIndefiniteIntegral(integrandInU, uSub) is { } resultInU)
+                if (!integrandInU.ContainsNode(x) && Integration.ComputeIndefiniteIntegral(integrandInU, uSub, integrateByParts) is { } resultInU)
                     // Substitute back: replace u with g(x)
                     return resultInU.Substitute(uSub, u);
             }

--- a/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
@@ -51,9 +51,13 @@ namespace AngouriMath.Functions.Algebra
         {
             if (!expr.ContainsNode(x)) return expr * x; // base case, handle here
             if ((IntegralPatterns.TryStandardIntegrals(expr, x)) is { } answer) return answer;
-            if ((answer = IndefiniteIntegralSolver.SolveAsPolynomialTerm(expr, x)) is { }) return answer;
-            if ((answer = IndefiniteIntegralSolver.SolveLogarithmic(expr, x)) is { }) return answer;
-            if ((answer = IndefiniteIntegralSolver.SolveBySubstitution(expr, x)) is { }) return answer;
+            // The flag has to be handed on. Every one of these recurses, and a solver that
+            // dropped it re-enabled integration by parts one level below the call that
+            // switched it off -- which is a cycle, since by parts calls back into here.
+            // `x * ln(x)` went round it until the stack ran out.
+            if ((answer = IndefiniteIntegralSolver.SolveAsPolynomialTerm(expr, x, integrateByParts)) is { }) return answer;
+            if ((answer = IndefiniteIntegralSolver.SolveLogarithmic(expr, x, integrateByParts)) is { }) return answer;
+            if ((answer = IndefiniteIntegralSolver.SolveBySubstitution(expr, x, integrateByParts)) is { }) return answer;
             if (integrateByParts && (answer = IndefiniteIntegralSolver.SolveIntegratingByParts(expr, x)) is { }) return answer;
             // this may expand to too many terms
             if ((answer = IndefiniteIntegralSolver.SolveBySplittingSum(expr, x, integrateByParts)) is { }) return answer;

--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Definition.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Definition.cs
@@ -248,8 +248,10 @@ namespace AngouriMath
         /// </code>
         /// </example>
         public Entity Factorize(int level = 2) => level <= 1
-            ? this.Replace(Patterns.FactorizeRules)
-            : this.Replace(Patterns.FactorizeRules).Factorize(level - 1);
+            // InnerSimplified, so that the factors come back finished: the rules leave
+            // x ^ 1 where they mean x, and sqrt(4) where they mean 2.
+            ? this.Replace(Patterns.FactorizeRules).InnerSimplified
+            : this.Replace(Patterns.FactorizeRules).InnerSimplified.Factorize(level - 1);
 
         /// <summary>
         /// Simplifies an equation ( e.g. (x - y) * (x + y) -> x^2 - y^2, but 3 * x + y * x = (3 + y) * x )

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.ExpandFactorize.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.ExpandFactorize.cs
@@ -21,10 +21,15 @@ namespace AngouriMath.Functions
 
         internal static Entity FactorizeRules(Entity x) => x switch
         {
-            // {1}2 - {2}2
-            Minusf(Powf(var any1, Number const1), Powf(var any2, Number const2)) =>
-                (new Powf(any1, const1 / 2) - new Powf(any2, const2 / 2)) *
-                (new Powf(any1, const1 / 2) + new Powf(any2, const2 / 2)),
+            // {1}^2n - {2}^2m = ({1}^n - {2}^m) * ({1}^n + {2}^m).
+            // Both exponents have to be even, or halving them introduces radicals and the
+            // rule fires again on the factors it has just produced: x^2 - y^2 came back as
+            // (sqrt(x) - sqrt(y)) * (sqrt(x) + sqrt(y)) * (x^1 + y^1). The halves are built
+            // as integers rather than as const/2, which left an unevaluated 2/2 behind.
+            Minusf(Powf(var any1, Integer const1), Powf(var any2, Integer const2))
+                when const1.EInteger.IsEven && const2.EInteger.IsEven =>
+                (new Powf(any1, Integer.Create(const1.EInteger / 2)) - new Powf(any2, Integer.Create(const2.EInteger / 2))) *
+                (new Powf(any1, Integer.Create(const1.EInteger / 2)) + new Powf(any2, Integer.Create(const2.EInteger / 2))),
 
             Minusf(Powf(var any1, Integer(2)), Number const1) =>
                 (any1 - new Powf(const1, Rational.Create(1, 2))) *
@@ -54,7 +59,63 @@ namespace AngouriMath.Functions
             // a ^ b * c ^ b = (a * c) ^ b
             Mulf(Powf(var any1, var any2), Powf(var any3, var any2a)) when any2 == any2a => new Powf(any1 * any3, any2),
 
+            Sumf or Minusf when CollectCommonFactors(x) is { } collected => collected,
+
             _ => x
         };
+
+        /// <summary>
+        /// Pulls a shared factor out of the terms of a sum: <c>a*c + a*d + b*c + b*d</c>
+        /// becomes <c>a*(c + d) + b*(c + d)</c>, which the pairwise rules above close to
+        /// <c>(a + b) * (c + d)</c> on the next pass.
+        /// </summary>
+        /// <remarks>
+        /// The pairwise rules only ever see two adjacent terms of the sum tree, so a sum of
+        /// four was left half-factored at <c>a*(c + d) + b*c + b*d</c> -- that is #531. Sums
+        /// of two are left to those rules, which are older and better tested.
+        /// </remarks>
+        /// <returns><see langword="null"/> when no factor is shared, so the rule does not fire.</returns>
+        private static Entity? CollectCommonFactors(Entity expr)
+        {
+            var terms = Sumf.LinearChildren(expr).ToList();
+            return terms.Count > 2 ? CollectOver(terms) : null;
+        }
+
+        private static Entity? CollectOver(IReadOnlyList<Entity> terms)
+        {
+            var factorsOf = terms.Select(term => Mulf.LinearChildren(term).ToList()).ToList();
+
+            // The factor shared by the most terms, so the largest group comes out first.
+            // Numbers are left alone: pulling a coefficient out only moves it about, and
+            // the rules that gather coefficients are elsewhere.
+            Entity? shared = null;
+            var sharedBy = 1;
+            foreach (var candidate in factorsOf.SelectMany(factors => factors).Distinct())
+                if (candidate is not Number
+                    && factorsOf.Count(factors => factors.Contains(candidate)) is var count
+                    && count > sharedBy)
+                    (shared, sharedBy) = (candidate, count);
+            if (shared is null)
+                return null;
+
+            var grouped = new List<Entity>();
+            var rest = new List<Entity>();
+            for (var i = 0; i < terms.Count; i++)
+            {
+                var factors = factorsOf[i];
+                var at = factors.IndexOf(shared);
+                if (at < 0)
+                {
+                    rest.Add(terms[i]);
+                    continue;
+                }
+                factors.RemoveAt(at); // one occurrence only, so a^2 keeps an a behind
+                grouped.Add(factors.Count == 0 ? 1 : factors.Aggregate((left, right) => left * right));
+            }
+
+            var collected = shared * Sumf.Sum(grouped);
+            // Every recursion drops at least the two terms just grouped, so this ends.
+            return rest.Count == 0 ? collected : collected + (CollectOver(rest) ?? Sumf.Sum(rest));
+        }
     }
 }

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Power.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Power.cs
@@ -5,6 +5,7 @@
 // Website: https://am.angouri.org.
 //
 
+using PeterO.Numbers;
 using static AngouriMath.Entity;
 
 namespace AngouriMath.Functions
@@ -100,7 +101,60 @@ namespace AngouriMath.Functions
             Sumf(Logf(var any3, var any1), Logf(var any3a, var any2)) when any3 == any3a => any3.Log(any1 * any2),
             Minusf(Logf(var any3, var any1), Logf(var any3a, var any2)) when any3 == any3a => any3.Log(any1 / any2),
 
+            // sqrt(8) = 2 * sqrt(2), cbrt(54) = 3 * cbrt(2)
+            Powf(Integer { IsPositive: true } radicand, Rational and not Integer and var power)
+                when ReduceRadical(radicand, power) is { } reduced => reduced,
+
             _ => x
         };
+
+        /// <summary>
+        /// Largest divisor tried when reducing a radical. Reducing sqrt(n) exactly would
+        /// mean factoring n, which is not something a simplification pass can afford to
+        /// do on every node. Trial division by small divisors catches every radical that
+        /// turns up in practice; anything left stays under the root, which is still a
+        /// correct answer, just not a fully reduced one.
+        /// </summary>
+        private const int MaxRadicalTrialDivisor = 1000;
+
+        /// <summary>
+        /// Rewrites <c>n ^ (p/q)</c> as <c>a ^ p * b ^ (p/q)</c> where <c>n = a^q * b</c>,
+        /// i.e. pulls every q-th power out from under the root.
+        /// </summary>
+        /// <returns>
+        /// <see langword="null"/> when nothing can be pulled out, so that the rule does
+        /// not fire and rewriting terminates.
+        /// </returns>
+        private static Entity? ReduceRadical(Integer radicand, Rational power)
+        {
+            var denominator = power.ERational.Denominator;
+            if (denominator < 2 || denominator > 64)
+                return null;
+            var root = denominator.ToInt32Checked();
+
+            var inside = radicand.EInteger;
+            if (inside <= 1)
+                return null;
+
+            var outside = EInteger.One;
+            for (int divisor = 2; divisor <= MaxRadicalTrialDivisor; divisor++)
+            {
+                var divisorPower = EInteger.FromInt32(divisor).Pow(root);
+                if (divisorPower > inside)
+                    break;
+                while (inside.Remainder(divisorPower).IsZero)
+                {
+                    inside /= divisorPower;
+                    outside *= EInteger.FromInt32(divisor);
+                }
+            }
+
+            if (outside.Equals(EInteger.One))
+                return null; // already reduced; firing here would loop forever
+
+            // n^(p/q) = (a^q * b)^(p/q) = a^p * b^(p/q)
+            return new Powf(Integer.Create(outside), Integer.Create(power.ERational.Numerator))
+                 * new Powf(Integer.Create(inside), power);
+        }
     }
 }

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Rational.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Rational.cs
@@ -15,6 +15,14 @@ namespace AngouriMath.Functions
         private static Entity SumOfFractions(Entity expr,
             Entity leftNum, Entity leftDen, Entity rightNum, Entity rightDen)
         {
+            // a/d + b/d = (a + b)/d. Cross-multiplying instead builds d*d and leaves the
+            // simplifier to cancel it back down, and since this rule runs inside Simplify's
+            // own pass -- calling Simplify again on both halves -- each fraction added to
+            // the sum squares the denominator before anything cancels. Three fractions over
+            // x + y + z never finished, which is #403.
+            if (leftDen == rightDen)
+                return (leftNum + rightNum).InnerSimplified / leftDen;
+
             var twoInt = ((leftNum + leftDen).Vars, (rightNum + rightDen).Vars).IntersectSequences().Any();
             if (twoInt)
                 return (leftNum * rightDen + rightNum * leftDen).Simplify() / (rightDen * leftDen).Simplify();

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Rational.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Rational.cs
@@ -19,7 +19,7 @@ namespace AngouriMath.Functions
             // simplifier to cancel it back down, and since this rule runs inside Simplify's
             // own pass -- calling Simplify again on both halves -- each fraction added to
             // the sum squares the denominator before anything cancels. Three fractions over
-            // x + y + z never finished, which is #403.
+            // x + y + z never finished, which is https://github.com/asc-community/AngouriMath/issues/403.
             if (leftDen == rightDen)
                 return (leftNum + rightNum).InnerSimplified / leftDen;
 

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/SolveOneEquation.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/SolveOneEquation.cs
@@ -179,7 +179,10 @@ namespace AngouriMath.Tests.Algebra
 
         [Theory]
         [InlineData("(x - b) / (x + a) + c", 1, "{ -(a * c + -b) / (1 + c) provided not -(a * c + -b) / (1 + c) + a = 0 }")]
-        [InlineData("(x - b) / (x + a) + c / (x + a)", 1, "{ -(c + -b) provided not a + -(c + -b) = 0 }")]
+        // Both operands share the denominator, so they now add as (x - b + c) / (x + a)
+        // rather than being cross-multiplied; the root is the same b - c, reached with its
+        // terms in the other order.
+        [InlineData("(x - b) / (x + a) + c / (x + a)", 1, "{ -(-b + c) provided not a + -(-b + c) = 0 }")]
         [InlineData("(x - b) / (x + a) + c / (x + a)2", 2, "{ (-(-b + a) - sqrt((-b + a) ^ 2 - 4 * (a * -b + c))) / 2 provided not (-(-b + a) - sqrt((-b + a) ^ 2 - 4 * (a * -b + c))) / 2 + a = 0, (-(-b + a) + sqrt((-b + a) ^ 2 - 4 * (a * -b + c))) / 2 provided not (-(-b + a) + sqrt((-b + a) ^ 2 - 4 * (a * -b + c))) / 2 + a = 0 }")]
         [InlineData("(x - b) / (x + a) + c + (x - c) / (x + d)", 2, null)]
         public void CDSolver(string expr, int rootCount, string? verifyRoots) => TestSolver(expr, rootCount, verifyRoots: verifyRoots);

--- a/Sources/Tests/UnitTests/Calculus/IntegrationTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/IntegrationTest.cs
@@ -244,12 +244,23 @@ namespace AngouriMath.Tests.Calculus
             
             var expr = "ln(abs(x)) ^ 2".ToEntity();
             var result = expr.Integrate("x").Simplify(1);
-            Assert.Equal("C + x * (ln(abs(x)) ^ 2 - ln(abs(x)) - ln(abs(x))) + 2 * x", result.Stringize());
+            // (ln|x| - 1)^2 + 1 = ln^2|x| - 2ln|x| + 2, so this is the antiderivative
+            // written above. Term collection used to stop short, leaving the repeated
+            // ln(abs(x)) uncombined and the 2 * x outside the bracket.
+            Assert.Equal("C + ((ln(abs(x)) - 1) ^ 2 + 1) * x", result.Stringize());
 
             // Verify the result by differentiation
             var derivative = result.Differentiate("x"); // TODO: Make this simplify to expr with Simplify()
             foreach (var point in new[] { -3, 7 }) // TODO: Implement and test for "provided x in R" in result
-                Assert.Equal(expr.Substitute(x, point).Evaled, derivative.Substitute(x, point).Evaled);
+            {
+                // Compared as a difference rather than digit for digit: the two are equal
+                // algebraically, but evaluating each to 100 digits separately need not
+                // agree in the last of them, and which form the antiderivative takes is
+                // not what this test is about.
+                var difference = (expr.Substitute(x, point) - derivative.Substitute(x, point)).EvalNumerical();
+                Assert.True(difference.Abs().EDecimal.ToDouble() < 1e-90,
+                    $"at x = {point} the derivative is off by {difference.Stringize()}");
+            }
         }
 
         [Theory(Skip = "TODO: integration by parts multiple times")]

--- a/Sources/Tests/UnitTests/Common/SimplificationRegressionTest.cs
+++ b/Sources/Tests/UnitTests/Common/SimplificationRegressionTest.cs
@@ -97,8 +97,8 @@ namespace AngouriMath.Tests.Common
             Assert.Equal("0 provided not (b - 1) * (1 - b) = 0".ToEntity(),
                 "(a - 1) / (1 - b) - (1 - a) / (b - 1)".ToEntity().Simplify());
 
-        // Not in the tracker; found by the integral corpus. Three separate defects sat on
-        // top of each other in the integrator, so each gets its own test below.
+        // Three separate defects sat on top of each other in the integrator,
+        // so each gets its own test below.
         //
         // 1. SolveAsPolynomialTerm, SolveLogarithmic and SolveBySubstitution recursed
         //    without handing on `integrateByParts`, so a solver re-enabled integration by
@@ -204,12 +204,11 @@ namespace AngouriMath.Tests.Common
             Assert.Equal(Entity.Number.Integer.Create(0), difference);
         }
 
-        // Also not in the tracker. Dividing the integrand by a derivative that is zero
-        // gives NaN, and NaN contains no x, which is exactly the test for a successful
-        // substitution -- so it was returned as the answer. The first guard caught the
-        // cases where the derivative is visibly zero; these two are only zero after
-        // simplification, since d/dx (sin(x)^2 + cos(x)^2) is written as
-        // 2sin(x)cos(x) - 2cos(x)sin(x).
+        // Dividing the integrand by a derivative that is zero gives NaN, and NaN
+        // contains no x, which is exactly the test for a successful ubstitution --
+        // so it was returned as the answer. The first guard caught the cases where
+        // the derivative is visibly zero; these two are only zero after simplification,
+        // since d/dx (sin(x)^2 + cos(x)^2) is written as 2sin(x)cos(x) - 2cos(x)sin(x).
         [Theory]
         [InlineData("sin(x) ^ 2 + cos(x) ^ 2")]
         [InlineData("x / (x + 1) + 1 / (x + 1)")]

--- a/Sources/Tests/UnitTests/Common/SimplificationRegressionTest.cs
+++ b/Sources/Tests/UnitTests/Common/SimplificationRegressionTest.cs
@@ -204,5 +204,17 @@ namespace AngouriMath.Tests.Common
             Assert.Equal(Entity.Number.Integer.Create(0), difference);
         }
 
+        // Also not in the tracker. Dividing the integrand by a derivative that is zero
+        // gives NaN, and NaN contains no x, which is exactly the test for a successful
+        // substitution -- so it was returned as the answer. The first guard caught the
+        // cases where the derivative is visibly zero; these two are only zero after
+        // simplification, since d/dx (sin(x)^2 + cos(x)^2) is written as
+        // 2sin(x)cos(x) - 2cos(x)sin(x).
+        [Theory]
+        [InlineData("sin(x) ^ 2 + cos(x) ^ 2")]
+        [InlineData("x / (x + 1) + 1 / (x + 1)")]
+        [InlineData("x * ln(x)")]
+        public void AntiderivativesNeverContainNaN(string integrand) =>
+            Assert.DoesNotContain("NaN", integrand.ToEntity().Integrate("x").Stringize());
     }
 }

--- a/Sources/Tests/UnitTests/Common/SimplificationRegressionTest.cs
+++ b/Sources/Tests/UnitTests/Common/SimplificationRegressionTest.cs
@@ -1,0 +1,208 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using PeterO.Numbers;
+using Xunit;
+
+namespace AngouriMath.Tests.Common
+{
+    /// <summary>
+    /// Regression tests for simplification, factoring and integration.
+    /// Each test names the issue it locks down, so a future refactor that
+    /// reintroduces the bug fails loudly.
+    /// </summary>
+    public sealed class SimplificationRegressionTest
+    {
+        // https://github.com/asc-community/AngouriMath/issues/205
+        // Radicands were never reduced to a square-free part, so like radicals could
+        // never be collected: sqrt(12) + sqrt(27) stayed as written instead of
+        // 5*sqrt(3). Pulling perfect powers out from under the root makes the terms
+        // share a radical, and the existing collection rules take it from there.
+        [Theory]
+        [InlineData("sqrt(12) + sqrt(27)", "5 * sqrt(3)")]
+        [InlineData("sqrt(8) + sqrt(2)", "3 * sqrt(2)")]
+        [InlineData("sqrt(18) + sqrt(8)", "5 * sqrt(2)")]
+        [InlineData("sqrt(50) - sqrt(2)", "4 * sqrt(2)")]
+        [InlineData("sqrt(20) + sqrt(45) + sqrt(5)", "6 * sqrt(5)")]
+        [InlineData("cbrt(54) + cbrt(2)", "4 * cbrt(2)")]
+        public void Issue205_LikeRadicalsCollect(string input, string expected)
+        {
+            var simplified = input.ToEntity().Simplify();
+            // Compared by difference, not by form: the collected result comes out as
+            // `sqrt(3) * 5` where the expectation reads `5 * sqrt(3)`.
+            Assert.Equal(Entity.Number.Integer.Create(0),
+                (simplified - expected.ToEntity()).Simplify());
+            // ...but it must genuinely have collected into a single term, which is the
+            // point of the issue.
+            Assert.DoesNotContain("+", simplified.Stringize());
+            Assert.DoesNotContain("-", simplified.Stringize());
+        }
+
+        // A standalone surd is a separate matter: Simplify picks between candidate
+        // forms by a complexity metric, and by that metric `sqrt(12)` beats
+        // `2 * sqrt(3)`, so the reduced form is generated but not selected. Changing
+        // that is a change to the metric, not to this rule. Pinning the current
+        // behaviour so the distinction is deliberate rather than accidental.
+        [Theory]
+        [InlineData("sqrt(12)")]
+        [InlineData("sqrt(18)")]
+        public void Issue205_StandaloneSurdsKeepTheShorterForm(string input) =>
+            Assert.Equal(input.ToEntity(), input.ToEntity().Simplify());
+
+        // Whatever form comes out, it must still be the same number.
+        [Theory]
+        [InlineData("sqrt(8)")]
+        [InlineData("sqrt(12) + sqrt(27)")]
+        [InlineData("sqrt(1000)")]
+        [InlineData("cbrt(54)")]
+        [InlineData("sqrt(2)")]     // already square-free, must not change
+        [InlineData("sqrt(4)")]     // perfect square
+        [InlineData("1 / sqrt(8)")] // negative exponent
+        public void Issue205_ReductionPreservesValue(string input)
+        {
+            var before = input.ToEntity().EvalNumerical().RealPart.EDecimal.ToDouble();
+            var after = input.ToEntity().Simplify().EvalNumerical().RealPart.EDecimal.ToDouble();
+            Assert.Equal(before, after, 10);
+        }
+
+        [Theory]
+        [InlineData("sqrt(2)")]
+        [InlineData("sqrt(3)")]
+        [InlineData("sqrt(6)")]
+        public void Issue205_SquareFreeRadicalsAreLeftAlone(string input) =>
+            Assert.Equal(input.ToEntity(), input.ToEntity().Simplify());
+
+        // https://github.com/asc-community/AngouriMath/issues/403
+        // Fractions over a common denominator were cross-multiplied into d*d and left to
+        // the simplifier to cancel back down. Since the rule calls Simplify on both halves
+        // from inside Simplify's own pass, each further fraction squared the denominator
+        // before anything cancelled: two terms took 25 ms, three never returned.
+        [Theory]
+        [InlineData("1 / (x + y + z) * dx + 1 / (x + y + z) * dy + 1 / (x + y + z) * dz", "(dx + dy + dz) / (x + y + z)")]
+        [InlineData("a / (x + y) + b / (x + y) + c / (x + y)", "(a + b + c) / (x + y)")]
+        [InlineData("a / (x + y + z) + b / (x + y + z) + c / (x + y + z) + d / (x + y + z)", "(a + b + c + d) / (x + y + z)")]
+        public void Issue403_FractionsOverACommonDenominatorCollapse(string input, string expected) =>
+            Assert.Equal(expected.ToEntity(), input.ToEntity().Simplify());
+
+        // The general case still brings unlike denominators together, which needs the
+        // numerator fully simplified to reach 0.
+        [Fact]
+        public void Issue403_UnlikeDenominatorsStillCombine() =>
+            Assert.Equal("0 provided not (b - 1) * (1 - b) = 0".ToEntity(),
+                "(a - 1) / (1 - b) - (1 - a) / (b - 1)".ToEntity().Simplify());
+
+        // Not in the tracker; found by the integral corpus. Three separate defects sat on
+        // top of each other in the integrator, so each gets its own test below.
+        //
+        // 1. SolveAsPolynomialTerm, SolveLogarithmic and SolveBySubstitution recursed
+        //    without handing on `integrateByParts`, so a solver re-enabled integration by
+        //    parts one level below the call that had switched it off. By parts calls back
+        //    into the dispatcher, so that is a cycle: x * ln(x) rode it into a stack
+        //    overflow, and sin(x)^2 and cos(x)^2 spun past 20 seconds.
+        [Theory]
+        [InlineData("x * ln(x)")]
+        [InlineData("sin(x) ^ 2")]
+        [InlineData("cos(x) ^ 2")]
+        public void IntegrationTerminates(string integrand)
+        {
+            var task = System.Threading.Tasks.Task.Run(() => integrand.ToEntity().Integrate("x"));
+            Assert.True(task.Wait(System.TimeSpan.FromSeconds(30)),
+                $"integrating {integrand} did not terminate");
+        }
+
+        // 2. Substitution candidates were not required to depend on x. `ln(e)`, picked out
+        //    of any integrand carrying a logarithm, has derivative 0, and dividing by it
+        //    gave a NaN that contained no x -- so it passed the "substitution succeeded"
+        //    test and was returned as the antiderivative.
+        [Theory]
+        [InlineData("x * ln(x)")]
+        [InlineData("ln(x)")]
+        [InlineData("x * e ^ x")]
+        public void AntiderivativesAreFreeOfNaN(string integrand) =>
+            Assert.DoesNotContain("NaN", integrand.ToEntity().Integrate("x").Stringize());
+
+        // 3. For a logarithm times a polynomial, by parts differentiated the polynomial,
+        //    which leaves the logarithm to integrate and puts the original integral back
+        //    in front of the solver. Differentiating the logarithm terminates instead.
+        [Theory]
+        [InlineData("x * ln(x)")]
+        [InlineData("x ^ 2 * ln(x)")]
+        [InlineData("ln(x) * x")]
+        // and the orderings that already worked must keep working
+        [InlineData("x * e ^ x")]
+        [InlineData("x * sin(x)")]
+        [InlineData("x ^ 2 * e ^ x")]
+        public void IntegrationByPartsAnswersAreCorrect(string integrand)
+        {
+            var antiderivative = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", antiderivative.Stringize());
+            // Differentiating back must return the integrand. The residual may carry the
+            // domain conditions of the antiderivative, which are not what is under test.
+            var residual = (antiderivative.Differentiate("x") - integrand.ToEntity()).Simplify();
+            while (residual is Entity.Providedf(var inner, _)) residual = inner;
+            Assert.Equal(Entity.Number.Integer.Create(0), residual);
+        }
+
+        // https://github.com/asc-community/AngouriMath/issues/531
+        // The factoring rules only ever looked at two adjacent terms of the sum tree, so a
+        // sum of four was left half-factored at a*(c + d) + b*c + b*d.
+        [Theory]
+        [InlineData("a * c + a * d + b * c + b * d", "(a + b) * (c + d)")]
+        [InlineData("a * b + a * c + a * d", "a * (b + c + d)")]
+        [InlineData("x * a + x * b + y * a + y * b + z * a + z * b", "(a + b) * (x + y + z)")]
+        public void Issue531_TermsCollectOverTheWholeSum(string input, string expected) =>
+            Assert.Equal(expected.ToEntity(), input.ToEntity().Simplify());
+
+        // Whatever form comes out, it has to be the same expression.
+        [Theory]
+        [InlineData("a * c + a * d + b * c + b * d")]
+        [InlineData("x * a + x * b + y * a + y * b + z * a + z * b")]
+        [InlineData("a * b + a * c + a * d")]
+        public void Issue531_CollectionPreservesValue(string input)
+        {
+            var difference = (input.ToEntity() - input.ToEntity().Simplify()).Simplify();
+            while (difference is Entity.Providedf(var inner, _)) difference = inner;
+            Assert.Equal(Entity.Number.Integer.Create(0), difference);
+        }
+
+        // https://github.com/asc-community/AngouriMath/issues/178
+        // Factorize left its own workings in the answer: the difference-of-squares rule
+        // halved the exponents without checking they were even, so it fired again on the
+        // linear factors it had just produced and turned x^2 - y^2 into
+        // (sqrt(x) - sqrt(y)) * (sqrt(x) + sqrt(y)) * (x^1 + y^1). Nothing simplified the
+        // result afterwards either, which is where the x^1 and the sqrt(4) survived.
+        [Theory]
+        [InlineData("4 * x ^ 2 - 4 * y ^ 2", "4 * (x - y) * (x + y)")]
+        [InlineData("x ^ 2 - y ^ 2", "(x - y) * (x + y)")]
+        [InlineData("x ^ 2 - 4", "(x - 2) * (x + 2)")]
+        [InlineData("x ^ 4 - y ^ 4", "(x - y) * (x + y) * (x ^ 2 + y ^ 2)")]
+        // Compared as printed text: what is under test is the form of the answer, and
+        // the tree differs from the parsed expectation only in how the product associates.
+        public void Issue178_FactorizeLeavesNoResidue(string input, string expected) =>
+            Assert.Equal(expected, input.ToEntity().Factorize().Stringize());
+
+        // Odd exponents must not be halved -- that is what introduced the radicals.
+        [Fact]
+        public void Issue178_OddPowersAreNotSplit() =>
+            Assert.Equal("x ^ 3 - y ^ 5".ToEntity(), "x ^ 3 - y ^ 5".ToEntity().Factorize());
+
+        [Theory]
+        [InlineData("4 * x ^ 2 - 4 * y ^ 2")]
+        [InlineData("x ^ 4 - y ^ 4")]
+        [InlineData("x ^ 6 - y ^ 6")]
+        [InlineData("x ^ 2 - 4")]
+        public void Issue178_FactorizationPreservesValue(string input)
+        {
+            var difference = (input.ToEntity() - input.ToEntity().Factorize()).Simplify();
+            while (difference is Entity.Providedf(var inner, _)) difference = inner;
+            Assert.Equal(Entity.Number.Integer.Create(0), difference);
+        }
+
+    }
+}


### PR DESCRIPTION
Four fixes to simplification, factoring and integration, including two hangs and a
stack overflow. Each has a regression test, and each was reproduced against a stock
`master` build before being claimed.

### #403 — `Simplify` never returned

```
1/(x+y+z)*dx + 1/(x+y+z)*dy + 1/(x+y+z)*dz     // never finished
a/(x+y) + b/(x+y) + c/(x+y)                    // 10.5 seconds
```

`a/d + b/d` was cross-multiplied into `(a*d + b*d)/(d*d)` like any unlike pair, leaving
the simplifier to cancel the square back down. That rule runs *inside* `Simplify`'s own
rewriting pass and calls `Simplify` again on both halves, so cancelling one pair is
paid for at full price — and the result is another fraction that pairs with the next
term, squaring the denominator again.

Equal denominators now add as `(a + b)/d`, which is what they are. The general case is
untouched: unlike denominators still come together through the full `Simplify`, which
is what gets `(a-1)/(1-b) - (1-a)/(b-1)` to 0. #403's expression now simplifies in
**8 ms**, and the three-fraction case in 5 ms.

### `integral(x * ln(x), x)` overflowed the stack

Not in the tracker. Three defects, stacked on top of each other.

`ComputeIndefiniteIntegral` takes an `integrateByParts` flag so that integration by
parts can call back into it without re-entering itself. `SolveAsPolynomialTerm`,
`SolveLogarithmic`, `SolveBySubstitution` and `SolveExponential` all recurse, and none
of them handed the flag on — so by parts was switched back on one level below the call
that had switched it off, closing the cycle. `sin(x)^2` and `cos(x)^2` rode the same
cycle past 20 seconds.

With the recursion bounded, the answer came back holding a `NaN`. Substitution
candidates were not required to depend on `x`, and `ln(e)` is picked up from any
integrand carrying a logarithm. Its derivative is 0, the integrand divided by it is
`NaN`, and `NaN` contains no `x` — so it passed the test for a successful substitution
and was returned as the antiderivative.

That left `x * ln(x)` merely unsolved, because by parts differentiated the polynomial
and integrated the logarithm. Only the other order terminates: the antiderivative of
`ln(x)` contains an `x * ln(x)`, so that choice hands the solver back the integral it
started with, while differentiating the logarithm gives `1/x`, which cancels against
the integrated polynomial. Logarithm-times-polynomial now takes that order — the
L-before-A of the usual LIATE ordering — and answers `ln(x) * x²/2 - x²/4`.

`sin(x)^2` and `cos(x)^2` still return *unsolved*, but in ~0.1 s rather than hanging.
The power-reduction rule is a real capability gap, not a defect.

### #531 — `a*c + a*d + b*c + b*d` was left half-factored

It came out as `a*(c + d) + b*c + b*d`. Every factoring rule there matches two
*adjacent* terms of the sum tree, so a sum of four could never be grouped twice over.
Sums of three or more now go through a pass that flattens them, takes out the factor
shared by the most terms, and repeats on what is left; the pairwise rules then close
`a*(c+d) + b*(c+d)` to `(a+b)*(c+d)` on the following pass.

Sums of two still go to the older, better-tested rules untouched, and constants are
deliberately left where they are.

### #178 — `Factorize` left its own workings in the answer

```
"x^2 - y^2".Factorize()   →  (sqrt(x) - sqrt(y)) * (sqrt(x) + sqrt(y)) * (x^1 + y^1)
```

The difference-of-squares rule halved both exponents without checking they were even,
so it fired again on the linear factors it had just made. The result is correct, but it
is no longer a factorisation. Both exponents must now be even, the halves are built as
integers rather than as `const/2` (which was leaving an unevaluated `2/2` behind), and
the result is `InnerSimplified` — which is what was leaving `x^1` where `x` was meant
and `sqrt(4)` where `2` was. `4*x^2 - 4*y^2` now factorises to `4*(x - y)*(x + y)`.

### #205 — surds were never reduced (partial)

Radicands now reduce to their square-free part, so like radicals collect:
`sqrt(12) + sqrt(27)` → `5*sqrt(3)`, `cbrt(54) + cbrt(2)` → `4*cbrt(2)`.

**Deliberately partial.** A standalone `sqrt(12)` is unchanged, because `Simplify`
chooses between candidate forms by a complexity metric and by that metric `sqrt(12)`
beats `2*sqrt(3)` — the reduced form is generated but not selected. Making it canonical
means changing the metric, which is a much wider change than belongs here. A test pins
the current behaviour so the distinction stays deliberate rather than accidental.

---

### Two existing tests changed

`TestLnAbsSquared` — because the answer got better. The antiderivative of `ln|x|²` now
collects to `((ln|x| - 1)² + 1)*x`, which is the `x(ln²|x| - 2ln|x| + 2)` written in
that test's own comment; before, the two `ln` terms sat uncombined and the `2*x` outside
the bracket. Its numeric check also compared two independently evaluated 100-digit
values for exact equality, and they differ in the last digit, so it compares a
difference now.

`SolveOneEquation.CDSolver` — sharing a denominator changes the numerator from a
cross-product to `x - b + c`, so the same root `b - c` prints as `-(-b + c)` rather than
`-(c + -b)`.

### Testing

`UnitTests` 3707 passed / 0 failed, `FSharpWrapperUnitTests` 127 passed / 0 failed. The
integration tests assert termination inside a bounded `Task.Wait` rather than a
duration, so a regression fails the run instead of hanging CI.

This is one of three independent PRs; the other two cover parsing and precision, and
the solvers. They touch disjoint files apart from two well-separated methods in
`IntegrationTest.cs`, and can be merged in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
