### PR TITLE
Apply the first remarkable limit down the product spine (#749)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -36,6 +36,7 @@ read first.
 | **silent** | an identity equation | `{ }` or `{ 0 }` | all of `CC` |
 | **silent** | numeric root sets | one root per starting point | one root per root |
 | **silent** | many limits | `NaN`, or unevaluated | a value |
+| **silent** | a vanishing sine behind a constant factor | `NaN` | a value — but `sin(x)*ln(x)*2` loses its `0` |
 | **silent** | some integrals | not antiderivatives | closed forms |
 | **silent** | two integrals | answered correctly | unevaluated — a deliberate loss |
 | loud | `Compile` over a missing variable | `KeyNotFoundException` | `UncompilableNodeException` |
@@ -756,6 +757,49 @@ PRs [#680](https://github.com/asc-community/AngouriMath/pull/680),
 [#710](https://github.com/asc-community/AngouriMath/pull/710),
 [#714](https://github.com/asc-community/AngouriMath/pull/714),
 [#724](https://github.com/asc-community/AngouriMath/pull/724).
+
+### A constant factor no longer decides whether a vanishing sine is seen
+
+The first remarkable limit — a vanishing `sin(u)`, `tan(u)`, `arcsin(u)` or `arctan(u)` rewritten as
+the `u` it is equivalent to — was applied at the root of the expression only. A constant factor
+written on one side pushes that function a level down and out of reach, so the same product answered
+two different things depending on how it was spelled:
+
+```
+lim x->+oo sin(1/x) * x * 2       was  2        is  2
+lim x->+oo 2 * sin(1/x) * x       was  NaN      is  2
+lim x->+oo sin(1/x) * x / 2       was  NaN      is  1/2
+lim x->0   sin(x) * 1/x / 2       was  NaN      is  1/2
+lim x->+oo 2 * tan(1/x) * x^2     was  NaN      is  +oo
+```
+
+The rule is now applied down the product-and-quotient spine. It stops at anything that is not a
+product or a quotient, which is what keeps it sound: the equivalence licenses replacing a *factor*
+of the expression as a whole, and not a term of a sum, where the difference between the two forms is
+the whole answer. `lim x->0 (sin(x)/x - 1)/x^2` is still `-1/6` and `lim x->0 (sin(x) - x)/x^3` is
+still `-1/6`, as they must be — a rule that descended into sums would answer both `0`.
+
+**The loss, and it is a value becoming `NaN`.** A vanishing factor against a logarithm was being
+shielded from a rewrite the library already applies to the same limit written without the constant:
+
+```
+lim x->0   sin(x) * ln(x) * 2     was  0        is  NaN
+lim x->0   2 * arctan(x) * ln(x)  was  0        is  NaN
+lim x->0   sin(x) * ln(x)         was  NaN      is  NaN     (unchanged, and the reason)
+```
+
+The rewrite is sound — `sin(x) * ln(x)` and `x * ln(x)` have the same limit — and what it exposes is
+that `lim x->0 x * ln(x)` is `NaN` by design, for the reason given above: `ln(x)` is not real to the
+left of `0`. So the previous `0` was the accident, and the two spellings of one limit now agree
+instead of contradicting each other. Under `MathS.Settings.Codomain.Set(Domain.Real)` both come back
+unevaluated, which is the honest answer where the function has no real left-hand neighbourhood.
+
+Measured over 811 generated products and quotients: 196 `NaN`s became values, 13 values became this
+one `NaN` — every one of them of the shape above, and in each case the constant-free spelling was
+already `NaN` — and no answer changed into a different answer.
+
+[#749](https://github.com/asc-community/AngouriMath/issues/749), PR
+[#759](https://github.com/asc-community/AngouriMath/pull/759).
 
 ### `lim x->2 signum(x)` no longer kills the process
 

--- a/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Solvers.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Solvers/Solvers.Definition.cs
@@ -184,7 +184,7 @@ namespace AngouriMath.Functions.Algebra
             // it, where the same expression approached from both sides gives e.
             expr = expr.Replace(a => TrivialTrigonometricReplacement(a, x));
             expr = ApplyTrivialTransformations(expr, x, dest, (_, exprLim) => exprLim);
-            expr = ApplyFirstRemarkable(expr, x, dest);
+            expr = ApplyFirstRemarkableOverFactors(expr, x, dest);
             expr = expr.Replace(c => ApplySecondRemarkable(c, x, dest));
             // A tangent is a quotient as much as a cosecant is a reciprocal, and leaving it
             // written as one function makes it opaque to everything that reads quotients --

--- a/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
@@ -148,6 +148,44 @@ namespace AngouriMath.Functions.Algebra
                 _ => expr
             };
 
+        /// <summary>
+        /// <see cref="ApplyFirstRemarkable"/> applied down the product-and-quotient spine
+        /// rather than at the root alone.
+        /// </summary>
+        /// <remarks>
+        /// The rule matches a product or a quotient whose own child is a vanishing sine, so a
+        /// constant factor written to the left pushes that sine one level down and out of
+        /// reach: <c>2 * sin(1/x) * x</c> parses as <c>(2 * sin(1/x)) * x</c>, whose children
+        /// are a product and a variable. The descent then reads it as <c>0 * (+oo)</c> and is
+        /// definite about it, while the same product written <c>sin(1/x) * x * 2</c> answers 2.
+        /// Which side a caller writes a constant on is not a mathematical difference, and
+        /// simplification produces either.
+        /// <para/>
+        /// **Not a plain <c>Replace</c>, and that is the whole of what keeps it sound.** The
+        /// equivalence holds for a *factor* of the expression as a whole -- if <c>f/g -> 1</c>
+        /// then <c>f*h</c> and <c>g*h</c> go to the same place -- and not for a term of a sum,
+        /// where the difference between <c>f</c> and <c>g</c> is the entire answer. Rewriting
+        /// the sine inside <c>(sin(x)/x - 1)/x^2</c> would answer 0 where the limit is -1/6.
+        /// Stopping at anything that is not a product or a quotient keeps every rewrite to a
+        /// factor of the whole.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/749">#749</a>
+        /// </remarks>
+        private static Entity ApplyFirstRemarkableOverFactors(Entity expr, Variable x, Entity dest)
+        {
+            var applied = ApplyFirstRemarkable(expr, x, dest);
+            if (applied is not (Mulf or Divf))
+                return applied;
+            var left = ApplyFirstRemarkableOverFactors(applied.DirectChildren[0], x, dest);
+            var right = ApplyFirstRemarkableOverFactors(applied.DirectChildren[1], x, dest);
+            // Rebuilt only where a factor actually changed, so an expression the rule has
+            // nothing to say about comes back as the very node it went in as, keeping whatever
+            // the rest of the machinery has already cached against it.
+            if (ReferenceEquals(left, applied.DirectChildren[0])
+                && ReferenceEquals(right, applied.DirectChildren[1]))
+                return applied;
+            return applied is Mulf ? left * right : left / right;
+        }
+
         private static Entity ApplySecondRemarkable(Entity expr, Variable x, Entity dest)
             => expr switch
             {

--- a/Sources/Tests/UnitTests/Calculus/FirstRemarkableOverFactorsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/FirstRemarkableOverFactorsTest.cs
@@ -1,0 +1,163 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// The first remarkable limit rewrites a vanishing <c>sin(u)</c>, <c>tan(u)</c>,
+    /// <c>arcsin(u)</c> or <c>arctan(u)</c> as the <c>u</c> it is equivalent to, and it
+    /// matched a product or quotient whose <em>own child</em> is one of those functions --
+    /// applied at the root of the expression alone. A constant factor written to the left
+    /// pushes the sine one level down and out of reach: <c>2 * sin(1/x) * x</c> parses as
+    /// <c>(2 * sin(1/x)) * x</c>, whose children are a product and a variable, and neither is
+    /// a sine. The descent then read it as <c>0 * (+oo)</c> and was definite about it, so the
+    /// same product answered 2 written one way round and NaN written the other.
+    /// https://github.com/asc-community/AngouriMath/issues/749
+    ///
+    /// The rule is now applied down the product-and-quotient spine. Deliberately not a plain
+    /// <c>Replace</c>: the equivalence holds for a <em>factor</em> of the whole expression,
+    /// and not for a term of a sum, where the difference between the two forms is the entire
+    /// answer. <see cref="ASumIsNotRewritten"/> is what holds that line.
+    /// </summary>
+    public sealed class FirstRemarkableOverFactorsTest
+    {
+        private static Entity LimitOf(string expression, string destination) =>
+            expression.ToEntity().Limit("x", destination.ToEntity()).Simplify();
+
+        /// <summary>
+        /// The mathematics rather than the printed form -- the same value reaches this by
+        /// several roundings depending on which factor the rewrite moved.
+        /// </summary>
+        private static void AssertLimit(string expression, string expected, string destination)
+        {
+            var difference = (LimitOf(expression, destination) - expected.ToEntity()).Simplify();
+            while (difference is Entity.Providedf(var inner, _)) difference = inner;
+            Assert.Equal(Entity.Number.Integer.Create(0), difference);
+        }
+
+        /// <summary>
+        /// An infinite limit, where the difference above says nothing: (+oo) - (+oo) is NaN.
+        /// </summary>
+        private static void AssertDiverges(string expression, string expected, string destination) =>
+            Assert.Equal(expected.ToEntity().Evaled, LimitOf(expression, destination).Evaled);
+
+        /// <summary>
+        /// The four spellings from the report. Only the first of them answered before, and
+        /// which side of a product a caller writes a constant on is not a mathematical
+        /// difference -- simplification produces either.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(1/x) * x * 2", "2")]
+        [InlineData("2 * sin(1/x) * x", "2")]
+        [InlineData("sin(1/x) * x / 2", "1/2")]
+        [InlineData("(1/2) * sin(1/x) * x", "1/2")]
+        public void AConstantFactorNoLongerHidesAVanishingSine(string expression, string expected) =>
+            AssertLimit(expression, expected, "+oo");
+
+        /// <summary>
+        /// The other three functions the rule knows, each shielded the same way by a constant.
+        /// </summary>
+        [Theory]
+        [InlineData("2 * tan(1/x) * x", "2")]
+        [InlineData("tan(1/x) * x / 2", "1/2")]
+        [InlineData("2 * arcsin(1/x) * x", "2")]
+        [InlineData("arcsin(1/x) * x / 2", "1/2")]
+        [InlineData("2 * arctan(1/x) * x", "2")]
+        [InlineData("arctan(1/x) * x / 2", "1/2")]
+        public void EveryFunctionTheRuleKnowsIsReachedThroughAConstant(string expression, string expected) =>
+            AssertLimit(expression, expected, "+oo");
+
+        /// <summary>
+        /// A finite destination, where the shielding factor sat under a quotient rather than a
+        /// product. The rule's quotient case fires only when both sides tend to 0, and a
+        /// constant divisor does not, so these were out of reach for the same reason.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x) * 1/x / 2", "1/2")]
+        [InlineData("sin(2*x) * 1/x / 2", "1")]
+        [InlineData("tan(x) * 1/x * (1/2)", "1/2")]
+        [InlineData("arcsin(x) * 1/x / 2", "1/2")]
+        [InlineData("arctan(2*x) * 1/x / 2", "1")]
+        public void TheQuotientCaseIsReachedBelowTheRootToo(string expression, string expected) =>
+            AssertLimit(expression, expected, "0");
+
+        /// <summary>
+        /// Where the rewrite leaves something that diverges. The point is that a value comes
+        /// back at all -- each of these was NaN, the claim that the limit does not exist.
+        /// </summary>
+        [Theory]
+        [InlineData("2 * sin(1/x) * x^2", "+oo")]
+        [InlineData("sin(1/x) * x^2 / 2", "+oo")]
+        [InlineData("2 * tan(1/x) * e^x", "+oo")]
+        [InlineData("2 * arctan(1/x^2) * ln(x)", "0")]
+        [InlineData("2 * arcsin(1/x^2) * x", "0")]
+        public void ARewrittenFactorThatDivergesStillAnswers(string expression, string expected) =>
+            AssertDiverges(expression, expected, "+oo");
+
+        /// <summary>
+        /// **The soundness guard, and the reason this is a spine walk rather than a
+        /// <c>Replace</c>.** The equivalence licenses replacing a factor of the expression as
+        /// a whole -- if <c>f/g -> 1</c> then <c>f*h</c> and <c>g*h</c> go to the same place --
+        /// and says nothing about a term of a sum, where the difference between <c>f</c> and
+        /// <c>g</c> is the whole answer. Rewriting the sine inside <c>(sin(x)/x - 1)/x^2</c>
+        /// would answer 0 where the limit is -1/6, so every one of these would break under a
+        /// rule that descended into sums.
+        /// </summary>
+        [Theory]
+        [InlineData("(sin(x)/x - 1)/x^2", "-1/6")]
+        [InlineData("(sin(x) - x)/x^3", "-1/6")]
+        [InlineData("(tan(x) - x)/x^3", "1/3")]
+        [InlineData("(x - sin(x))/(x - tan(x))", "-1/2")]
+        public void ASumIsNotRewritten(string expression, string expected) =>
+            AssertLimit(expression, expected, "0");
+
+        /// <summary>
+        /// The same sums with a constant factor on them -- which is exactly what this change
+        /// makes reachable, so it is where a rule that walked one level too far would show up.
+        /// </summary>
+        [Theory]
+        [InlineData("2 * (sin(x) - x)/x^3", "-1/3")]
+        [InlineData("(sin(x)/x - 1) * 2/x^2", "-1/3")]
+        [InlineData("(sin(x) - x)/(x^3) * 6", "-1")]
+        public void AConstantFactorOnASumDoesNotOpenItEither(string expression, string expected) =>
+            AssertLimit(expression, expected, "0");
+
+        /// <summary>
+        /// What this costs, pinned rather than left to be discovered.
+        /// <para/>
+        /// <c>lim x->0 sin(x) * ln(x) * 2</c> answered 0 before and is NaN now. The rewrite is
+        /// sound -- <c>sin(x) * ln(x)</c> and <c>x * ln(x)</c> have the same limit -- and what
+        /// it exposes is that the library answers <c>lim x->0 x * ln(x)</c> with NaN by
+        /// design: <c>ln(x)</c> is not real to the left of 0, which is the same judgement that
+        /// pins <c>lim x->0 x^x</c> as non-existent in <c>LimitTest.TestNoLimit</c>. The
+        /// constant factor was accidentally shielding these from a rewrite the library already
+        /// applies to the constant-free spelling, so master answered <c>sin(x) * ln(x)</c>
+        /// with NaN and <c>sin(x) * ln(x) * 2</c> with 0 -- two spellings of one limit
+        /// disagreeing. They now agree.
+        /// <para/>
+        /// Every answer this change turns into a NaN is of this one shape, and in each case
+        /// the constant-free spelling was already NaN on master: measured over 811 generated
+        /// products and quotients, 196 NaNs became values, 13 values became this NaN, and no
+        /// answer changed into a different answer.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x) * ln(x)")]
+        [InlineData("sin(x) * ln(x) * 2")]
+        [InlineData("2 * sin(x) * ln(x)")]
+        [InlineData("arctan(x) * ln(x) * 2")]
+        [InlineData("x * ln(x)")]
+        public void AVanishingFactorAgainstALogarithmAgreesWithItsOwnSpellings(string expression)
+        {
+            var limit = expression.ToEntity().Limit("x", 0);
+            Assert.Equal(MathS.NaN, limit.Evaled);
+        }
+    }
+}


### PR DESCRIPTION
Closes #749 (its remaining half — the first half was withdrawn in a comment there, being #719, which has since landed).

## What was wrong

`ApplyFirstRemarkable` rewrites a vanishing `sin(u)`, `tan(u)`, `arcsin(u)` or `arctan(u)` as the `u` it is equivalent to, and it matches a product or quotient whose **own child** is one of those functions. It was called on the whole expression, where its sibling one line below is applied at every node.

So a constant factor written to the left pushes the sine one level down and out of reach: `2 * sin(1/x) * x` parses as `(2 * sin(1/x)) * x`, whose children are a product and a variable, and neither is a sine. The descent then reads it as `0 * (+oo)` and is definite about it:

```
lim x->+oo sin(1/x) * x * 2   ->  2      ✅
lim x->+oo 2 * sin(1/x) * x   ->  NaN    ❌   the same product, associated the other way
lim x->+oo sin(1/x) * x / 2   ->  NaN    ❌
lim x->0   sin(x) * 1/x / 2   ->  NaN    ❌
```

Which side of a product a caller writes a constant on is not a mathematical difference, and simplification produces either.

## The fix, and why it is not a `Replace`

The rule is applied down the product-and-quotient spine, stopping at anything that is not a product or a quotient.

That stop is the whole of what keeps it sound. The equivalence licenses replacing a **factor** of the expression as a whole — if `f/g -> 1` then `f*h` and `g*h` go to the same place — and says nothing about a term of a sum, where the difference between `f` and `g` is the entire answer. Rewriting the sine inside `(sin(x)/x - 1)/x^2` would answer `0` where the limit is `-1/6`. Those cases are pinned in `ASumIsNotRewritten` and `AConstantFactorOnASumDoesNotOpenItEither`:

```
lim x->0 (sin(x)/x - 1)/x^2        -1/6
lim x->0 (sin(x) - x)/x^3          -1/6
lim x->0 (tan(x) - x)/x^3           1/3
lim x->0 (x - sin(x))/(x - tan(x)) -1/2
lim x->0 2 * (sin(x) - x)/x^3      -1/3
```

## What it costs — a value becoming `NaN`

Stated plainly, because it is not purely an improvement:

```
lim x->0 sin(x) * ln(x) * 2      was  0    is  NaN
lim x->0 2 * arctan(x) * ln(x)   was  0    is  NaN
lim x->0 sin(x) * ln(x)          was  NaN  is  NaN   (unchanged — and the reason)
```

A vanishing factor against a logarithm was being shielded by its constant from a rewrite the library **already applies to the same limit written without the constant**. The rewrite is sound (`sin(x) * ln(x)` and `x * ln(x)` have the same limit); what it exposes is that `lim x->0 x * ln(x)` is `NaN` by design — `ln(x)` is not real to the left of `0`, the same judgement that pins `lim x->0 x^x` in `LimitTest.TestNoLimit`. So master answered two spellings of one limit differently, and they now agree. Under `MathS.Settings.Codomain.Set(Domain.Real)` both come back unevaluated, which is the honest answer where there is no real left-hand neighbourhood.

Recorded in `BREAKING-CHANGES.md` rather than filed under "fixed".

## Measured

Generated 811 products and quotients of a vanishing `sin`/`tan`/`arcsin`/`arctan` against `x`, `1/x`, `ln(x)`, `x^2`, `e^x` with constants in every position, at `0` and `+oo`, and diffed this branch against `master`:

| | count |
|---|---|
| `NaN` → a value | **196** |
| a value → `NaN` | **13** — all of the `trig(u) * ln(x)` shape above, each with a constant-free twin already `NaN` on master |
| a value → a *different* value | **0** |

Suites and harnesses, all from a clean build of this branch:

- unit tests **5201 passed, 0 failed** (5169 on master; 32 added here, 21 of which fail without the one-line call-site change)
- F# wrapper tests **130 passed**
- `casbench` **112/117 solved, 0 wrong, 0 error, 0 timeout** — unchanged
- `propcheck` **0 failures** of 1337 checks
- `rootcheck` **596/596 clean**
- `simpsweep` **0 disagreements** of 10463