### PR TITLE
Give sgn a derivative, and stop a constant exponent taking the logarithmic rule

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Differentiation.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Differentiation.cs
@@ -141,11 +141,6 @@ namespace AngouriMath
             protected override Entity InnerDifferentiate(Variable variable) =>
                 Exponent == Integer.One
                 ? Base.InnerDifferentiate(variable).Provided(Base.DomainCondition) // don't create x^0 which is undefined for x=0
-                // Evaled, not a plain type test: an exponent that is constant but written
-                // as a sum, which is how the integral table leaves them -- (x - 1)^(4 + 1)
-                // -- is still constant. Read as non-constant it fell to the logarithmic
-                // rule below, which needs a positive base, so differentiating the
-                // antiderivative of (x - 1)^4 came back undefined for x < 1.
                 : Exponent.Evaled is Number exp
                 ? exp * Base.Pow(exp - 1) * Base.InnerDifferentiate(variable)
                 : Base is Number
@@ -310,13 +305,6 @@ namespace AngouriMath
             // sgn is flat either side of zero and has no derivative at zero, so the
             // derivative is 0 wherever it exists. Saying so with a condition is the same
             // stance Absf takes just below, whose derivative is likewise undefined at zero.
-            //
-            // As a distribution this is 2*delta(x) rather than 0, which is what the note
-            // that used to be here was waiting for. But leaving the node unevaluated does
-            // not represent that either -- it only means the derivative of anything
-            // containing sgn cannot be evaluated at all, and that reached callers: the
-            // antiderivative of abs(x) is sgn(x)*x^2/2, and differentiating it back
-            // produced derivative(sgn(x), x) and stopped there.
             /// <inheritdoc/>
             protected override Entity InnerDifferentiate(Variable variable)
                 => Integer.Zero.Provided(!Argument.EqualTo(Integer.Zero));

--- a/Sources/AngouriMath/Functions/Continuous/Differentiation.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Differentiation.cs
@@ -141,7 +141,12 @@ namespace AngouriMath
             protected override Entity InnerDifferentiate(Variable variable) =>
                 Exponent == Integer.One
                 ? Base.InnerDifferentiate(variable).Provided(Base.DomainCondition) // don't create x^0 which is undefined for x=0
-                : Exponent is Number exp
+                // Evaled, not a plain type test: an exponent that is constant but written
+                // as a sum, which is how the integral table leaves them -- (x - 1)^(4 + 1)
+                // -- is still constant. Read as non-constant it fell to the logarithmic
+                // rule below, which needs a positive base, so differentiating the
+                // antiderivative of (x - 1)^4 came back undefined for x < 1.
+                : Exponent.Evaled is Number exp
                 ? exp * Base.Pow(exp - 1) * Base.InnerDifferentiate(variable)
                 : Base is Number
                 ? Base.Pow(Exponent) * MathS.Ln(Base) * Exponent.InnerDifferentiate(variable)
@@ -302,11 +307,19 @@ namespace AngouriMath
 
         partial record Signumf
         {
-            // TODO: the Delta function required to be defined,
-            // or a piecewise definition
+            // sgn is flat either side of zero and has no derivative at zero, so the
+            // derivative is 0 wherever it exists. Saying so with a condition is the same
+            // stance Absf takes just below, whose derivative is likewise undefined at zero.
+            //
+            // As a distribution this is 2*delta(x) rather than 0, which is what the note
+            // that used to be here was waiting for. But leaving the node unevaluated does
+            // not represent that either -- it only means the derivative of anything
+            // containing sgn cannot be evaluated at all, and that reached callers: the
+            // antiderivative of abs(x) is sgn(x)*x^2/2, and differentiating it back
+            // produced derivative(sgn(x), x) and stopped there.
             /// <inheritdoc/>
             protected override Entity InnerDifferentiate(Variable variable)
-                => MathS.Derivative(this, variable);
+                => Integer.Zero.Provided(!Argument.EqualTo(Integer.Zero));
         }
 
         partial record Absf

