### PR TITLE
Link the commits the performance columns are measured at (#167)

### DIFF
--- a/Sources/AngouriMath/Docs/WhatsNew/version_performance_control.md
+++ b/Sources/AngouriMath/Docs/WhatsNew/version_performance_control.md
@@ -2,7 +2,15 @@ We compare performances through different versions with CommonFunctionsInterVers
 
 Units: nanoseconds
 
-|          Method |         331st |          380th |     391st      |         410th |           483rd |         520th |         690th |         826th |         914th |         920th |        1034th |        1066th |        1090th |           1446th |
+Each column is headed by how far along the history of `master` the version measured is,
+counting the first commit as the 1st, and links to that commit. To find the number for a
+new column, count the commits up to the one being measured:
+
+```
+git rev-list --count <commit>
+```
+
+|          Method |         [331st](https://github.com/asc-community/AngouriMath/commit/10e6e5a90e7270336b68dc5fd6aa36f3e0e65d2b) |          [380th](https://github.com/asc-community/AngouriMath/commit/73ae36488ddb863c1d6f35db5ed2f5dcf1484a26) |     [391st](https://github.com/asc-community/AngouriMath/commit/c7e08e6936bfdc2373377bec81ffd160e406244f)      |         [410th](https://github.com/asc-community/AngouriMath/commit/20814936bc740a9f410af4a4368e9895eab7aaf7) |           [483rd](https://github.com/asc-community/AngouriMath/commit/355963dcdf0ff9da568e9f1144ad2b7b68c19584) |         [520th](https://github.com/asc-community/AngouriMath/commit/70aa71acb73307c9f7df0aac006faae31b06058c) |         [690th](https://github.com/asc-community/AngouriMath/commit/5cc894939cb3657f0aa7ef5a25fd55011058929f) |         [826th](https://github.com/asc-community/AngouriMath/commit/87e33ec3590a95dd4ec59ff5c1f77064a64196d1) |         [914th](https://github.com/asc-community/AngouriMath/commit/6134338df083a908369b6bcfb69e70a4269ec51b) |         [920th](https://github.com/asc-community/AngouriMath/commit/501a0a3a9b2e07cddf92c4446b73ad6e2748253a) |        [1034th](https://github.com/asc-community/AngouriMath/commit/a3f48b47795b2dc2b3435152989a6e15639a65b4) |        [1066th](https://github.com/asc-community/AngouriMath/commit/a33746651f56a380b6c17913aa844f162f258d8c) |        [1090th](https://github.com/asc-community/AngouriMath/commit/9530c5b04484e98023941f7693bbeb1a3282cee6) |           [1446th](https://github.com/asc-community/AngouriMath/commit/2abb2b537c03977281f3fc2cab1da2c78c36a5f5) |
 |---------------- |--------------:|---------------:|---------------:|--------------:|----------------:|--------------:|--------------:|--------------:|--------------:|--------------:|--------------:|--------------:|--------------:|-----------------:|
 |       ParseEasy |        28,599 |         73,669 |        134,120 |        44,328 |          54,675 |        21,722 |        32,212 |        32,138 |        34,702 |        32,199 |        33,008 |        27,483 |        33,043 |        34,664 ns |
 |       ParseHard |        92,037 |        208,710 |        415,440 |       178,760 |         287,865 |       209,853 |       624,769 |       698,094 |     4,272,898 |     3,862,375 |     4,731,275 |     4,051,823 |     5,284,613 |     5,657,058 ns |


### PR DESCRIPTION
Addresses the first half of #167.

The columns in `version_performance_control.md` are headed `331st`, `380th`, `1446th` and so on, which a reader cannot resolve to anything — @dasingh92 asked on the issue for a better explanation because they could not find any commit numbers in the file at all. Each heading now links to the commit it names, and a note at the top says what the numbering is and how to produce it for a new column.

## The numbering was checked, not assumed

It is how far along the history of `master` the measured version is, counting the first commit as the 1st. Two independent confirmations:

- Every column's ordinal resolves to a commit dated on or just before the commit that *added that column to this file*. The 1034th resolves to a commit of 2021-02-25 and the column was added on 2021-02-25; the 1090th to 2021-03-10 and the column was added 2021-03-11; the 920th to 2020-11-17, added 2020-11-21. Measure, then write it down.
- For the 1446th the two are the same commit — `2abb2b53`, *"Memory diagnoser added and perf report update (#501)"*. `git rev-list --count 2abb2b53` gives 1446.

So the recipe in the note reproduces the file's own numbers.

## What is not here

The issue also asks for a new column for the cost of arbitrary precision in the trigonometric functions. Those numbers would come from a different machine than the fourteen already in the table and would not be comparable with them — the whole point of the table is comparison down a row. That needs whoever owns the machine the rest were taken on, so I have left the issue open rather than closing it with this.