### PR TITLE
Promote two agreeing one-sided limits over the reals (#719, step 2; #596)

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Solvers.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Solvers.Definition.cs
@@ -81,6 +81,61 @@ namespace AngouriMath.Functions.Algebra
             return null;
         }
 
+        /// <summary>
+        /// The limit where the two one-sided limits agree, asked of each side through the
+        /// whole of <see cref="ComputeLimit"/>, or <see langword="null"/> where either side
+        /// has no answer, the two differ, or the reading is not of real-valued functions.
+        /// </summary>
+        /// <remarks>
+        /// A two-sided limit is the two one-sided ones agreeing, and the branch that compares
+        /// them compares two <c>ComputeLimitDivideEtImpera</c> results -- the bare descent --
+        /// where a caller who names a side gets that descent *and* everything behind it:
+        /// <see cref="SolveAsIndeterminatePower"/>, l'Hopital's rule, and the substitution
+        /// that moves a finite destination out to infinity.
+        /// <para/>
+        /// **Only under a real codomain, and that is the whole of what makes it sound.** The
+        /// promotion cannot be made over the complex plane, because there the one-sided limits
+        /// do not stay inside the reals: `lim x->0- x^x` answers 1 from the continuation, so
+        /// promoting agreement would give `lim x->0 x^x` the value 1 where `x^x` is not real
+        /// to the left of 0 at all, and `LimitTest.TestNoLimit` pins it as non-existent.
+        /// Under <see cref="AngouriMath.Core.Domain.Real"/> that side has no value to agree
+        /// with, so the case this could get wrong is the case that no longer arises.
+        /// <para/>
+        /// Asked only where the answer would otherwise be NaN, so nothing that already answers
+        /// pays for it, and it can only ever turn a refusal into an answer.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/719">#719</a>,
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/596">#596</a>
+        /// </remarks>
+        private static Entity? WhereBothSidesAgree(Entity expr, Variable x, Entity dest)
+        {
+            if (MathS.Settings.Codomain.Value is not AngouriMath.Core.Domain.Real
+                || bothSidesDepth >= MaxBothSidesDepth)
+                return null;
+            bothSidesDepth++;
+            try
+            {
+                if (ComputeLimit(expr, x, dest, ApproachFrom.Left) is not { } fromLeft
+                    || fromLeft.Evaled == MathS.NaN)
+                    return null;
+                if (ComputeLimit(expr, x, dest, ApproachFrom.Right) is not { } fromRight
+                    || fromRight.Evaled == MathS.NaN)
+                    return null;
+                return fromLeft == fromRight || ExpressionNumerical.AreEqual(fromLeft, fromRight)
+                    ? fromLeft : null;
+            }
+            finally { bothSidesDepth--; }
+        }
+
+        /// <summary>
+        /// How deep <see cref="WhereBothSidesAgree"/> may nest. Each one-sided limit it asks
+        /// for may itself reach a two-sided limit of a subexpression, so without a bound the
+        /// two questions would branch into four and so on down the tree, for expressions that
+        /// have no answer either way and where the whole cost buys nothing.
+        /// </summary>
+        private const int MaxBothSidesDepth = 2;
+
+        [System.ThreadStatic] private static int bothSidesDepth;
+
         private static Entity ExpandLogarithm(Entity expr)
             => expr switch
             {
@@ -108,8 +163,15 @@ namespace AngouriMath.Functions.Algebra
             // asks for it again, through the same rewrite, without end. Answering here costs
             // nothing and asks nothing.
             // https://github.com/asc-community/AngouriMath/issues/719
-            if (RealCodomainWithdraws(expr, x, dest,
-                    side is ApproachFrom.Left ? ApproachFrom.Left : ApproachFrom.Right))
+            // A two-sided limit is withdrawn if *either* approach leaves the reals, since it
+            // is the two one-sided ones agreeing and one of them is not there to agree.
+            // Checking only one direction left lim x->0 sqrt(x) answering 0 while its own
+            // left-hand limit had been withdrawn, which is the two halves disagreeing about
+            // the same reading.
+            if (side is ApproachFrom.BothSides
+                ? RealCodomainWithdraws(expr, x, dest, ApproachFrom.Left)
+                    || RealCodomainWithdraws(expr, x, dest, ApproachFrom.Right)
+                : RealCodomainWithdraws(expr, x, dest, side))
                 return null;
 
             expr = expr.Replace(ExpandLogarithm);
@@ -229,15 +291,27 @@ namespace AngouriMath.Functions.Algebra
                         return fromLeft;
                     if (ExpressionNumerical.AreEqual(fromLeft, fromRight) && (acceptNaN || fromLeft.Evaled != MathS.NaN))
                         return fromLeft;
-                    var lhopital = ApplylHopitalRule(expr, x, dest);
-                    if (lhopital != null) return ComputeLimit(lhopital, x, dest, acceptNaN: true);
-                    else return MathS.NaN; // A two-sided limit cannot exist if the limit from left and right don't match.
+                    if (ApplylHopitalRule(expr, x, dest) is { } lhopital
+                        && ComputeLimit(lhopital, x, dest, acceptNaN: true) is { } byRule
+                        && (acceptNaN || byRule.Evaled != MathS.NaN))
+                        return byRule;
+                    // Asking each side properly, which is what the two above were not asked.
+                    // https://github.com/asc-community/AngouriMath/issues/719
+                    if (WhereBothSidesAgree(expr, x, dest) is { } agreed)
+                        return agreed;
+                    return MathS.NaN; // A two-sided limit cannot exist if the limit from left and right don't match.
                 }
                 else
                 {
-                    var lhopital = ApplylHopitalRule(expr, x, dest);
-                    if (lhopital != null) return ComputeLimit(lhopital, x, dest);
-                    else return null;
+                    if (ApplylHopitalRule(expr, x, dest) is { } lhopital
+                        && ComputeLimit(lhopital, x, dest) is { } byRule)
+                        return byRule;
+                    // The same promotion as above. This branch is reached where the descent
+                    // has nothing to say about one of the sides at all, rather than saying
+                    // something that disagrees -- which is most of what the one-sided
+                    // fallbacks are for, so it is where the promotion is worth the most.
+                    // https://github.com/asc-community/AngouriMath/issues/719
+                    return WhereBothSidesAgree(expr, x, dest);
                 }
             }
             throw new AngouriBugException($"Unresolved enum parameter {side}");

