### PR TITLE
Drop MyGet, and the deprecation notice

### DIFF
--- a/.github/workflows/Nuget.yml
+++ b/.github/workflows/Nuget.yml
@@ -1,11 +1,6 @@
-name: 'Upload to MyGet and NuGet'
-
-run-name: ${{ github.event_name == 'push' && 'Upload to MyGet' || 'Upload to NuGet' }}
+name: 'Upload to NuGet'
 
 on:
-  push:
-    branches:
-      - master
   release:
     types: [published]
 
@@ -23,49 +18,31 @@ jobs:
           
       - uses: actions/checkout@v6
         
-      - name: 'Determine version and target'
+      - name: 'Determine version'
         id: version
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            # MyGet versioning
-            commithash=$(git rev-parse --short HEAD)
-            currtime=$(date +%s)
-            echo "commit hash is $commithash"
-            echo "time is $currtime"
-            version=10.0.0-master-$currtime-$commithash
-            echo "version is $version"
-            echo "version=$version" >> $GITHUB_OUTPUT
-            echo "apikey=${{ secrets.MYGET_KEY }}" >> $GITHUB_OUTPUT
-            echo "source=myget" >> $GITHUB_OUTPUT
-            echo "target=MyGet" >> $GITHUB_OUTPUT
-          else
-            # NuGet versioning from release tag
-            tagname="${{ github.event.release.tag_name }}"
-            
-            # Validate tag name exists
-            if [[ -z "$tagname" ]]; then
-              echo "Error: Release tag name is empty"
-              exit 1
-            fi
-            
-            # Remove 'v' prefix if present (e.g., v1.0.0 -> 1.0.0)
-            version="${tagname#v}"
-            echo "Release tag is $tagname"
-            echo "Package version is $version"
-            
-            # Validate version format (SemVer 2.0.0: X.Y.Z[-prerelease][+build])
-            if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
-              echo "Error: Invalid version format '$version'."
-              echo "Expected semantic version (e.g., 1.0.0, 1.0.0-beta.1, 1.0.0+build.123)"
-              exit 1
-            fi
-            
-            echo "version=$version" >> $GITHUB_OUTPUT
-            echo "apikey=${{ secrets.NUGET_KEY }}" >> $GITHUB_OUTPUT
-            echo "source=nuget.org" >> $GITHUB_OUTPUT
-            echo "target=NuGet" >> $GITHUB_OUTPUT
+          tagname="${{ github.event.release.tag_name }}"
+
+          # Validate tag name exists
+          if [[ -z "$tagname" ]]; then
+            echo "Error: Release tag name is empty"
+            exit 1
           fi
-        
+
+          # Remove 'v' prefix if present (e.g., v1.0.0 -> 1.0.0)
+          version="${tagname#v}"
+          echo "Release tag is $tagname"
+          echo "Package version is $version"
+
+          # Validate version format (SemVer 2.0.0: X.Y.Z[-prerelease][+build])
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "Error: Invalid version format '$version'."
+            echo "Expected semantic version (e.g., 1.0.0, 1.0.0-beta.1, 1.0.0+build.123)"
+            exit 1
+          fi
+
+          echo "version=$version" >> $GITHUB_OUTPUT
+
       - name: 'Pack and publish AngouriMath'
         run: |
           cd Sources/AngouriMath
@@ -73,7 +50,7 @@ jobs:
           dotnet build AngouriMath.csproj -c release
           dotnet pack AngouriMath.csproj -c release -p:PackageVersion=${{ steps.version.outputs.version }}
           cd bin/release
-          dotnet nuget push AngouriMath.${{ steps.version.outputs.version }}.nupkg --api-key ${{ steps.version.outputs.apikey }} --source "${{ steps.version.outputs.source }}"
+          dotnet nuget push AngouriMath.${{ steps.version.outputs.version }}.nupkg --api-key ${{ secrets.NUGET_KEY }} --source nuget.org
           
       - name: 'Pack and publish AngouriMath.FSharp'
         run: |
@@ -82,7 +59,7 @@ jobs:
           dotnet build -c Release
           dotnet pack -c Release -p:PackageVersion=${{ steps.version.outputs.version }}
           cd bin/Release
-          dotnet nuget push AngouriMath.FSharp.${{ steps.version.outputs.version }}.nupkg --api-key ${{ steps.version.outputs.apikey }} --source "${{ steps.version.outputs.source }}"
+          dotnet nuget push AngouriMath.FSharp.${{ steps.version.outputs.version }}.nupkg --api-key ${{ secrets.NUGET_KEY }} --source nuget.org
           
       - name: 'Pack and publish AngouriMath.Interactive'
         run: |
@@ -91,7 +68,7 @@ jobs:
           dotnet build -c Release
           dotnet pack -c Release -p:PackageVersion=${{ steps.version.outputs.version }}
           cd bin/Release
-          dotnet nuget push AngouriMath.Interactive.${{ steps.version.outputs.version }}.nupkg --api-key ${{ steps.version.outputs.apikey }} --source "${{ steps.version.outputs.source }}"
+          dotnet nuget push AngouriMath.Interactive.${{ steps.version.outputs.version }}.nupkg --api-key ${{ secrets.NUGET_KEY }} --source nuget.org
           
       - name: 'Pack and publish AngouriMath.Terminal'
         run: |
@@ -100,4 +77,4 @@ jobs:
           dotnet build -c Release
           dotnet pack -c Release -p:PackageVersion=${{ steps.version.outputs.version }}
           cd bin/Release
