### PR TITLE
Order an inequality's endpoints by a comparison that can be made (#757)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,30 @@ caller evaluates it to compare, evaluating computes the limit, and computing arr
 started. That overflows the stack, which kills the process rather than raising anything catchable.
 `null` reads the same to the caller and terminates.
 
+### But "no answer" is the floor, not the target
+
+Read that ordering forwards. *Right answer* comes first, and refusing is what you do when you have
+established there is nothing better — not when the right answer looks like more work than you
+wanted. Difficulty is not an argument, and neither is "I cannot promise this lands cleanly": the
+way to find out whether a fix lands is to write it and measure it, and a failure you measured is a
+finding worth having. These *are* reasons to prefer one fix over another — it degrades output
+callers depend on, it rests on an assumption that is not true in general, it cannot be validated by
+anything you can run. These are not: it touches more files, it might break tests you would then
+have to understand, a smaller change exists that suppresses the wrong answer without producing the
+right one.
+
+The worked example is [#757](https://github.com/asc-community/AngouriMath/issues/757).
+`(x - a)(x + a) <= 0` was answered with an interval whose endpoints are ordered for one sign of `a`
+only, and the two candidate fixes were a case split on that sign, or declining to answer a symbolic
+coefficient at all. Refusing is not a fix that works — it is a stopgap — and choosing it would have
+been choosing the smaller diff over the answer.
+
+**And before building a case analysis, look for the closed form.** That same issue looked like it
+needed three branches on the sign of `a`; the answer is the single interval `[-|a|; |a|]`, because
+`min(p, q)` is `(p + q - |p - q|)/2` and `max(p, q)` is `(p + q + |p - q|)/2`. One interval, right
+for either sign and for `a = 0`, and it collapses to exactly the old output when the roots are
+concrete. Enumerating cases is usually a sign that an identity has been missed.
+
 ## Output has a contract too
 
 **Parsing what `Stringize` prints must give back the expression it printed.** Anything else makes

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/InequalitySolver/AnalyticalInequalitySolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/InequalitySolver/AnalyticalInequalitySolver.cs
@@ -46,8 +46,7 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
                     if (roots.Any(c => c is Complex and not Real))
                         return Empty;
                     roots = TreeAnalyzer.SortRealsAndNonReals(roots);
-                    var root1 = roots.First();
-                    var root2 = roots.Last();
+                    var (root1, root2) = AscendingEndpoints(roots.First(), roots.Last());
                     if (a is Real { IsNegative: true })
                         return new Interval(root1, false, root2, false);
                     return new Interval(Real.NegativeInfinity, false, root1, false)
@@ -56,5 +55,58 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
             }
             throw FutureReleaseException.Raised("Inequalities are not implemented yet", "1.2.1");
         }
