### PR TITLE
Say which infinity a quotient with a vanishing divisor tends to

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Limit.Classes.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Limit.Classes.cs
@@ -94,7 +94,15 @@ namespace AngouriMath
                             ({ } bas, { IsFinite: true } lim2) => (bas, lim2),
                             _ => (Dividend, Divisor)
                         };
-                    return ComputeLimitImpl(New(dividend, divisor), x, dist, side);
+                    var substituted = ComputeLimitImpl(New(dividend, divisor), x, dist, side);
+                    if (substituted is { } found && found.Evaled != MathS.NaN)
+                        return found;
+                    // Putting the two parts' limits in place of the parts loses the one thing
+                    // that decides a quotient whose divisor vanishes: 1 / 0 says nothing about
+                    // which side the divisor vanishes from, and so comes back NaN. Only where
+                    // nothing above answered, and whatever it did answer is kept if this finds
+                    // nothing better.
+                    return DivergesAtAVanishingDivisor(Dividend, Divisor, x, dist, side) ?? substituted;
                 }
             }
         }

--- a/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
@@ -82,6 +82,68 @@ namespace AngouriMath.Functions.Algebra
             => !IsInfiniteNode(expr) && expr != MathS.NaN;
 
         /// <summary>
+        /// How many derivatives of the divisor to take looking for the order at which it
+        /// vanishes. A divisor that is still flat after four of them is one whose sign this has
+        /// no cheap reading of, and reading it wrongly would answer +oo where the truth is -oo,
+        /// which is worse than not answering. The forms this is for vanish at the first order
+        /// (sin(x), e^x - 1, x - a) or the second (1 - cos(x), x^2).
+        /// </summary>
+        private const int MaxVanishingOrder = 4;
+
+        /// <summary>
+        /// The infinity a quotient tends to when its divisor vanishes and its dividend does not,
+        /// or <see langword="null"/> where that is not the shape or the side the divisor
+        /// vanishes from cannot be read off.
+        /// </summary>
+        /// <remarks>
+        /// The descent puts each part's own limit in place of the part, and for this shape that
+        /// throws away the only thing that decides the answer. <c>cos(x) / sin(x)</c> at 0
+        /// becomes <c>1 / 0</c>, which is NaN -- the claim that the limit does not exist -- where
+        /// on the right it is +oo and on the left -oo.
+        /// <para/>
+        /// The side the divisor vanishes from is read off its first derivative that does not
+        /// vanish with it. Where <c>g(a) = 0</c> and the first non-vanishing derivative there is
+        /// the k-th, <c>g(x)</c> has the sign of <c>g_k(a) * (x - a)^k</c> near a, which is the
+        /// sign of <c>g_k(a)</c> on the right and that times <c>(-1)^k</c> on the left. Nothing
+        /// is claimed unless a derivative comes out finite and non-zero at the point: an
+        /// expression that is not differentiable there, or whose derivative diverges as
+        /// <c>sqrt(x)</c>'s does, is left alone.
+        /// </remarks>
+        internal static Entity? DivergesAtAVanishingDivisor(Entity dividend, Entity divisor, Variable x, Entity dest, ApproachFrom side)
+        {
+            if (side is not (ApproachFrom.Left or ApproachFrom.Right) || !dest.IsFinite || !divisor.ContainsNode(x))
+                return null;
+            if (EvalAssumingContinuous(divisor.Limit(x, dest, side)) is not Real { IsZero: true })
+                return null;
+            // A dividend that vanishes too makes the quotient indeterminate rather than
+            // divergent, and one that diverges is a different question again. Only a dividend
+            // with a definite non-zero size leaves the divisor to decide the answer.
+            if (EvalAssumingContinuous(dividend.Limit(x, dest, side)) is not Real { IsFinite: true, IsZero: false } dividendLimit)
+                return null;
+
+            var derivative = divisor;
+            for (var order = 1; order <= MaxVanishingOrder; order++)
+            {
+                MultithreadingFunctional.ExitIfCancelled();
+                derivative = derivative.Differentiate(x).Simplify();
+                var atThePoint = EvalAssumingContinuous(derivative.Substitute(x, dest).InnerSimplified);
+                if (atThePoint is not Real { IsFinite: true } value)
+                    return null;
+                if (value.IsZero)
+                    continue;
+                // (x - a)^k is positive on the right whatever k is, and on the left it takes the
+                // sign of (-1)^k, so approaching from the left at an odd order turns the sign of
+                // the derivative around and nothing else does.
+                var turnsAround = side is ApproachFrom.Left && order % 2 != 0;
+                var divisorIsPositive = value.IsNegative == turnsAround;
+                return dividendLimit.IsNegative == divisorIsPositive
+                    ? Real.NegativeInfinity
+                    : Real.PositiveInfinity;
+            }
+            return null;
+        }
+
+        /// <summary>
         /// How deep the rule may be applied to one limit. Differentiating both parts does not
         /// always make the quotient simpler -- x / sqrt(x^2 + 1) turns into sqrt(x^2 + 1) / x,
         /// which turns back, so the two stay indeterminate forever -- and without a bound the

