### PR TITLE
Only invert an equation whose variable occurs once (#744)

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
@@ -134,7 +134,32 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
                         goto default;
                     // TODO: optimize?
                     return subtrahend.Invert(minuend, lastChild).Select(result => Solve(lastChild - result, x, compensateSolving: true)).Unite();
-                case Function:
+                // A power is zero exactly where its base is, so f(x)^n = 0 has the roots of
+                // f(x) = 0 and no others. Routing it that way rather than leaving it to the
+                // replacement machinery below is what makes it answer *identically* to the
+                // equation it is: without this (x^2 + x + 1)^2 = 0 is answered
+                // { -1/2 + -sqrt(-3/4), -1/2 + sqrt(-3/4) } where x^2 + x + 1 = 0 gives
+                // { (-1 - sqrt(-3))/2, (-1 + sqrt(-3))/2 }, and takes about four times as
+                // long to get there. https://github.com/asc-community/AngouriMath/issues/744
+                //
+                // Only for an exponent that is a positive number and free of x. A negative
+                // one is never zero, and one that moves with x is a different equation; both
+                // are left to the inversion below, which is what has always answered them.
+                case Powf(var @base, var power)
+                    when @base.ContainsNode(x) && !power.ContainsNode(x)
+                         && power.Evaled is Real { IsPositive: true }:
+                    return Solve(@base, x, compensateSolving);
+                // Inverting isolates x only where x occurs once, which is what Invert's own
+                // documentation requires and what this case did not check. Given
+                // sin(x^2 + x) = 0 it inverted the sine, then the sum, then the square, and
+                // handed back { +-sqrt(2*pi*n_1 - x), ... } -- the equation rearranged rather
+                // than solved, since the x left on the right stayed where it stood. Where the
+                // variable occurs more than once, the replacement machinery below is what
+                // answers: it solves sin(t) = 0 and then t = x^2 + x for each root, which is
+                // how the same equation written cos(x^2 + x + 1) = 1 was answered correctly
+                // all along -- a right-hand side of zero is the only reason this case was
+                // reached at all. https://github.com/asc-community/AngouriMath/issues/744
+                case Function when expr.Nodes.Count(node => node == x) == 1:
                     return expr.Invert(0, x).Select(ent => TryDowncast(expr, x, ent)).ToSet();
                 case Providedf(var expression, var predicate):
                     return Solve(expression, x, compensateSolving).Filter(predicate, x);

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/SolveStatement.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/SolveStatement.cs
@@ -74,6 +74,21 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
         /// </summary>
         private static bool IsSpurious(Entity equation, Variable x, Entity root)
         {
+            // A root that still mentions the variable it solves for is the equation
+            // rearranged, not an answer to it: x = sqrt(-1 - x) says nothing about x. This
+            // is decided before the parameter exemption below, which would otherwise keep
+            // such a root unconditionally -- it carries a variable, so substituting it back
+            // leaves an expression rather than a residual, and there is no evidence to drop
+            // it on. That is how (x^2 + x + 1)^2 = 0 came to be answered with two of them.
+            //
+            // No equation reaches this today: the routes that produced such a root are
+            // fixed at their source in AnalyticalEquationSolver, which is what makes those
+            // equations answer correctly rather than emptily. It is kept because Invert
+            // requires the variable to occur once and only one of its five callers checks
+            // that, so the next caller to forget is caught here rather than in a bug report.
+            // https://github.com/asc-community/AngouriMath/issues/744
+            if (root.ContainsNode(x))
+                return true;
             if (root.Vars.Any())
                 return false;
             try

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/RepeatedVariableSolveTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/RepeatedVariableSolveTest.cs
@@ -1,0 +1,173 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Algebra
+{
+    /// <summary>
+    /// Inverting an expression isolates the variable only where the variable occurs once,
+    /// which is what <c>Invert</c> requires of its callers. Solving <c>f(x) = 0</c> did not
+    /// check it, so an equation whose variable occurs twice came back rearranged rather than
+    /// solved: <c>(x^2 + x + 1)^2 = 0</c> was answered <c>{ sqrt(-1 - x), -sqrt(-1 - x) }</c>,
+    /// which is <c>x^2 = -1 - x</c> with the square inverted and the <c>x</c> on the right
+    /// left where it stood.
+    /// https://github.com/asc-community/AngouriMath/issues/744
+    /// </summary>
+    public sealed class RepeatedVariableSolveTest
+    {
+        private static Entity.Set.FiniteSet Roots(string equation) =>
+            (Entity.Set.FiniteSet)equation.ToEntity().Solve("x");
+
+        private static bool IsNear(Entity root, double re, double im)
+        {
+            // The absolute-value inversion leaves `provided r_1 in RR` behind, which is a
+            // condition on the working rather than part of the answer.
+            while (root is Entity.Providedf(var inner, _))
+                root = inner;
+            if (root.Vars.Any())
+                return false;
+            var value = root.EvalNumerical();
+            return System.Math.Abs(value.RealPart.EDecimal.ToDouble() - re) < 1e-9
+                && System.Math.Abs(value.ImaginaryPart.EDecimal.ToDouble() - im) < 1e-9;
+        }
+
+        /// <summary>
+        /// The whole class, stated as the property that failed rather than as the shapes that
+        /// failed it: an answer to an equation in x cannot mention x. Such a "root" satisfies
+        /// nothing and cannot even be evaluated, so substituting answers back does not catch
+        /// it -- the residual is not a number, and a root is only ever dropped on evidence.
+        /// </summary>
+        [Theory]
+        [InlineData("(x ^ 2 + x + 1) ^ 2 = 0")]
+        [InlineData("(x ^ 2 + x) ^ 2 = 0")]
+        [InlineData("(x ^ 3 + x + 1) ^ 2 = 0")]
+        [InlineData("(x ^ 2 + 2 * x + 3) ^ 2 = 0")]
+        [InlineData("(x ^ 2 - 2) ^ 2 = 0")]
+        [InlineData("(x - 1) ^ 2 = 0")]
+        [InlineData("sqrt(x ^ 2 + x + 1) = 0")]
+        [InlineData("(x ^ 2 + x) ^ (3/2) = 0")]
+        [InlineData("sin(x ^ 2 + x) = 0")]
+        [InlineData("ln(x ^ 2 + x) = 0")]
+        [InlineData("abs(x ^ 2 + x) = 0")]
+        [InlineData("tan(x ^ 2 + x) = 0")]
+        public void NoRootMentionsTheVariableItSolvesFor(string equation)
+        {
+            foreach (var root in Roots(equation))
+                Assert.False(root.Vars.Any(v => v.Name == "x"),
+                    $"{equation} was answered with {root.Stringize()}, which still contains x");
+        }
+
+        /// <summary>
+        /// A power is zero exactly where its base is, so <c>f(x)^n = 0</c> has the roots of
+        /// <c>f(x) = 0</c> -- and must give them in the same form, not merely the same values.
+        /// </summary>
+        [Theory]
+        [InlineData("(x ^ 2 + x + 1) ^ 2 = 0", -0.5, 0.8660254037844386)]
+        [InlineData("(x ^ 2 + x + 1) ^ 3 = 0", -0.5, 0.8660254037844386)]
+        [InlineData("(x ^ 2 + 2 * x + 3) ^ 2 = 0", -1.0, 1.4142135623730951)]
+        // The exponent does not have to be a whole number, and the issue records only whole
+        // ones. sqrt(f(x)) = 0 is the same equation as f(x) = 0 and failed the same way.
+        [InlineData("sqrt(x ^ 2 + x + 1) = 0", -0.5, 0.8660254037844386)]
+        [InlineData("(x ^ 2 + x + 1) ^ (3/2) = 0", -0.5, 0.8660254037844386)]
+        public void APowerOfAPolynomialHasTheRootsOfThatPolynomial(
+            string equation, double re, double im)
+        {
+            var roots = Roots(equation);
+            Assert.Contains(roots, root => IsNear(root, re, im));
+            Assert.Contains(roots, root => IsNear(root, re, -im));
+            Assert.Equal(2, roots.Count);
+        }
+
+        /// <summary>
+        /// A power of a polynomial must answer identically to the polynomial, not merely
+        /// equivalently. Routing it through the replacement machinery instead reaches the
+        /// same two numbers written <c>-1/2 + -sqrt(-3/4)</c>, which is the output-quality
+        /// complaint of https://github.com/asc-community/AngouriMath/issues/272 one step on.
+        /// </summary>
+        [Theory]
+        [InlineData("(x ^ 2 + x + 1) ^ 2 = 0", "x ^ 2 + x + 1 = 0")]
+        [InlineData("(x ^ 2 + x + 1) ^ 3 = 0", "x ^ 2 + x + 1 = 0")]
+        [InlineData("(x ^ 3 + x + 1) ^ 2 = 0", "x ^ 3 + x + 1 = 0")]
+        [InlineData("(x ^ 2 - 2) ^ 2 = 0", "x ^ 2 - 2 = 0")]
+        public void APowerIsAnsweredExactlyAsItsBaseIs(string powered, string @base) =>
+            Assert.Equal(Roots(@base), Roots(powered));
+
+        // The plainest case, because it is not a hard equation: (x^2 + x)^2 = 0 has the roots
+        // 0 and -1, and it was answered { sqrt(-x), -sqrt(-x) }.
+        [Theory]
+        [InlineData("(x ^ 2 + x) ^ 2 = 0")]
+        [InlineData("(x ^ 2 + x) ^ (3/2) = 0")]
+        public void APowerOfAPolynomialWithRationalRootsKeepsThem(string equation)
+        {
+            var roots = Roots(equation);
+            Assert.Contains(Entity.Number.Integer.Create(0), roots);
+            Assert.Contains(Entity.Number.Integer.Create(-1), roots);
+            Assert.Equal(2, roots.Count);
+        }
+
+        /// <summary>
+        /// The same defect through any other function, and the half of it that turned into
+        /// right answers rather than into no answer. A right-hand side of zero is the only
+        /// reason the inverting route was taken at all: <c>cos(x^2 + x + 1) = 1</c> was
+        /// answered correctly all along, because a non-zero side leaves a subtraction that
+        /// reaches the replacement machinery instead.
+        /// </summary>
+        [Fact]
+        public void ALogarithmOfARepeatedVariableIsSolvedThroughItsArgument()
+        {
+            // ln(x^2 + x) = 0 means x^2 + x = 1, whose roots are (-1 +- sqrt(5))/2.
+            var roots = Roots("ln(x ^ 2 + x) = 0");
+            var half = (System.Math.Sqrt(5) - 1) / 2;
+            Assert.Contains(roots, root => IsNear(root, half, 0));
+            Assert.Contains(roots, root => IsNear(root, -half - 1, 0));
+        }
+
+        [Fact]
+        public void AnAbsoluteValueOfARepeatedVariableIsSolvedThroughItsArgument()
+        {
+            var roots = Roots("abs(x ^ 2 + x) = 0");
+            Assert.Contains(roots, root => IsNear(root, 0, 0));
+            Assert.Contains(roots, root => IsNear(root, -1, 0));
+        }
+
+        /// <summary>
+        /// The parametric families keep their parameter and lose the variable:
+        /// sin(x^2 + x) = 0 means x^2 + x = pi*k, so x = (-1 +- sqrt(1 + 4*pi*k))/2.
+        /// </summary>
+        [Fact]
+        public void ASineOfARepeatedVariableIsSolvedThroughItsArgument()
+        {
+            var roots = Roots("sin(x ^ 2 + x) = 0");
+            Assert.NotEmpty(roots);
+            foreach (var root in roots)
+            {
+                Assert.False(root.Vars.Any(v => v.Name == "x"),
+                    $"{root.Stringize()} still contains x");
+                // Every root is a genuine one at k = 0, where the parameter drops out.
+                var atZero = root.Substitute(root.Vars.First(), 0).EvalNumerical();
+                var residual = "sin(x ^ 2 + x)".ToEntity()
+                    .Substitute("x", atZero).EvalNumerical().Abs().EDecimal.ToDouble();
+                Assert.True(residual < 1e-9,
+                    $"{root.Stringize()} leaves a residual of {residual}");
+            }
+        }
+
+        // What must not change: an equation whose variable occurs once is still inverted, and
+        // is still answered the way it always was.
+        [Theory]
+        [InlineData("sin(x) = 0", "2 * pi * n_1")]
+        [InlineData("ln(x) = 0", "1")]
+        [InlineData("x ^ 2 - 2 = 0", "sqrt(2)")]
+        [InlineData("sin(x ^ 2 - 2) = 0", "sqrt(2 * pi * n_1 + 2)")]
+        public void AVariableThatOccursOnceIsStillInverted(string equation, string expected) =>
+            Assert.Contains(expected.ToEntity().InnerSimplified, Roots(equation));
+    }
+}


### PR DESCRIPTION
Closes #744.

## What was wrong

Inverting an expression isolates the variable by walking down to it and undoing each node on the way, which works only if there is one place to walk to — `Invert`'s own documentation requires "exactly ONE occurance of x". Solving `f(x) = 0` did not check it, so an equation whose variable occurs more than once came back **rearranged rather than solved**:

| equation | was | is |
|---|---|---|
| `(x^2 + x + 1)^2 = 0` | `{ sqrt(-1 - x), -sqrt(-1 - x) }` | `{ (-1 - sqrt(-3))/2, (-1 + sqrt(-3))/2 }` |
| `(x^2 + x)^2 = 0` | `{ sqrt(-x), -sqrt(-x) }` | `{ 0, -1 }` |
| `(x^3 + x + 1)^2 = 0` | `{ (-1 - x)^(1/3), … }` | the three roots of the cubic |
| `sqrt(x^2 + x + 1) = 0` | `{ sqrt(-1 - x), -sqrt(-1 - x) }` | the two roots of the quadratic |
| `sin(x^2 + x) = 0` | `{ ±sqrt(2·pi·n_1 - x), ±sqrt(pi + 2·pi·n_1 - x) }` | `{ (-1 ± sqrt(1 + 8·pi·n_1))/2, (-1 ± sqrt(1 + 4·pi + 8·pi·n_1))/2 }` |
| `ln(x^2 + x) = 0` | `{ sqrt(1 - x), -sqrt(1 - x) }` | `{ (-1 - sqrt(5))/2, (-1 + sqrt(5))/2 }` |
| `abs(x^2 + x) = 0` | `{ ±sqrt(-x) provided r_1 in RR }` | `{ 0, -1 }` |

`x = sqrt(-1 - x)` is `x^2 + x + 1 = 0` moved to `x^2 = -1 - x` with the square inverted and the `x` on the right left where it stood. It is a true statement and not an answer.

Such a "root" satisfies nothing and cannot be evaluated at all, which is why nothing caught it: substituting it back leaves an expression rather than a residual, and root verification drops an answer only on positive evidence against it.

The issue records only the power shape and only whole exponents. The `sqrt` / `^(3/2)` cases and the whole `sin` / `ln` / `abs` family are the same defect and are fixed with it.

## What the fix does

**1. `case Function` now requires the variable to occur once.** Where it occurs more than once, the replacement machinery further down is what answers — it solves `sin(t) = 0` and then `t = x^2 + x` for each root. That machinery was always there; a right-hand side of zero is the only reason it was being skipped, since a non-zero side leaves a subtraction that reaches it. This is why `cos(x^2 + x + 1) = 1` has never been wrong while `sin(x^2 + x) = 0` always was.

**2. A power is routed directly to its base**, because a power is zero exactly where its base is. This is not needed for correctness — the replacement machinery gets there too — but it makes `f(x)^n = 0` answer *identically* to `f(x) = 0` rather than merely equivalently. Without it `(x^2 + x + 1)^2 = 0` reaches the same two numbers written `-1/2 + -sqrt(-3/4)`, which is the output-quality complaint of #272 one step along, and takes about four times as long (238 ms vs 63 ms). Restricted to an exponent that is a positive number and free of `x`: a negative one is never zero, and one that moves with `x` is a different equation.

**3. A root that mentions the variable it solves for is rejected in `IsSpurious`.** Nothing reaches this once (1) and (2) are in — measured over eighteen function-shaped equations with the check disabled, none produced such a root — so it is a net rather than the fix, and the comment says so. It is kept because `Invert` requires the variable to occur once and only one of its five callers checks that.

## How it was found

By `work/rootcheck`, a completeness harness that multiplies polynomials up from factors whose roots are known before anything is solved, then asks not "is every answer right" but "is every root there". Substituting answers back can only confirm the roots you were given.

Its one failing case was `(x^2 + x + 1) * (x^2 + x + 1)` — a product only until `InnerSimplified` writes it as a square.

## Measured

- **rootcheck**: 596 cases, `1 incomplete / 2 missing roots` → **0 and 0**; 0 unsound either way.
- **Corpus** (`work/casbench`): 112/117 solved, 0 wrong, 0 error, 0 timeout — unchanged, and every verdict and answer byte-identical to before (only the ms column moves).
- **Suite**: 4979 → **4992 passed / 0 failed**, F# **130/130**.

Regression tests are in a new `RepeatedVariableSolveTest`, including the property the harness checks — no root mentions the variable it solves for — and the cases that must not change, where the variable occurs once and inversion is still the route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
