### PR TITLE
Put quotients of polynomials into lowest terms (#55)

### DIFF
--- a/Sources/AngouriMath/Functions/Simplification/MultivariatePolynomial.cs
+++ b/Sources/AngouriMath/Functions/Simplification/MultivariatePolynomial.cs
@@ -1,0 +1,459 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using PeterO.Numbers;
+using System;
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// A polynomial in several variables over the rationals, stored sparsely.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The coefficient domain is deliberately only <c>Q</c>. A polynomial whose
+    /// coefficients are arbitrary expressions is not one this can reason about: deciding
+    /// whether <c>sqrt(2) - a</c> is zero is as hard as the problem that sent us here, and
+    /// a divisor wrongly believed nonzero produces a wrong cancellation rather than a
+    /// missing one. Anything outside <c>Q</c> is refused at the door by
+    /// <see cref="TryParse"/>.
+    /// </para>
+    /// <para>
+    /// An exponent vector is packed into one <see cref="ulong"/>, a byte to a variable,
+    /// the first variable in the most significant byte. Comparing packed monomials is then
+    /// exactly the lexicographic order on exponents that <see cref="DivideExact"/> needs,
+    /// and looking a monomial up costs one hash.
+    /// </para>
+    /// </remarks>
+    internal sealed class MultivariatePolynomial
+    {
+        /// <summary>One byte of the packed monomial each, so eight of them fit.</summary>
+        internal const int MaxVariables = 8;
+
+        /// <summary>
+        /// Multiplying two monomials adds their exponents, so half of what a byte holds is
+        /// the most a single exponent may carry if the sum is to stay in its byte.
+        /// </summary>
+        internal const int MaxDegree = 127;
+
+        /// <summary>
+        /// Past this an intermediate result is refused rather than paid for. Nothing here
+        /// is asked a question worth thousands of monomials, and the simplifier runs it on
+        /// every quotient it passes.
+        /// </summary>
+        internal const int MaxTerms = 512;
+
+        private const int BitsPerVariable = 8;
+        private const ulong PowerMask = 0xFF;
+
+        /// <summary>Monomial to its coefficient. A zero coefficient is never stored.</summary>
+        private readonly Dictionary<ulong, ERational> terms;
+
+        internal int VariableCount { get; }
+
+        private MultivariatePolynomial(int variableCount, Dictionary<ulong, ERational> terms)
+        {
+            VariableCount = variableCount;
+            this.terms = terms;
+        }
+
+        internal static MultivariatePolynomial Zero(int variableCount)
+            => new(variableCount, new Dictionary<ulong, ERational>());
+
+        internal static MultivariatePolynomial Constant(int variableCount, ERational value)
+        {
+            var terms = new Dictionary<ulong, ERational>();
+            if (!value.IsZero)
+                terms[0] = value.ToLowestTerms();
+            return new(variableCount, terms);
+        }
+
+        internal static MultivariatePolynomial One(int variableCount)
+            => Constant(variableCount, ERational.One);
+
+        internal static MultivariatePolynomial Monomial(int variableCount, int variable)
+            => new(variableCount, new Dictionary<ulong, ERational> { [Pack(variable, 1)] = ERational.One });
+
+        internal bool IsZero => terms.Count == 0;
+
+        internal bool IsConstant => terms.Count == 0 || (terms.Count == 1 && terms.ContainsKey(0));
+
+        internal int TermCount => terms.Count;
+
+        private static int ShiftOf(int variable) => (MaxVariables - 1 - variable) * BitsPerVariable;
+
+        private static int PowerOf(ulong monomial, int variable)
+            => (int)((monomial >> ShiftOf(variable)) & PowerMask);
+
+        private static ulong Pack(int variable, int power) => (ulong)power << ShiftOf(variable);
+
+        private static ulong Without(ulong monomial, int variable) => monomial & ~Pack(variable, (int)PowerMask);
+
+        /// <summary>
+        /// The highest power of <paramref name="variable"/> occurring. Zero both for a
+        /// polynomial free of it and for the zero polynomial, so callers to which the
+        /// difference matters test <see cref="IsZero"/> first.
+        /// </summary>
+        internal int DegreeIn(int variable)
+        {
+            var degree = 0;
+            foreach (var monomial in terms.Keys)
+            {
+                var power = PowerOf(monomial, variable);
+                if (power > degree)
+                    degree = power;
+            }
+            return degree;
+        }
+
+        /// <summary>The greatest monomial in lexicographic order; zero if there is none.</summary>
+        private ulong LeadingMonomial()
+        {
+            ulong leading = 0;
+            foreach (var monomial in terms.Keys)
+                if (monomial > leading)
+                    leading = monomial;
+            return leading;
+        }
+
+        internal MultivariatePolynomial Add(MultivariatePolynomial other) => Combine(other, subtract: false);
+
+        internal MultivariatePolynomial Subtract(MultivariatePolynomial other) => Combine(other, subtract: true);
+
+        private MultivariatePolynomial Combine(MultivariatePolynomial other, bool subtract)
+        {
+            var result = new Dictionary<ulong, ERational>(terms);
+            foreach (var term in other.terms)
+                Accumulate(result, term.Key, subtract ? term.Value.Negate() : term.Value);
+            return new(VariableCount, result);
+        }
+
+        private static void Accumulate(Dictionary<ulong, ERational> into, ulong monomial, ERational value)
+        {
+            if (!into.TryGetValue(monomial, out var existing))
+            {
+                if (!value.IsZero)
+                    into[monomial] = value;
+                return;
+            }
+            var sum = existing.Add(value).ToLowestTerms();
+            if (sum.IsZero)
+                into.Remove(monomial);
+            else
+                into[monomial] = sum;
+        }
+
+        internal MultivariatePolynomial? Multiply(MultivariatePolynomial other)
+        {
+            if (IsZero || other.IsZero)
+                return Zero(VariableCount);
+            var result = new Dictionary<ulong, ERational>();
+            foreach (var left in terms)
+                foreach (var right in other.terms)
+                {
+                    if (!TryMultiplyMonomials(left.Key, right.Key, VariableCount, out var monomial))
+                        return null;
+                    Accumulate(result, monomial, left.Value.Multiply(right.Value).ToLowestTerms());
+                    if (result.Count > MaxTerms)
+                        return null;
+                }
+            return new(VariableCount, result);
+        }
+
+        internal MultivariatePolynomial? Power(int exponent)
+        {
+            if (exponent < 0 || exponent > MaxDegree)
+                return null;
+            var result = One(VariableCount);
+            var square = this;
+            while (exponent > 0)
+            {
+                if ((exponent & 1) == 1)
+                {
+                    if (result.Multiply(square) is not { } multiplied)
+                        return null;
+                    result = multiplied;
+                }
+                exponent >>= 1;
+                if (exponent == 0)
+                    break;
+                if (square.Multiply(square) is not { } squared)
+                    return null;
+                square = squared;
+            }
+            return result;
+        }
+
+        internal MultivariatePolynomial ScaleBy(ERational factor)
+        {
+            if (factor.IsZero)
+                return Zero(VariableCount);
+            var result = new Dictionary<ulong, ERational>(terms.Count);
+            foreach (var term in terms)
+                result[term.Key] = term.Value.Multiply(factor).ToLowestTerms();
+            return new(VariableCount, result);
+        }
+
+        /// <summary>Multiplied by <c>variable ^ power</c>.</summary>
+        internal MultivariatePolynomial? ShiftedBy(int variable, int power)
+        {
+            if (power == 0)
+                return this;
+            var result = new Dictionary<ulong, ERational>(terms.Count);
+            foreach (var term in terms)
+            {
+                var raised = PowerOf(term.Key, variable) + power;
+                if (raised > MaxDegree)
+                    return null;
+                result[Without(term.Key, variable) | Pack(variable, raised)] = term.Value;
+            }
+            return new(VariableCount, result);
+        }
+
+        /// <summary>
+        /// Read as a polynomial in <paramref name="variable"/> alone: the power of that
+        /// variable mapped to the coefficient, itself a polynomial in the others.
+        /// </summary>
+        internal Dictionary<int, MultivariatePolynomial> CoefficientsIn(int variable)
+        {
+            var buckets = new Dictionary<int, Dictionary<ulong, ERational>>();
+            foreach (var term in terms)
+            {
+                var power = PowerOf(term.Key, variable);
+                if (!buckets.TryGetValue(power, out var bucket))
+                    buckets[power] = bucket = new Dictionary<ulong, ERational>();
+                bucket[Without(term.Key, variable)] = term.Value;
+            }
+            var result = new Dictionary<int, MultivariatePolynomial>(buckets.Count);
+            foreach (var bucket in buckets)
+                result[bucket.Key] = new(VariableCount, bucket.Value);
+            return result;
+        }
+
+        internal MultivariatePolynomial LeadingCoefficientIn(int variable)
+        {
+            var degree = DegreeIn(variable);
+            var result = new Dictionary<ulong, ERational>();
+            foreach (var term in terms)
+                if (PowerOf(term.Key, variable) == degree)
+                    result[Without(term.Key, variable)] = term.Value;
+            return new(VariableCount, result);
+        }
+
+        /// <summary>
+        /// <paramref name="divisor"/> divided out, or <see langword="null"/> when it does
+        /// not divide exactly.
+        /// </summary>
+        /// <remarks>
+        /// The leading term in lexicographic order is cancelled at each step, which lowers
+        /// it strictly, so the loop terminates; when the divisor really divides, its
+        /// leading term divides the leading term of what is left every time, and what
+        /// remains at the end is zero. Anything else — a leading term that will not divide,
+        /// or a remainder that never reaches zero — is the answer that it does not divide.
+        /// That is the check the caller relies on: nothing is cancelled that has not been
+        /// divided out and seen to leave nothing behind.
+        /// </remarks>
+        internal MultivariatePolynomial? DivideExact(MultivariatePolynomial divisor)
+        {
+            if (divisor.IsZero)
+                return null;
+            if (IsZero)
+                return Zero(VariableCount);
+            if (divisor.IsConstant)
+                return ScaleBy(ERational.One.Divide(divisor.terms[0]));
+
+            var divisorLead = divisor.LeadingMonomial();
+            var divisorValue = divisor.terms[divisorLead];
+            var quotient = new Dictionary<ulong, ERational>();
+            var rest = this;
+            for (var step = 0; step <= MaxTerms; step++)
+            {
+                if (rest.IsZero)
+                    return new(VariableCount, quotient);
+                var lead = rest.LeadingMonomial();
+                if (!TryDivideMonomials(lead, divisorLead, VariableCount, out var monomial))
+                    return null;
+                var value = rest.terms[lead].Divide(divisorValue).ToLowestTerms();
+                quotient[monomial] = value;
+                if (divisor.MultiplyByTerm(monomial, value) is not { } product)
+                    return null;
+                rest = rest.Subtract(product);
+                if (rest.TermCount > MaxTerms)
+                    return null;
+            }
+            return null;
+        }
+
+        private MultivariatePolynomial? MultiplyByTerm(ulong monomial, ERational value)
+        {
+            var result = new Dictionary<ulong, ERational>(terms.Count);
+            foreach (var term in terms)
+            {
+                if (!TryMultiplyMonomials(term.Key, monomial, VariableCount, out var product))
+                    return null;
+                result[product] = term.Value.Multiply(value).ToLowestTerms();
+            }
+            return new(VariableCount, result);
+        }
+
+        private static bool TryMultiplyMonomials(ulong left, ulong right, int variableCount, out ulong product)
+        {
+            product = 0;
+            for (var i = 0; i < variableCount; i++)
+            {
+                var power = PowerOf(left, i) + PowerOf(right, i);
+                if (power > MaxDegree)
+                    return false;
+                product |= Pack(i, power);
+            }
+            return true;
+        }
+
+        private static bool TryDivideMonomials(ulong dividend, ulong divisor, int variableCount, out ulong quotient)
+        {
+            quotient = 0;
+            for (var i = 0; i < variableCount; i++)
+            {
+                var power = PowerOf(dividend, i) - PowerOf(divisor, i);
+                if (power < 0)
+                    return false;
+                quotient |= Pack(i, power);
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// The same polynomial up to a rational factor, with whole coprime coefficients and
+        /// a positive leading one.
+        /// </summary>
+        /// <remarks>
+        /// A greatest common divisor is only defined up to a unit, and over <c>Q</c> every
+        /// nonzero rational is one, so a representative has to be chosen. This is the one
+        /// that reads the way the answer is usually written: <c>x + y</c>, not
+        /// <c>-x/2 - y/2</c>.
+        /// </remarks>
+        internal MultivariatePolynomial Normalized()
+        {
+            if (IsZero)
+                return this;
+            var denominators = EInteger.One;
+            foreach (var term in terms)
+                denominators = Lcm(denominators, term.Value.Denominator);
+            var numerators = EInteger.Zero;
+            foreach (var term in terms)
+                numerators = numerators.Gcd(
+                    term.Value.Numerator.Multiply(denominators.Divide(term.Value.Denominator)));
+            if (numerators.IsZero)
+                return this;
+            var scale = ERational.Create(denominators, numerators);
+            if (terms[LeadingMonomial()].Sign < 0)
+                scale = scale.Negate();
+            return ScaleBy(scale);
+        }
+
+        private static EInteger Lcm(EInteger a, EInteger b) => a.Divide(a.Gcd(b)).Multiply(b);
+
+        internal bool SameAs(MultivariatePolynomial other)
+        {
+            if (terms.Count != other.terms.Count)
+                return false;
+            foreach (var term in terms)
+                if (!other.terms.TryGetValue(term.Key, out var value) || value.CompareTo(term.Value) != 0)
+                    return false;
+            return true;
+        }
+
+        /// <summary>
+        /// Reads <paramref name="expr"/> as a polynomial over <c>Q</c> in the given
+        /// variables, or answers <see langword="null"/> where it is not one.
+        /// </summary>
+        /// <remarks>
+        /// Products and powers are multiplied out as they are read rather than by expanding
+        /// the expression first, so that the term ceiling stops a <c>(x + y) ^ 100</c>
+        /// before it is built rather than after.
+        /// </remarks>
+        internal static MultivariatePolynomial? TryParse(Entity expr, IReadOnlyDictionary<Variable, int> variables)
+            => expr switch
+            {
+                // Integer is a Rational, so this arm takes both.
+                Rational rational => Constant(variables.Count, rational.ERational),
+                Variable variable => variables.TryGetValue(variable, out var index)
+                    ? Monomial(variables.Count, index)
+                    : null,
+                Sumf(var augend, var addend) =>
+                    TryParse(augend, variables) is { } left && TryParse(addend, variables) is { } right
+                    ? left.Add(right) : null,
+                Minusf(var subtrahend, var minuend) =>
+                    TryParse(subtrahend, variables) is { } left && TryParse(minuend, variables) is { } right
+                    ? left.Subtract(right) : null,
+                Mulf(var multiplier, var multiplicand) =>
+                    TryParse(multiplier, variables) is { } left && TryParse(multiplicand, variables) is { } right
+                    ? left.Multiply(right) : null,
+                Divf(var dividend, var divisor) =>
+                    TryParse(divisor, variables) is { IsConstant: true, IsZero: false } bottom
+                    && TryParse(dividend, variables) is { } top
+                    ? top.ScaleBy(ERational.One.Divide(bottom.ConstantValue)) : null,
+                Powf(var @base, Integer exponent) => ParsePower(@base, exponent, variables),
+                _ => null
+            };
+
+        private static MultivariatePolynomial? ParsePower(
+            Entity @base, Integer exponent, IReadOnlyDictionary<Variable, int> variables)
+        {
+            if (!exponent.EInteger.CanFitInInt32())
+                return null;
+            var power = exponent.EInteger.ToInt32Checked();
+            if (power > MaxDegree || power < -MaxDegree)
+                return null;
+            if (TryParse(@base, variables) is not { } parsed)
+                return null;
+            if (power >= 0)
+                return parsed.Power(power);
+            // A negative power is only a polynomial when what it inverts is a nonzero
+            // number; a genuine 1/x is not one and is refused.
+            if (!parsed.IsConstant || parsed.IsZero)
+                return null;
+            var inverse = ERational.One.Divide(parsed.ConstantValue);
+            var result = ERational.One;
+            for (var i = 0; i < -power; i++)
+                result = result.Multiply(inverse).ToLowestTerms();
+            return Constant(variables.Count, result);
+        }
+
+        private ERational ConstantValue => terms.Count == 0 ? ERational.Zero : terms[0];
+
+        internal Entity ToEntity(IReadOnlyList<Variable> variables)
+        {
+            Entity? result = null;
+            foreach (var monomial in terms.Keys.OrderByDescending(key => key))
+            {
+                var coefficient = terms[monomial];
+                var negative = coefficient.Sign < 0;
+                var magnitude = negative ? coefficient.Negate() : coefficient;
+                Entity? term = null;
+                for (var i = 0; i < VariableCount; i++)
+                {
+                    var power = PowerOf(monomial, i);
+                    if (power == 0)
+                        continue;
+                    Entity factor = power == 1 ? variables[i] : MathS.Pow(variables[i], power);
+                    term = term is null ? factor : term * factor;
+                }
+                if (term is null)
+                    term = Rational.Create(magnitude);
+                else if (magnitude.CompareTo(ERational.One) != 0)
+                    term = Rational.Create(magnitude) * term;
+                result = result is null
+                    ? negative ? -term : term
+                    : negative ? result - term : result + term;
+            }
+            return result ?? Integer.Create(0);
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.cs
@@ -50,5 +50,17 @@ namespace AngouriMath.Functions
             && TreeAnalyzer.PolynomialLongDivision(num, denom) is var (divided, remainder)
             ? divided + remainder
             : x;
+
+        /// <summary>
+        /// A quotient of polynomials put into lowest terms:
+        /// <c>(x^2 + 2xy + y^2) / (x^2 - y^2)</c> becomes <c>(x + y) / (x - y)</c>.
+        /// See <see cref="PolynomialGcd"/> for what is and is not attempted, and
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/55">#55</a>.
+        /// </summary>
+        internal static Entity PolynomialGcdCancellation(Entity x) =>
+            x is Divf(var num, var denom)
+            && PolynomialGcd.TryCancel(num, denom, out var cancelled)
+            ? cancelled
+            : x;
     }
 }

--- a/Sources/AngouriMath/Functions/Simplification/PolynomialGcd.cs
+++ b/Sources/AngouriMath/Functions/Simplification/PolynomialGcd.cs
@@ -1,0 +1,302 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath.Core.Multithreading;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using static AngouriMath.Entity;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// The greatest common divisor of two polynomials in several variables over the
+    /// rationals, and the cancellation of a quotient that it makes possible:
+    /// <c>(x^2 + 2xy + y^2) / (x^2 - y^2)</c> is <c>(x + y) / (x - y)</c>
+    /// (<a href="https://github.com/asc-community/AngouriMath/issues/55">#55</a>).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A polynomial in several variables is a polynomial in one of them whose coefficients
+    /// are polynomials in the rest, so the algorithm is the univariate one applied down a
+    /// recursion on the variable count. What it cannot be is the plain Euclidean algorithm
+    /// over that coefficient ring: pseudo-division multiplies through by the leading
+    /// coefficient every step, and the coefficients of the remainder sequence then grow
+    /// exponentially in the degree. The classic example is Knuth's, where two degree-8
+    /// polynomials over the integers produce a remainder with a coefficient near 10^35.
+    /// </para>
+    /// <para>
+    /// Two things keep that in hand, and both are needed. The greatest common divisor
+    /// splits as the gcd of the contents times the gcd of the primitive parts, because the
+    /// content carries everything free of the main variable and the primitive parts carry
+    /// nothing of it; so the content is taken out first, recursively, in one variable
+    /// fewer. And within the remainder sequence the subresultant coefficients are divided
+    /// out at each step — that division is exact, since what is left is a subresultant, and
+    /// it is what turns exponential growth into linear. Knuth, <i>TAOCP</i> vol. 2,
+    /// §4.6.1, algorithms C and E; Geddes, Czapor and Labahn, <i>Algorithms for Computer
+    /// Algebra</i>, §7.3.
+    /// </para>
+    /// <para>
+    /// Nothing here trusts the result of that machinery. The divisor it computes is
+    /// divided out of both sides and multiplied back, and the quotient is only used when
+    /// both come out equal to what they started as. A divisor that is merely common and
+    /// not greatest costs an incomplete cancellation; one that is not a divisor at all
+    /// would be a wrong answer, and is the thing the check is there to stop.
+    /// </para>
+    /// </remarks>
+    internal static class PolynomialGcd
+    {
+        /// <summary>
+        /// A quotient larger than this is left alone. The bound is on node count, and is
+        /// there because this runs on every quotient the simplifier constructs, not
+        /// because a larger one would be wrong.
+        /// </summary>
+        private const int MaxComplexity = 256;
+
+        /// <summary>
+        /// Enough for any sequence a polynomial within the degree bound can produce; a
+        /// cheap ceiling so that a mistake shows up as a refusal rather than a hang.
+        /// </summary>
+        private const int MaxSteps = 256;
+
+        /// <summary>
+        /// Puts <c>numerator / denominator</c> into lowest terms, or answers
+        /// <see langword="null"/> where it is already in them, where either side is not a
+        /// polynomial over the rationals, or where the machinery declines.
+        /// </summary>
+        /// <remarks>
+        /// The answer carries the condition that the cancelled factor is nonzero. Where
+        /// that factor vanishes the quotient was <c>0/0</c> and the reduced form is
+        /// something definite, so dropping the condition would widen the domain and claim a
+        /// value where there is none — which is how the library already answers the cases
+        /// it can reach without this, <c>(x^2 - 1) / (x - 1)</c> being
+        /// <c>x + 1 provided not x - 1 = 0</c>.
+        /// </remarks>
+        internal static bool TryCancel(Entity numerator, Entity denominator,
+            [NotNullWhen(true)] out Entity? cancelled)
+        {
+            cancelled = null;
+
+            // Cheap refusals first. Two polynomials with no variable in common are coprime
+            // whatever they are, and there is no point parsing them to find that out.
+            if (!numerator.Vars.Any(denominator.Vars.Contains))
+                return false;
+            if (numerator.Complexity + denominator.Complexity > MaxComplexity)
+                return false;
+
+            var variables = numerator.Vars
+                .Concat(denominator.Vars)
+                .Distinct()
+                .OrderBy(variable => variable.Name, StringComparer.Ordinal)
+                .ToArray();
+            if (variables.Length > MultivariatePolynomial.MaxVariables)
+                return false;
+            var indices = new Dictionary<Variable, int>(variables.Length);
+            for (var i = 0; i < variables.Length; i++)
+                indices[variables[i]] = i;
+
+            if (MultivariatePolynomial.TryParse(numerator, indices) is not { } top
+                || MultivariatePolynomial.TryParse(denominator, indices) is not { } bottom)
+                return false;
+            // A constant numerator or denominator has nothing to cancel against, and a
+            // zero denominator is not this function's business to rewrite.
+            if (top.IsConstant || bottom.IsConstant)
+                return false;
+
+            var order = new int[variables.Length];
+            for (var i = 0; i < order.Length; i++)
+                order[i] = i;
+
+            if (Gcd(top, bottom, order, 0) is not { } divisor || divisor.IsConstant)
+                return false;
+            if (top.DivideExact(divisor) is not { } reducedTop
+                || bottom.DivideExact(divisor) is not { } reducedBottom)
+                return false;
+
+            // Multiplied back, independently of the division that produced them: a
+            // cancellation is only made once it has been seen to be one.
+            if (reducedTop.Multiply(divisor) is not { } checkedTop || !checkedTop.SameAs(top)
+                || reducedBottom.Multiply(divisor) is not { } checkedBottom || !checkedBottom.SameAs(bottom))
+                return false;
+
+            cancelled = new Providedf(
+                reducedTop.ToEntity(variables) / reducedBottom.ToEntity(variables),
+                !divisor.ToEntity(variables).EqualTo(0));
+            return true;
+        }
+
+        /// <summary>
+        /// The greatest common divisor of two polynomials over the rationals, normalized to
+        /// whole coprime coefficients with a positive leading one, or <see langword="null"/>
+        /// where a step of the algorithm declined.
+        /// </summary>
+        internal static MultivariatePolynomial? Gcd(
+            MultivariatePolynomial left, MultivariatePolynomial right, IReadOnlyList<int> variables, int depth)
+        {
+            if (depth > MultivariatePolynomial.MaxVariables)
+                return null;
+            if (left.IsZero)
+                return right.Normalized();
+            if (right.IsZero)
+                return left.Normalized();
+            if (left.IsConstant || right.IsConstant)
+                return MultivariatePolynomial.One(left.VariableCount);
+
+            // A variable occurring in only one of the two cannot occur in a common factor,
+            // so the main variable is chosen among those they share. Sharing none, the two
+            // lie in polynomial rings meeting only in the constants, and are coprime.
+            // Among the shared ones the lowest degree goes first: the remainder sequence is
+            // as long as that degree, and every step of it costs a recursion.
+            var main = -1;
+            var lowest = int.MaxValue;
+            foreach (var variable in variables)
+            {
+                var here = left.DegreeIn(variable);
+                var there = right.DegreeIn(variable);
+                if (here == 0 || there == 0)
+                    continue;
+                var degree = Math.Max(here, there);
+                if (degree < lowest)
+                {
+                    lowest = degree;
+                    main = variable;
+                }
+            }
+            if (main < 0)
+                return MultivariatePolynomial.One(left.VariableCount);
+
+            var rest = new List<int>(variables.Count - 1);
+            foreach (var variable in variables)
+                if (variable != main)
+                    rest.Add(variable);
+
+            if (ContentIn(left, main, rest, depth) is not { } leftContent
+                || ContentIn(right, main, rest, depth) is not { } rightContent
+                || left.DivideExact(leftContent) is not { } leftPrimitive
+                || right.DivideExact(rightContent) is not { } rightPrimitive
+                || Gcd(leftContent, rightContent, rest, depth + 1) is not { } contentGcd
+                || PrimitiveGcd(leftPrimitive, rightPrimitive, main, rest, depth) is not { } primitiveGcd
+                || contentGcd.Multiply(primitiveGcd) is not { } result)
+                return null;
+            return result.Normalized();
+        }
+
+        /// <summary>
+        /// The greatest common divisor of the coefficients of <paramref name="poly"/> taken
+        /// as a polynomial in <paramref name="main"/> — a polynomial in the remaining
+        /// variables.
+        /// </summary>
+        private static MultivariatePolynomial? ContentIn(
+            MultivariatePolynomial poly, int main, IReadOnlyList<int> rest, int depth)
+        {
+            MultivariatePolynomial? content = null;
+            foreach (var coefficient in poly.CoefficientsIn(main).Values)
+            {
+                content = content is null ? coefficient.Normalized() : Gcd(content, coefficient, rest, depth + 1);
+                if (content is null)
+                    return null;
+                if (content.IsConstant)
+                    return MultivariatePolynomial.One(poly.VariableCount);
+            }
+            return content ?? MultivariatePolynomial.One(poly.VariableCount);
+        }
+
+        private static MultivariatePolynomial? PrimitivePartIn(
+            MultivariatePolynomial poly, int main, IReadOnlyList<int> rest, int depth)
+            => ContentIn(poly, main, rest, depth) is { } content && poly.DivideExact(content) is { } primitive
+                ? primitive.Normalized()
+                : null;
+
+        /// <summary>
+        /// The subresultant polynomial remainder sequence of two polynomials already free
+        /// of content in <paramref name="main"/>. Its last nonzero member is the greatest
+        /// common divisor up to a factor free of <paramref name="main"/>, which the
+        /// primitive part then removes.
+        /// </summary>
+        private static MultivariatePolynomial? PrimitiveGcd(
+            MultivariatePolynomial left, MultivariatePolynomial right, int main, IReadOnlyList<int> rest, int depth)
+        {
+            if (left.DegreeIn(main) < right.DegreeIn(main))
+                (left, right) = (right, left);
+            var one = MultivariatePolynomial.One(left.VariableCount);
+            var previousLead = one;
+            var scale = one;
+            for (var step = 0; step < MaxSteps; step++)
+            {
+                MultithreadingFunctional.ExitIfCancelled();
+                var delta = left.DegreeIn(main) - right.DegreeIn(main);
+                if (PseudoRemainder(left, right, main) is not { } remainder)
+                    return null;
+                if (remainder.IsZero)
+                    return PrimitivePartIn(right, main, rest, depth);
+                // A remainder free of the main variable means the two primitive parts have
+                // no factor carrying it, and being primitive they have no other.
+                if (remainder.DegreeIn(main) == 0)
+                    return MultivariatePolynomial.One(left.VariableCount);
+
+                // The division below is the whole point of the subresultant sequence: what
+                // it leaves is a subresultant, so it comes out exact, and the coefficients
+                // stay the size of the subresultants instead of compounding.
+                if (scale.Power(delta) is not { } scalePower
+                    || previousLead.Multiply(scalePower) is not { } factor
+                    || remainder.DivideExact(factor) is not { } next)
+                    return null;
+
+                left = right;
+                right = next;
+                previousLead = left.LeadingCoefficientIn(main);
+                if (delta == 1)
+                    scale = previousLead;
+                else if (delta > 1)
+                {
+                    if (previousLead.Power(delta) is not { } raised
+                        || scale.Power(delta - 1) is not { } divisor
+                        || raised.DivideExact(divisor) is not { } updated)
+                        return null;
+                    scale = updated;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// <c>lc(divisor) ^ (deg(dividend) - deg(divisor) + 1) * dividend</c> reduced modulo
+        /// <paramref name="divisor"/>, all with respect to <paramref name="main"/>. The
+        /// power in front is what makes every division by the leading coefficient come out
+        /// whole, so that no denominator ever enters the coefficient ring.
+        /// </summary>
+        private static MultivariatePolynomial? PseudoRemainder(
+            MultivariatePolynomial dividend, MultivariatePolynomial divisor, int main)
+        {
+            var divisorDegree = divisor.DegreeIn(main);
+            var divisorLead = divisor.LeadingCoefficientIn(main);
+            var remainder = dividend;
+            var outstanding = dividend.DegreeIn(main) - divisorDegree + 1;
+            for (var step = 0; step < MaxSteps; step++)
+            {
+                if (remainder.IsZero || remainder.DegreeIn(main) < divisorDegree)
+                    break;
+                MultithreadingFunctional.ExitIfCancelled();
+                var shift = remainder.DegreeIn(main) - divisorDegree;
+                if (divisorLead.Multiply(remainder) is not { } scaled
+                    || remainder.LeadingCoefficientIn(main).Multiply(divisor) is not { } cancelling
+                    || cancelling.ShiftedBy(main, shift) is not { } shifted)
+                    return null;
+                remainder = scaled.Subtract(shifted);
+                outstanding--;
+            }
+            if (remainder.IsZero)
+                return remainder;
+            for (var i = 0; i < outstanding; i++)
+            {
+                if (divisorLead.Multiply(remainder) is not { } scaled)
+                    return null;
+                remainder = scaled;
+            }
+            return remainder;
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Simplification/Simplificator.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Simplificator.cs
@@ -92,6 +92,15 @@ namespace AngouriMath.Functions
 
                 AddHistory(res = res.Replace(Patterns.InvertNegativePowers).Replace(Patterns.DivisionPreparingRules).InnerSimplified);
 
+                // Lowest terms, offered as one more candidate rather than taken. Cancelling
+                // means multiplying out, and a quotient that cancels down to a polynomial
+                // was often better off in the form it was already written in:
+                // 3x^2 (u + 2)^2 / (3x^2) is (u + 2)^2, which the rules below reach as it
+                // stands, and u^2 + 4u + 4 only once this has expanded it. The complexity
+                // metric is what should decide between them.
+                if (res.Nodes.Any(child => child is Divf))
+                    AddHistory(res.Replace(Patterns.PolynomialGcdCancellation).InnerSimplified);
+
                 AddHistory(res = res.Replace(Patterns.PolynomialLongDivision).InnerSimplified);
 
                 AddHistory(res = res.Replace(Patterns.NormalTrigonometricForm).InnerSimplified);

--- a/Sources/Tests/UnitTests/Common/SimplificationRegressionTest.cs
+++ b/Sources/Tests/UnitTests/Common/SimplificationRegressionTest.cs
@@ -8,6 +8,7 @@
 using AngouriMath;
 using AngouriMath.Extensions;
 using PeterO.Numbers;
+using System.Linq;
 using Xunit;
 
 namespace AngouriMath.Tests.Common
@@ -202,6 +203,78 @@ namespace AngouriMath.Tests.Common
             var difference = (input.ToEntity() - input.ToEntity().Factorize()).Simplify();
             while (difference is Entity.Providedf(var inner, _)) difference = inner;
             Assert.Equal(Entity.Number.Integer.Create(0), difference);
+        }
+
+        // https://github.com/asc-community/AngouriMath/issues/55
+        // A quotient of polynomials only ever reached lowest terms where the common
+        // factor was one the pattern rules could see written out. In one variable the
+        // factoring rules found most of them; in several there was nothing at all, so
+        // (x + y)^2 / ((x - y)(x + y)) came back long-divided as
+        // 1 + (2y^2 + 2xy)/(x^2 - y^2) -- still carrying the factor it should have lost.
+        [Theory]
+        [InlineData("(x ^ 2 + 2 * x * y + y ^ 2) / (x ^ 2 - y ^ 2)", "(x + y) / (x - y)")]
+        [InlineData("(x ^ 2 - 2 * x * y + y ^ 2) / (x ^ 2 - y ^ 2)", "(x - y) / (x + y)")]
+        [InlineData("(a ^ 2 - b ^ 2) / (a ^ 2 + 2 * a * b + b ^ 2)", "(a - b) / (a + b)")]
+        [InlineData("(x ^ 2 * y - y ^ 3) / (x * y + y ^ 2)", "x - y")]
+        [InlineData("(x ^ 2 * y ^ 2 - 1) / (x * y - 1)", "x * y + 1")]
+        [InlineData("(x ^ 3 - y ^ 3) / (x ^ 2 - y ^ 2)", "(x ^ 2 + x * y + y ^ 2) / (x + y)")]
+        public void Issue55_MultivariateQuotientsReachLowestTerms(string input, string expected)
+        {
+            var simplified = input.ToEntity().Simplify();
+            var bare = simplified;
+            while (bare is Entity.Providedf(var inner, _)) bare = inner;
+
+            // Equal as expressions, wherever both are defined...
+            var difference = (bare - expected.ToEntity()).Simplify();
+            while (difference is Entity.Providedf(var inner, _)) difference = inner;
+            Assert.Equal(Entity.Number.Integer.Create(0), difference);
+
+            // ...and no bigger than the reduced form, which is what the issue is about:
+            // the answer it complains of is the same number too, just not in lowest terms.
+            Assert.True(bare.Nodes.Count() <= expected.ToEntity().Nodes.Count(), bare.Stringize());
+        }
+
+        // Cancelling widens the domain -- at x = -y the quotient was 0/0 where the
+        // reduced form is 0 -- so the condition has to travel with the answer.
+        [Fact]
+        public void Issue55_CancellationKeepsTheDomainCondition()
+        {
+            var simplified = "(x ^ 2 + 2 * x * y + y ^ 2) / (x ^ 2 - y ^ 2)".ToEntity().Simplify();
+            var atRemovedFactor = simplified.Substitute("x", 1).Substitute("y", -1).Evaled;
+            Assert.Equal(MathS.NaN, atRemovedFactor);
+        }
+
+        // A common divisor that is not there must not be found. These are all coprime,
+        // and the point of the check is that nothing is cancelled out of them.
+        [Theory]
+        [InlineData("(x + y) / (x - y)")]
+        [InlineData("(x ^ 2 + y ^ 2) / (x + y)")]
+        [InlineData("(x + 1) / (y + 1)")]
+        public void Issue55_CoprimeQuotientsAreLeftAlone(string input) =>
+            Assert.Equal(input.ToEntity(), input.ToEntity().Simplify());
+
+        // The strongest thing that can be said about a computed divisor is that the
+        // quotient still takes the same values. Sampled at whole points, where a divisor
+        // that did not really divide shows up as a different number.
+        [Theory]
+        [InlineData("(x ^ 2 + 2 * x * y + y ^ 2) / (x ^ 2 - y ^ 2)")]
+        [InlineData("(x ^ 3 - y ^ 3) / (x ^ 2 - y ^ 2)")]
+        [InlineData("(a ^ 2 - b ^ 2) / (a ^ 2 + 2 * a * b + b ^ 2)")]
+        [InlineData("(x ^ 4 - y ^ 4) / (x ^ 2 - 2 * x * y + y ^ 2)")]
+        [InlineData("(x ^ 3 + x ^ 2 * y - x * y ^ 2 - y ^ 3) / (x ^ 2 - y ^ 2)")]
+        [InlineData("(x ^ 2 * y ^ 2 - 1) / (x * y - 1)")]
+        [InlineData("(6 * x ^ 2 - 6 * y ^ 2) / (4 * x + 4 * y)")]
+        public void Issue55_CancellationPreservesValue(string input)
+        {
+            var original = input.ToEntity();
+            var simplified = original.Simplify();
+            var variables = original.Vars.OrderBy(variable => variable.Name).ToArray();
+            foreach (var (first, second) in new[] { (3, 5), (7, 2), (-4, 9), (11, -6) })
+            {
+                Entity Bind(Entity expr) =>
+                    expr.Substitute(variables[0], first).Substitute(variables[1], second);
+                Assert.Equal(Bind(original).EvalNumerical(), Bind(simplified).EvalNumerical());
+            }
         }
 
         // Dividing the integrand by a derivative that is zero gives NaN, and NaN

--- a/Sources/Tests/UnitTests/PatternsTest/SimplifyTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/SimplifyTest.cs
@@ -48,7 +48,11 @@ namespace AngouriMath.Tests.PatternsTest
         [Fact] public void Patt9() => AssertSimplify(MathS.Arccotan(x * 3) + MathS.Arctan(x * 6), MathS.Arccotan(3 * x) + MathS.Arctan(6 * x));
         [Fact] public void Patt10() => AssertSimplify(MathS.Arcsin(x * 3) + MathS.Arccos(x * 1), MathS.Arcsin(3 * x) + MathS.Arccos(x));
         [Fact] public void Patt11() => AssertSimplify(3 + x + 4 + x, 7 + 2 * x);
-        [Fact] public void Patt12() => AssertSimplify((x * y * a * b * c) / (c * b * a * x * x), "y / x provided not c = 0 and not a * b * c * x ^ 2 = 0", 4);
+        // The condition used to read `not c = 0 and not a * b * c * x ^ 2 = 0`, which says
+        // the same thing twice: a product is nonzero exactly when each of its factors is,
+        // so a b c x^2 != 0 already carries c != 0. Cancelling the common divisor in one
+        // step states the domain once, over the same set of points.
+        [Fact] public void Patt12() => AssertSimplify((x * y * a * b * c) / (c * b * a * x * x), "y / x provided not a * b * c * x = 0", 4);
         [Fact] public void Frac1() => AssertSimplify("x / (y / z)", "x * z / y");
         [Fact] public void Frac2() => AssertSimplify("x / y / z", "x / (y * z)");
         [Fact] public void Factorial2() => AssertSimplify(MathS.Factorial(2), 2);


### PR DESCRIPTION
Closes #55.

`(x^2 + 2xy + y^2) / (x + y)` already simplified to `x + y`; `(x^2 + 2xy + y^2) / (x^2 - y^2)` did not, because there was no multivariate polynomial GCD. This adds one.

## What it is

A polynomial in several variables is a polynomial in one of them whose coefficients are polynomials in the rest, so the algorithm is the univariate one applied down a recursion on the variable count. What it cannot be is plain Euclid over that coefficient ring: pseudo-division multiplies through by the leading coefficient at every step and the remainder coefficients then grow exponentially in the degree — Knuth's example reaches ~10^35 from two degree-8 inputs.

Two things keep that in hand, and both are needed:

- the gcd splits as gcd(contents) x gcd(primitive parts), so the content comes out first, recursively, in one variable fewer;
- within the remainder sequence the **subresultant** coefficients are divided out each step. That division is exact, and it is what turns exponential growth into linear.

Knuth *TAOCP* vol. 2 4.6.1 algorithms C and E; Geddes/Czapor/Labahn 7.3.

Two files: `MultivariatePolynomial.cs` (sparse; an exponent vector packs into one `ulong`, a byte per variable, so comparing packed monomials *is* lexicographic order and lookup is one hash) and `PolynomialGcd.cs` (the algorithm and the cancellation).

## Nothing trusts the algorithm's output

The divisor is exact-divided out of both sides, then multiplied back and compared against the originals. The cancellation happens only if both come back equal. A divisor that is common but not greatest costs an incomplete cancellation; one that is not a divisor at all cannot get through.

## Two decisions, each of which cost a wrong first attempt

**The answer carries the domain condition** — `(x + y)/(x - y) provided not x + y = 0`. Dropping it matches sympy, Mathematica and Maxima, and it silently degraded four existing answers: `(x^2-1)/(x-1)` went from `x + 1 provided not x - 1 = 0` to a bare `x + 1`. Cancelling widens the domain, and this library records that everywhere else.

**The reduced form is offered as a candidate, not taken**, the way `PolynomialFactoring` and `ExpandMultipleAngleRules` already are. Cancelling means multiplying out, and committing to it turned `3x^2(u+2)^2/(3x^2)` into `u^2 + 4u + 4` instead of `(u+2)^2` — which broke the closed form of one of the integrals in the suite. The complexity metric should decide, so it does. The step is gated on the expression actually containing a `Divf`, which is what makes it free.

## Before / after

| | master | branch |
|---|---|---|
| `(x^2+2xy+y^2)/(x^2-y^2)` | `1 + (2y^2 + 2yx)/(x^2 - y^2)` | `(x + y)/(x - y) provided not x + y = 0` |
| `(x^2-2xy+y^2)/(x^2-y^2)` | unchanged | `(x - y)/(x + y) provided not x - y = 0` |
| `(a^2-b^2)/(a^2+2ab+b^2)` | unchanged | `(a - b)/(a + b) provided not a + b = 0` |
| `((x^2-y^2)(z+1))/((x-y)(z^2-1))` | unchanged | `(x + y)/(z - 1) provided not (z + 1)(x - y) = 0` |

## Measured

- Unit tests 4675 -> 4692 passing, 0 failing (17 new here). F# wrapper 130/130.
- Corpus 111/117 -> **112/117**, and the counts that matter stay at **0 wrong, 0 error, 0 timeout**.
- Corpus wall time 7.25 s before, 6.96 s after (mean of 4 runs). Ungated it was ~7.4 s, a real ~8% cost — hence the gate.
- Knuth's coefficient-blowup pair, which is coprime, answers in 59 ms with no false cancellation.

## One existing test changed

`SimplifyTest.Patt12`: `y/x provided not c = 0 and not a*b*c*x^2 = 0` becomes `y/x provided not a*b*c*x = 0`. The old condition stated the domain twice — a product is nonzero exactly when each factor is, so `abcx^2 != 0` already carried `c != 0` — and `x^2 != 0` iff `x != 0`. Same set of points, said once. The reason is written into the test.

## What this does not do

- `(x^4-y^4)/(x^2-2xy+y^2)` still comes back unreduced. The GCD finds `x - y` correctly, but the reduced numerator `x^3+x^2y+xy^2+y^3` loses the complexity contest against the original's two terms. Since the form is offered rather than taken, that is the metric's call, and changing it is a larger decision than this branch.
- Coefficients are rationals and nothing else. Factoring over a radical extension — #176 — is deliberately out.
- #203 stays open: `Factorize()` still returns `x^2+2x+1` unchanged where `Simplify()` reaches `(1+x)^2`, so the public `collapse` is still inconsistent with the simplifier.