-          dotnet nuget push AngouriMath.Terminal.${{ steps.version.outputs.version }}.nupkg --api-key ${{ steps.version.outputs.apikey }} --source "${{ steps.version.outputs.source }}"
+          dotnet nuget push AngouriMath.Terminal.${{ steps.version.outputs.version }}.nupkg --api-key ${{ secrets.NUGET_KEY }} --source nuget.org

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <br>
   <a href="https://dotnetfiddle.net/u901sI"><img src="https://img.shields.io/static/v1?label=Fiddle&message=Try%21&color=purple&style=flat&logo=.NET&labelColor=646"></a>
   <a href="https://mybinder.org/v2/gh/asc-community/AngouriMathLab/try"><img src="https://img.shields.io/static/v1?label=Jupyter&message=Try%21&color=purple&style=flat&logo=Jupyter&labelColor=646"></a>
-  <a href="https://matrix.to/#/#angourimath:matrix.org"><img alt="Join Matrix Chat" src="https://img.shields.io/badge/chat%20with%20us-7eb7e2?logo=matrix&style=flat&labelColor=474&logoColor=white&color=252"></a> 
+  <a href="https://discord.gg/YWJEX7a"><img alt="Join our Discord" src="https://img.shields.io/discord/642350046213439489?label=chat%20with%20us&logo=discord&style=flat&labelColor=474&logoColor=white&color=252"></a> 
   <a href="https://github.com/quozd/awesome-dotnet"><img src="https://awesome.re/mentioned-badge.svg"></a>
   
 </p>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-> [!WARNING]
-> AngouriMath is no longer actively maintained. You can still use it, but there won't be active development anymore (full story at [wbg.gg](https://wbg.gg/blog/angourimath-deprecation)). Feel free to submit pull requests though.
-
 <p align="center">
   <a href="https://github.com/asc-community/AngouriMath">
     <img src="./.github/additional/readme/icon_white.png" alt="AngouriMath logo" width="200" height="200">

--- a/README.md
+++ b/README.md
@@ -58,18 +58,6 @@ Note, that all tests and builds are tested for the following three operating sys
 | Terminal | <a href="https://www.nuget.org/packages/AngouriMath.Terminal"><img alt="Nuget (with prereleases)" src="https://img.shields.io/nuget/vpre/AngouriMath.Terminal?color=blue&label=NuGet&logo=nuget&style=flat-square"></a> | <a href="https://www.nuget.org/packages/AngouriMath.Terminal"><img alt="Nuget" src="https://img.shields.io/nuget/v/AngouriMath.Terminal?color=blue&label=NuGet&logo=nuget&style=flat-square"></a> | <a href="https://www.nuget.org/packages/AngouriMath.Terminal"><img alt="Nuget" src="https://img.shields.io/nuget/dt/AngouriMath.Terminal?color=darkblue&label=Downloads&style=flat-square"></a> |
 | C++ | <img alt="GitHub release (latest SemVer including pre-releases)" src="https://img.shields.io/github/v/release/asc-community/AngouriMathLab?include_prereleases&label=GH%20Releases"> | WIP | WIP |
 
-There are also latest-master versions (updated on every push to master) on [MyGet](https://www.myget.org/feed/Packages/angourimath):
-| MyGet | Downloads |
-|-------|-----------|
-| [![MyGet (with prereleases)](https://img.shields.io/myget/angourimath/vpre/AngouriMath?label=AngouriMath)](https://www.myget.org/feed/angourimath/package/nuget/AngouriMath) | ![MyGet](https://img.shields.io/myget/angourimath/dt/AngouriMath?label=Downloads) |
-| [![MyGet (with prereleases)](https://img.shields.io/myget/angourimath/vpre/AngouriMath.FSharp?label=AngouriMath.FSharp)](https://www.myget.org/feed/angourimath/package/nuget/AngouriMath.FSharp) | ![MyGet](https://img.shields.io/myget/angourimath/dt/AngouriMath.FSharp?label=Downloads) |
-| [![MyGet (with prereleases)](https://img.shields.io/myget/angourimath/vpre/AngouriMath.Interactive?label=AngouriMath.Interactive)](https://www.myget.org/feed/angourimath/package/nuget/AngouriMath.Interactive) | ![MyGet](https://img.shields.io/myget/angourimath/dt/AngouriMath.Interactive?label=Downloads) |
-| [![MyGet (with prereleases)](https://img.shields.io/myget/angourimath/vpre/AngouriMath.Terminal?label=AngouriMath.Terminal)](https://www.myget.org/feed/angourimath/package/nuget/AngouriMath.Terminal) | ![MyGet](https://img.shields.io/myget/angourimath/dt/AngouriMath.Terminal?label=Downloads) |
-  
-Source to install from MyGet:
-```
-https://www.myget.org/F/angourimath/api/v3/index.json  
-```
   
 #### Other info
 | Website | Stars | License |

--- a/Sources/NuGet.Config
+++ b/Sources/NuGet.Config
@@ -6,6 +6,5 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-experimental" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="myget" value="https://www.myget.org/F/angourimath/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Two things the maintainers asked for.

**MyGet goes.** The workflow no longer publishes a per-push `10.0.0-master-<time>-<hash>` build to MyGet; it now only publishes to NuGet on a release, which is all it does. The feed comes out of `Sources/NuGet.Config` so restores stop reaching for it, and the badge table comes out of the README so nothing advertises a feed that will stop being fed. NuGet publishing is untouched — same packages, same versioning from the release tag, same `NUGET_KEY`.

The version-determining step loses its branch: there is only one path now, so the `if push / else release` disappears and the api key and source are named directly instead of being passed through step outputs.

**The deprecation notice goes.** `AngouriMath is no longer actively maintained` is no longer true. This closes #635, which asks about exactly that.