### PR TITLE
Simplify an opened multiple angle before judging it (#557)

### DIFF
--- a/Sources/AngouriMath/Functions/Simplification/Simplificator.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Simplificator.cs
@@ -206,6 +206,26 @@ namespace AngouriMath.Functions
             {
                 AddHistory(res.Expand().Simplify(-level));
                 AddHistory(res.Factorize().Simplify(-level));
+
+                // A multiple angle written out is worth having only where the pieces then
+                // cancel, so it has to be simplified in full before the metric can be
+                // asked -- the same reason Expand and Factorize are re-simplified above,
+                // and for the same reason it is a candidate rather than a step. The pass
+                // inside the loop offers the opened form to the trigonometric rules only,
+                // which settles an expression that is already one term; it cannot settle
+                // one whose cancellation needs a common denominator, because the passes
+                // that build one ran earlier in the loop, while the angles were still shut.
+                // That is https://github.com/asc-community/AngouriMath/issues/557: the
+                // reporter's second expression is 0, and reaches 0 through
+                // 2 sin(t) cos(t) and not through sin(2t).
+                var openedAngles = res
+                    .Replace(Patterns.ExpandMultipleAngleRules)
+                    .Replace(Patterns.NormalTrigonometricForm)
+                    .InnerSimplified;
+                if (openedAngles != res)
+                    // Expanded, and for the same reason res is expanded above: the
+                    // cancellation only shows up once the products are multiplied out.
+                    AddHistory(openedAngles.Expand().Simplify(-level));
             }
 
             return history.Values.SelectMany(x => x);

--- a/Sources/Tests/UnitTests/PatternsTest/DoubleAngleOverSineTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/DoubleAngleOverSineTest.cs
@@ -38,6 +38,34 @@ namespace AngouriMath.Tests.PatternsTest
             Assert.Equal(expected.ToEntity().Simplify(), Bare(expression));
 
         /// <summary>
+        /// The second expression the reporter gives, which is the first one with a
+        /// quotient of sixth and eighth powers of sin(t) added in front of it. Both are 0.
+        /// <para/>
+        /// This one needs the opened angle to survive as far as the fractions: the quotient
+        /// only cancels once its terms are over a common denominator, and the passes that
+        /// build one run before the angles are opened. So the opened form was offered to the
+        /// complexity metric in the one shape where its payoff had not happened yet, and was
+        /// rightly rejected as the longer of the two. It is now simplified in full first --
+        /// including expanded, since the cancellation only shows up once the products are
+        /// multiplied out -- which is what Expand and Factorize already get.
+        /// </summary>
+        [Fact]
+        public void TheReportersSecondExpressionIsAlsoZero() =>
+            Assert.Equal(Entity.Number.Integer.Create(0), Bare(
+                "(cos(2 * t) * sin(t) ^ 6 * (-1) + cos(t) * sin(t) ^ 5 * sin(2 * t)"
+                + " - sin(2 * t) ^ 2 * sin(t) ^ 4 / 4) / sin(t) ^ 8 - 1"
+                + " + (sin(2 * t) * cosec(t)) ^ 2 / 4 - cos(2 * t) - sin(t) ^ 2"));
+
+        // The pieces it is built from, each 0 or 1 on its own. Together they say the
+        // cancellation is the quotient's and not only the tail's.
+        [Theory]
+        [InlineData("(cos(2 * t) * sin(t) ^ 6 * (-1) + cos(t) * sin(t) ^ 5 * sin(2 * t)"
+                    + " - sin(2 * t) ^ 2 * sin(t) ^ 4 / 4) / sin(t) ^ 8", "1")]
+        [InlineData("(sin(t) ^ 6 - sin(2 * t) ^ 2 * sin(t) ^ 4 / 4) / sin(t) ^ 8 - 1", "0")]
+        public void TheQuotientCancelsOnItsOwn(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity(), Bare(expression));
+
+        /// <summary>
         /// 2cos(u) is a number where sin(u) is zero and sin(2u) csc(u) is not, so the
         /// cosecant's own condition has to be carried rather than dropped. It is the same
         /// condition the cancellation of sin(u) csc(u) already comes back with.


### PR DESCRIPTION
Closes #557.

The reporter gives two expressions. Both are 0. The first was already handled — opening `sin(2t)` up is what settles it — and the second came back as a sum of five terms.

## What was wrong

Opening a multiple angle is offered as a **candidate** rather than taken, because written out `sin(4x)` is longer than it started and the complexity metric should decide. That judgement is right. What was wrong is the form it was asked to judge.

The opened form was handed to the trigonometric rules only, which settles an expression that is already a single term. The reporter’s second expression is a **quotient**, and it cancels only once its terms are over a common denominator — and the passes that build one run earlier in the loop, while the angles are still shut. So the metric saw the opened form with none of its payoff collected, and rightly rejected it as the longer of the two.

That the cancellation is real is easy to see in isolation:

```
(sin(t)^6 - (2*sin(t)*cos(t))^2*sin(t)^4/4)/sin(t)^8 - 1   =>  0    // already worked
(sin(t)^6 - sin(2*t)^2*sin(t)^4/4)/sin(t)^8 - 1            =>  ...  // same number, not reduced
```

Same expression, and only the shut form failed.

## The fix

The opened form is simplified in full before being offered — which is exactly what `Expand()` and `Factorize()` already get two lines above, and for the same reason. Expanded as well, since the cancellation here only appears once the products are multiplied out.

One candidate, not two: offering the unexpanded opening alongside it made no difference to any expression measured and doubled the added cost.

## Measured

| | before | after |
|---|---|---|
| reporter’s 2nd expression | sum of five terms | `0 provided not sin(t) = 0` (269 ms) |

Multiple angles that do **not** cancel keep their compact form — `sin(4x)`, `cos(6x)` and `sin(3x)` are unchanged, and `sin(2x)*cos(2x)` still collapses to `sin(4x)/2`. They cost roughly 1.2–2× what they did, in the tens of milliseconds, and only an expression that contains a multiple angle pays anything at all.

Full suite **4858 passed / 0 failed**, F# **130/130**, corpus **112/117 with 0 wrong, 0 error, 0 timeout** and unchanged in total time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)