--- a/Sources/Tests/UnitTests/Calculus/VanishingDenominatorTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/VanishingDenominatorTest.cs
@@ -1,0 +1,115 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Core;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// A quotient whose divisor vanishes while its dividend does not. The descent puts each
+    /// part's own limit in place of the part, and 1 / 0 says nothing about which side the
+    /// divisor vanishes from, so cos(x) / sin(x) at 0 came out as NaN -- the claim that the
+    /// limit does not exist -- where on the right it is +oo and on the left -oo. Only 1 / x and
+    /// the other quotients of polynomials escaped it, because those the solvers read outright
+    /// once x has been moved out to infinity.
+    /// </summary>
+    public sealed class VanishingDenominatorTest
+    {
+        private static void AssertLimit(string expression, string destination, ApproachFrom side, string expected) =>
+            Assert.Equal(
+                expected.ToEntity().Evaled,
+                expression.ToEntity().Limit("x", destination.ToEntity(), side).Evaled);
+
+        /// <summary>
+        /// A divisor whose first derivative does not vanish at the point takes the sign of that
+        /// derivative on the right and the opposite on the left.
+        /// </summary>
+        [Theory]
+        [InlineData("1 / sin(x)", "0", ApproachFrom.Right, "+oo")]
+        [InlineData("1 / sin(x)", "0", ApproachFrom.Left, "-oo")]
+        [InlineData("-1 / sin(x)", "0", ApproachFrom.Right, "-oo")]
+        [InlineData("-1 / sin(x)", "0", ApproachFrom.Left, "+oo")]
+        [InlineData("cos(x) / sin(x)", "0", ApproachFrom.Right, "+oo")]
+        [InlineData("cos(x) / sin(x)", "0", ApproachFrom.Left, "-oo")]
+        [InlineData("1 / tan(x)", "0", ApproachFrom.Right, "+oo")]
+        [InlineData("1 / tan(x)", "0", ApproachFrom.Left, "-oo")]
+        [InlineData("-2 / (e ^ x - 1)", "0", ApproachFrom.Right, "-oo")]
+        [InlineData("-2 / (e ^ x - 1)", "0", ApproachFrom.Left, "+oo")]
+        [InlineData("2 / ln(x)", "1", ApproachFrom.Right, "+oo")]
+        [InlineData("2 / ln(x)", "1", ApproachFrom.Left, "-oo")]
+        public void AFirstOrderZeroTurnsTheSignAroundOnTheLeft(string expression, string destination, ApproachFrom side, string expected) =>
+            AssertLimit(expression, destination, side, expected);
+
+        /// <summary>
+        /// An even order does not: (x - a)^k is positive on both sides of a. 1 - cos(x) is flat
+        /// at 0 and curves upward, so 1 / (1 - cos(x)) is +oo whichever way 0 is approached --
+        /// and so the two-sided limit exists as well.
+        /// </summary>
+        [Theory]
+        [InlineData("1 / (1 - cos(x))", "0", ApproachFrom.Right, "+oo")]
+        [InlineData("1 / (1 - cos(x))", "0", ApproachFrom.Left, "+oo")]
+        [InlineData("3 / (sin(x) - 1)", "pi / 2", ApproachFrom.Right, "-oo")]
+        [InlineData("3 / (sin(x) - 1)", "pi / 2", ApproachFrom.Left, "-oo")]
+        public void AnEvenOrderZeroLooksTheSameFromEitherSide(string expression, string destination, ApproachFrom side, string expected) =>
+            AssertLimit(expression, destination, side, expected);
+
+        /// <summary>
+        /// And an odd order beyond the first turns it around again.
+        /// </summary>
+        [Theory]
+        [InlineData("1 / x ^ 3", "0", ApproachFrom.Right, "+oo")]
+        [InlineData("1 / x ^ 3", "0", ApproachFrom.Left, "-oo")]
+        [InlineData("cos(x) / (x - 1) ^ 3", "1", ApproachFrom.Right, "+oo")]
+        [InlineData("cos(x) / (x - 1) ^ 3", "1", ApproachFrom.Left, "-oo")]
+        public void AnOddOrderTurnsItAroundAgain(string expression, string destination, ApproachFrom side, string expected) =>
+            AssertLimit(expression, destination, side, expected);
+
+        [Theory]
+        [InlineData("1 / (1 - cos(x))", "0", "+oo")]
+        [InlineData("1 / x ^ 2", "0", "+oo")]
+        public void ATwoSidedLimitFollowsWhereBothSidesAgree(string expression, string destination, string expected) =>
+            Assert.Equal(
+                expected.ToEntity().Evaled,
+                expression.ToEntity().Limit("x", destination.ToEntity()).Evaled);
+
+        /// <summary>
+        /// Where the two sides disagree there is no two-sided limit, and NaN is the right answer
+        /// rather than the absence of one. These have to keep saying so.
+        /// </summary>
+        [Theory]
+        [InlineData("1 / sin(x)", "0")]
+        [InlineData("cos(x) / sin(x)", "0")]
+        [InlineData("1 / x", "0")]
+        [InlineData("1 / x ^ 3", "0")]
+        public void TwoSidesThatDisagreeStillHaveNoLimit(string expression, string destination) =>
+            Assert.Equal(
+                MathS.NaN.Evaled,
+                expression.ToEntity().Limit("x", destination.ToEntity()).Evaled);
+
+        /// <summary>
+        /// Nothing is claimed where the shape is not this one. A dividend that vanishes too
+        /// makes the quotient indeterminate rather than divergent, and a divisor that is not
+        /// differentiable at the point -- or whose derivative diverges there, as sqrt(x)'s does
+        /// -- is left alone.
+        /// </summary>
+        [Theory]
+        [InlineData("(x ^ 2 - 1) / (x - 1)", "1", ApproachFrom.Left, "2")]
+        [InlineData("1 / x", "0", ApproachFrom.Right, "+oo")]
+        [InlineData("1 / x", "0", ApproachFrom.Left, "-oo")]
+        [InlineData("1 / (x - 2)", "2", ApproachFrom.Right, "+oo")]
+        [InlineData("1 / (x - 2)", "2", ApproachFrom.Left, "-oo")]
+        [InlineData("(x ^ 2 - 1) / (x - 1)", "1", ApproachFrom.Right, "2")]
+        [InlineData("x / (x + 1)", "0", ApproachFrom.Right, "0")]
+        [InlineData("1 / x", "+oo", ApproachFrom.Left, "0")]
+        [InlineData("x ^ 2 / (x ^ 2 + 1)", "+oo", ApproachFrom.Left, "1")]
+        public void EstablishedLimitsAreUnaffected(string expression, string destination, ApproachFrom side, string expected) =>
+            AssertLimit(expression, destination, side, expected);
+    }
+}


