### PR TITLE
Take the two review notes from #664

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
@@ -65,9 +65,17 @@ namespace AngouriMath.Functions.Algebra
         /// <c>g(x) * (f(x) - 1)</c>, which is well defined from either side.
         /// </remarks>
         private static bool DivergesInMagnitude(Entity power, Variable x, Entity dest)
-            => IsInfiniteNode(power.Limit(x, dest))
-                || (IsInfiniteNode(power.Limit(x, dest, ApproachFrom.Left))
-                    && IsInfiniteNode(power.Limit(x, dest, ApproachFrom.Right)));
+        {
+            if (IsInfiniteNode(power.Limit(x, dest)))
+                return true;
+            // Only worth asking one side at a time where there are two sides to ask about.
+            // Approaching an infinite destination there is only one, so the two further
+            // limits would be wasted work and would not mean anything either.
+            if (IsInfiniteNode(dest))
+                return false;
+            return IsInfiniteNode(power.Limit(x, dest, ApproachFrom.Left))
+                && IsInfiniteNode(power.Limit(x, dest, ApproachFrom.Right));
+        }
 
         private static bool IsFiniteNode(Entity expr)
             => !IsInfiniteNode(expr) && expr != MathS.NaN;

--- a/Sources/Tests/UnitTests/Common/SolverRegressionTest.cs
+++ b/Sources/Tests/UnitTests/Common/SolverRegressionTest.cs
@@ -7,7 +7,6 @@
 
 using AngouriMath;
 using AngouriMath.Extensions;
-using PeterO.Numbers;
 using Xunit;
 
 namespace AngouriMath.Tests.Common


### PR DESCRIPTION
Two notes the Copilot reviewer left on #664, which merged before I had read them.

### The unused `using`

`SolverRegressionTest` had `using PeterO.Numbers;` and never named a type from it — every
`EDecimal` occurrence is a property access on a `Real`, which needs no using. Removed.
The library builds with `TreatWarningsAsErrors`, so it is not worth leaving lying about.

### `DivergesInMagnitude`

Flagged for calling `Limit` up to three times, with a suggestion to cache the two-sided
result. The three calls are distinct and the `||` short-circuits, so there was nothing to
cache — but there was a real waste next to it that the note led me to:

**At an infinite destination there is only one side to approach from.** The two one-sided
limits are both pointless and meaningless there, and were being computed anyway whenever
the two-sided limit was not infinite. They are now only asked for when the destination is
finite.

### Testing

`UnitTests` 3880 passed / 0 failed; both target frameworks build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
