### PR TITLE
Answer the limits that were left unevaluated, and un-invert a quotient (#536, #335, #333)

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Limit.Classes.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Limit.Classes.cs
@@ -187,11 +187,18 @@ namespace AngouriMath
 
         partial record Arcsecantf
         {
-            internal override Entity? ComputeLimitDivideEtImpera(Variable x, Entity dist, ApproachFrom side) =>
-                ComputeLimitImpl(this, x, dist, side) is { } lim ? lim
-                : ComputeLimitImpl(New(
-                    Argument.ComputeLimitDivideEtImpera(x, dist, side) is { IsFinite: true } lim1 ? lim1 : Argument),
-                    x, dist, side);
+            internal override Entity? ComputeLimitDivideEtImpera(Variable x, Entity dist, ApproachFrom side)
+            {
+                // Asked in front of the substitution, which for a diverging argument does answer
+                // -- with arcsec(+oo), a right angle written as a function of an infinity rather
+                // than as the right angle it is.
+                if (InverseTrigonometryAtInfinity(this, Argument.ComputeLimitDivideEtImpera(x, dist, side)) is { } atInfinity)
+                    return atInfinity;
+                return ComputeLimitImpl(this, x, dist, side) is { } lim ? lim
+                    : ComputeLimitImpl(New(
+                        Argument.ComputeLimitDivideEtImpera(x, dist, side) is { IsFinite: true } lim1 ? lim1 : Argument),
+                        x, dist, side);
+            }
         }
 
         partial record Arccosecantf
@@ -256,20 +263,28 @@ namespace AngouriMath
 
         partial record Arcsinf
         {
-            internal override Entity? ComputeLimitDivideEtImpera(Variable x, Entity dist, ApproachFrom side) =>
-                ComputeLimitImpl(this, x, dist, side) is { } lim ? lim
-                : ComputeLimitImpl(New(
-                    Argument.ComputeLimitDivideEtImpera(x, dist, side) is { IsFinite: true } lim1 ? lim1 : Argument),
-                    x, dist, side);
+            internal override Entity? ComputeLimitDivideEtImpera(Variable x, Entity dist, ApproachFrom side)
+            {
+                if (InverseTrigonometryAtInfinity(this, Argument.ComputeLimitDivideEtImpera(x, dist, side)) is { } atInfinity)
+                    return atInfinity;
+                return ComputeLimitImpl(this, x, dist, side) is { } lim ? lim
+                    : ComputeLimitImpl(New(
+                        Argument.ComputeLimitDivideEtImpera(x, dist, side) is { IsFinite: true } lim1 ? lim1 : Argument),
+                        x, dist, side);
+            }
         }
 
         partial record Arccosf
         {
-            internal override Entity? ComputeLimitDivideEtImpera(Variable x, Entity dist, ApproachFrom side) =>
-                ComputeLimitImpl(this, x, dist, side) is { } lim ? lim
-                : ComputeLimitImpl(New(
-                    Argument.ComputeLimitDivideEtImpera(x, dist, side) is { IsFinite: true } lim1 ? lim1 : Argument),
-                    x, dist, side);
+            internal override Entity? ComputeLimitDivideEtImpera(Variable x, Entity dist, ApproachFrom side)
+            {
+                if (InverseTrigonometryAtInfinity(this, Argument.ComputeLimitDivideEtImpera(x, dist, side)) is { } atInfinity)
+                    return atInfinity;
+                return ComputeLimitImpl(this, x, dist, side) is { } lim ? lim
+                    : ComputeLimitImpl(New(
+                        Argument.ComputeLimitDivideEtImpera(x, dist, side) is { IsFinite: true } lim1 ? lim1 : Argument),
+                        x, dist, side);
+            }
         }
 
         partial record Arctanf

--- a/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Limit.Classes.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Limit.Classes.cs
@@ -367,13 +367,24 @@ namespace AngouriMath
         {
             internal override Entity? ComputeLimitDivideEtImpera(Variable x, Entity dist, ApproachFrom side)
             {
-                var allLims = Cases.Select(c => (lim: c.Expression.ComputeLimitDivideEtImpera(x, dist, side), pred: c.Predicate));
-                if (allLims.Select(c => c.lim is null).Any())
-                    return null;
-                return New(allLims.Select(
-                    c => c.lim is not null ? 
-                    new Providedf(c.lim, c.pred) : 
-                    throw new AngouriBugException("It's been checked before")));
+                // Close enough to the destination one case is the whole of the expression, so the
+                // limit is that case's limit -- and which case that is is decided the same way
+                // evaluation decides it, by the first predicate that holds once every earlier one
+                // has failed. A limit of the cases with their predicates carried along was what
+                // used to be built here, and it answers nothing: the predicates still speak about
+                // x, which the limit has just got rid of.
+                foreach (var (expression, predicate) in Cases)
+                    switch (HoldsNear(predicate, x, dist, side))
+                    {
+                        case true: return ComputeLimit(expression, x, dist, side);
+                        case false: continue;
+                        // A case that may or may not hold near the destination leaves it open
+                        // which expression the limit is of, and the ones after it unreachable.
+                        default: return null;
+                    }
+                // Every case fails throughout the neighbourhood, so the expression is undefined
+                // on the whole of the way in and there is nothing for it to tend to.
+                return MathS.NaN;
             }
         }
 

--- a/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Limit.Classes.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Limit.Classes.cs
@@ -33,22 +33,36 @@ namespace AngouriMath
 
         partial record Sumf
         {
-            internal override Entity? ComputeLimitDivideEtImpera(Variable x, Entity dist, ApproachFrom side) =>
-                ComputeLimitImpl(this, x, dist, side) is { } lim ? lim
-                : ComputeLimitImpl(New(
-                    Augend.ComputeLimitDivideEtImpera(x, dist, side) is { IsFinite: true } lim1 ? lim1 : Augend,
-                    Addend.ComputeLimitDivideEtImpera(x, dist, side) is { IsFinite: true } lim2 ? lim2 : Addend),
-                    x, dist, side);
+            internal override Entity? ComputeLimitDivideEtImpera(Variable x, Entity dist, ApproachFrom side)
+            {
+                if (ComputeLimitImpl(this, x, dist, side) is { } lim)
+                    return lim;
+                var (augend, addend) =
+                    (Augend.ComputeLimitDivideEtImpera(x, dist, side), Addend.ComputeLimitDivideEtImpera(x, dist, side)) switch
+                    {
+                        ({ } lim1, { } lim2) when IsDeterminate(New(lim1, lim2), x) => (lim1, lim2),
+                        var (lim1, lim2) => (lim1 is { IsFinite: true } ? lim1 : Augend,
+                                             lim2 is { IsFinite: true } ? lim2 : Addend)
+                    };
+                return ComputeLimitImpl(New(augend, addend), x, dist, side);
+            }
         }
 
         partial record Minusf
         {
-            internal override Entity? ComputeLimitDivideEtImpera(Variable x, Entity dist, ApproachFrom side) =>
-                ComputeLimitImpl(this, x, dist, side) is { } lim ? lim
-                : ComputeLimitImpl(New(
-                    Minuend.ComputeLimitDivideEtImpera(x, dist, side) is { IsFinite: true } lim1 ? lim1 : Minuend,
-                    Subtrahend.ComputeLimitDivideEtImpera(x, dist, side) is { IsFinite: true } lim2 ? lim2 : Subtrahend),
-                    x, dist, side);
+            internal override Entity? ComputeLimitDivideEtImpera(Variable x, Entity dist, ApproachFrom side)
+            {
+                if (ComputeLimitImpl(this, x, dist, side) is { } lim)
+                    return lim;
+                var (minuend, subtrahend) =
+                    (Minuend.ComputeLimitDivideEtImpera(x, dist, side), Subtrahend.ComputeLimitDivideEtImpera(x, dist, side)) switch
+                    {
+                        ({ } lim1, { } lim2) when IsDeterminate(New(lim1, lim2), x) => (lim1, lim2),
+                        var (lim1, lim2) => (lim1 is { IsFinite: true } ? lim1 : Minuend,
+                                             lim2 is { IsFinite: true } ? lim2 : Subtrahend)
+                    };
+                return ComputeLimitImpl(New(minuend, subtrahend), x, dist, side);
+            }
         }
 
         partial record Mulf
@@ -62,6 +76,7 @@ namespace AngouriMath
                     var (mp, md) =
                         (Multiplier.ComputeLimitDivideEtImpera(x, dist, side), Multiplicand.ComputeLimitDivideEtImpera(x, dist, side)) switch
                         {
+                            ({ } lim1, { } lim2) when IsDeterminate(New(lim1, lim2), x) => (lim1, lim2),
                             ({ IsFinite: true } lim1, { IsFinite: true } lim2) => (lim1, lim2),
                             (_, { } l2) when !Multiplier.ContainsNode(x) => (Multiplier, l2),
                             ({ } l1, _) when !Multiplicand.ContainsNode(x) => (l1, Multiplicand),
@@ -86,6 +101,7 @@ namespace AngouriMath
                     var (dividend, divisor) =
                         (Dividend.ComputeLimitDivideEtImpera(x, dist, side), Divisor.ComputeLimitDivideEtImpera(x, dist, side)) switch
                         {
+                            ({ } lim1, { } lim2) when IsDeterminate(New(lim1, lim2), x) => (lim1, lim2),
                             ({ } lim1, { } lim2) when lim1.InnerSimplified.IsFinite && lim2.InnerSimplified.IsFinite && lim2.InnerSimplified != 0 => (lim1, lim2),
                             ({ IsFinite: true } lim1, { IsFinite: true } lim2) => (lim1, lim2),
                             (_, { } l2) when !Dividend.ContainsNode(x) => (Dividend, l2),

--- a/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Solvers.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Solvers.Definition.cs
@@ -46,7 +46,13 @@ namespace AngouriMath.Functions.Algebra
 
         public static Entity? ComputeLimit(Entity expr, Variable x, Entity dest, ApproachFrom side = ApproachFrom.BothSides, bool acceptNaN = false)
         {
-            if (expr is not ContinuousNode and not Variable)
+            // A piecewise is not continuous and is still something a limit can be taken of: it
+            // agrees with one of its cases on the whole of the way in, and that case is
+            // continuous. Without it here the descent's reading of one was never reached --
+            // https://github.com/asc-community/AngouriMath/issues/536. The gate itself stays,
+            // since it is what keeps a statement like `a and x` out of machinery that would
+            // differentiate it.
+            if (expr is not ContinuousNode and not Variable and not Piecewise)
                 return null;
             expr = expr.Replace(ExpandLogarithm);
 

--- a/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
@@ -16,12 +16,23 @@ namespace AngouriMath.Functions.Algebra
 {
     partial class LimitFunctional
     {
+        /// <summary>
+        /// A vanishing function written as the vanishing argument it is equivalent to, where
+        /// that argument is what vanishes. <c>sin(u) / u</c>, <c>tan(u) / u</c>,
+        /// <c>arcsin(u) / u</c> and <c>arctan(u) / u</c> all tend to 1 as u tends to 0, so one
+        /// may be written for the other in a product or a quotient without changing its limit.
+        /// </summary>
+        /// <remarks>
+        /// The argument's own limit is what the equivalence needs, not the function's. sin(x)
+        /// vanishes at pi as surely as at 0 and is not equivalent to x there -- it is equivalent
+        /// to pi - x -- so rewriting it as x turned <c>lim x-&gt;pi sin(x) / (x - pi)</c>, which
+        /// is -1, into pi / 0.
+        /// </remarks>
         private static Entity EquivalenceRules(Entity expr, Variable x, Entity dest)
-            => expr switch
-            {
-                Sinf or Tanf or Arcsinf or Arctanf => expr.DirectChildren[0],
-                _ => expr
-            };
+            => expr is (Sinf or Tanf or Arcsinf or Arctanf)
+               && EvalAssumingContinuous(expr.DirectChildren[0].Limit(x, dest)) == 0
+                ? expr.DirectChildren[0]
+                : expr;
         private static Entity EvalAssumingContinuous(Entity expr) =>
             expr.Evaled switch
             {
@@ -34,6 +45,17 @@ namespace AngouriMath.Functions.Algebra
                 Divf(var a, var b) div
                     when EvalAssumingContinuous(a.Limit(x, dest)) == 0 && EvalAssumingContinuous(b.Limit(x, dest)) == 0
                         => div.New(EquivalenceRules(a, x, dest), EquivalenceRules(b, x, dest)),
+
+                // A product takes the substitution as much as a quotient does -- it is the ratio
+                // of the two forms tending to 1 that licenses it, and that says nothing about
+                // which of them the rest of the expression is written over. Only the quotient
+                // had it, so lim x->0+ tan(x) * ln(x) went the long way round through l'Hopital's
+                // rule and came back NaN, where the same limit written sin(x) * ln(x) is 0.
+                Mulf(var a, var b)
+                    when EquivalenceRules(a, x, dest) is var equivalentA
+                      && EquivalenceRules(b, x, dest) is var equivalentB
+                      && (!ReferenceEquals(equivalentA, a) || !ReferenceEquals(equivalentB, b))
+                        => equivalentA * equivalentB,
 
                 _ => expr
             };

--- a/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
@@ -181,8 +181,31 @@ namespace AngouriMath.Functions.Algebra
             // with a definite non-zero size leaves the divisor to decide the answer.
             if (EvalAssumingContinuous(dividend.Limit(x, dest, side)) is not Real { IsFinite: true, IsZero: false } dividendLimit)
                 return null;
+            if (SignFromVanishingOrder(divisor, x, dest, side) is not { } divisorSign)
+                return null;
+            return dividendLimit.IsNegative == divisorSign > 0
+                ? Real.NegativeInfinity
+                : Real.PositiveInfinity;
+        }
 
-            var derivative = divisor;
+        /// <summary>
+        /// The sign an expression that vanishes at the destination keeps on one side of it,
+        /// or <see langword="null"/> where it cannot be read off.
+        /// </summary>
+        /// <remarks>
+        /// The sign is read off the first derivative that does not vanish with the expression.
+        /// Where <c>g(a) = 0</c> and the first non-vanishing derivative there is the k-th,
+        /// <c>g(x)</c> has the sign of <c>g_k(a) * (x - a)^k</c> near a, which is the sign of
+        /// <c>g_k(a)</c> on the right and that times <c>(-1)^k</c> on the left. Nothing is
+        /// claimed unless a derivative comes out finite and non-zero at the point: an expression
+        /// that is not differentiable there, or whose derivative diverges as <c>sqrt(x)</c>'s
+        /// does, is left alone.
+        /// </remarks>
+        private static int? SignFromVanishingOrder(Entity expr, Variable x, Entity dest, ApproachFrom side)
+        {
+            if (side is not (ApproachFrom.Left or ApproachFrom.Right) || !dest.IsFinite)
+                return null;
+            var derivative = expr;
             for (var order = 1; order <= MaxVanishingOrder; order++)
             {
                 MultithreadingFunctional.ExitIfCancelled();
@@ -196,12 +219,85 @@ namespace AngouriMath.Functions.Algebra
                 // sign of (-1)^k, so approaching from the left at an odd order turns the sign of
                 // the derivative around and nothing else does.
                 var turnsAround = side is ApproachFrom.Left && order % 2 != 0;
-                var divisorIsPositive = value.IsNegative == turnsAround;
-                return dividendLimit.IsNegative == divisorIsPositive
-                    ? Real.NegativeInfinity
-                    : Real.PositiveInfinity;
+                return value.IsNegative == turnsAround ? 1 : -1;
             }
             return null;
+        }
+
+        /// <summary>
+        /// The sign an expression keeps throughout a punctured one-sided neighbourhood of the
+        /// destination, or <see langword="null"/> where it cannot be read off.
+        /// </summary>
+        private static int? SignNear(Entity expr, Variable x, Entity dest, ApproachFrom side)
+        {
+            if (EvalAssumingContinuous(expr.Limit(x, dest, side)) is not Real { IsNaN: false } limit)
+                return null;
+            // A non-zero limit, infinities included, fixes the sign on its own: the expression
+            // is within any margin of that limit close enough to the destination, and one of
+            // those margins keeps it on the same side of zero.
+            if (!limit.IsZero)
+                return limit.IsNegative ? -1 : 1;
+            return SignFromVanishingOrder(expr, x, dest, side);
+        }
+
+        /// <summary>
+        /// Whether a predicate holds throughout a punctured one-sided neighbourhood of the
+        /// destination, fails throughout one, or cannot be settled either way
+        /// (<see langword="null"/>).
+        /// </summary>
+        /// <remarks>
+        /// This is what a limit of a piecewise expression needs and all it needs: near enough to
+        /// the destination one case is the whole of the expression, so the limit is that case's
+        /// limit. What decides a comparison is the sign the difference of its two sides keeps
+        /// near the destination, which is one question per comparison and not a solution set.
+        /// <para/>
+        /// A comparison whose difference vanishes identically -- <c>x &lt; x</c>, or any
+        /// predicate whose truth changes infinitely often on the way in -- settles nothing here
+        /// and comes back null, since neither answer would hold throughout a neighbourhood.
+        /// </remarks>
+        internal static bool? HoldsNear(Entity predicate, Variable x, Entity dest, ApproachFrom side)
+        {
+            // A predicate the variable does not occur in is the same statement everywhere, so
+            // there is nothing to approach: it either evaluates or it says nothing.
+            if (!predicate.ContainsNode(x))
+                return predicate.Evaled is Entity.Boolean constant ? constant.Value : null;
+            switch (predicate)
+            {
+                case Entity.Boolean(var value):
+                    return value;
+                case Notf(var argument):
+                    return HoldsNear(argument, x, dest, side) is { } inner ? !inner : null;
+                case Andf(var left, var right):
+                    {
+                        var (l, r) = (HoldsNear(left, x, dest, side), HoldsNear(right, x, dest, side));
+                        if (l is false || r is false) return false;
+                        return l is true && r is true ? true : null;
+                    }
+                case Orf(var left, var right):
+                    {
+                        var (l, r) = (HoldsNear(left, x, dest, side), HoldsNear(right, x, dest, side));
+                        if (l is true || r is true) return true;
+                        return l is false && r is false ? false : null;
+                    }
+                // Strict and non-strict read the same here. They differ only where the difference
+                // is exactly zero, and a difference that is zero anywhere on the way in is one
+                // this has no sign for either way.
+                case Lessf(var left, var right):
+                    return SignNear(left - right, x, dest, side) is { } lessSign ? lessSign < 0 : null;
+                case LessOrEqualf(var left, var right):
+                    return SignNear(left - right, x, dest, side) is { } lessOrEqualSign ? lessOrEqualSign < 0 : null;
+                case Greaterf(var left, var right):
+                    return SignNear(left - right, x, dest, side) is { } greaterSign ? greaterSign > 0 : null;
+                case GreaterOrEqualf(var left, var right):
+                    return SignNear(left - right, x, dest, side) is { } greaterOrEqualSign ? greaterOrEqualSign > 0 : null;
+                // A difference that keeps a sign is never zero, so the two sides are unequal
+                // throughout the neighbourhood. The other way round is not readable here: a
+                // difference this cannot sign is not thereby zero.
+                case Equalsf(var left, var right):
+                    return SignNear(left - right, x, dest, side) is { } ? false : null;
+                default:
+                    return null;
+            }
         }
 
         /// <summary>

--- a/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
@@ -165,6 +165,41 @@ namespace AngouriMath.Functions.Algebra
             => !IsInfiniteNode(expr) && expr != MathS.NaN;
 
         /// <summary>
+        /// What an inverse trigonometric function tends to where its argument grows without
+        /// bound, or <see langword="null"/> where the argument does not diverge or the function
+        /// is not one this has a reading for.
+        /// </summary>
+        /// <remarks>
+        /// Neither arcsine nor arccosine is real past 1, and this library reads both on the side
+        /// of the cut below the real axis: arcsin(t) is pi/2 - i*arcosh(t) for real t greater
+        /// than 1 and -pi/2 - i*arcosh(t) for t less than -1, with arccos being pi/2 - arcsin
+        /// throughout. arcosh grows without bound, so what is left in the limit is that real part
+        /// with an infinite imaginary one -- https://github.com/asc-community/AngouriMath/issues/333.
+        /// <para/>
+        /// C99 and Python take the other side of both cuts and so answer the conjugates.
+        /// CompiledArcsinBranchTest pins the side this library takes, and a limit that disagreed
+        /// with the function it is a limit of would be worse than either convention.
+        /// <para/>
+        /// An arcsecant is an arccosine of the reciprocal, so a diverging argument takes it to
+        /// arccos(0), which is a right angle and is real. Substituting the infinity does settle
+        /// that one, but it settles it as arcsec(+oo) -- the right angle written as a function of
+        /// an infinity rather than as the right angle.
+        /// </remarks>
+        internal static Entity? InverseTrigonometryAtInfinity(Entity function, Entity? argumentLimit)
+        {
+            if (argumentLimit?.Evaled is not Real { IsFinite: false, IsNaN: false } diverging)
+                return null;
+            var downwards = MathS.i * Real.PositiveInfinity;
+            return function switch
+            {
+                Arcsinf => (diverging.IsNegative ? -MathS.pi / 2 : MathS.pi / 2) - downwards,
+                Arccosf => (diverging.IsNegative ? MathS.pi : 0) + downwards,
+                Arcsecantf => MathS.pi / 2,
+                _ => null
+            };
+        }
+
+        /// <summary>
         /// Whether putting the parts' own limits in place of the parts settles the whole -- that
         /// is, whether the combination of the two is a number rather than an indeterminate form.
         /// </summary>

--- a/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
@@ -143,6 +143,32 @@ namespace AngouriMath.Functions.Algebra
             => !IsInfiniteNode(expr) && expr != MathS.NaN;
 
         /// <summary>
+        /// Whether putting the parts' own limits in place of the parts settles the whole -- that
+        /// is, whether the combination of the two is a number rather than an indeterminate form.
+        /// </summary>
+        /// <remarks>
+        /// The algebra of limits holds for the infinities as much as for the finite values:
+        /// where f tends to A and g to B, f * g tends to A * B whenever A * B means anything, and
+        /// 1 * +oo means +oo as surely as 2 * 3 means 6. The descent asked only whether both
+        /// limits were finite, so the determinate infinite combinations were left to the solvers,
+        /// which substitute the destination and read what comes out --
+        /// https://github.com/asc-community/AngouriMath/issues/335. That left
+        /// <c>lim x-&gt;0+ cos(x) / sin(x)</c> answered and <c>lim x-&gt;0+ cos(x) * (1 / sin(x))</c>
+        /// not, the same limit written two ways.
+        /// <para/>
+        /// The indeterminate forms are exactly the ones the arithmetic calls NaN: 0 * oo,
+        /// oo - oo, oo / oo, 0 / 0 and a non-zero over 0, whose answer depends on which side the
+        /// divisor vanishes from. Each of those is left to fall through to the readings that can
+        /// take it apart.
+        /// <para/>
+        /// Powers are not asked this question. The arithmetic answers <c>1 ^ (+oo)</c> with 1 and
+        /// <c>(+oo) ^ 0</c> with 1, and as limits both are indeterminate -- <c>(1 + 1/x)^x</c>
+        /// tends to e -- so a power settled this way would be settled wrongly.
+        /// </remarks>
+        internal static bool IsDeterminate(Entity combined, Variable x)
+            => !combined.ContainsNode(x) && combined.Evaled is Number { IsNaN: false };
+
+        /// <summary>
         /// How many derivatives of the divisor to take looking for the order at which it
         /// vanishes. A divisor that is still flat after four of them is one whose sign this has
         /// no cheap reading of, and reading it wrongly would answer +oo where the truth is -oo,

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Common.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Common.cs
@@ -39,8 +39,15 @@ namespace AngouriMath.Functions
             Divf(Mulf(var any1, Real { IsNegative: true } num), var any2) => -((-num) * (any1 / any2)),
             Mulf(var any2, Mulf(Real { IsNegative: true } num, var any1)) => -((-num) * (any1 * any2)),
             Mulf(var any2, Mulf(var any1, Real { IsNegative: true } num)) => -((-num) * (any1 * any2)),
-            Divf(var any2, Mulf(Real { IsNegative: true } num, var any1)) => -((-num) * (any1 / any2)),
-            Divf(var any2, Mulf(var any1, Real { IsNegative: true } num)) => -((-num) * (any1 / any2)),
+            // A negative factor under the line comes out as a sign in front, and what is left
+            // stays under the line: a / (-b * c) is -(a / (b * c)), not -(b * (c / a)). Written
+            // the latter way -- as the four rules above it are, where the negative factor is in
+            // the numerator and multiplying by it is right -- the quotient came back inverted,
+            // and Simplify takes whichever candidate is shortest, so the inverted one won
+            // wherever it was smaller: 1 / (x * (-1 - 1/x)) simplified to -(1 + x), which is its
+            // reciprocal.
+            Divf(var any2, Mulf(Real { IsNegative: true } num, var any1)) => -(any2 / ((-num) * any1)),
+            Divf(var any2, Mulf(var any1, Real { IsNegative: true } num)) => -(any2 / ((-num) * any1)),
 
             _ => x
         };

--- a/Sources/Tests/UnitTests/Calculus/DeterminateCombinationLimitTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/DeterminateCombinationLimitTest.cs
@@ -1,0 +1,77 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Core;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// https://github.com/asc-community/AngouriMath/issues/335 -- the descent substituted the
+    /// parts' own limits only where both of them were finite, so a combination that is perfectly
+    /// determinate with an infinity in it was left to the solvers, which substitute the
+    /// destination and read what comes out. That answered the same limit differently depending on
+    /// how it was written: cos(x) / sin(x) at 0+ was +oo and cos(x) * (1 / sin(x)) was
+    /// unevaluated.
+    /// </summary>
+    public sealed class DeterminateCombinationLimitTest
+    {
+        private static void AssertLimit(string expression, string destination, ApproachFrom side, string expected) =>
+            Assert.Equal(expected.ToEntity().Evaled,
+                expression.ToEntity().Limit("x", destination.ToEntity(), side).Simplify().Evaled);
+
+        /// <summary>
+        /// A finite non-zero factor against a diverging one: the product diverges, with the sign
+        /// the finite factor gives it.
+        /// </summary>
+        [Theory]
+        [InlineData("cos(x) * (1 / sin(x))", "0", ApproachFrom.Right, "+oo")]
+        [InlineData("cos(x) * (1 / sin(x))", "0", ApproachFrom.Left, "-oo")]
+        [InlineData("(3 + x) * ln(x)", "0", ApproachFrom.Right, "-oo")]
+        [InlineData("(2 + 1/x) * x", "+oo", ApproachFrom.BothSides, "+oo")]
+        [InlineData("(x - 5) * (1 / x)", "0", ApproachFrom.Right, "-oo")]
+        public void AFiniteFactorAgainstADivergingOne(string expression, string destination, ApproachFrom side, string expected) =>
+            AssertLimit(expression, destination, side, expected);
+
+        /// <summary>
+        /// The rest of the algebra of limits, which reads the same way: a finite part added to a
+        /// diverging one diverges, and a finite dividend over a diverging divisor vanishes.
+        /// </summary>
+        [Theory]
+        [InlineData("cos(x) + 1 / x", "0", ApproachFrom.Right, "+oo")]
+        [InlineData("cos(x) - 1 / x", "0", ApproachFrom.Right, "-oo")]
+        [InlineData("cos(x) / (1 / x)", "0", ApproachFrom.Right, "0")]
+        [InlineData("ln(x) + ln(x)", "0", ApproachFrom.Right, "-oo")]
+        public void TheRestOfTheAlgebraOfLimits(string expression, string destination, ApproachFrom side, string expected) =>
+            AssertLimit(expression, destination, side, expected);
+
+        /// <summary>
+        /// The indeterminate combinations are still indeterminate and must keep falling through
+        /// to the readings that can take them apart. Each of these is a form the arithmetic
+        /// answers with NaN, and each has a limit that is not NaN.
+        /// </summary>
+        [Theory]
+        [InlineData("x * ln(x)", "0", ApproachFrom.Right, "0")]            // 0 * -oo
+        [InlineData("(1 / x) / (1 / x ^ 2)", "0", ApproachFrom.Right, "0")] // +oo / +oo
+        [InlineData("1 / x - 1 / sin(x)", "0", ApproachFrom.Right, "0")]    // +oo - +oo
+        [InlineData("sin(x) / x", "0", ApproachFrom.Right, "1")]            // 0 / 0
+        public void TheIndeterminateOnesStillFallThrough(string expression, string destination, ApproachFrom side, string expected) =>
+            AssertLimit(expression, destination, side, expected);
+
+        /// <summary>
+        /// Powers are deliberately not settled this way. The arithmetic gives 1 for both
+        /// 1 ^ (+oo) and (+oo) ^ 0, and as limits neither is settled at all.
+        /// </summary>
+        [Theory]
+        [InlineData("(1 + 1/x) ^ x", "+oo", "e")]
+        [InlineData("(1 + x) ^ (1/x)", "0", "e")]
+        public void APowerIsNotSettledByItsPartsAlone(string expression, string destination, string expected) =>
+            AssertLimit(expression, destination, ApproachFrom.BothSides, expected);
+    }
+}

--- a/Sources/Tests/UnitTests/Calculus/EquivalentInfinitesimalTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/EquivalentInfinitesimalTest.cs
@@ -1,0 +1,84 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Core;
+using AngouriMath.Extensions;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// sin(u), tan(u), arcsin(u) and arctan(u) are all equivalent to u where u vanishes, and one
+    /// may be written for the other wherever the expression is a product or a quotient of them.
+    /// Only the quotient had the substitution, and it was made on the function vanishing rather
+    /// than on its argument vanishing, which are two different conditions.
+    /// </summary>
+    public sealed class EquivalentInfinitesimalTest
+    {
+        private static Entity Limit(string expression, string destination, ApproachFrom side)
+        {
+            var task = Task.Run(() =>
+                expression.ToEntity().Limit("x", destination.ToEntity(), side).Simplify());
+            Assert.True(task.Wait(TimeSpan.FromSeconds(30)), $"the limit of {expression} did not terminate");
+            return task.Result;
+        }
+
+        private static void AssertLimit(string expression, string destination, ApproachFrom side, string expected) =>
+            Assert.Equal(expected.ToEntity().Evaled, Limit(expression, destination, side).Evaled);
+
+        /// <summary>
+        /// A product takes the substitution as much as a quotient does. tan(x) * ln(x) at 0+ is
+        /// the case that names this: written sin(x) * ln(x) the same limit was 0, and written
+        /// with a tangent it was NaN -- the claim that it does not exist.
+        /// </summary>
+        [Theory]
+        [InlineData("tan(x) * ln(x)", "0", ApproachFrom.Right, "0")]
+        [InlineData("arcsin(x) * ln(x)", "0", ApproachFrom.Right, "0")]
+        [InlineData("arctan(x) * ln(x)", "0", ApproachFrom.Right, "0")]
+        [InlineData("tan(x) * ln(-x)", "0", ApproachFrom.Left, "0")]
+        [InlineData("tan(2 * x) * ln(x)", "0", ApproachFrom.Right, "0")]
+        public void AProductTakesTheSubstitution(string expression, string destination, ApproachFrom side, string expected) =>
+            AssertLimit(expression, destination, side, expected);
+
+        /// <summary>
+        /// It is the argument that has to vanish, not the function. sin(x) vanishes at pi as
+        /// surely as at 0, and there it is equivalent to pi - x rather than to x, so rewriting
+        /// it as x turned a limit of -1 into pi / 0.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x) / (x - pi)", "pi", "-1")]
+        [InlineData("sin(x) / (pi - x)", "pi", "1")]
+        public void TheArgumentIsWhatHasToVanish(string expression, string destination, string expected) =>
+            AssertLimit(expression, destination, ApproachFrom.BothSides, expected);
+
+        /// <summary>The quotients the substitution was already made in, unchanged.</summary>
+        [Theory]
+        [InlineData("sin(x) / x", "0", "1")]
+        [InlineData("tan(x) / x", "0", "1")]
+        [InlineData("x / sin(x)", "0", "1")]
+        [InlineData("arcsin(x) / x", "0", "1")]
+        [InlineData("arctan(x) / x", "0", "1")]
+        [InlineData("sin(3 * x) / sin(5 * x)", "0", "3/5")]
+        [InlineData("tan(x) / sin(x)", "0", "1")]
+        public void TheQuotientsAreUnchanged(string expression, string destination, string expected) =>
+            AssertLimit(expression, destination, ApproachFrom.BothSides, expected);
+
+        /// <summary>
+        /// A product with no vanishing argument in it must be left alone, so that the ordinary
+        /// readings still answer it.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x) * x", "0", "0")]
+        [InlineData("sin(1 / x) * x", "+oo", "1")]
+        [InlineData("tan(x) * cotan(x)", "0", "1")]
+        public void ProductsWithoutOneAreLeftAlone(string expression, string destination, string expected) =>
+            AssertLimit(expression, destination, ApproachFrom.BothSides, expected);
+    }
+}

--- a/Sources/Tests/UnitTests/Calculus/InverseTrigonometryLimitTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/InverseTrigonometryLimitTest.cs
@@ -1,0 +1,94 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Core;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// https://github.com/asc-community/AngouriMath/issues/333 -- arcsine had no limit at an
+    /// infinite argument. It is not real past 1, and the library reads it on the side of the cut
+    /// below the real axis, so along the reals it goes off to infinity in the imaginary direction
+    /// with its real part settling at a right angle.
+    /// </summary>
+    public sealed class InverseTrigonometryLimitTest
+    {
+        private static Entity Limit(string expression, string destination) =>
+            expression.ToEntity().Limit("x", destination.ToEntity(), ApproachFrom.BothSides).Simplify();
+
+        /// <summary>
+        /// Compared as numbers rather than as decimals: a right angle reached one way carries a
+        /// trailing zero the same right angle reached another way does not, and the two are the
+        /// same number. An infinite part has to match in sign and in being infinite.
+        /// </summary>
+        private static void AssertSameNumber(string expected, Entity actual)
+        {
+            var (want, got) = ((Entity.Number.Complex)expected.ToEntity().Evaled,
+                               (Entity.Number.Complex)actual.Evaled);
+            AssertSamePart(want.RealPart, got.RealPart, "real");
+            AssertSamePart(want.ImaginaryPart, got.ImaginaryPart, "imaginary");
+
+            static void AssertSamePart(Entity.Number.Real want, Entity.Number.Real got, string which)
+            {
+                Assert.True(want.IsFinite == got.IsFinite, $"the {which} part: wanted {want}, got {got}");
+                if (want.IsFinite)
+                    Assert.True(System.Math.Abs(want.EDecimal.ToDouble() - got.EDecimal.ToDouble()) < 1e-12,
+                        $"the {which} part: wanted {want}, got {got}");
+                else
+                    Assert.True(want.IsNegative == got.IsNegative, $"the {which} part: wanted {want}, got {got}");
+            }
+        }
+
+        [Theory]
+        [InlineData("arcsin(x)", "+oo", "pi / 2 - i * (+oo)")]
+        [InlineData("arcsin(x)", "-oo", "-pi / 2 - i * (+oo)")]
+        [InlineData("arccos(x)", "+oo", "i * (+oo)")]
+        [InlineData("arccos(x)", "-oo", "pi + i * (+oo)")]
+        [InlineData("arcsec(x)", "+oo", "pi / 2")]
+        [InlineData("arcsec(x)", "-oo", "pi / 2")]
+        [InlineData("arccsc(x)", "+oo", "0")]
+        public void ADivergingArgumentIsAnswered(string expression, string destination, string expected) =>
+            AssertSameNumber(expected, Limit(expression, destination));
+
+        /// <summary>
+        /// The limit has to be the limit of the function this library computes, whichever side of
+        /// the cut that is. arcsin(10^6) is a right angle with a large negative imaginary part
+        /// here, so the limit is a right angle with an infinite negative imaginary part, and the
+        /// two must at least agree in sign.
+        /// </summary>
+        [Theory]
+        [InlineData("arcsin(x)", "1000000", "+oo")]
+        [InlineData("arcsin(x)", "-1000000", "-oo")]
+        [InlineData("arccos(x)", "1000000", "+oo")]
+        [InlineData("arccos(x)", "-1000000", "-oo")]
+        public void TheLimitAgreesWithTheFunctionItIsALimitOf(string expression, string farOut, string destination)
+        {
+            var atAPoint = (Entity.Number.Complex)expression.ToEntity().Substitute("x", farOut.ToEntity()).EvalNumerical();
+            var atInfinity = (Entity.Number.Complex)Limit(expression, destination).Evaled;
+            Assert.Equal(atAPoint.RealPart, atInfinity.RealPart);
+            Assert.False(atAPoint.ImaginaryPart.IsZero);
+            Assert.False(atInfinity.ImaginaryPart.IsFinite);
+            Assert.Equal(atAPoint.ImaginaryPart.IsNegative, atInfinity.ImaginaryPart.IsNegative);
+        }
+
+        /// <summary>
+        /// The arguments that stay inside the domain are unaffected, and so is the first
+        /// remarkable limit that arcsine takes part in.
+        /// </summary>
+        [Theory]
+        [InlineData("arcsin(x) / x", "0", "1")]
+        [InlineData("arcsin(1 / x)", "+oo", "0")]
+        [InlineData("arccos(1 / x)", "+oo", "pi / 2")]
+        [InlineData("arctan(x)", "+oo", "pi / 2")]
+        [InlineData("arctan(x)", "-oo", "-pi / 2")]
+        public void TheOnesInsideTheDomainAreUnaffected(string expression, string destination, string expected) =>
+            AssertSameNumber(expected, Limit(expression, destination));
+    }
+}

--- a/Sources/Tests/UnitTests/Calculus/OneSidedLimitTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/OneSidedLimitTest.cs
@@ -110,6 +110,24 @@ namespace AngouriMath.Tests.Calculus
             AssertLimit(expression, destination, side, expected);
 
         /// <summary>
+        /// https://github.com/asc-community/AngouriMath/issues/596 -- the reporter's difference
+        /// of reciprocal logarithms, which is -1/2. Both one-sided readings answer it; the
+        /// two-sided one does not, and promoting the agreement of the two into a two-sided answer
+        /// is not open, since it would also make lim x->0 x * ln(x) equal 0, where the library
+        /// deliberately answers NaN because ln(x) is not real on the left.
+        /// </summary>
+        [Theory]
+        [InlineData(ApproachFrom.Right)]
+        [InlineData(ApproachFrom.Left)]
+        public void ADifferenceOfReciprocalLogarithms(ApproachFrom side)
+        {
+            var task = System.Threading.Tasks.Task.Run(() =>
+                Limit("1 / ln(x + sqrt(x * x + 1)) - 1 / ln(x + 1)", "0", side));
+            Assert.True(task.Wait(System.TimeSpan.FromSeconds(60)), "the limit did not terminate");
+            Assert.Equal("-1/2".ToEntity().Evaled, task.Result.Evaled);
+        }
+
+        /// <summary>
         /// The fallback moves x out to infinity, which is what a finite destination does in any
         /// case. It must not be reached for a destination that is already infinite, where the
         /// substitution would mean nothing.

--- a/Sources/Tests/UnitTests/Calculus/PiecewiseLimitTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/PiecewiseLimitTest.cs
@@ -1,0 +1,108 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Core;
+using AngouriMath.Extensions;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// https://github.com/asc-community/AngouriMath/issues/536 -- a limit of a piecewise
+    /// expression came back unevaluated wherever it was taken, including at points nowhere
+    /// near a seam.
+    /// </summary>
+    public sealed class PiecewiseLimitTest
+    {
+        private const string Sign = "piecewise(-1 provided x < 0, 1 provided x > 0, 0)";
+
+        private static Entity Limit(string expression, string destination, ApproachFrom side) =>
+            expression.ToEntity().Limit("x", destination.ToEntity(), side).Simplify();
+
+        private static void AssertLimit(string expression, string destination, ApproachFrom side, string expected) =>
+            Assert.Equal(expected.ToEntity().Evaled, Limit(expression, destination, side).Evaled);
+
+        /// <summary>
+        /// Which case a piecewise agrees with near the destination is decided by the sign its
+        /// predicates keep on the way in, so the seam matters only where the destination is on
+        /// it. Away from one, the limit is the limit of the single case that holds there.
+        /// </summary>
+        [Theory]
+        [InlineData(Sign, "0", ApproachFrom.Left, "-1")]
+        [InlineData(Sign, "0", ApproachFrom.Right, "1")]
+        [InlineData(Sign, "-456", ApproachFrom.BothSides, "-1")]
+        [InlineData(Sign, "123", ApproachFrom.BothSides, "1")]
+        [InlineData(Sign, "-oo", ApproachFrom.BothSides, "-1")]
+        [InlineData(Sign, "+oo", ApproachFrom.BothSides, "1")]
+        public void ThePieceThatHoldsNearTheDestinationDecides(string expression, string destination, ApproachFrom side, string expected) =>
+            AssertLimit(expression, destination, side, expected);
+
+        /// <summary>
+        /// The case that holds gets the whole of the machinery, not only the substitution: the
+        /// piecewise below is sin(x)/x everywhere the limit looks, and that is an indeterminate
+        /// form in its own right.
+        /// </summary>
+        [Theory]
+        [InlineData("piecewise(sin(x) / x provided not (x = 0), 0)", "0", ApproachFrom.Right, "1")]
+        [InlineData("piecewise(sin(x) / x provided not (x = 0), 0)", "0", ApproachFrom.Left, "1")]
+        [InlineData("piecewise(sin(x) / x provided not (x = 0), 0)", "0", ApproachFrom.BothSides, "1")]
+        public void TheCaseThatHoldsIsAnsweredInFull(string expression, string destination, ApproachFrom side, string expected) =>
+            AssertLimit(expression, destination, side, expected);
+
+        /// <summary>
+        /// The value at the point is not the limit and does not have to agree with it. Both
+        /// cases here tend to 1 while the piecewise is 5 at the destination itself.
+        /// </summary>
+        [Theory]
+        [InlineData("piecewise(x + 1 provided x < 0, x + 1 provided x > 0, 5)", "0", ApproachFrom.Left, "1")]
+        [InlineData("piecewise(x + 1 provided x < 0, x + 1 provided x > 0, 5)", "0", ApproachFrom.Right, "1")]
+        [InlineData("piecewise(x + 1 provided x < 0, x + 1 provided x > 0, 5)", "0", ApproachFrom.BothSides, "1")]
+        public void TheValueAtThePointIsNotTheLimit(string expression, string destination, ApproachFrom side, string expected) =>
+            AssertLimit(expression, destination, side, expected);
+
+        /// <summary>
+        /// A jump: the two one-sided limits exist and disagree, so the two-sided one does not
+        /// exist. That is a claim about the mathematics, and NaN is how it is made.
+        /// </summary>
+        [Fact]
+        public void AJumpHasNoTwoSidedLimit() =>
+            Assert.Equal(MathS.NaN, Sign.ToEntity().Limit("x", 0, ApproachFrom.BothSides).Evaled);
+
+        /// <summary>
+        /// Where no case holds at all the expression is undefined on the whole of the way in,
+        /// so there is nothing for it to tend to.
+        /// </summary>
+        [Fact]
+        public void NoCaseHoldingMeansNoLimit() =>
+            Assert.Equal(MathS.NaN, "piecewise(1 provided x > 5)".ToEntity().Limit("x", 0, ApproachFrom.Right).Evaled);
+
+        /// <summary>
+        /// A predicate whose truth near the destination cannot be read off leaves it open which
+        /// case the limit is of, and an unevaluated limit is how that is said.
+        /// </summary>
+        [Fact]
+        public void AnUnreadablePredicateIsLeftUnevaluated() =>
+            Assert.IsType<Entity.Limitf>(
+                "piecewise(1 provided x > a, 2)".ToEntity().Limit("x", 0, ApproachFrom.Right));
+
+        /// <summary>
+        /// The predicates are asked about one at a time and each of those questions is a limit,
+        /// so a piecewise of several cases must not fan out. Termination is the assertion.
+        /// </summary>
+        [Fact]
+        public void ManyCasesTerminate()
+        {
+            var task = Task.Run(() =>
+                "piecewise(1 / x provided x < -1, x ^ 2 provided x < 0, sin(x) / x provided x < 1, ln(x), 7)"
+                    .ToEntity().Limit("x", 0, ApproachFrom.Right));
+            Assert.True(task.Wait(TimeSpan.FromSeconds(30)), "the limit of a piecewise did not terminate");
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Common/SimplificationRegressionTest.cs
+++ b/Sources/Tests/UnitTests/Common/SimplificationRegressionTest.cs
@@ -215,5 +215,27 @@ namespace AngouriMath.Tests.Common
         [InlineData("x * ln(x)")]
         public void AntiderivativesNeverContainNaN(string integrand) =>
             Assert.DoesNotContain("NaN", integrand.ToEntity().Integrate("x").Stringize());
+
+        // A negative factor under the line was taken out by multiplying by it and inverting
+        // what was left, so a / (-b * c) came back as -(b * (c / a)) -- the reciprocal of the
+        // right answer. Simplify keeps whichever candidate is shortest, so the inverted form
+        // won wherever it was smaller, which is wherever the numerator was 1.
+        //
+        // Checked numerically as well as symbolically: an inverted answer differs from the
+        // original by a factor, and subtracting the two can simplify to something that only
+        // looks like zero if the same wrong rule fires on the difference.
+        [Theory]
+        [InlineData("(1/x) / (-1 - 1/x)", 2.0, -1.0 / 3)]
+        [InlineData("(1/x) / (-1 - 1/x^2)", 2.0, -0.4)]
+        [InlineData("1 / (x * (-1 - 1/x))", 2.0, -1.0 / 3)]
+        [InlineData("(1/x) / (-1 - y^2/x^2)", 2.0, -0.4)]
+        [InlineData("1 / (-2 * x)", 2.0, -0.25)]
+        public void ANegativeFactorUnderTheLineStaysUnderIt(string input, double at, double expected)
+        {
+            var simplified = input.ToEntity().Simplify();
+            var value = simplified.Substitute("x", at).Substitute("y", 1).EvalNumerical();
+            Assert.True(System.Math.Abs(((Entity.Number.Complex)value).RealPart.EDecimal.ToDouble() - expected) < 1e-9,
+                $"{input} simplified to {simplified.Stringize()}, which is {value.Stringize()} at x = {at}");
+        }
     }
 }


### PR DESCRIPTION
Closes #536, #335, #333, #347. Adds tests to #596 without closing it.

Six commits, one per finding. **`d30c4541` is the one to review first: it is a wrong-answer fix in core simplification, not a limits change**, and it is reachable from any `Simplify` of a quotient whose denominator carries a negative factor.

## The wrong answer

Four of the rules that take a negative constant out of a product read it from the numerator, where multiplying the rest by it is right. The two that read it from the *denominator* were written the same way, and there it is not: `a / (-b*c)` is `-(a / (b*c))` and came back as `-(b * (c/a))` — the reciprocal. `Simplify` keeps whichever candidate is shortest, so the inverted form won wherever it was smaller, which is wherever the numerator was 1.

```
simplify((1/x) / (-1 - 1/x))    was  -(1 + x)
```

That is **-2** at `x = 1`, where the expression is **-1/2**. Found from a limit rather than by hand — l'Hôpital's rule simplifies the quotient of derivatives it builds, and this is the shape of one. Five regression cases added, each checking the value at a point rather than the form.

## The limits

**#536 — limits of piecewise.** All five of the reporter's calls came back unevaluated, from two causes. The gate at the top of `ComputeLimit` admits `ContinuousNode` only and a `Piecewise` is not one, so the descent's `Piecewise` case was unreachable; and that case was dead anyway — `allLims.Select(c => c.lim is null).Any()` is `Any()` with no predicate, i.e. "is the sequence non-empty", so it always returned `null`. Even had it run, it built a piecewise of the cases' limits carrying predicates that still speak about the variable the limit had just removed. Rewritten to pick the case that holds *near* the destination, reading each predicate from the sign its comparisons keep on the way in. After: `-1` at `0-`, `1` at `0+`, `NaN` two-sided at 0, `-1` at -456, `1` at 123.

**#335 — process the parts' limits.** The maintainer's own comment names the fix: "cases when one of operands is finite and non-zero". The descent substituted the parts' limits only when *both* were finite, so `lim x->0+ cos(x)/sin(x)` was `+oo` while the same limit written `cos(x)*(1/sin(x))` was unevaluated. Sum, difference, product and quotient now take both limits whenever the combination is a number rather than NaN — which is the arithmetic's own test for an indeterminate form. Powers are deliberately excluded: the arithmetic answers `1^(+oo)` and `(+oo)^0` with 1, and as limits neither is settled.

**`tan(x)*ln(x)` — the gap left open in #712.** Two causes. The first is the simplification inversion above. The second: the equivalent-infinitesimal substitution (`sin(u) ~ u`, `tan(u) ~ u`) fired only for a quotient, never a product, and was keyed on the *function* vanishing rather than its *argument* vanishing. Both corrected. `lim x->0+ tan(x)*ln(x)`: **NaN after 4.8 s -> 0 in 0.27 s**. The argument check also fixed `lim x->pi sin(x)/(x-pi)`, **NaN -> -1** — the old rule rewrote `sin(x)` as `x` at pi, giving pi/0.

**#333 — limit of arcsin.** `arcsin(+oo)` evaluates to NaN, so substitution had nothing to work with. The library reads `arcsin(t)` on the side of both cuts *below* the real axis, which `CompiledArcsinBranchTest` pins; the limit follows the library rather than introducing a second convention. `pi/2 - (+oo)i` at `+oo`, `-pi/2 - (+oo)i` at `-oo`, arccos correspondingly. Also caught `arcsec`, which was "answered" with `arcsec(+oo)` — a right angle written as a function of an infinity — now `pi/2`.

**#347 — stack overflow. Does not reproduce.** `"a and x".Limit("x", "+oo")` returns an unevaluated `limit(a and x, x, +oo)` on stock master, no crash, and it is already pinned in `AlreadyFixedIssuesTest.Issue347_LimitOfABooleanDoesNotCrash`. No change here; the issue is closeable.

## #596, and why one part is not fixed

- `x^4 * e^(-x)` at `+oo` is already 0 on master and already tested.
- `1/ln(x+sqrt(x^2+1)) - 1/ln(x+1)` at 0 is **-1/2 from either side already on master**. The *two-sided* reading is unevaluated. Tests pin both one-sided values; the two-sided case is **not** fixed, on purpose. The obvious fix — a two-sided limit is the two one-sided ones agreeing — is exactly the guard that rejects it: AngouriMath's one-sided limits do not stay inside the reals (`lim x->0- ln(x)` is `-oo`, `lim x->0- x*ln(x)` is 0, `lim x->0- x^x` is 1), so that promotion would also turn `lim x->0 x*ln(x)` into 0 and `lim x->0 x^x` into 1 — both deliberately NaN, one pinned by `LimitTest.TestNoLimit`. The question underneath is whether a one-sided limit may leave the reals, which is a design decision rather than something to settle inside this issue.
- `((x!)/x^x)^(1/x)` at `+oo` needs an asymptotic for the factorial and is still declined by the documented guard in `SolveAsIndeterminatePower`. Unevaluated, not wrong.

## Measured

| | base `5f4269e0` | branch head |
|---|---|---|
| UnitTests | 4675 passed, 0 failed, 14 skipped | **4746 passed, 0 failed**, 14 skipped (71 new) |
| FSharpWrapperUnitTests | 130 | 130 |
| corpus | 111/117, 0 wrong, 0 error, 0 timeout | 111/117, **0 wrong, 0 error, 0 timeout** |

No existing test changed behaviour and nothing was loosened. Suite wall time 3m42s -> 3m31s. One limit got slower: the #596 difference at `0+`, 2.4 s -> 3.9 s from extra descent work, well inside budget.

## Noticed, not touched

AngouriMath's `arcsin` on the cuts is the conjugate of C99, Python and Mathematica: `arcsin(2)` is `pi/2 - 1.317i` here and `pi/2 + 1.317i` there. It is internally consistent and pinned by an existing test, so the new limit follows it — but the convention itself probably deserves its own issue.
