### PR TITLE
Try another equation when elimination stalls, fixing dense linear systems (#608)

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver.cs
@@ -82,24 +82,37 @@ namespace AngouriMath.Functions.Algebra
                        : new();
             var result = new List<List<Entity>>();
             var replacements = new Dictionary<Variable, Entity>();
+            var remainingVars = vars.Slice(0, vars.Length - 1);
+            // Which equation to eliminate `var` from is decided by whether it occurs in
+            // one, and occurring is a syntactic question. Substituting an earlier variable
+            // routinely leaves an occurrence that cancels: eliminating x_4 from a dense
+            // 4x4 turns the next equation into x_1 + 2*x_2 + x_3 - (x_1 + x_2 + x_3 - 4) - 5,
+            // where x_3 is written twice and worth nothing. Solving that for x_3 has no
+            // answer, and committing to the first candidate meant the whole system was
+            // then declared unsolvable -- #608. So a candidate that yields nothing is
+            // passed over for the next one rather than ending the search.
             for (int i = 0; i < equations.Count; i++)
                 if (equations[i].ContainsNode(var))
                 {
-                    var solutionsOverVar = equations[i].SolveEquation(var).InnerSimplified;
-                    equations.RemoveAt(i);
-                    vars = vars.Slice(0, vars.Length - 1);
+                    if (equations[i].SolveEquation(var).InnerSimplified is not FiniteSet sols
+                        || sols.Count == 0)
+                        continue;
 
-                    if (solutionsOverVar is FiniteSet sols)
-                        foreach (var sol in sols)
-                        foreach (var j in InSolveSystem(equations.Select(eq => eq.Substitute(var, sol)).ToList(), vars))
+                    var rest = new List<Entity>(equations);
+                    rest.RemoveAt(i);
+
+                    foreach (var sol in sols)
+                        foreach (var j in InSolveSystem(rest.Select(eq => eq.Substitute(var, sol)).ToList(), remainingVars))
                         {
                             replacements.Clear();
-                            for (int varid = 0; varid < vars.Length; varid++)
-                                replacements.Add(vars[varid], j[varid]);
+                            for (int varid = 0; varid < remainingVars.Length; varid++)
+                                replacements.Add(remainingVars[varid], j[varid]);
                             j.Add(sol.Substitute(replacements).InnerSimplified);
                             result.Add(j);
                         }
-                    break;
+
+                    if (result.Count > 0)
+                        return result;
                 }
             return result;
         }

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver.cs
@@ -89,8 +89,8 @@ namespace AngouriMath.Functions.Algebra
             // 4x4 turns the next equation into x_1 + 2*x_2 + x_3 - (x_1 + x_2 + x_3 - 4) - 5,
             // where x_3 is written twice and worth nothing. Solving that for x_3 has no
             // answer, and committing to the first candidate meant the whole system was