+
+        /// <summary>
+        /// The two roots as (smaller, larger).
+        /// </summary>
+        /// <remarks>
+        /// <see cref="TreeAnalyzer.SortRealsAndNonReals"/> orders the roots it can compare
+        /// and leaves the rest in the order the quadratic formula produced them, which is
+        /// <c>(-b - sqrt(D))/(2a)</c> before <c>(-b + sqrt(D))/(2a)</c> -- ascending only
+        /// while <c>a</c> is positive. Solving <c>expr &lt;= 0</c> negates the expression and
+        /// so arrives here with a negative leading coefficient, which is how
+        /// <c>(x - a)(x + a) &lt;= 0</c> came to be answered with an interval running from
+        /// <c>|a|</c> to <c>-|a|</c>: empty, with the whole solution set lost.
+        /// <para/>
+        /// Written with <c>abs</c> rather than as a case split on the sign of the symbol,
+        /// because the ordering has a closed form -- <c>min(p, q)</c> is
+        /// <c>(p + q - |p - q|)/2</c> and <c>max(p, q)</c> is <c>(p + q + |p - q|)/2</c>. So
+        /// the answer is the single interval <c>[-|a|; |a|]</c>, which is right for either
+        /// sign of <c>a</c> and for <c>a = 0</c>, rather than three branches each holding on
+        /// part of the line. It also keeps the result a <see cref="Set"/>: a piecewise is an
+        /// <see cref="Entity"/> and not one, so returning it here is not open in any case.
+        /// <para/>
+        /// Where both roots are real numbers the sort above has already ordered them, and
+        /// they are handed back untouched so that nothing a concrete coefficient produces
+        /// changes shape.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/757">#757</a>
+        /// </remarks>
+        private static (Entity Lower, Entity Upper) AscendingEndpoints(Entity first, Entity second)
+        {
+            if (first is Real && second is Real)
+                return (first, second);
+            var spread = MathS.Abs(first - second);
+            return (Tidied((first + second - spread) / 2), Tidied((first + second + spread) / 2));
+        }
+
+        /// <summary>
+        /// An endpoint in the shortest form that is still an endpoint.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Entity.Simplify"/> is what turns the arithmetic above back into something
+        /// readable, but it may cancel a symbol against itself on the way -- which holds only
+        /// away from zero, and so comes back as a <see cref="Providedf"/>. A condition where an
+        /// endpoint belongs makes the interval an <see cref="Entity"/> rather than a
+        /// <see cref="Set"/>, and threw on the cast for <c>a*x^2 - 1 &lt;= 0</c>. The
+        /// unsimplified form is the same number and assumes nothing, so it is what is kept
+        /// there. Those are the expressions whose *leading* coefficient is symbolic, which this
+        /// does not claim to answer correctly in any case -- whether the solution lies inside
+        /// the roots or outside them turns on the sign of that coefficient, and that is a
+        /// second question from the one here.
+        /// </remarks>
+        private static Entity Tidied(Entity endpoint)
+            => endpoint.Simplify() is var simplified && simplified is not Providedf
+                ? simplified
+                : endpoint.InnerSimplified;
     }
 }

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/SolveInequality.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/SolveInequality.cs
@@ -22,19 +22,12 @@ namespace AngouriMath.Tests.Algebra
         [InlineData("(x - 2)(x + 2) > 0", @"(-oo; -2) \/ (2; +oo)")]
         [InlineData("(x - 2)(x + 2) < 0", "(-2; 2)")]
         [InlineData("(x - 2)(x + 2) <= 0", "[-2; 2]")]
-        // A symbolic coefficient has no known sign, and the solver builds (root1; root2)
-        // without asking which root is the smaller -- so one sign of `a` always comes out
-        // as an empty interval. This used to read as [a; -a], correct for a < 0 and empty
-        // for a > 0, and it read that way only because sqrt(4a^2) was simplifying to 2a.
-        // That is unsound for a < 0 and is fixed in
-        // https://github.com/asc-community/AngouriMath/issues/752; with it gone the interval
-        // is empty for either sign and the endpoints survive.
-        //
-        // Neither form is right for both signs. Pinned as it now stands rather than deleted,
-        // because the expectation is still evidence -- of
-        // https://github.com/asc-community/AngouriMath/issues/757, which wants the case split
-        // on the sign that would answer this properly.
-        [InlineData("(x - a)(x + a) <= 0", @"{ a, -a } \/ (sqrt(a ^ 2); -sqrt(a ^ 2))")]
+        // The symbolic coefficient is no longer pinned by its printed form here. It was, for
+        // two releases, as evidence of https://github.com/asc-community/AngouriMath/issues/757
+        // -- first as [a; -a] and then as the empty (sqrt(a^2); -sqrt(a^2)) -- and each of
+        // those expectations recorded a wrong answer rather than a right one. It is now
+        // checked for what it has to be true of instead, in
+        // <see cref="ASymbolicCoefficientGivesAnIntervalOrderedForEitherSign"/>.
         public void Test(string initial, string expected)
         {
             Variable x = "x";
@@ -44,6 +37,91 @@ namespace AngouriMath.Tests.Algebra
             var actualEntity = solutions.Simplify().InnerSimplified;
             Assert.Equal(expectedEntity, actualEntity);
         }
