### PR TITLE
Let Modf ask for the remainder rather than computing it

### DIFF
--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Arithmetics.Classes.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Arithmetics.Classes.cs
@@ -105,30 +105,6 @@ namespace AngouriMath
             // Like division, undefined when the divisor is zero
             private protected override Entity IntrinsicCondition => !Divisor.EqualTo(0);
 
-            /// <summary>
-            /// The remainder of the floored division, a - b * floor(a / b), which takes the sign
-            /// of the divisor: -7 mod 3 is 2, and 7 mod -3 is -2.
-            /// </summary>
-            /// <remarks>
-            /// This is what a mathematician means by mod. It is the convention under which the
-            /// residues modulo n are the numbers from 0 to n - 1, which is the whole point of
-            /// the operation in number theory, and it is what the other systems answer: SymPy,
-            /// Mathematica and Maxima all give 2 for -7 mod 3. C and the languages descended
-            /// from it truncate instead and so answer -1, but their % is an operation on
-            /// machine integers, not this one.
-            /// <para/>
-            /// Built from the truncated remainder rather than from a floor, since there is no
-            /// floor in this library: the two differ by exactly one divisor, and only where the
-            /// remainder and the divisor disagree in sign.
-            /// </remarks>
-            private static Real FlooredRemainder(Real a, Real b)
-            {
-                var truncated = a % b;
-                return truncated == 0 || truncated.IsNegative == b.IsNegative
-                    ? truncated
-                    : (Real)(truncated + b);
-            }
-
             /// <inheritdoc/>
             protected override Entity InnerSimplify(bool isExact) =>
                 ExpandOnTwoArguments(Dividend, Divisor,
@@ -137,7 +113,13 @@ namespace AngouriMath
                     (_, Integer(0)) => Real.NaN,
                     // Only for reals: the remainder of a complex number by another is not
                     // one thing, and guessing at it would be worse than leaving it alone.
-                    (Real n1, Real n2) when !isExact => FlooredRemainder(n1, n2),
+                    //
+                    // The operator is the floored remainder, which is this node's own reading of
+                    // mod, so there is nothing left here to do by hand. It was not always: until
+                    // https://github.com/asc-community/AngouriMath/issues/708 the three numeric
+                    // types answered % three different ways, and this had to compute the answer
+                    // rather than ask for it.
+                    (Real n1, Real n2) when !isExact => n1 % n2,
                     (Integer(0), var n0) =>
                         n0.Evaled is Complex c
                         ? c.IsZero ? MathS.NaN : 0


### PR DESCRIPTION
The follow-up I promised on #703.

`Modf` carried a private `FlooredRemainder` because, at the time it was written, the three numeric `%` operators each answered differently and none of them was the floored remainder the node wanted — `Integer` threw on a negative divisor, `Real` truncated, `Rational` was wrong. Since #708 landed they all are, so the helper now says by hand exactly what the operator says, and the switch goes back to `n1 % n2`.

Net -15 lines, no behaviour change. Suite `Failed: 0, Passed: 4667, Skipped: 14, Total: 4681`, with the 70 modulus tests from #703 and #709 passing unchanged — which is the point: they pin the four sign pairs, so if the operator and the helper had disagreed anywhere, they would say so.

First PR from a branch on this repository rather than from my fork, now that the fork has served its purpose.