### PR TITLE
Squeeze a bounded factor against a vanishing one (#723)

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Limit.Solvers.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Limit.Solvers.cs
@@ -131,6 +131,137 @@ namespace AngouriMath.Functions.Algebra
             else return null;
         }
 
+        /// <summary>
+        /// The squeeze theorem, in the one shape that does not need the bounded factor's own
+        /// limit: a factor bounded near the destination times one that vanishes there tends to
+        /// zero, however wildly the bounded one oscillates. Also written as a quotient, where a
+        /// bounded dividend over a diverging divisor is the same statement.
+        /// </summary>
+        /// <remarks>
+        /// Every other rule reads a limit as a value -- the descent puts each part's own limit in
+        /// place of the part, l'Hopital's rule wants a determinate quotient, Gruntz compares rates
+        /// of growth. <c>sin(x)</c> has no limit at infinity, so each of them correctly declines
+        /// and the product is left indeterminate in the shape <c>(no limit) * 0</c>. What the
+        /// theorem needs of the factor is not its limit but its boundedness, which is a weaker
+        /// fact and one that can be read off the shape --
+        /// https://github.com/asc-community/AngouriMath/issues/723.
+        /// </remarks>
+        internal static Entity? SolveAsBoundedTimesVanishing(Entity expr, Variable x)
+        {
+            switch (expr)
+            {
+                case Mulf(var multiplier, var multiplicand):
+                    if (IsBoundedAtInfinity(multiplier, x) && VanishesAtInfinity(multiplicand, x))
+                        return Integer.Zero;
+                    if (IsBoundedAtInfinity(multiplicand, x) && VanishesAtInfinity(multiplier, x))
+                        return Integer.Zero;
+                    return null;
+                case Divf(var dividend, var divisor):
+                    if (IsBoundedAtInfinity(dividend, x) && DivergesAtInfinity(divisor, x))
+                        return Integer.Zero;
+                    return null;
+                default:
+                    return null;
+            }
+        }
+
+        /// <summary>
+        /// That a sine or a cosine has no limit where its argument grows without bound: it takes
+        /// every value in its range infinitely often on the way in and settles on none of them.
+        /// </summary>
+        /// <remarks>
+        /// NaN is the claim that there is no limit, which is a different and stronger statement
+        /// than leaving the node unevaluated -- that one says only that none of the rules found
+        /// one. The distinction is worth making where it can be: it is the one this library draws
+        /// between a limit it has decided against and a limit it has not reached.
+        /// <para/>
+        /// Only for a real argument, as with boundedness above, and for the same reason:
+        /// sin(i * t) diverges rather than oscillating.
+        /// </remarks>
+        internal static Entity? SolveAsOscillationWithoutLimit(Entity expr, Variable x)
+            => expr is Sinf or Cosf
+               && IsRealValued(expr.DirectChildren[0], x)
+               && DivergesAtInfinity(expr.DirectChildren[0], x)
+                ? Real.NaN
+                : null;
+
+        private static bool VanishesAtInfinity(Entity expr, Variable x)
+            => LimitFunctional.ComputeLimit(expr, x, Real.PositiveInfinity) is { } limit
+               && limit.Evaled is Real { IsZero: true };
+
+        private static bool DivergesAtInfinity(Entity expr, Variable x)
+            => LimitFunctional.ComputeLimit(expr, x, Real.PositiveInfinity) is { } limit
+               && limit.Evaled is Real { IsFinite: false, IsNaN: false };
+
+        /// <summary>
+        /// Whether the expression stays within some finite bound as x grows, established without
+        /// asking what it tends to. Nothing is claimed for a shape not listed here.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately not "has a finite limit": that is the case the rest of the machinery
+        /// already covers, and asking for it here would only repeat work while missing the
+        /// factors this exists for, which have no limit at all.
+        /// </remarks>
+        private static bool IsBoundedAtInfinity(Entity expr, Variable x)
+        {
+            if (!expr.ContainsNode(x))
+                return expr.Evaled is Number { IsFinite: true };
+            switch (expr)
+            {
+                // A sine and a cosine never exceed 1 in magnitude and a sign never exceeds 1;
+                // an arctangent and an arccotangent stay within an interval of angles. Each of
+                // those is a fact about a real argument, and none of them holds otherwise:
+                // sin(i * t) is i * sinh(t), which grows without bound.
+                case Sinf or Cosf or Signumf or Arctanf or Arccotanf:
+                    return IsRealValued(expr.DirectChildren[0], x);
+                case Absf(var argument):
+                    return IsBoundedAtInfinity(argument, x);
+                case Mulf(var multiplier, var multiplicand):
+                    return IsBoundedAtInfinity(multiplier, x) && IsBoundedAtInfinity(multiplicand, x);
+                case Sumf(var augend, var addend):
+                    return IsBoundedAtInfinity(augend, x) && IsBoundedAtInfinity(addend, x);
+                case Minusf(var minuend, var subtrahend):
+                    return IsBoundedAtInfinity(minuend, x) && IsBoundedAtInfinity(subtrahend, x);
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Whether the expression is real wherever it is defined, given that x is. A free variable
+        /// is read as complex by this library, so one appearing anywhere but under a modulus
+        /// settles nothing and the answer is no.
+        /// </summary>
+        private static bool IsRealValued(Entity expr, Variable x)
+        {
+            if (!expr.ContainsNode(x))
+                return expr.Evaled is Real { IsNaN: false };
+            switch (expr)
+            {
+                case Variable variable:
+                    return variable == x;
+                case Sumf(var augend, var addend):
+                    return IsRealValued(augend, x) && IsRealValued(addend, x);
+                case Minusf(var minuend, var subtrahend):
+                    return IsRealValued(minuend, x) && IsRealValued(subtrahend, x);
+                case Mulf(var multiplier, var multiplicand):
+                    return IsRealValued(multiplier, x) && IsRealValued(multiplicand, x);
+                case Divf(var dividend, var divisor):
+                    return IsRealValued(dividend, x) && IsRealValued(divisor, x);
+                // Only an integer exponent keeps a real base real: x ^ (1/2) is not real below 0.
+                case Powf(var @base, Integer):
+                    return IsRealValued(@base, x);
+                case Sinf or Cosf or Tanf or Cotanf or Secantf or Cosecantf
+                     or Arctanf or Arccotanf or Signumf:
+                    return IsRealValued(expr.DirectChildren[0], x);
+                // A modulus is real whatever it is taken of.
+                case Absf:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
         internal static Entity? SolveAsLogarithmDivision(Entity expr, Variable x)
         {
             if (expr is Divf(Logf(var upperLogBase, var upperLogArgument), Logf(var lowerLogBase, var lowerLogArgument)))

--- a/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Solvers.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Solvers.Definition.cs
@@ -34,6 +34,19 @@ namespace AngouriMath.Functions.Algebra
             var logarithmDivisionResult = LimitSolvers.SolveAsLogarithmDivision(expr, x);
             if (logarithmDivisionResult is { }) return logarithmDivisionResult;
 
+            // Last, because it is the only one here that asks for a limit of its own and so is
+            // the only one whose cost is another walk of the machinery. Everything above reads
+            // the expression where it stands.
+            var boundedResult = LimitSolvers.SolveAsBoundedTimesVanishing(expr, x);
+            if (boundedResult is { }) return boundedResult;
+
+            // After the rule above and not before it. This one answers NaN, which is the claim
+            // that there is no limit, and the squeeze theorem is precisely the case where a
+            // factor with no limit of its own still leaves the product with one. Asked first it
+            // would settle sin(x) / x as (no limit) / (+oo) before the theorem was reached.
+            var oscillationResult = LimitSolvers.SolveAsOscillationWithoutLimit(expr, x);
+            if (oscillationResult is { }) return oscillationResult;
+
             return null;
         }
 

--- a/Sources/Tests/UnitTests/Calculus/BoundedTimesVanishingTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/BoundedTimesVanishingTest.cs
@@ -1,0 +1,121 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath.Core;
+using AngouriMath.Extensions;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// The squeeze theorem in the one shape that does not need the bounded factor's own limit.
+    /// Every rule above this one reads a limit as a value -- the descent substitutes each part's
+    /// limit, l'Hopital's rule wants a determinate quotient, Gruntz compares rates of growth --
+    /// so a factor with no limit at all, such as sin(x) at infinity, made each of them decline
+    /// and left the product indeterminate in the shape (no limit) * 0.
+    /// https://github.com/asc-community/AngouriMath/issues/723
+    /// </summary>
+    public sealed class BoundedTimesVanishingTest
+    {
+        private static void AssertLimit(string expression, string destination, string expected)
+        {
+            var task = Task.Run(() =>
+                expression.ToEntity().Limit("x", destination.ToEntity()).Simplify());
+            Assert.True(task.Wait(TimeSpan.FromSeconds(30)), "the limit did not terminate");
+            Assert.Equal(expected.ToEntity().Evaled, task.Result.Evaled);
+        }
+
+        /// <summary>
+        /// A bounded dividend over a diverging divisor. The standard example of the theorem is
+        /// the first of these.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x) / x", "+oo")]
+        [InlineData("cos(x) / x", "+oo")]
+        [InlineData("sin(x) / x ^ 2", "+oo")]
+        [InlineData("sin(x) / x", "-oo")]
+        [InlineData("sin(x ^ 2) / x", "+oo")]
+        [InlineData("(2 + sin(x)) / x", "+oo")]
+        [InlineData("(sin(x) + cos(x)) / x", "+oo")]
+        [InlineData("sin(x) * cos(x) / x", "+oo")]
+        public void BoundedOverDiverging(string expression, string destination) =>
+            AssertLimit(expression, destination, "0");
+
+        /// <summary>The same theorem written as a product rather than as a quotient.</summary>
+        [Theory]
+        [InlineData("sin(x) * e ^ (-x)", "+oo")]
+        [InlineData("x * sin(1 / x)", "0")]
+        [InlineData("x ^ 2 * sin(1 / x)", "0")]
+        [InlineData("x * cos(1 / x)", "0")]
+        [InlineData("signum(x) * x", "0")]
+        public void BoundedTimesVanishing(string expression, string destination) =>
+            AssertLimit(expression, destination, "0");
+
+        /// <summary>
+        /// The answers that were already given by putting the parts' own limits in place of the
+        /// parts, which this must not disturb: an arctangent does have a limit at infinity, and
+        /// the quotient is settled without any appeal to boundedness.
+        /// </summary>
+        [Theory]
+        [InlineData("arctan(x) / x", "+oo")]
+        [InlineData("arccotan(x) / x", "+oo")]
+        [InlineData("signum(sin(x)) / x", "+oo")]
+        public void TheLimitsThatWereAlreadyGiven(string expression, string destination) =>
+            AssertLimit(expression, destination, "0");
+
+        /// <summary>
+        /// An oscillation whose argument grows without bound has no limit at all, which is a
+        /// different claim from the one above and a stronger one than leaving the node
+        /// unevaluated. It is asked after the squeeze theorem and not before it: the theorem is
+        /// precisely the case where a factor with no limit of its own still leaves the product
+        /// with one, and sin(x) / x would otherwise be settled as (no limit) / (+oo).
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x)", "+oo")]
+        [InlineData("cos(x)", "+oo")]
+        [InlineData("sin(x)", "-oo")]
+        [InlineData("sin(x ^ 2)", "+oo")]
+        [InlineData("sin(1 / x)", "0")]
+        [InlineData("cos(1 / x)", "0")]
+        public void AnOscillationHasNoLimit(string expression, string destination)
+        {
+            var task = Task.Run(() => expression.ToEntity()
+                .Limit("x", destination.ToEntity(), ApproachFrom.BothSides));
+            Assert.True(task.Wait(TimeSpan.FromSeconds(30)), "the limit did not terminate");
+            Assert.Equal(MathS.NaN, task.Result.Evaled);
+        }
+
+        /// <summary>An argument that settles leaves the function settled with it.</summary>
+        [Theory]
+        [InlineData("cos(1 / x)", "+oo", "1")]
+        [InlineData("sin(1 / x)", "+oo", "0")]
+        [InlineData("sin(x) / x", "0", "1")]
+        public void AnArgumentThatSettlesIsNotAnOscillation(string expression, string destination, string expected) =>
+            AssertLimit(expression, destination, expected);
+
+        /// <summary>
+        /// Boundedness of a sine is a fact about a *real* argument. This library reads a free
+        /// variable as complex, and sin(i * x) is sinh(x) up to a factor, which grows without
+        /// bound -- so lim x-&gt;+oo sin(a * x) / x is not 0 for every a, and is left unanswered.
+        /// It is the example in <see cref="Entity.Limit(Entity.Variable, Entity)"/>'s own
+        /// documentation, which prints it unevaluated.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x * a) / x", "+oo")]
+        [InlineData("cos(a * x) / x", "+oo")]
+        [InlineData("sin(x * a)", "+oo")]
+        [InlineData("cos(a * x)", "+oo")]
+        public void AComplexArgumentIsNotBounded(string expression, string destination)
+        {
+            var task = Task.Run(() => expression.ToEntity().Limit("x", destination.ToEntity()));
+            Assert.True(task.Wait(TimeSpan.FromSeconds(30)), "the limit did not terminate");
+            Assert.IsType<Entity.Limitf>(task.Result);
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Calculus/GruntzTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/GruntzTest.cs
@@ -64,8 +64,14 @@ namespace AngouriMath.Tests.Calculus
         /// monotone and so comparable at all. A sine is not: it has no limit at infinity and no
         /// comparability class, so this declines rather than guesses.
         /// </summary>
+        /// <remarks>
+        /// A bare sin(x) used to be the first of these and is now answered NaN -- not by this
+        /// algorithm, which still declines it, but by the rule that reads a sine's range
+        /// directly (<see cref="BoundedTimesVanishingTest"/>). What this test is about is
+        /// unchanged: the two forms left are ones no rule anywhere has a reading of, and the
+        /// series must not invent one for them.
+        /// </remarks>
         [Theory]
-        [InlineData("sin(x)")]
         [InlineData("(x + sin(x)) / x")]
         [InlineData("x * cos(x)")]
         public void AnOscillationIsDeclinedRatherThanGuessedAt(string expression)

--- a/Sources/Tests/UnitTests/Calculus/LimitAtInfinityTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/LimitAtInfinityTest.cs
@@ -82,10 +82,16 @@ namespace AngouriMath.Tests.Calculus
         /// <see cref="CompetingGrowthAtInfinity"/>. They were here because l'Hopital's rule
         /// cannot reach them within its bound on steps, which is still true of the rule and is
         /// no longer true of the library. Nothing about that bound changed.
+        /// <para/>
+        /// sin(x) itself has moved to <see cref="BoundedTimesVanishingTest"/> for the opposite
+        /// reason: it is now NaN, and that is not a guess. Nothing here established
+        /// non-existence, so claiming it here would have been one; a sine takes every value in
+        /// [-1, 1] infinitely often on the way out to infinity, which does establish it. The
+        /// distinction this summary draws is the point and it still holds -- the two forms left
+        /// are ones nothing has established anything about.
         /// </remarks>
         [Theory]
         [InlineData("(x + sin(x)) / x")]
-        [InlineData("sin(x)")]
         [InlineData("x * sin(x)")]
         public void AFormThatCannotBeSettledTerminatesWithoutClaimingAnAnswer(string expression)
         {


### PR DESCRIPTION
Closes #723.

## What was wrong

Every rule in the limits pipeline reads a limit as a *value*: the descent substitutes each part's own limit, l'Hopital's rule wants a determinate quotient, Gruntz compares rates of growth. `sin(x)` has no limit at infinity, so each of them correctly declines and the product is left indeterminate in the shape `(no limit) * 0`. That is why the squeeze theorem's most standard example came back unevaluated:

```
lim x->+oo  sin(x) / x      =>  limit(sin(x) / x, x, +oo)
```

## The rule

The theorem does not need the factor's limit. It needs the factor to be **bounded**, which is a weaker fact and one that can be read off the shape: a sine, a cosine and a sign never exceed 1; an arctangent and an arccotangent stay within an interval of angles; sums, products and moduli of bounded things are bounded. That predicate, plus one case for a product and one for a quotient, is the whole of it.

It is deliberately *not* "has a finite limit". That is the case the rest of the machinery already covers, and asking for it here would repeat work while missing the factors this exists for — the ones with no limit at all.

Both rules live in `LimitSolvers` and are reached from `SimplifyAndComputeLimitToInfinity`, which every destination and side is normalised into, so one statement covers `x -> +oo`, `x -> -oo` and either side of a finite point.

## Boundedness is a fact about a *real* argument

This library reads a free variable as complex, and `sin(i * t)` is `i * sinh(t)`, which grows without bound. So the argument is established real before anything is claimed, which leaves

```
lim x->+oo  sin(a * x) / x  =>  limit(sin(x * a) / x, x, +oo)
```

unanswered — correctly, since it is not 0 for every `a`. That limit is the example in `Limit`'s own documentation, and it prints exactly as it did.

## The other half

A sine or cosine whose argument grows without bound takes every value in its range infinitely often and settles on none, so its limit does not exist. `NaN` says that; leaving the node unevaluated says only that no rule found one. It is asked *after* the theorem and not before — asked first it would settle `sin(x) / x` as `(no limit) / (+oo)`.

## Two tests changed rather than broke

`LimitAtInfinityTest.AFormThatCannotBeSettledTerminatesWithoutClaimingAnAnswer` and `GruntzTest.AnOscillationIsDeclinedRatherThanGuessedAt` both pinned a bare `sin(x)` at infinity as unevaluated, and the first says in its own summary that the answer must not become NaN "since NaN asserts that the limit does not exist rather than that it was not found."

That principle is right, and it is why the case **moved** rather than the assertion being loosened. Nothing in either test established non-existence, so claiming it there would have been a guess; a sine's range does establish it. The other forms in both tests — `(x + sin(x)) / x`, `x * sin(x)`, `x * cos(x)` — are still unevaluated and stay where they are. Gruntz still declines all three; a different rule now answers one of them.

## Measured

| | before | after |
|---|---|---|
| `lim x->+oo sin(x) / x` | unevaluated | `0` |
| `lim x->0 x * sin(1 / x)` | unevaluated | `0` |
| `lim x->+oo sin(x) * e^(-x)` | unevaluated | `0` |
| `lim x->+oo sin(x)` | unevaluated | `NaN` |
| `lim x->0 sin(1 / x)` | unevaluated | `NaN` |
| `lim x->+oo sin(a * x) / x` | unevaluated | unevaluated |
| `lim x->0 sin(x) / x` | `1` | `1` |
| `lim x->+oo (1 + 1/x)^x` | `e` | `e` |

29 regression cases in a new `BoundedTimesVanishingTest`, covering the theorem in both shapes, the answers that were already given by the descent, the complex-argument guard and the arguments that settle rather than oscillate.

Unit tests 4807 -> 4834 passing with none failing; F# 130 of 130; the 117-problem solver corpus stays at 112 solved with 0 wrong, 0 error and 0 timeout; suite 3m33s -> 3m28s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)