### PR TITLE
Answer an identity equation with every value, not with none (#550)

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver.cs
@@ -57,7 +57,7 @@ namespace AngouriMath.Functions.Algebra
                 throw new WrongNumberOfArgumentsException("Number of equations must be equal to that of vars");
             int initVarCount = vars.Length;
 
-            var res = InSolveSystem(equations, vars);
+            var res = InSolveSystem(equations, vars, Sumf.Sum(equations));
             foreach (var tuple in res)
                 if (tuple.Count != initVarCount)
                     throw new AngouriBugException("InSolveSystem incorrect output");
@@ -73,13 +73,27 @@ namespace AngouriMath.Functions.Algebra
         /// <see cref="List{T}"/> of <see cref="Variable"/>s,
         /// where each of them must be mentioned in at least one entity from equations
         /// </param>
-        internal static List<List<Entity>> InSolveSystem(List<Entity> equations, ReadOnlySpan<Variable> vars)
+        /// <param name="nameSource">
+        /// The system as a whole, so that a parameter standing for a free variable is given
+        /// a name that none of the equations already uses
+        /// </param>
+        internal static List<List<Entity>> InSolveSystem(List<Entity> equations, ReadOnlySpan<Variable> vars, Entity nameSource)
         {
             var var = vars[^1];
             if (equations.Count == 1)
-                return equations[0].InnerSimplified.SolveEquation(var).InnerSimplified is FiniteSet els 
-                       ? els.Select(sol => new List<Entity> { sol }).ToList()
-                       : new();
+            {
+                var solutions = equations[0].InnerSimplified.SolveEquation(var).InnerSimplified;
+                if (solutions is FiniteSet els)
+                    return els.Select(sol => new List<Entity> { sol }).ToList();
+                // Nothing is left to constrain `var`, so every value of it extends to a solution
+                // of the system rather than none of them doing so. Reporting no solutions here is
+                // what made a solvable system come back as null from SolveSystem --
+                // https://github.com/asc-community/AngouriMath/issues/550. A free parameter says
+                // what the answer is in the same way the trigonometric solvers say it with n_1.
+                if (solutions == MathS.Sets.C)
+                    return new() { new List<Entity> { Variable.CreateUnique(nameSource, "t") } };
+                return new();
+            }
             var result = new List<List<Entity>>();
             var replacements = new Dictionary<Variable, Entity>();
             var remainingVars = vars.Slice(0, vars.Length - 1);
@@ -102,7 +116,7 @@ namespace AngouriMath.Functions.Algebra
                     rest.RemoveAt(i);
 
                     foreach (var sol in sols)
-                        foreach (var j in InSolveSystem(rest.Select(eq => eq.Substitute(var, sol)).ToList(), remainingVars))
+                        foreach (var j in InSolveSystem(rest.Select(eq => eq.Substitute(var, sol)).ToList(), remainingVars, nameSource))
                         {
                             replacements.Clear();
                             for (int varid = 0; varid < remainingVars.Length; varid++)

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
@@ -144,8 +144,10 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
                     break;
             }
 
-            if (PolynomialSolver.SolveAsPolynomial(expr, x) is { } poly)
+            if (PolynomialSolver.SolveAsPolynomial(expr, x, out var isIdentity) is { } poly)
                 return poly.Select(e => TryDowncast(expr, x, e.InnerSimplified)).ToSet();
+            if (isIdentity)
+                return MathS.Sets.C;
 
             // If the replacement isn't one-variable one,
             // then solving over replacements is already useless,
@@ -158,7 +160,9 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
                 {
                     MultithreadingFunctional.ExitIfCancelled();
                     if (!alt.ContainsNode(x))
-                        return Set.Empty; // in this case there is either 0 or +oo solutions
+                        // There are either 0 or +oo solutions, and which of the two it is
+                        // is decided by whether what is left of the equation is zero.
+                        return alt.Evaled is Complex { IsZero: true } ? MathS.Sets.C : Set.Empty;
                     var minimumSubtree = TreeAnalyzer.GetMinimumSubtree(alt, x);
                     if (minimumSubtree == x)
                         continue;

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/PolynomialSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/PolynomialSolver.cs
@@ -174,9 +174,15 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
         /// <param name="subtree">
         /// The expression the polynomial of (e. g. cos(x)^2 + cos(x) + 1 is a polynomial of cos(x))
         /// </param>
+        /// <param name="isIdentity">
+        /// Whether every coefficient cancelled, which leaves an equation that every value of
+        /// <paramref name="subtree"/> satisfies rather than one that none does
+        /// </param>
         /// <returns>A finite <see cref="Set"/> if successful, <see langword="null"/> otherwise</returns>
-        internal static IEnumerable<Entity>? SolveAsPolynomial(Entity expr, Variable subtree)
+        internal static IEnumerable<Entity>? SolveAsPolynomial(Entity expr, Variable subtree, out bool isIdentity)
         {
+            isIdentity = false;
+
             // Safely expand the expression
             // Here we find all terms
             var children = TreeAnalyzer.GatherLinearChildrenOverSumAndExpand(expr, entity => entity.ContainsNode(subtree));
@@ -189,7 +195,20 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
                 <EInteger, TreeAnalyzer.PrimitiveInteger>(children, subtree);
             if (monomialsByPower == null)
                 return null; // meaning that the given equation is not polynomial
-            
+
+            // A monomial whose coefficient cancelled is not a term of the polynomial, and
+            // leaving it in makes the equation look as though it had a degree it does not.
+            // x - x was read as one times x and answered with the root 0, when in fact
+            // every x satisfies it -- https://github.com/asc-community/AngouriMath/issues/550.
+            foreach (var power in monomialsByPower.Keys.ToList())
+                if (monomialsByPower[power].Evaled is Complex { IsZero: true })
+                    monomialsByPower.Remove(power);
+            if (monomialsByPower.Count == 0)
+            {
+                isIdentity = true;
+                return null;
+            }
+
             var res = ReduceCommonPower(ref monomialsByPower)
                 ? new Entity[] { 0 } // x5 + x3 + x2 - common power is 2, one root is 0, then x3 + x + 1
                 : Enumerable.Empty<Entity>();

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/IdentityEquationTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/IdentityEquationTest.cs
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Algebra
+{
+    /// <summary>
+    /// An equation that puts no condition on the variable is satisfied by every value of it,
+    /// not by none. Answering such an equation with the empty set, or with the single root 0,
+    /// is what made a system containing one come back as null from
+    /// <see cref="Core.EquationSystem.Solve"/> --
+    /// https://github.com/asc-community/AngouriMath/issues/550.
+    /// </summary>
+    public sealed class IdentityEquationTest
+    {
+        [Theory]
+        [InlineData("x - x = 0")]
+        [InlineData("0 = 0")]
+        [InlineData("2 * x - 2 * x = 0")]
+        [InlineData("x + 1 - x - 1 = 0")]
+        [InlineData("x ^ 2 - x ^ 2 = 0")]
+        [InlineData("x ^ 2 + x = x + x ^ 2")]
+        public void EveryValueSatisfiesAnIdentity(string equation) =>
+            Assert.Equal(MathS.Sets.C, equation.ToEntity().Solve("x"));
+
+        [Theory]
+        [InlineData("1 = 0")]
+        [InlineData("x - x + 1 = 0")]
+        [InlineData("x - x = 1")]
+        [InlineData("2 = 3")]
+        public void NoValueSatisfiesAContradiction(string equation) =>
+            Assert.Equal(MathS.Sets.Empty, equation.ToEntity().Solve("x"));
+
+        // A term that cancelled must not be counted towards the degree either. x^2 - x^2 + x + 1
+        // is linear, and reading it as a quadratic with a zero leading coefficient is how the
+        // wrong root of x - x arose.
+        [Theory]
+        [InlineData("x - 3 = 0", new[] { 3.0 })]
+        [InlineData("x ^ 2 - 4 = 0", new[] { 2.0, -2.0 })]
+        [InlineData("x ^ 2 - x ^ 2 + x + 1 = 0", new[] { -1.0 })]
+        [InlineData("x ^ 2 - x ^ 2 + x ^ 2 - 4 = 0", new[] { 2.0, -2.0 })]
+        [InlineData("x ^ 3 - x = 0", new[] { 0.0, 1.0, -1.0 })]
+        public void OrdinaryEquationsKeepTheirRoots(string equation, double[] expected)
+        {
+            var roots = (Entity.Set.FiniteSet)equation.ToEntity().Solve("x");
+            Assert.Equal(expected.Length, roots.Count);
+            foreach (var root in roots)
+                Assert.Contains(expected, e =>
+                    System.Math.Abs(e - root.EvalNumerical().RealPart.EDecimal.ToDouble()) < 1e-9);
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/UnderdeterminedSystemTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/UnderdeterminedSystemTest.cs
@@ -1,0 +1,118 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Algebra
+{
+    /// <summary>
+    /// https://github.com/asc-community/AngouriMath/issues/550. A system whose equations do
+    /// not pin every unknown down still has solutions; there are just infinitely many of them.
+    /// The solver used to answer either null or a single tuple that is not the whole answer.
+    /// </summary>
+    public sealed class UnderdeterminedSystemTest
+    {
+        private const string h =
+            "0.000100000000000000004792173602385929598312941379845142364501953125";
+        private const string g =
+            "9789.0960964999997808359069040306866750797257845497032630044387246925907675176858901977539062500000017547";
+
+        /// <summary>
+        /// Puts a solution row back into the equations it came from. A parametric answer has to
+        /// satisfy them for every value of the parameter, so the residual must simplify to zero
+        /// rather than merely evaluate to zero at a point.
+        /// </summary>
+        private static void AssertSatisfies(Entity[] equations, Entity.Variable[] vars, Entity.Matrix solutions)
+        {
+            Assert.Equal(vars.Length, solutions.ColumnCount);
+            for (var row = 0; row < solutions.RowCount; row++)
+                foreach (var equation in equations)
+                {
+                    var residual = equation;
+                    for (var column = 0; column < vars.Length; column++)
+                        residual = residual.Substitute(vars[column], solutions[row, column]);
+                    Assert.Equal(Entity.Number.Integer.Create(0), residual.Simplify());
+                }
+        }
+
+        // Two equations saying the same thing leave one unknown free. Before, x - y together
+        // with 2x - 2y answered { (0, 0) }, which is a solution but not the solution set.
+        [Theory]
+        [InlineData("x - y", "2 * x - 2 * y")]
+        [InlineData("x + y - 1", "2 * x + 2 * y - 2")]
+        [InlineData("x - y", "3 * x - 3 * y")]
+        public void ARepeatedEquationLeavesAFreeParameter(string first, string second)
+        {
+            Entity[] equations = { first.ToEntity(), second.ToEntity() };
+            Entity.Variable[] vars = { "x", "y" };
+            var solutions = MathS.Equations(equations).Solve(vars);
+            Assert.NotNull(solutions);
+            AssertSatisfies(equations, vars, solutions!);
+            // A parameter, not a number: the answer stands for infinitely many tuples.
+            Assert.NotEmpty(solutions![0, 0].Vars);
+        }
+
+        // A system that contradicts itself has no solutions at all, and null still says so.
+        [Fact]
+        public void AContradictorySystemHasNoSolutions() =>
+            Assert.Null(MathS.Equations("x + y - 1", "x + y - 2").Solve("x", "y"));
+
+        // A system that does pin every unknown down must keep answering with numbers.
+        [Theory]
+        [InlineData("x + y - 3", "x - y - 1")]
+        [InlineData("2 * x + y", "x - y - 3")]
+        public void ADeterminedSystemStillAnswersWithNumbers(string first, string second)
+        {
+            Entity[] equations = { first.ToEntity(), second.ToEntity() };
+            Entity.Variable[] vars = { "x", "y" };
+            var solutions = MathS.Equations(equations).Solve(vars);
+            Assert.NotNull(solutions);
+            AssertSatisfies(equations, vars, solutions!);
+            Assert.Empty(solutions![0, 0].Vars);
+        }
+
+        /// <summary>
+        /// The system from the report itself. Rewriting one equation from -(a + b + c) to
+        /// -a - b - c used to decide whether it solved at all; both forms must solve, in either
+        /// of the two orders the reporter tried them in.
+        /// </summary>
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TheReportedSystemSolvesWhicheverWayItIsWritten(bool parenthesised, bool numericOrder)
+        {
+            Entity y1 = $"-Y_3 - v_3 * {h} * Y_4";
+            Entity y2 = $"-Y_8 - v_1 * {h} * Y_1";
+            Entity y3 = $"-Y_8 - v_5 * {h} * Y_7";
+            Entity y4 = "Y_7 - Y_6 + Y_1";
+            Entity y5 = $"-Y_2 - v_2 * {h} * Y_6";
+            Entity y6 = $"-Y_5 - v_4 * {h} * Y_6";
+            Entity y7 = "Y_4 - Y_6 + (-40743.6654315252017113380134105682373046875) * Y_3";
+            Entity y8 = "Y_9 - Y_3 + Y_2 - Y_8";
+            Entity y9 = parenthesised ? "-(Y_5 + Y_12 + Y_9)" : "-Y_9 - Y_5 - Y_12";
+            Entity y10 = "Y_6 - Y_10 - Y_11";
+            Entity y11 = "Y_11 + 80000 * Y_12 * n + (-800000) * n * n";
+            Entity y12 = $"Y_12 - v_6 * {h} * Y_13";
+            Entity y13 = $"Y_13 - {g} * v_7 + Y_10";
+
+            var equations = numericOrder
+                ? new[] { y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11, y12, y13 }
+                : new[] { y2, y5, y1, y7, y6, y4, y3, y8, y9, y10, y11, y12, y13 };
+            var vars = Enumerable.Range(1, 13)
+                .Select(i => (Entity.Variable)$"Y_{i}").ToArray();
+
+            var solutions = MathS.Equations(equations).Solve(vars);
+            Assert.NotNull(solutions);
+            Assert.Equal(13, solutions!.ColumnCount);
+        }
+    }
+}


### PR DESCRIPTION
Closes #550.

@Happypig375 — you said the null-returning line is the one to be fixed, so this is about that line and not about a 3x3 example. What follows is where the null comes from.

## The line, and what reaches it

`SolveSystem` returns `null` when `InSolveSystem` hands back nothing. It gets nothing because an equation that has stopped constraining the variable is reported as having **no** solutions, when it has all of them.

```cs
"0 = 0".ToEntity().Solve("x")      // {  }    -- says no value satisfies it
"x - x = 0".ToEntity().Solve("x")  // { 0 }   -- says exactly one does
```

The second is a wrong answer rather than a missing one. `GatherMonomialInformation` collects `x` and `-x` into a single monomial of degree one whose coefficient is `1 + (-1)`, and nothing ever looks at that coefficient — so the equation is read as `1 * x` and solved for the root `0`.

That is what the report is about. Substituting one variable routinely leaves an equation that cancels away, and then:

```cs
MathS.Equations("x - y", "2 * x - 2 * y").Solve("x", "y")   // was [[0, 0]]
```

which is *a* solution but not the solution set — every `x = y` is one.

## What this changes

**Coefficients that evaluate to zero are dropped before the degree is read.** When none is left the equation is an identity, and it is answered with `C` rather than the empty set. This also stops a cancelled leading term being counted towards the degree.

**The branch that already knew about this now decides.** It carried the comment `in this case there is either 0 or +oo solutions` and returned the empty set for both; it now looks at whether what is left is zero.

**A free variable in a system gets a parameter** instead of ending the search, the way `sin(x) = 0` is already answered with `n_1`:

```cs
MathS.Equations("x - y", "2 * x - 2 * y").Solve("x", "y")           // [[t_1, t_1]]
MathS.Equations("x + y - 1", "2 * x + 2 * y - 2").Solve("x", "y")   // [[t_1, 1 - t_1]]
```

`null` now means what it says in the doc comment: there are no solutions. That is still the answer for a system that contradicts itself, e.g. `{ x + y - 1, x + y - 2 }`.

## What this does not change

A variable mentioned in **no** equation at all still ends in `null`, because dropping it leaves more equations than unknowns and the recursion is built on the two being equal. That belongs with #212 and I have not touched it here.

## On the reported system

The 13-equation system in the report solves on `master` today — in both of the equation orders and both of the ways of writing the ninth equation that the reporter tried. `TheReportedSystemSolvesWhicheverWayItIsWritten` pins all four combinations, since a cosmetic rewrite deciding whether it solved is the complaint. It is a pin, not a demonstration of this fix; the nine tests that do fail without the change are marked below.

## Verification

- 25 new tests. **9 fail without this change** (`EveryValueSatisfiesAnIdentity` x6, `ARepeatedEquationLeavesAFreeParameter` x3).
- Parametric answers are verified by substituting the row back into the original equations and `Simplify`ing the residual to exactly `0`, so they hold for every value of the parameter rather than at a sample point.
- **3905 unit tests, 0 failed.** 127 F# tests, 0 failed. Both target frameworks build.
- Solver corpus unchanged at **85/117**, with 0 wrong answers, 0 errors and 0 timeouts — measured on `master` and on this branch with the same harness.
- A property checker over 151 expressions (1320 checks) is clean.
