### PR TITLE
Compile expressions whose matrices cancel out, and name what cannot be (#425, #526)

### DIFF
--- a/Sources/AngouriMath/Functions/Compilation/IntoLinq/CompilationProtocol.cs
+++ b/Sources/AngouriMath/Functions/Compilation/IntoLinq/CompilationProtocol.cs
@@ -215,7 +215,8 @@ namespace AngouriMath.Core.Compilation.IntoLinq
                 
                 Providedf => HandleProvidedf(left, right),
 
-                _ => throw new AngouriBugException("A binary node seems to be not added")
+                _ => throw new UncompilableNodeException(
+                    $"The node of type {typeHolder.GetType()} does not support compilation.")
             };
             
             Expression HandleProvidedf(Expression expr, Expression cond)
@@ -238,7 +239,13 @@ namespace AngouriMath.Core.Compilation.IntoLinq
             {
                 Piecewise => HandlePiecewise(en),
                 // TODO: finite set -> hash set
-                _ => throw new AngouriBugException("A node seems to be not added")
+                // Reaching a node with no compiled form is the caller asking for something
+                // that is not supported, not a bug in the library, and the exception should
+                // say which node it was. It used to report "a node seems to be not added"
+                // as an internal bug assertion, which is what compiling a matrix hit (#425,
+                // #526).
+                _ => throw new UncompilableNodeException(
+                    $"The node of type {typeHolder.GetType()} does not support compilation.")
                 //FiniteSet => Expression.
             };
         }

--- a/Sources/AngouriMath/Functions/Compilation/IntoLinq/CompilationProtocol.cs
+++ b/Sources/AngouriMath/Functions/Compilation/IntoLinq/CompilationProtocol.cs
@@ -239,11 +239,6 @@ namespace AngouriMath.Core.Compilation.IntoLinq
             {
                 Piecewise => HandlePiecewise(en),
                 // TODO: finite set -> hash set
-                // Reaching a node with no compiled form is the caller asking for something
-                // that is not supported, not a bug in the library, and the exception should
-                // say which node it was. It used to report "a node seems to be not added"
-                // as an internal bug assertion, which is what compiling a matrix hit (#425,
-                // #526).
                 _ => throw new UncompilableNodeException(
                     $"The node of type {typeHolder.GetType()} does not support compilation.")
                 //FiniteSet => Expression.

--- a/Sources/AngouriMath/Functions/Compilation/IntoLinq/IntoLinqCompiler.cs
+++ b/Sources/AngouriMath/Functions/Compilation/IntoLinq/IntoLinqCompiler.cs
@@ -24,7 +24,8 @@ namespace AngouriMath.Core.Compilation.IntoLinq
             // has a value that is an ordinary number -- [0, 1]T * [[a, b], [c, d]] * [1, 0]
             // is c -- and there is nothing to stop that being compiled. Nothing simplified
             // before compiling, so those failed along with the ones that genuinely cannot
-            // be compiled (#425). Only expressions that mention a matrix pay for this.
+            // be compiled (https://github.com/asc-community/AngouriMath/issues/425).
+            // Only expressions that mention a matrix pay for this.
             if (expr.Nodes.Any(node => node is Entity.Matrix))
                 expr = expr.InnerSimplified;
 

--- a/Sources/AngouriMath/Functions/Compilation/IntoLinq/IntoLinqCompiler.cs
+++ b/Sources/AngouriMath/Functions/Compilation/IntoLinq/IntoLinqCompiler.cs
@@ -20,6 +20,14 @@ namespace AngouriMath.Core.Compilation.IntoLinq
             IEnumerable<(Type type, Variable variable)> typesAndNames
             ) where TDelegate : Delegate
         {
+            // A matrix has no compiled form, but an expression built out of matrices often
+            // has a value that is an ordinary number -- [0, 1]T * [[a, b], [c, d]] * [1, 0]
+            // is c -- and there is nothing to stop that being compiled. Nothing simplified
+            // before compiling, so those failed along with the ones that genuinely cannot
+            // be compiled (#425). Only expressions that mention a matrix pay for this.
+            if (expr.Nodes.Any(node => node is Entity.Matrix))
+                expr = expr.InnerSimplified;
+
             var subexpressionsCache = typesAndNames.ToDictionary(c => (Entity)c.variable, c => Expression.Parameter(c.type));
             var functionArguments = subexpressionsCache.Select(c => c.Value).ToArray(); // copying
             var localVars = new List<ParameterExpression>();

--- a/Sources/Tests/UnitTests/Common/MatrixCompilationTest.cs
+++ b/Sources/Tests/UnitTests/Common/MatrixCompilationTest.cs
@@ -37,9 +37,6 @@ namespace AngouriMath.Tests.Common
             Assert.Equal(1 * 3 + 2 * 4, compiled(3, 4), 9);
         }
 