--- a/Sources/Tests/UnitTests/Calculus/DerivativeGapsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/DerivativeGapsTest.cs
@@ -1,0 +1,78 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// Two ways a derivative could come back unusable: as an unevaluated node, or with a
+    /// condition on it that does not belong. Both were found by differentiating
+    /// antiderivatives back and checking them at points.
+    /// </summary>
+    public sealed class DerivativeGapsTest
+    {
+        [Fact]
+        public void SignumHasADerivative() =>
+            Assert.Equal("0 provided not x = 0".ToEntity(), "sgn(x)".ToEntity().Differentiate("x"));
+
+        // The antiderivative of abs(x) is sgn(x) * x^2 / 2. Differentiating it back used to
+        // produce derivative(sgn(x), x) and stop, so the answer could not be checked or
+        // used numerically.
+        [Theory]
+        [InlineData("abs(x)")]
+        [InlineData("abs(x) + x")]
+        [InlineData("abs(x + 1)")]
+        [InlineData("sgn(x) * x")]
+        public void AntiderivativesOfAbsoluteValuesDifferentiateBack(string integrand)
+        {
+            var f = integrand.ToEntity();
+            var derivative = f.Integrate("x").Substitute("C", 0).Differentiate("x");
+            foreach (var point in new[] { 0.37, 1.41, 2.71 })
+            {
+                var expected = f.Substitute("x", point).EvalNumerical().RealPart.EDecimal.ToDouble();
+                var actual = derivative.Substitute("x", point).EvalNumerical().RealPart.EDecimal.ToDouble();
+                Assert.Equal(expected, actual, 8);
+            }
+        }
+
+        // A constant exponent that happens to be written as a sum is still constant. Read
+        // as non-constant it took the logarithmic rule, which needs a positive base, so
+        // this came back undefined for x < 1.
+        [Fact]
+        public void ConstantExponentWrittenAsASumUsesThePowerRule() =>
+            Assert.Equal("(x - 1) ^ 4".ToEntity(),
+                "(x - 1) ^ (4 + 1) / (4 + 1)".ToEntity().Differentiate("x").Simplify());
+
+        [Fact]
+        public void AntiderivativeOfAPowerDifferentiatesBackEverywhere()
+        {
+            var f = "(x - 1) ^ 4".ToEntity();
+            var derivative = f.Integrate("x").Substitute("C", 0).Differentiate("x");
+            // 0.37 is below the base's root, which is where the spurious condition bit.
+            foreach (var point in new[] { 0.37, 1.41, 2.71 })
+            {
+                var expected = f.Substitute("x", point).EvalNumerical().RealPart.EDecimal.ToDouble();
+                var actual = derivative.Substitute("x", point).EvalNumerical().RealPart.EDecimal.ToDouble();
+                Assert.Equal(expected, actual, 8);
+            }
+        }
+
+        // A genuinely symbolic exponent must still take the logarithmic rule, condition
+        // and all.
+        [Theory]
+        [InlineData("x ^ n", "x ^ n * n / x provided x > 0")]
+        [InlineData("2 ^ x", "ln(2) * 2 ^ x")]
+        // Compared as printed text: what is under test is that the logarithmic rule and
+        // its condition are still used, and the tree differs from the parsed expectation
+        // only in how the condition nests.
+        public void SymbolicExponentsAreUnaffected(string input, string expected) =>
+            Assert.Equal(expected, input.ToEntity().Differentiate("x").Simplify().Stringize());
+    }
+}

--- a/Sources/Tests/UnitTests/Calculus/DerivativeTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/DerivativeTest.cs
@@ -121,12 +121,23 @@ namespace AngouriMath.Tests.Calculus
             Assert.Equal(0, derFunc);
         }
 
+        // sgn is flat either side of zero and has no derivative at zero, so its
+        // derivative is 0 wherever it exists, stated with the condition that says where
+        // that is. This used to come back as an unevaluated derivative node, which meant
+        // the derivative of anything containing sgn could not be evaluated at all -- the
+        // antiderivative of abs(x) is sgn(x) * x^2 / 2, and differentiating it back
+        // stopped at derivative(sgn(x), x).
+        //
+        // As a distribution the answer is 2*delta(x) rather than 0. Leaving the node
+        // unevaluated did not represent that either; whichever way that is eventually
+        // handled, it is the same question for abs, whose derivative already answers
+        // sgn(x) provided not x = 0.
         [Fact]
         public void TestSgnDer()
         {
             Entity func = "sgn(x + 2)";
             var derived = func.Differentiate("x");
-            Assert.Equal(MathS.Derivative(func, x), derived);
+            Assert.Equal("0 provided not x + 2 = 0".ToEntity(), derived);
         }
 
         [Fact]