-            // then declared unsolvable -- #608. So a candidate that yields nothing is
-            // passed over for the next one rather than ending the search.
+            // then declared unsolvable -- https://github.com/asc-community/AngouriMath/issues/608.
+            // So a candidate that yields nothing is passed over for the next one rather than ending the search.
             for (int i = 0; i < equations.Count; i++)
                 if (equations[i].ContainsNode(var))
                 {

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/LinearSystemTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/LinearSystemTest.cs
@@ -1,0 +1,92 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Algebra
+{
+    /// <summary>
+    /// Systems whose elimination order matters. Substituting one variable leaves
+    /// occurrences of the next that cancel, and the solver used to commit to the first
+    /// equation those occurrences appeared in.
+    /// </summary>
+    public sealed class LinearSystemTest
+    {
+        /// <summary>
+        /// Solves and checks by substitution, so that the assertion does not depend on the
+        /// form the solver returns the values in.
+        /// </summary>
+        private static void AssertSolves(params string[] equations)
+        {
+            var variables = new Entity.Variable[equations.Length];
+            for (var i = 0; i < equations.Length; i++)
+                variables[i] = $"x_{i + 1}";
+
+            var solution = MathS.Equations(System.Array.ConvertAll(equations, e => (Entity)e.ToEntity()))
+                .Solve(variables);
+            Assert.NotNull(solution);
+
+            foreach (var equation in equations)
+            {
+                var substituted = equation.ToEntity();
+                for (var i = 0; i < variables.Length; i++)
+                    substituted = substituted.Substitute(variables[i], solution![0, i]);
+                var residual = substituted.EvalNumerical();
+                Assert.True(residual.Abs().EDecimal.ToDouble() < 1e-9,
+                    $"{equation} left {residual.Stringize()} at the returned solution");
+            }
+        }
+
+        // https://github.com/asc-community/AngouriMath/issues/608
+        // Returned null. Eliminating x_4 from the first equation leaves the second reading
+        // x_1 + 2*x_2 + x_3 - (x_1 + x_2 + x_3 - 4) - 5, in which x_3 is written twice and
+        // cancels; solving that for x_3 has no answer, and the search stopped there.
+        [Fact]
+        public void Issue608_DenseFourByFourSolves() => AssertSolves(
+            "2 * x_1 * (-66) - 6 * x_2 + 24 * x_3 - 12 * x_4 + 270",
+            "-6 * x_1 - 2 * x_2 * 74 - 8 * x_3 + 4 * x_4 - 440",
+            "24 * x_1 - 8 * x_2 - 2 * x_3 * 59 - 16 * x_4 - 190",
+            "-12 * x_1 + 4 * x_2 - 16 * x_3 - 2 * x_4 * 71 + 20");
+
+        [Fact]
+        public void Issue608_SmallestFailingCase() => AssertSolves(
+            "x_1 + x_2 + x_3 + x_4 - 4",
+            "x_1 + 2 * x_2 + x_3 + x_4 - 5",
+            "x_1 + x_2 + 3 * x_3 + x_4 - 6",
+            "x_1 + x_2 + x_3 + 4 * x_4 - 7");
+
+        [Fact]
+        public void Issue608_FiveByFiveSolves() => AssertSolves(
+            "2 * x_1 + x_2 + x_3 + x_4 + x_5 - 6",
+            "x_1 + 3 * x_2 + x_3 + x_4 + x_5 - 7",
+            "x_1 + x_2 + 4 * x_3 + x_4 + x_5 - 8",
+            "x_1 + x_2 + x_3 + 5 * x_4 + x_5 - 9",
+            "x_1 + x_2 + x_3 + x_4 + 6 * x_5 - 10");
+
+        // The sizes that already worked have to keep working.
+        [Fact]
+        public void SparseSystemsStillSolve() => AssertSolves(
+            "x_1 + x_2 - 3",
+            "x_2 + x_3 - 5",
+            "x_3 + x_4 - 7",
+            "x_1 - x_4 + 1");
+
+        [Fact]
+        public void DenseThreeByThreeStillSolves() => AssertSolves(
+            "2 * x_1 + x_2 + x_3 - 4",
+            "x_1 + 3 * x_2 + x_3 - 5",
+            "x_1 + x_2 + 4 * x_3 - 6");
+
+        // Trying further equations must not invent a solution where there is none.
+        [Fact]
+        public void InconsistentSystemStillReturnsNothing() =>
+            Assert.Null(MathS.Equations("x_1 + x_2 - 1".ToEntity(), "x_1 + x_2 - 2".ToEntity())
+                .Solve("x_1", "x_2"));
+    }
+}


### PR DESCRIPTION
Closes [#608](https://github.com/asc-community/AngouriMath/issues/608): a dense 4×4
linear system returned `null`.

### It is not the reporter's coefficients

Any dense 4×4 does it, and 5×5 too. Three-by-three is fine, and so is a sparse or
triangular 4×4 — which is what made this look like a question of scale rather than a
bug. The smallest case I found is:

```
x_1 +   x_2 +   x_3 +   x_4 - 4
x_1 + 2*x_2 +   x_3 +   x_4 - 5
x_1 +   x_2 + 3*x_3 +   x_4 - 6
x_1 +   x_2 +   x_3 + 4*x_4 - 7
```

### What happens

`InSolveSystem` eliminates one variable at a time and picks the equation to eliminate
it from by asking which equations contain it. That is a *syntactic* question, and
substituting the previous variable routinely leaves an occurrence that is worth
nothing. Eliminating `x_4` from the first equation turns the second into

```
x_1 + 2*x_2 + x_3 - (x_1 + x_2 + x_3 - 4) - 5
```

where `x_3` is written twice and cancels. Solving that for `x_3` correctly has no
answer — but the loop had already committed to that equation with a `break`, so the
recursion unwound empty and the whole system was declared unsolvable. The two
equations after it would each have worked.

### The change

A candidate equation that yields no solutions is passed over for the next one instead
of ending the search. The loop still stops at the first equation that *does* produce
solutions, so no work is repeated, and the equation list is copied rather than mutated
in place so a failed candidate leaves nothing behind.

An inconsistent system still returns `null`, because there every candidate fails —
that case is in the tests.

The alternative was to simplify the substituted equations before asking which contain
the variable. `InnerSimplified` does not collapse the expression above, so it would
have taken a full `Simplify` on every equation at every level of the elimination, which
is both slower and still only a heuristic — the occurrence can always be hidden more
cleverly than the simplifier can see. Retrying is cheap and does not depend on how well
anything simplifies.

### Result

The reporter's system now answers `x = (2, -3, -1, 0)`, which satisfies all four
equations exactly.

### Testing

`UnitTests` 3664 passed / 0 failed. Six new tests: the reporter's system, the smallest
failing case, a 5×5, the sparse and 3×3 shapes that already worked, and the
inconsistent system. All of them check by substituting the solution back rather than
against printed values, so they do not depend on the form the solver returns.

This is independent of #663, #664, #665 and #666, and touches no file any of them
touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