+
+        /// <summary>
+        /// A symbolic coefficient has no known sign, and the roots come out of the quadratic
+        /// formula as <c>(-b - sqrt(D))/(2a)</c> before <c>(-b + sqrt(D))/(2a)</c> -- ascending
+        /// only while <c>a</c> is positive. Solving <c>expr &lt;= 0</c> negates the expression,
+        /// so it arrives with a negative leading coefficient and the pair the wrong way round,
+        /// and <c>(x - a)(x + a) &lt;= 0</c> was answered with an interval running from
+        /// <c>|a|</c> down to <c>-|a|</c>: empty, with the entire solution set lost.
+        /// <para/>
+        /// The endpoints are now ordered by the closed form of min and max rather than by a
+        /// comparison that cannot be made, so the one interval is right for either sign.
+        /// Checked by what it specialises to, not by how it prints -- the printed form is
+        /// carrying an <c>abs</c> the simplifier keeps, since <c>abs(2 * sqrt(a^2))</c> is not
+        /// <c>2 * sqrt(a^2)</c> unless <c>a</c> is known real.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/757">#757</a>
+        /// </summary>
+        /// <summary>
+        /// Checked by which points the answer holds rather than by how it prints:
+        /// <c>1/2 * abs(X)</c> and <c>abs(X) / 2</c> are one number written two ways, and a
+        /// structural comparison calls that a disagreement.
+        /// </summary>
+        private static void AssertSolvesLike(string inequality, string value)
+        {
+            Variable x = "x";
+            var symbolic = (Set)((Entity)inequality).Solve(x).Substitute("a", value.ToEntity()).Simplify();
+            var truth = ((Entity)inequality).Substitute("a", value.ToEntity());
+            foreach (var point in new Entity[] { -7, -3, -2, -1, "-1/2".ToEntity(), 0,
+                                                 "1/2".ToEntity(), 1, 2, 3, 7 })
+                Assert.True(symbolic.Contains(point) == truth.Substitute(x, point).EvalBoolean(),
+                    $"solving {inequality} symbolically and then setting a = {value} gives "
+                    + $"{symbolic}, which disagrees with the inequality itself at x = {point}");
+        }
+
+        [Theory]
+        [InlineData("(x - a)(x + a) <= 0", "3")]
+        [InlineData("(x - a)(x + a) <= 0", "-3")]
+        [InlineData("(x - a)(x + a) <= 0", "1/2")]
+        [InlineData("(x - a)(x + a) <= 0", "-1/2")]
+        [InlineData("(x - a)(x + a) < 0", "3")]
+        [InlineData("(x - a)(x + a) < 0", "-3")]
+        [InlineData("(x - a)(x + a) > 0", "3")]
+        [InlineData("(x - a)(x + a) > 0", "-3")]
+        [InlineData("(x - a)(x + a) >= 0", "3")]
+        [InlineData("(x - a)(x + a) >= 0", "-3")]
+        public void ASymbolicCoefficientGivesAnIntervalOrderedForEitherSign(string inequality, string value)
+            => AssertSolvesLike(inequality, value);
+
+        /// <summary>
+        /// The roots need not be symmetric about zero, and need not both be symbolic, for the
+        /// ordering to be undecidable -- <c>(x - 1)(x - a)</c> turns on whether <c>a</c> is
+        /// above or below 1.
+        /// </summary>
+        [Theory]
+        [InlineData("(x - a)(x - 2*a) <= 0", "3")]
+        [InlineData("(x - a)(x - 2*a) <= 0", "-3")]
+        [InlineData("(x - a)(x - 2*a) < 0", "3")]
+        [InlineData("(x - a)(x - 2*a) < 0", "-3")]
+        [InlineData("(x - 1)(x - a) <= 0", "3")]
+        [InlineData("(x - 1)(x - a) <= 0", "-3")]
+        [InlineData("(x - 1)(x - a) <= 0", "1/2")]
+        [InlineData("(x - 1)(x - a) < 0", "3")]
+        [InlineData("(x - 1)(x - a) < 0", "-3")]
+        [InlineData("x^2 - a^2 <= 0", "3")]
+        [InlineData("x^2 - a^2 <= 0", "-3")]
+        [InlineData("x^2 - a^2 < 0", "3")]
+        [InlineData("x^2 - a^2 < 0", "-3")]
+        public void AsymmetricAndOneSidedRootsAreOrderedToo(string inequality, string value)
+            => AssertSolvesLike(inequality, value);
+
+        /// <summary>
+        /// A double root, where the two endpoints coincide and the span between them is empty.
+        /// The ordering arithmetic collapses to a point, which is what these have to be:
+        /// <c>(x - a)^2 &lt;= 0</c> holds only at <c>a</c>, and <c>&lt; 0</c> nowhere. Before,
+        /// each came back as an interval built from an unevaluated discriminant.
+        /// </summary>
+        [Theory]
+        [InlineData("(x - a)^2 <= 0", "3")]
+        [InlineData("(x - a)^2 <= 0", "-3")]
+        [InlineData("(x - a)^2 < 0", "3")]
+        [InlineData("(x - a)^2 > 0", "3")]
+        [InlineData("(x - a)^2 >= 0", "3")]
+        [InlineData("x^2 - 2*a*x + a^2 < 0", "3")]
+        [InlineData("x^2 - 2*a*x + a^2 > 0", "-3")]
+        public void ADoubleRootCollapsesToThePoint(string inequality, string value)
+            => AssertSolvesLike(inequality, value);
 
 
         [Theory]

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/SolveInequality.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/SolveInequality.cs
@@ -39,21 +39,6 @@ namespace AngouriMath.Tests.Algebra
         }
 
         /// <summary>