--- a/Sources/Tests/UnitTests/Calculus/DerivativeTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/DerivativeTest.cs
@@ -123,15 +123,7 @@ namespace AngouriMath.Tests.Calculus
 
         // sgn is flat either side of zero and has no derivative at zero, so its
         // derivative is 0 wherever it exists, stated with the condition that says where
-        // that is. This used to come back as an unevaluated derivative node, which meant
-        // the derivative of anything containing sgn could not be evaluated at all -- the
-        // antiderivative of abs(x) is sgn(x) * x^2 / 2, and differentiating it back
-        // stopped at derivative(sgn(x), x).
-        //
-        // As a distribution the answer is 2*delta(x) rather than 0. Leaving the node
-        // unevaluated did not represent that either; whichever way that is eventually
-        // handled, it is the same question for abs, whose derivative already answers
-        // sgn(x) provided not x = 0.
+        // that is.
         [Fact]
         public void TestSgnDer()
         {


### PR DESCRIPTION
Two ways a derivative came back unusable. Both were found by differentiating
antiderivatives back and checking them at points, rather than by reading code.

### `sgn` had no derivative

```csharp
// TODO: the Delta function required to be defined, or a piecewise definition
protected override Entity InnerDifferentiate(Variable variable)
    => MathS.Derivative(this, variable);
```

**This is the one to look at first, because it changes a deliberate decision.**

Leaving the node unevaluated does not represent the delta either. What it does is make
the derivative of *anything containing* `sgn` unevaluable, and that reaches callers: the
antiderivative of `abs(x)` is `sgn(x) * x^2 / 2`, and differentiating it back stops at
`derivative(sgn(x), x)`. So `∫abs(x) dx` cannot be checked or used numerically.

`sgn` is flat either side of zero and has no derivative at zero, so its derivative is `0`
wherever it exists, and a condition says where that is:

```
d/dx sgn(x)   →   0 provided not x = 0
```

That is the stance `abs` already takes directly below it — `sgn(x) provided not x = 0`,
likewise undefined at zero. Whichever way the distributional reading is eventually
handled, it is the same question for both, and answering one but not the other is what
was inconsistent.

`TestSgnDer` asserted the unevaluated form and now asserts this one, with the reasoning
beside it. If you would rather keep the node unevaluated, say so and I will drop this
half — the second half stands on its own.

### A constant exponent was read as symbolic

`Powf` decided whether the exponent was constant with a type test:

```csharp
: Exponent is Number exp
```

An exponent written as a sum is not a `Number` even when it is constant — and the
integral table leaves them exactly that way, `(x - 1)^(4 + 1)`. Read as non-constant it
fell through to the logarithmic rule, which needs a positive base, so:

```
d/dx [ (x-1)^(4+1) / (4+1) ]   →   ... provided x - 1 > 0
```

The antiderivative of `(x - 1)^4` differentiated back to something **undefined for
x < 1**. It now asks `Exponent.Evaled` instead. Genuinely symbolic exponents are
untouched and still carry their condition:

| | |
|---|---|
| `d/dx x^n` | `x^n * n / x provided x > 0` |
| `d/dx 2^x` | `ln(2) * 2^x` |
| `d/dx x^x` | `(1 + ln(x)) * x^x provided not x = 0` |

### Testing

`UnitTests` 3667 passed / 0 failed, `FSharpWrapperUnitTests` 127 passed / 0 failed, both
`netstandard2.0` and `net7.0` build.

Nine new tests: the `sgn` derivative, four antiderivatives of absolute values
differentiating back at points, the power case at a point below the base's root — which
is where the spurious condition bit — and the symbolic exponents that must not change.

Independent of #663 through #671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