-        // What genuinely has no compiled form should say so, and say which node it was.
-        // It used to throw AngouriBugException("A node seems to be not added"), which reads
-        // as a defect in the library rather than as a limit of it.
         [Theory]
         [InlineData("[[a, b], [c, d]]")]
         [InlineData("[[a, b], [c, d]] * [1, 0]")]

--- a/Sources/Tests/UnitTests/Common/MatrixCompilationTest.cs
+++ b/Sources/Tests/UnitTests/Common/MatrixCompilationTest.cs
@@ -1,0 +1,63 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Core.Exceptions;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Common
+{
+    /// <summary>
+    /// Compiling expressions that mention matrices. A matrix has no compiled form, but an
+    /// expression built out of matrices often has a value that is an ordinary number.
+    /// </summary>
+    public sealed class MatrixCompilationTest
+    {
+        // https://github.com/asc-community/AngouriMath/issues/425
+        // This is the issue's own example of what ought to work, and did not: it is the
+        // scalar c, but nothing simplified before compiling, so it reached the matrix node
+        // and threw.
+        [Fact]
+        public void ScalarBuiltFromMatricesCompiles()
+        {
+            var compiled = "[0, 1]T * [[a, b], [c, d]] * [1, 0]".ToEntity()
+                .Compile<double, double, double, double, double>("a", "b", "c", "d");
+            Assert.Equal(3, compiled(1, 2, 3, 4), 9);
+        }
+
+        [Fact]
+        public void ScalarProductOfVectorsCompiles()
+        {
+            var compiled = "[1, 2]T * [a, b]".ToEntity().Compile<double, double, double>("a", "b");
+            Assert.Equal(1 * 3 + 2 * 4, compiled(3, 4), 9);
+        }
+
+        // What genuinely has no compiled form should say so, and say which node it was.
+        // It used to throw AngouriBugException("A node seems to be not added"), which reads
+        // as a defect in the library rather than as a limit of it.
+        [Theory]
+        [InlineData("[[a, b], [c, d]]")]
+        [InlineData("[[a, b], [c, d]] * [1, 0]")]
+        [InlineData("[a, b]")]
+        public void MatrixValuedExpressionsSayTheyCannotBeCompiled(string expression)
+        {
+            var thrown = Assert.Throws<UncompilableNodeException>(
+                () => expression.ToEntity().Compile<double, double>("a"));
+            Assert.Contains("Matrix", thrown.Message);
+        }
+
+        // Expressions with no matrix in them must be unaffected -- they do not go anywhere
+        // near the extra simplification.
+        [Theory]
+        [InlineData("x + 1", 2.0, 3.0)]
+        [InlineData("x ^ 2", 3.0, 9.0)]
+        [InlineData("sin(x)", 0.0, 0.0)]
+        public void OrdinaryExpressionsAreUnaffected(string expression, double argument, double expected) =>
+            Assert.Equal(expected, expression.ToEntity().Compile<double, double>("x")(argument), 9);
+    }
+}


### PR DESCRIPTION
Partly answers [#425](https://github.com/asc-community/AngouriMath/issues/425) and
[#526](https://github.com/asc-community/AngouriMath/issues/526).

### The scalar case did not work, though #425 says it should

#425 gives `[0, 1]T * [[a, b], [c, d]] * [1, 0]` as the case that is *fine*, against
`[[a, b], [c, d]] * [1, 0]` which is not. It was not fine:

```
AngouriBugException: A node seems to be not added
```

That expression is the scalar `c`. Nothing simplified before compiling, so the walk
reached the matrix node and threw, even though the value has no matrix in it at all. It
compiles now and returns `c`.

Only expressions that mention a matrix are simplified first, so matrix-free ones go
exactly the way they always did — that is asserted in the tests rather than assumed.

### What cannot be compiled now says so

Reaching a node the compiler does not handle threw
`AngouriBugException("A node seems to be not added")`. That reads as a defect in the
library rather than a limit of it, and gives the caller nothing to act on — it is also
what anyone hitting #526 sees. It now throws `UncompilableNodeException` naming the node,
which is what the other compiler already threw for `Providedf`:

```
The node of type AngouriMath.Entity+Matrix does not support compilation.
```

### This is not matrix compilation

Worth being plain about, since these two issues ask for that. An expression whose
**value** is a matrix still cannot be compiled. Choosing what a compiled matrix should
return — a `double[,]`, some runtime matrix type, element-wise delegates — is a design
decision rather than an oversight, and it belongs to whoever owns the compilation
protocol. This PR removes the two things that are simply wrong around it: a case that
should have worked and did not, and an internal bug assertion where a plain
"not supported" belongs.

### Testing

`UnitTests` 3666 passed / 0 failed, `FSharpWrapperUnitTests` 127 passed / 0 failed, both
`netstandard2.0` and `net7.0` build.

Eight new tests: the two scalar cases, three genuinely matrix-valued expressions
asserting the exception type *and* that its message names the node, and three ordinary
expressions asserting nothing changed for them.

Independent of #663 through #672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