### PR DESCRIPTION
`limitright(cos(x) / sin(x), x, 0)` answers NaN. It is +oo. From the left it is -oo, and that is NaN too.

The descent puts each part's own limit in place of the part, so the quotient becomes `1 / 0` — which says nothing about *which side* the divisor vanishes from, and comes back NaN. NaN is not "I could not tell"; it is the claim that the limit does not exist.

`1 / x` escapes this, which is why the gap is easy to miss: once x is moved out to infinity that one is a quotient of polynomials and the solvers read it outright. Anything whose divisor is not a polynomial — `sin(x)`, `tan(x)`, `e^x - 1`, `ln(x)` at 1 — fell through.

## How the side is read

Off the divisor's first derivative that does not vanish with it. Where `g(a) = 0` and the first non-vanishing derivative there is the k-th, `g(x)` has the sign of `g_k(a) * (x - a)^k` near a — so the sign of `g_k(a)` on the right, and that times `(-1)^k` on the left.

That covers the first order (`sin(x)`, `e^x - 1`, `x - a`) and the second (`1 - cos(x)`, `sin(x) - 1` at pi/2). An even order looks the same from both sides, so `1 / (1 - cos(x))` gains a two-sided limit of +oo as well.

**Nothing is claimed unless a derivative comes out finite and non-zero at the point.** An expression that is not differentiable there, or whose derivative diverges as `sqrt(x)`'s does, is left alone rather than guessed at — reading the sign wrongly would answer +oo where the truth is -oo, which is worse than not answering at all. Four derivatives is as far as it looks.

## What it answers

| | before | after (right / left) |
|---|---|---|
| `1 / sin(x)` at 0 | NaN / NaN | +oo / -oo |
| `cos(x) / sin(x)` at 0 | NaN / NaN | +oo / -oo |
| `1 / tan(x)` at 0 | NaN / NaN | +oo / -oo |
| `-2 / (e^x - 1)` at 0 | NaN / NaN | -oo / +oo |
| `2 / ln(x)` at 1 | NaN / NaN | +oo / -oo |
| `1 / x^3` at 0 | NaN / NaN | +oo / -oo |
| `cos(x) / (x - 1)^3` at 1 | NaN / NaN | +oo / -oo |
| `1 / (1 - cos(x))` at 0 | NaN / NaN | +oo / +oo, and +oo two-sided |
| `3 / (sin(x) - 1)` at pi/2 | NaN / NaN | -oo / -oo |

17 of the 35 new tests fail without the change.

The cases where the two sides genuinely disagree keep saying so: `1 / sin(x)` and `1 / x^3` at 0 still have no two-sided limit, and there are tests pinning that, because turning a correct NaN into a wrong infinity is the failure mode this change could have had.

## Cost

Reached only where the substitution above answered nothing or NaN, so it costs nothing on any path that already worked, and whatever that answered is kept if this finds nothing better.

## Measurements

- Suite: `Failed: 0, Passed: 4044, Skipped: 14, Total: 4058`.
- A 117-problem corpus of simplifications, solves, integrals and limits: unchanged at 101/117 solved, 0 wrong / 0 error / 0 timeout, measured with and without the change on this branch.

Independent of my other open PRs; `git merge-tree` reports no conflict with any of them. It does compose with #697 — with both, `sin(x) / (1 - cos(x))` at 0 answers +oo on the right and -oo on the left, since l'Hopital's rule turns it into `cos(x) / sin(x)` and this reads that. On this branch alone it is still NaN.

Fork CI to follow in a comment.