### PR TITLE
Write out the issue links in comments rather than the shorthand

### DIFF
--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.ExpandFactorize.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.ExpandFactorize.cs
@@ -71,7 +71,8 @@ namespace AngouriMath.Functions
         /// </summary>
         /// <remarks>
         /// The pairwise rules only ever see two adjacent terms of the sum tree, so a sum of
-        /// four was left half-factored at <c>a*(c + d) + b*c + b*d</c> -- that is #531. Sums
+        /// four was left half-factored at <c>a*(c + d) + b*c + b*d</c> -- that is
+        /// https://github.com/asc-community/AngouriMath/issues/531. Sums
         /// of two are left to those rules, which are older and better tested.
         /// </remarks>
         /// <returns><see langword="null"/> when no factor is shared, so the rule does not fire.</returns>

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Trigonometry.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Trigonometry.cs
@@ -94,7 +94,7 @@ namespace AngouriMath.Functions
         /// ever reached for numeric angles that are multiples of pi. Nothing opened a
         /// symbolic <c>sin(2x)</c>, so <c>cos(2x) - (1 - 2sin(x)^2)</c> did not reduce to
         /// zero and neither did <c>(sin(2t)csc(t))^2/4 - cos(2t) - sin(t)^2</c>, which is
-        /// #557.
+        /// https://github.com/asc-community/AngouriMath/issues/557.
         /// </remarks>
         internal static Entity ExpandMultipleAngleRules(Entity x) => x switch
         {

--- a/Sources/Tests/UnitTests/Calculus/IntegrationTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/IntegrationTest.cs
@@ -335,7 +335,8 @@ namespace AngouriMath.Tests.Calculus
             var expr = MathS.Sin(x);
             // Quadrature over a symmetric interval leaves a residual around 1e-17, which
             // downcasting used to round away. It no longer does, because the same rounding
-            // was destroying every legitimate small number (see IssueRegressionTest, #602).
+            // was destroying every legitimate small number (see IssueRegressionTest, and
+            // https://github.com/asc-community/AngouriMath/issues/602).
             // Asserted the way Test1 and Test3 assert, against the method's own accuracy.
             Assert.True(MathS.Compute.DefiniteIntegral(expr, x, -1, 1).Abs() < 1e-15);
         }

--- a/Sources/Tests/UnitTests/Common/AlreadyFixedIssuesTest.cs
+++ b/Sources/Tests/UnitTests/Common/AlreadyFixedIssuesTest.cs
@@ -86,7 +86,8 @@ namespace AngouriMath.Tests.Common
 
         // https://github.com/asc-community/AngouriMath/issues/550
         // The reporter's small system did not solve. The 25x26 one from the same report
-        // is a question of scale and is tracked separately at #608.
+        // is a question of scale and is tracked separately at
+        // https://github.com/asc-community/AngouriMath/issues/608.
         [Fact]
         public void Issue550_SmallLinearSystemSolves()
         {

--- a/Sources/Tests/UnitTests/Common/NumericsRegressionTest.cs
+++ b/Sources/Tests/UnitTests/Common/NumericsRegressionTest.cs
@@ -70,7 +70,8 @@ namespace AngouriMath.Tests.Common
                 $"round-trip of {text} gave {back}");
         }
 
-        // Adjacent to #584: a zero integer part used to render as the empty string,
+        // Adjacent to https://github.com/asc-community/AngouriMath/issues/584:
+        // a zero integer part used to render as the empty string,
         // so ToBaseN(0.5m, 2) produced ".1" and ToBaseN(0m, 2) produced "".
         [Theory]
         [InlineData(0, 2, "0")]
@@ -171,7 +172,8 @@ namespace AngouriMath.Tests.Common
         // https://github.com/asc-community/AngouriMath/issues/561
         // The reporter's 4x4 matrix spans 1e5 to 1e50, so entries of its inverse fall
         // below 1e-16 and downcasting rounded them to zero. Fixed by the same change as
-        // #602; pinned here because the matrix path reaches it by its own route.
+        // https://github.com/asc-community/AngouriMath/issues/602;
+        // pinned here because the matrix path reaches it by its own route.
         [Fact]
         public void Issue561_LargeValuedMatrixInvertsExactly()
         {

--- a/Sources/Tests/UnitTests/PatternsTest/MultipleAngleTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/MultipleAngleTest.cs
@@ -30,7 +30,8 @@ namespace AngouriMath.Tests.PatternsTest
         // The same identity written as cos(2x) - (2cos(x)^2 - 1) gets as far as
         // 1 - cos(x)^2 - sin(x)^2 and stops: sin^2 + cos^2 = 1 is matched as a pair, and
         // there the pair sits either side of a subtraction. That is the same
-        // pairwise-versus-flattened gap as #531, in a product of trigonometric terms
+        // pairwise-versus-flattened gap as
+        // https://github.com/asc-community/AngouriMath/issues/531, in a product of trigonometric terms
         // rather than a sum, and is not something opening the angle can reach.
         [Fact]
         public void PythagoreanPairAcrossASubtractionIsStillMissed() =>


### PR DESCRIPTION
@Happypig375 asked for this — thanks for saying so.

A comment saying `#531` only resolves inside GitHub's own interface. Read from a checkout, from `git log`, or from an editor, it names neither the project nor anything reachable. On a pull request the shorthand is linked automatically, so it reads fine there; in a comment nothing links it.

Seven of these, all in comments I wrote:

| file | issue |
|---|---|
| `Patterns.ExpandFactorize.cs` | 531 |
| `Patterns.Trigonometry.cs` | 557 |
| `IntegrationTest.cs` | 602 |
| `AlreadyFixedIssuesTest.cs` | 608 |
| `NumericsRegressionTest.cs` | 584, 602 |
| `MultipleAngleTest.cs` | 531 |

The six that were already here — 327 three times in `InnerSimplifyTest`, 254 and 311 in `FractionSimplify`, 170 in `PatternTest` — are left alone, since they are not mine to restyle. Say the word and they can go the same way.

Comments only, no behaviour. 4009 unit tests, none failing. I have noted the convention and will follow it from here.