--- a/Sources/Tests/UnitTests/Calculus/RealCodomainLimitTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/RealCodomainLimitTest.cs
@@ -131,21 +131,77 @@ namespace AngouriMath.Tests.Calculus
         }
 
         /// <summary>
-        /// What this does not yet do. Promoting two agreeing one-sided limits to a two-sided
-        /// one is the point of the setting and is deliberately not part of it: step 1 changes
-        /// what every one-sided limit answers under a real codomain, and that wants measuring
-        /// on its own before anything is built on top. Pinned so the next step has somewhere
-        /// to land and so the current state is a decision rather than an oversight.
+        /// The point of the setting. Two agreeing one-sided limits are a two-sided one, and
+        /// the promotion is safe here for the reason it was unsafe before: over the complex
+        /// plane it would give <c>lim x-&gt;0 x^x</c> the value 1, and over the reals that
+        /// side has no value to agree with.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/596">#596</a> is the
+        /// expression that reported it.
         /// </summary>
         [Fact]
-        public void AgreeingOneSidedLimitsAreNotYetPromoted()
+        public void AgreeingOneSidedLimitsArePromoted()
+        {
+            const string reported = "1 / ln(x + sqrt(x ^ 2 + 1)) - 1 / ln(x + 1)";
+            // Both sides answer, and agree.
+            Assert.Equal("-1/2".ToEntity().Evaled, LimitOverTheReals(reported, "0", ApproachFrom.Left).Evaled);
+            Assert.Equal("-1/2".ToEntity().Evaled, LimitOverTheReals(reported, "0", ApproachFrom.Right).Evaled);
+
+            using var _ = MathS.Settings.Codomain.Set(Domain.Real);
+            var twoSided = reported.ToEntity().Limit("x", 0).Simplify();
+            Assert.Equal("-1/2".ToEntity().Evaled, twoSided.Evaled);
+        }
+
+        /// <summary>
+        /// The two the promotion must not reach, and the reason it could not be made at all
+        /// before the codomain existed. Each is real on one side only, so under this reading
+        /// there is nothing on the other side to agree with.
+        /// </summary>
+        [Theory]
+        [InlineData("x * ln(x)")]
+        [InlineData("x ^ x")]
+        [InlineData("sqrt(x)")]
+        [InlineData("ln(x)")]
+        public void AFunctionRealOnOneSideOnlyIsNotPromoted(string expr)
         {
             using var _ = MathS.Settings.Codomain.Set(Domain.Real);
-            // Both sides are 0 and the two-sided answer is still NaN.
-            Assert.Equal(Entity.Number.Integer.Create(0),
-                Limit("x * ln(x)", "0", ApproachFrom.Right).Evaled);
-            Assert.Equal(MathS.NaN.Evaled,
-                "x * ln(x)".ToEntity().Limit("x", 0).Simplify().Evaled);
+            Assert.True(IsUnevaluated(expr.ToEntity().Limit("x", 0).Simplify()),
+                $"{expr} was given a two-sided limit over the reals");
         }