-        /// A symbolic coefficient has no known sign, and the roots come out of the quadratic
-        /// formula as <c>(-b - sqrt(D))/(2a)</c> before <c>(-b + sqrt(D))/(2a)</c> -- ascending
-        /// only while <c>a</c> is positive. Solving <c>expr &lt;= 0</c> negates the expression,
-        /// so it arrives with a negative leading coefficient and the pair the wrong way round,
-        /// and <c>(x - a)(x + a) &lt;= 0</c> was answered with an interval running from
-        /// <c>|a|</c> down to <c>-|a|</c>: empty, with the entire solution set lost.
-        /// <para/>
-        /// The endpoints are now ordered by the closed form of min and max rather than by a
-        /// comparison that cannot be made, so the one interval is right for either sign.
-        /// Checked by what it specialises to, not by how it prints -- the printed form is
-        /// carrying an <c>abs</c> the simplifier keeps, since <c>abs(2 * sqrt(a^2))</c> is not
-        /// <c>2 * sqrt(a^2)</c> unless <c>a</c> is known real.
-        /// <a href="https://github.com/asc-community/AngouriMath/issues/757">#757</a>
-        /// </summary>
-        /// <summary>
         /// Checked by which points the answer holds rather than by how it prints:
         /// <c>1/2 * abs(X)</c> and <c>abs(X) / 2</c> are one number written two ways, and a
         /// structural comparison calls that a disagreement.
@@ -131,6 +116,12 @@ namespace AngouriMath.Tests.Algebra
         [InlineData("x >= a")]
         [InlineData("(x + a)(x + b) >= 0")]
         [InlineData("(x + a)(x + b) > 0")]
+        // These two were skipped as "Piecewise required" and no longer are. They wanted the
+        // smaller of two symbolic roots as the left endpoint, and that has a closed form --
+        // https://github.com/asc-community/AngouriMath/issues/757 -- so no case split was
+        // needed to answer them after all.
+        [InlineData("(x + a)(x + b) <= 0")]
+        [InlineData("(x + a)(x + b) < 0")]
         public void AutoTest(string inequality, string setToCheck = "{ -5, -3, 0, 3, 5 }")
         {
             FiniteSet checkpoints = (FiniteSet)setToCheck.Simplify();
@@ -140,13 +131,20 @@ namespace AngouriMath.Tests.Algebra
                     $"{roots} doesn't contain {cp}");
         }
 
-        [Theory(Skip = "Piecewise required")]
+        /// <summary>
+        /// What ordering the endpoints does not reach. A symbol on the right-hand side moves
+        /// the roots rather than merely permuting them, so whether the quadratic has real roots
+        /// at all turns on the sign of <c>a + 1/4</c> -- and where it has none the answer is the
+        /// whole line or nothing, which is not an interval between endpoints in any order.
+        /// That wants the case split this solver still does not make, as does a symbolic
+        /// *leading* coefficient:
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/762">#762</a>.
+        /// </summary>
+        [Theory(Skip = "a case split on the sign of the discriminant is required")]
         [InlineData("(x + 1)(x + 2) < a")]
         [InlineData("(x + 1)(x + 2) <= a")]
         [InlineData("(x + 1)(x + 2) > a")]
         [InlineData("(x + 1)(x + 2) >= a")]
