### PR TITLE
Apply l'Hopital's rule at infinity too (#596)

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Solvers.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Solvers.Definition.cs
@@ -62,9 +62,21 @@ namespace AngouriMath.Functions.Algebra
 
                 MultithreadingFunctional.ExitIfCancelled();
                 if (!dest.IsFinite)
+                {
                     // just compute limit with no check for left/right equality
                     // here approach left will be ignored anyways, as dest is infinite number
-                    return expr.ComputeLimitDivideEtImpera(x, dest, ApproachFrom.Left);
+                    var atInfinity = expr.ComputeLimitDivideEtImpera(x, dest, ApproachFrom.Left);
+                    if (atInfinity is { } found && found.Evaled != MathS.NaN)
+                        return found;
+                    // l'Hopital's rule was only ever reached for a finite destination, so the
+                    // textbook oo/oo cases at infinity -- ln(x) / x, x / e^x, ln(x) / sqrt(x) --
+                    // were left with nothing to catch them. The rule is only allowed to improve
+                    // on what is already there: sqrt(x) / sqrt(x + 1) merely turns into its own
+                    // reciprocal, and a NaN from it would claim the limit does not exist.
+                    if (ApplylHopitalRule(expr, x, dest) is { } lhopital && lhopital.Evaled != MathS.NaN)
+                        return lhopital;
+                    return atInfinity;
+                }
                 else if (expr.ComputeLimitDivideEtImpera(x, dest, ApproachFrom.Left) is { } fromLeft
                   && expr.ComputeLimitDivideEtImpera(x, dest, ApproachFrom.Right) is { } fromRight)
                 {

--- a/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
@@ -7,6 +7,7 @@
 
 using AngouriMath.Core.Multithreading;
 using System;
+using System.Linq;
 using static AngouriMath.Entity;
 
 namespace AngouriMath.Functions.Algebra
@@ -84,6 +85,43 @@ namespace AngouriMath.Functions.Algebra
         [ThreadStatic] private static int lHopitalDepth;
 
         /// <summary>
+        /// How many times in all the rule may differentiate a quotient while one limit is being
+        /// computed. Bounding the depth alone does not bound the work: each step asks what the
+        /// two parts of its quotient tend to, and those are limits the rule may be applied to
+        /// in turn, so the steps fan out rather than follow one another, and sixteen deep is
+        /// far more than sixteen of them. This is a backstop rather than the answer to that --
+        /// the two conditions below are what keep the fan-out from starting.
+        /// </summary>
+        private const int MaxlHopitalApplications = 64;
+
+        [ThreadStatic] private static int lHopitalApplications;
+
+        [ThreadStatic] private static List<Entity>? lHopitalChain;
+
+        /// <summary>
+        /// Whether the rule is already partway through this very quotient. Differentiating both
+        /// parts of sqrt(x^2 - x) / x gives its reciprocal, and differentiating that gives the
+        /// first back, so the rule can go round for as long as the bound on its depth allows.
+        /// Each step of the way costs a simplification and two limits of its own, which is why
+        /// bounding the depth is not by itself enough to stop that limit running for a minute.
+        /// </summary>
+        private static bool AlreadyBeingDifferentiated(Entity quotient)
+            => (lHopitalChain ??= new()).Contains(quotient);
+
+        /// <summary>
+        /// Whether differentiating both parts has left a quotient bigger than the one it came
+        /// from by more than the derivative of a power or a logarithm accounts for. Each step
+        /// asks what the two parts of its quotient tend to, and a bigger quotient makes those
+        /// two questions harder than the one being answered, so a step that grows is a step
+        /// away from an answer rather than towards one. The room left over is measured: the
+        /// steps that do reach an answer add two nodes, and the most any of them was seen to
+        /// add is six, while one step of x^(3/2) * sqrt(1 + 1/x^2) / x^2 adds eighteen and
+        /// leaves the rule tens of seconds of work that ends in nothing.
+        /// </summary>
+        private static bool GrewTooMuch(Entity quotient, Entity applied)
+            => applied.Nodes.Count() > quotient.Nodes.Count() + 8;
+
+        /// <summary>
         /// A product that has a reciprocal factor in it, rewritten as a quotient, or
         /// <see langword="null"/> if it has none. The rule below only reads quotients, so
         /// <c>lim x -&gt; +oo x^4 * e^(-x)</c> came out as NaN while the same limit written
@@ -121,8 +159,20 @@ namespace AngouriMath.Functions.Algebra
 
         private static Entity? ApplylHopitalRule(Entity expr, Variable x, Entity dest)
         {
-            if (lHopitalDepth >= MaxlHopitalDepth)
+            if (lHopitalDepth == 0)
+                lHopitalApplications = 0;
+            if (lHopitalDepth >= MaxlHopitalDepth || lHopitalApplications >= MaxlHopitalApplications)
                 return null;
+            // Held for the whole of the rule and not just for the recursive call below, since
+            // asking what the two parts tend to is itself a limit that the rule may be applied
+            // to, and counting only the recursion left those two free to nest without a bound.
+            lHopitalDepth++;
+            try { return ApplylHopitalRuleImpl(expr, x, dest); }
+            finally { lHopitalDepth--; }
+        }
+
+        private static Entity? ApplylHopitalRuleImpl(Entity expr, Variable x, Entity dest)
+        {
             if (expr is not Divf && AsQuotient(expr) is { } quotient)
                 expr = quotient;
             if (expr is Divf(var num, var den))
@@ -144,14 +194,17 @@ namespace AngouriMath.Functions.Algebra
                                 // unread. Limits already treat the expression as continuous, as
                                 // SimplifyAndComputeLimitToInfinity does with the same shape.
                                 while (applied is Providedf(var body, _)) applied = body;
+                                if (AlreadyBeingDifferentiated(applied) || GrewTooMuch(expr, applied))
+                                    return null;
+                                lHopitalApplications++;
                                 MultithreadingFunctional.ExitIfCancelled();
-                                lHopitalDepth++;
+                                lHopitalChain!.Add(applied);
                                 try
                                 {
                                     if (ComputeLimit(applied, x, dest) is { } resLim)
                                         return resLim;
                                 }
-                                finally { lHopitalDepth--; }
+                                finally { lHopitalChain.RemoveAt(lHopitalChain.Count - 1); }
                             }
             return null;
         }

--- a/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
@@ -72,8 +72,59 @@ namespace AngouriMath.Functions.Algebra
         private static bool IsFiniteNode(Entity expr)
             => !IsInfiniteNode(expr) && expr != MathS.NaN;
 
+        /// <summary>
+        /// How deep the rule may be applied to one limit. Differentiating both parts does not
+        /// always make the quotient simpler -- x / sqrt(x^2 + 1) turns into sqrt(x^2 + 1) / x,
+        /// which turns back, so the two stay indeterminate forever -- and without a bound the
+        /// recursion below would not end. The bound has to leave room for the degree of a
+        /// polynomial: x^10 / e^x takes ten steps.
+        /// </summary>
+        private const int MaxlHopitalDepth = 16;
+
+        [ThreadStatic] private static int lHopitalDepth;
+
+        /// <summary>
+        /// A product that has a reciprocal factor in it, rewritten as a quotient, or
+        /// <see langword="null"/> if it has none. The rule below only reads quotients, so
+        /// <c>lim x -&gt; +oo x^4 * e^(-x)</c> came out as NaN while the same limit written
+        /// <c>x^4 / e^x</c> gave 0 --
+        /// https://github.com/asc-community/AngouriMath/issues/596.
+        /// </summary>
+        private static Entity? AsQuotient(Entity expr)
+        {
+            if (expr is not Mulf)
+                return null;
+            Entity numerator = 1, denominator = 1;
+            var reciprocal = false;
+            foreach (var factor in Mulf.LinearChildren(expr))
+                switch (factor)
+                {
+                    case Powf(var @base, Real { IsNegative: true } power):
+                        denominator *= @base.Pow(-power);
+                        reciprocal = true;
+                        break;
+                    case Powf(var @base, Mulf(Real { IsNegative: true } coefficient, var rest)):
+                        denominator *= @base.Pow(-coefficient * rest);
+                        reciprocal = true;
+                        break;
+                    case Divf(var dividend, var divisor):
+                        numerator *= dividend;
+                        denominator *= divisor;
+                        reciprocal = true;
+                        break;
+                    default:
+                        numerator *= factor;
+                        break;
+                }
+            return reciprocal ? numerator / denominator : null;
+        }
+
         private static Entity? ApplylHopitalRule(Entity expr, Variable x, Entity dest)
         {
+            if (lHopitalDepth >= MaxlHopitalDepth)
+                return null;
+            if (expr is not Divf && AsQuotient(expr) is { } quotient)
+                expr = quotient;
             if (expr is Divf(var num, var den))
                 if (EvalAssumingContinuous(num.Limit(x, dest)) is var numLimit && EvalAssumingContinuous(den.Limit(x, dest)) is var denLimit)
                     if (numLimit == 0 && denLimit == 0 ||
@@ -81,10 +132,26 @@ namespace AngouriMath.Functions.Algebra
                         if (num is not Number && den is not Number)
                             if (num.ContainsNode(x) && den.ContainsNode(x))
                             {
-                                var applied = num.Differentiate(x) / den.Differentiate(x);
+                                // Simplified, because the shape of the quotient is what the
+                                // machinery below matches on and differentiation does not
+                                // produce it: d/dx ln(x)^2 is 2 * ln(x) * (1 / x), a product
+                                // with a quotient inside rather than the quotient
+                                // 2 * ln(x) / x, and only the second has a limit here.
+                                var applied = (num.Differentiate(x) / den.Differentiate(x)).Simplify();
+                                // The domain condition simplification leaves behind is what the
+                                // derivative of a logarithm or a root carries, and a Providedf is
+                                // not a continuous node, so the quotient would be turned away
+                                // unread. Limits already treat the expression as continuous, as
+                                // SimplifyAndComputeLimitToInfinity does with the same shape.
+                                while (applied is Providedf(var body, _)) applied = body;
                                 MultithreadingFunctional.ExitIfCancelled();
-                                if (ComputeLimit(applied, x, dest) is { } resLim)
-                                    return resLim;
+                                lHopitalDepth++;
+                                try
+                                {
+                                    if (ComputeLimit(applied, x, dest) is { } resLim)
+                                        return resLim;
+                                }
+                                finally { lHopitalDepth--; }
                             }
             return null;
         }

--- a/Sources/Tests/UnitTests/Calculus/LimitAtInfinityTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/LimitAtInfinityTest.cs
@@ -72,10 +72,20 @@ namespace AngouriMath.Tests.Calculus
         /// honest. What must not happen is a hang, and the answer must not become NaN either,
         /// since NaN asserts that the limit does not exist.
         /// </summary>
+        /// <remarks>
+        /// The last two are the forms that showed a bound on the number of steps is not by
+        /// itself a bound on the work. Each step asks what the two parts of its quotient tend
+        /// to, and those are limits the rule may be applied to in turn, so sixteen steps deep
+        /// is far more than sixteen steps: both of these ran for over twenty seconds before the
+        /// rule was stopped from going round a cycle or handing on a quotient bigger than the
+        /// one it came from.
+        /// </remarks>
         [Theory]
         [InlineData("x / sqrt(x ^ 2 + 1)")]
         [InlineData("(x + sin(x)) / x")]
         [InlineData("x ^ 20 / e ^ x")]
+        [InlineData("sqrt(x ^ 2 - x) / x")]
+        [InlineData("x ^ (3/2) * sqrt(1 + 1 / x ^ 2) / x ^ 2")]
         public void AFormTheRuleCannotSettleTerminatesWithoutClaimingAnAnswer(string expression)
         {
             var task = Task.Run(() => Limit(expression, "+oo"));

--- a/Sources/Tests/UnitTests/Calculus/LimitAtInfinityTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/LimitAtInfinityTest.cs
@@ -1,0 +1,86 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Threading.Tasks;
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// l'Hopital's rule was only applied when the destination was finite, so the ordinary
+    /// competing-growth limits at infinity came back unevaluated.
+    /// </summary>
+    public sealed class LimitAtInfinityTest
+    {
+        private static Entity Limit(string expression, string destination) =>
+            expression.ToEntity().Limit("x", destination.ToEntity());
+
+        [Theory]
+        [InlineData("ln(x) / x", "+oo", "0")]
+        [InlineData("x / e ^ x", "+oo", "0")]
+        [InlineData("x ^ 2 / e ^ x", "+oo", "0")]
+        [InlineData("ln(x) / sqrt(x)", "+oo", "0")]
+        [InlineData("e ^ x / (e ^ x + 1)", "+oo", "1")]
+        [InlineData("ln(x) ^ 2 / x", "+oo", "0")]
+        [InlineData("x / e ^ (2 * x)", "+oo", "0")]
+        [InlineData("x / ln(x) ^ 2", "+oo", "+oo")]
+        [InlineData("x ^ 3 / ln(x)", "+oo", "+oo")]
+        [InlineData("ln(ln(x)) / ln(x)", "+oo", "0")]
+        [InlineData("sqrt(x) / sqrt(x + 1)", "+oo", "1")]
+        [InlineData("x ^ 10 / e ^ x", "+oo", "0")]
+        public void CompetingGrowthAtInfinity(string expression, string destination, string expected) =>
+            Assert.Equal(expected.ToEntity(), Limit(expression, destination).Simplify());
+
+        // https://github.com/asc-community/AngouriMath/issues/596. The same limits written as
+        // products with a reciprocal factor. Only the shape differs, and only the quotient
+        // shape was read.
+        [Theory]
+        [InlineData("(x ^ (5 - 1)) * e ^ (-x)", "+oo", "0")]
+        [InlineData("x ^ 4 * e ^ (-x)", "+oo", "0")]
+        [InlineData("x * e ^ (-x)", "+oo", "0")]
+        [InlineData("ln(x) * x ^ (-1)", "+oo", "0")]
+        [InlineData("e ^ (-2 * x) * x ^ 3", "+oo", "0")]
+        public void AProductWithAReciprocalFactorIsAQuotient(string expression, string destination, string expected) =>
+            Assert.Equal(expected.ToEntity(), Limit(expression, destination).Simplify());
+
+        // The forms that already had an answer must keep it, in particular the ones that do
+        // not go through the rule at all.
+        [Theory]
+        [InlineData("x ^ 2 / (x ^ 2 + 1)", "+oo", "1")]
+        [InlineData("(2 * x + 1) / (x - 3)", "+oo", "2")]
+        [InlineData("1 / x", "+oo", "0")]
+        [InlineData("x ^ 3", "+oo", "+oo")]
+        [InlineData("sin(x) / x", "0", "1")]
+        [InlineData("(1 + x) ^ (1/x)", "0", "e")]
+        [InlineData("(x ^ 2 - 1) / (x - 1)", "1", "2")]
+        [InlineData("sqrt(x + 1) / sqrt(x)", "+oo", "1")]
+        [InlineData("sqrt(x + 5) / sqrt(x + 1)", "+oo", "1")]
+        public void EstablishedLimitsAreUnaffected(string expression, string destination, string expected) =>
+            Assert.Equal(expected.ToEntity(), Limit(expression, destination).Simplify());
+
+        /// <summary>
+        /// Differentiating both parts of x / sqrt(x^2 + 1) gives its own reciprocal, so the rule
+        /// never settles and has to be stopped; x^20 / e^x would settle but only after more
+        /// steps than the bound allows. Either way the limit is left unevaluated, which is
+        /// honest. What must not happen is a hang, and the answer must not become NaN either,
+        /// since NaN asserts that the limit does not exist.
+        /// </summary>
+        [Theory]
+        [InlineData("x / sqrt(x ^ 2 + 1)")]
+        [InlineData("(x + sin(x)) / x")]
+        [InlineData("x ^ 20 / e ^ x")]
+        public void AFormTheRuleCannotSettleTerminatesWithoutClaimingAnAnswer(string expression)
+        {
+            var task = Task.Run(() => Limit(expression, "+oo"));
+            Assert.True(task.Wait(TimeSpan.FromSeconds(30)), "the limit did not terminate");
+            Assert.IsType<Entity.Limitf>(task.Result);
+        }
+    }
+}


### PR DESCRIPTION
Addresses part of #596, and a class of limits that had no answer at all.

## What was missing

l'Hopital's rule is already implemented, but `ComputeLimit` only reaches it on the branch for a **finite** destination. At infinity the call simply returns whatever `ComputeLimitDivideEtImpera` found, so the textbook competing-growth limits had nothing to catch them:

```cs
"ln(x) / x".ToEntity().Limit("x", "+oo")        // limit(ln(x) / x, x, +oo), and NaN once simplified
"x / e ^ x".ToEntity().Limit("x", "+oo")        //   "
"ln(x) / sqrt(x)".ToEntity().Limit("x", "+oo")  //   "
"e ^ x / (e ^ x + 1)".ToEntity().Limit("x", "+oo")  //   "
```

## Three things had to be settled first

**It has to stop.** Differentiating both parts does not always make the quotient simpler — `x / sqrt(x^2 + 1)` turns into `sqrt(x^2 + 1) / x`, which turns back — so the recursion is bounded. The bound leaves room for the degree of a polynomial, since `x^10 / e^x` takes ten steps.

**It must not make an answer worse.** `NaN` asserts that a limit does not exist, which is a stronger claim than the rule can make when it has not settled. Its answer is only taken when it is not `NaN`; otherwise whatever was there before stands, unevaluated included.

**It has to recognise the quotient.** Two shapes were being turned away:

- *Differentiation does not produce quotients.* `d/dx ln(x)^2` is `2 * ln(x) * (1 / x)` — a product with a quotient inside, not `2 * ln(x) / x` — and only the second has a limit here. The derivative quotient is now simplified before use, and the domain condition that simplification leaves behind goes with it, since a `Providedf` is not a `ContinuousNode` and `ComputeLimit` turns it away unread. Limits already treat the expression as continuous; `SimplifyAndComputeLimitToInfinity` drops the same node for the same reason.
- *A product with a reciprocal factor is a quotient.* This is the shape reported in #596:

```cs
"(x ^ (5 - 1)) * e ^ (-x)".ToEntity().Limit("x", "+oo")  // was NaN, now 0
"x ^ 4 / e ^ x".ToEntity().Limit("x", "+oo")             // 0 either way
```

## Effect

| | before | after |
|---|---|---|
| `lim x->+oo ln(x) / x` | unevaluated | `0` |
| `lim x->+oo x / e^x` | unevaluated | `0` |
| `lim x->+oo ln(x) / sqrt(x)` | unevaluated | `0` |
| `lim x->+oo ln(x)^2 / x` | unevaluated | `0` |
| `lim x->+oo e^x / (e^x + 1)` | unevaluated | `1` |
| `lim x->+oo x / ln(x)^2` | unevaluated | `+oo` |
| `lim x->+oo x^3 / ln(x)` | unevaluated | `+oo` |
| `lim x->+oo ln(ln(x)) / ln(x)` | unevaluated | `0` |
| `lim x->+oo sqrt(x) / sqrt(x + 1)` | unevaluated | `1` |
| `lim x->+oo x^10 / e^x` | unevaluated | `0` |
| `lim x->+oo x^4 * e^(-x)` | unevaluated | `0` |

## Verification

- 29 new tests, including three forms the rule cannot settle (`x / sqrt(x^2 + 1)`, `(x + sin(x)) / x`, `x^20 / e^x`) asserting that each terminates and stays unevaluated rather than hanging or claiming `NaN`.
- **3909 unit tests, 0 failed.** 127 F# tests, 0 failed. Both target frameworks build.
- Solver corpus **88/117 -> 91/117**, still **0 wrong, 0 error, 0 timeout**. `lim:oo/oo` goes to 4 out of 4.
- A property checker over 151 expressions (1320 checks) is clean.

## Not covered

`e^x - x`, `sqrt(x^2 + x) - x` and `e^(x + e^(-x)) - e^x` are still unevaluated — none of them is a quotient, and rewriting an `oo - oo` as one is a separate piece of work (#231, #353). They are left unevaluated rather than guessed.