+
+        /// <summary>
+        /// And the ones that genuinely have no limit keep saying so: the promotion asks
+        /// whether the sides *agree*, not merely whether they exist.
+        /// </summary>
+        [Theory]
+        [InlineData("1 / x")]
+        [InlineData("abs(x) / x")]
+        [InlineData("e ^ (1/x)")]
+        [InlineData("arctan(1/x)")]
+        public void SidesThatDisagreeStillHaveNoTwoSidedLimit(string expr)
+        {
+            using var _ = MathS.Settings.Codomain.Set(Domain.Real);
+            Assert.Equal(MathS.NaN.Evaled, expr.ToEntity().Limit("x", 0).Simplify().Evaled);
+        }
+
+        /// <summary>
+        /// The promotion is opt-in with everything else. Over the complex plane these answer
+        /// exactly as they always have, which is what keeps <c>LimitTest.TestNoLimit</c>
+        /// meaning what it meant.
+        /// </summary>
+        [Theory]
+        [InlineData("sqrt(x)", "0")]
+        [InlineData("sin(x) / x", "1")]
+        public void TheDefaultReadingIsUnchangedForTwoSidedLimitsToo(string expr, string expected) =>
+            Assert.Equal(expected.ToEntity().Evaled,
+                expr.ToEntity().Limit("x", 0).Simplify().Evaled);
+
+        // The two the real reading withdraws are, by default, still the definite NaN they
+        // always were -- which is what keeps LimitTest.TestNoLimit meaning what it meant.
+        [Theory]
+        [InlineData("x ^ x")]
+        [InlineData("x * ln(x)")]
+        public void TheDefaultReadingStillCallsTheseNonExistent(string expr) =>
+            Assert.Equal(MathS.NaN.Evaled, expr.ToEntity().Limit("x", 0).Simplify().Evaled);
+
     }
 }


### PR DESCRIPTION
**Step 2 of #719**, on top of #755. Closes #596's reported expression.

## What was wrong

A two-sided limit *is* the two one-sided ones agreeing, and AngouriMath could not say so. The branch that compares them compares two `ComputeLimitDivideEtImpera` results — the bare descent — where a caller who **names** a side gets that descent *and* everything behind it: `SolveAsIndeterminatePower`, l'Hôpital's rule, and the substitution that moves a finite destination out to infinity.

The promotion could not be made before, and #719 says exactly why: the sides did not stay inside the reals. Over the complex plane `lim x->0- x^x` answers 1 from the continuation, so promoting agreement would give `lim x->0 x^x` the value 1 — and `x^x` is not real to the left of 0 at all. `LimitTest.TestNoLimit` pins it as non-existent.

#755 gave limits a codomain to read. This uses it.

## What it does

**Only under `Domain.Real`**, and that is exactly what makes it sound: there the offending side has no value to agree with, so the case this could get wrong is the case that no longer arises.

The expression #596 reported, at 0, over the reals:

```
1 / ln(x + sqrt(x^2 + 1)) - 1 / ln(x + 1)

  left    -1/2          already
  right   -1/2          already
  both    unevaluated  ->  -1/2
```

What must not be promoted, and is not:

| | why |
|---|---|
| `x * ln(x)`, `x ^ x`, `sqrt(x)`, `ln(x)` | real on one side only — nothing to agree with |
| `1/x`, `abs(x)/x`, `e^(1/x)`, `arctan(1/x)` | both sides real and they disagree — still `NaN` |

## A second change, which this exposed

A **two-sided** limit is now withdrawn if *either* approach leaves the reals, where the check added in #755 asked about one direction only. `lim x->0 sqrt(x)` answered `0` while its own left-hand limit had been withdrawn — the two halves disagreeing about the same reading. It belongs in this PR rather than #755 because promoting from the sides is what made the inconsistency visible.

## Cost

Asked only where the answer would otherwise be `NaN` or nothing, so no limit that already answers pays for it. Bounded at a depth of two: each side may itself reach a two-sided limit of a subexpression, and without a bound the two questions branch into four and so on down the tree.

## Measured

- Suite **5135 → 5147 passed / 0 failed**, F# **130/130**.
- Corpus 112/117, 0 wrong / 0 error / 0 timeout, every verdict and answer byte-identical.
- `work/rootcheck` 596/596 clean, `work/propcheck` 0 failures.

**Nothing changes by default.** The complex reading answers as it always has — pinned by tests, including that `x^x` and `x*ln(x)` at 0 are still the definite `NaN` they were.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