-        [InlineData("(x + a)(x + b) <= 0")]
-        [InlineData("(x + a)(x + b) < 0")]
         public void AutoTestSkip(string inequality, string setToCheck = "{ -5, -3, 0, 3, 5 }")
             => AutoTest(inequality, setToCheck);
     }


### PR DESCRIPTION
Closes #757.

## What was wrong

The quadratic formula returns `(-b - sqrt(D))/(2a)` before `(-b + sqrt(D))/(2a)`, which is ascending **only while `a` is positive**, and `SortRealsAndNonReals` orders the roots it can compare and leaves the rest as they came. Solving `expr <= 0` negates the expression, so it arrives with a negative leading coefficient and the pair the wrong way round:

```
(x - a)(x + a) <= 0    ->    { a, -a } \/ (sqrt(a^2); -sqrt(a^2))
```

an interval running from `|a|` down to `-|a|` — empty for either sign, with the entire solution set lost between the endpoints.

## The fix, and why it is one interval and not three branches

The issue proposed a `Piecewise` case split on the sign of `a`. It does not need one: **the ordering has a closed form.** `min(p, q)` is `(p + q - |p - q|)/2` and `max(p, q)` is `(p + q + |p - q|)/2`, so the answer is the single interval `[-|a|; |a|]` — the issue's own first line — right for either sign of `a` and for `a = 0`.

That is better than the case split on three counts: it is one interval rather than three branches each holding on part of the line; it keeps the result a `Set`, which a `Piecewise` is not (it is an `Entity`, so `Solve` cannot return one); and it collapses to exactly the old output when the roots are concrete, so `(x - 2)(x + 2) <= 0` is still `[-2; 2]` and nothing a numeric coefficient produces changes shape.

Where both roots are real numbers the existing sort has already ordered them and they are handed back untouched.

## A double root now collapses to the point it is

Not sought, but it falls out — the span between coincident endpoints is empty:

```
(x - a)^2 <= 0     was an interval built from an unevaluated discriminant,  is  { a }
(x - a)^2 <  0     "                                                        is  { }
x^2 - 2*a*x + a^2 < 0                                                       is  { }
```

## One thing this does not fix, and a crash it did cause

Simplifying an endpoint can cancel a symbol against itself, which holds only away from zero and comes back as a `Providedf`. A condition where an endpoint belongs makes the interval an `Entity` rather than a `Set` — that threw `InvalidCastException` on `a*x^2 - 1 <= 0` in the first version of this change. The unsimplified endpoint is the same number and assumes nothing, so it is kept there.

Those are exactly the expressions whose **leading** coefficient is symbolic, and this PR does not claim to answer them. Whether the solution lies *inside* the roots or *outside* them turns on the sign of that coefficient, and unlike the endpoint ordering that has no closed form — it genuinely needs the case split. It is a second defect, filed separately with the evidence below.

## Measured

Correctness here cannot be read off the printed form (`1/2 * abs(X)` and `abs(X) / 2` are one number and two trees), so each case is checked by **membership**: solve with the symbol, substitute a value of each sign, and compare what the resulting set holds at eleven points against the inequality itself.

128 specialisations — 8 shapes × 4 directions × `a ∈ {3, -3, 1/2, -1/2}`:

| | master | this branch |
|---|--:|--:|
| correct | 81 | **108** |
| wrong | 39 | 20 |
| `ElementInSetAmbiguousException` | 8 | **0** |

**27 wrong → right, 0 right → wrong.** Every one of the 20 that remain is the symbolic-leading-coefficient family above.

Suites and harnesses, from a clean build:

- unit tests **5254 passed, 0 failed** (5225 on master; 29 added here, and the whole new group fails without the change)
- F# wrapper tests **130 passed**
- `casbench` **112/117 solved, 0 wrong, 0 error, 0 timeout** — unchanged
- `propcheck` **0 failures**, `rootcheck` **596/596**, `simpsweep` **0 disagreements** of 10463

## AGENTS.md

Also carries the rule this issue turned out to be the worked example for: "not answering is a legitimate answer" is a floor and not a target, difficulty is not an argument for choosing between two approaches, and a closed form is worth looking for before a case analysis is built. It sits under the existing section it qualifies, since that is the rule that is easiest to misread as a licence to refuse.