### PR TITLE
Split an inequality on the signs it cannot decide (#762)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -34,6 +34,7 @@ read first.
 | **silent** | radicals, everywhere | `sqrt(12)` | `2 * sqrt(3)` |
 | **silent** | `Expand` | left like terms uncollected | collects them |
 | **silent** | an identity equation | `{ }` or `{ 0 }` | all of `CC` |
+| **silent** | a quadratic inequality | wrong for one sign of a symbolic coefficient | a case split on that sign |
 | **silent** | numeric root sets | one root per starting point | one root per root |
 | **silent** | many limits | `NaN`, or unevaluated | a value |
 | **silent** | a vanishing sine behind a constant factor | `NaN` | a value — but `sin(x)*ln(x)*2` loses its `0` |
@@ -536,6 +537,49 @@ hundred decimal places.
 ---
 
 ## Solving
+
+### A quadratic inequality is answered for every sign its coefficients may have
+
+Three things decided a quadratic inequality's answer that the solver was not asking about, each of
+them the sign of something it could not evaluate:
+
+```
+x^2 + 1 > 0                    was  { }                    is  RR
+3*x^2 + 1 > 0                  was  (-oo; c) \/ (c; +oo)   is  RR
+a*x^2 - 1 < 0     at a = 3     was  the complement of      is  (-1/sqrt(3); 1/sqrt(3))
+                                    the solution set
+(x + 1)(x + 2) < a             was  an interval even where it has no real roots
+```
+
+A parabola lies above zero *between* its roots when it opens downwards and *outside* them when it
+opens upwards, and the test for that read `a is Real { IsNegative: true }` — which a symbol fails,
+so every symbolic leading coefficient was read as positive. Where the quadratic has no real roots it
+sits wholly on one side, and the empty set was returned whichever side that was. And whether "no
+real roots" was noticed at all depended on how far the radical simplified: `sqrt(-4)` is the literal
+`2i` and `sqrt(-12)` is a product that is not one, so `x^2 + 1` was recognised and `3*x^2 + 1` was
+not. The linear branch had the same defect in miniature — `a*x + b > 0` is `x > -b/a` for a positive
+`a` and `x < -b/a` for a negative one.
+
+**What changes for callers.** A *concrete* coefficient is untouched: `(x - 2)(x + 2) <= 0` is still
+`[-2; 2]` and `x^2 - 4 < 0` is still `(-2; 2)`. Where a coefficient is symbolic the answer is now a
+union of conditional sets rather than a single interval — the case split written in the vocabulary
+the library already has, since `Piecewise` is an `Entity` and `Solve` returns a `Set`:
+
+```
+{ x : a > 0 and x in ... or a < 0 and x in ... or a = 0 and x in ... }
+```
+
+Code that assumed `Solve` on an inequality returns an `Interval` will now sometimes get a
+`ConditionalSet` or a `Unionf`. It was returning a wrong interval before.
+
+Measured over 128 specialisations — solve with the symbol, substitute a value of each sign, and
+compare membership against the inequality itself at eleven points: **81/128 correct on 1.4.0,
+128/128 now**. Four cases skipped as "Piecewise required" since 1.2 pass.
+
+[#757](https://github.com/asc-community/AngouriMath/issues/757) and
+[#762](https://github.com/asc-community/AngouriMath/issues/762), PRs
+[#761](https://github.com/asc-community/AngouriMath/pull/761) and
+[#763](https://github.com/asc-community/AngouriMath/pull/763).
 
 ### An identity equation is answered with every value, not with none
 

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/InequalitySolver/AnalyticalInequalitySolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/InequalitySolver/AnalyticalInequalitySolver.cs
@@ -31,9 +31,17 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
                     var root = PolynomialSolver.SolveLinear(a, b).First();
                     if (root is Complex and not Real)
                         return Empty;
+                    // a*x + b > 0 is x > -b/a for a positive a and x < -b/a for a negative one,
+                    // and for a = 0 it is not an inequality in x at all -- it is b > 0, which
+                    // holds everywhere or nowhere.
+                    Set below = new Interval(Real.NegativeInfinity, false, root, false);
+                    Set above = new Interval(root, false, Real.PositiveInfinity, false);
                     if (a is Real { IsNegative: true })
-                        return new Interval(Real.NegativeInfinity, false, root, false);
-                    return new Interval(root, false, Real.PositiveInfinity, false);
+                        return below;
+                    if (a is Real)
+                        return above;
+                    return BySignOf(a, x, whenPositive: above, whenNegative: below,
+                                    whenZero: Everywhere(b, x));
                 }
             }
             {
@@ -43,18 +51,102 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
                     b = b.InnerSimplified;
                     c = c.InnerSimplified;
                     var roots = PolynomialSolver.SolveQuadratic(a, b, c);
-                    if (roots.Any(c => c is Complex and not Real))
-                        return Empty;
+                    var discriminant = (MathS.Sqr(b) - 4 * a * c).InnerSimplified;
+                    // Read off the discriminant and not off the roots. Whether a root comes back
+                    // as something `is Complex` depends on how far the radical simplified:
+                    // sqrt(-4) is the literal 2i and sqrt(-12) is a product that is not one, so
+                    // x^2 + 1 was recognised as never reaching zero and 3*x^2 + 1 was not.
+                    // Where the leading coefficient vanishes there is no parabola: what is left
+                    // is b*x + c, which the linear branch above answers -- unless b vanishes
+                    // too, and then there is no x in it at all and the statement is a
+                    // comparison of constants, true on the whole line or on none of it.
+                    var degenerate = (b * x + c).InnerSimplified;
+                    Set whenDegenerate = degenerate.ContainsNode(x)
+                        ? Solve(degenerate, x)
+                        : Everywhere(degenerate, x);
+                    // No real root means the parabola never crosses zero, so it is above it
+                    // everywhere or below it everywhere -- and which of those is the sign of the
+                    // leading coefficient. Returning the empty set regardless answered
+                    // x^2 + 1 > 0 with nothing, where it holds at every real x.
+                    Set NeverZero() => ByLeadingSign(a, x, SpecialSet.Create(Domain.Real), Empty,
+                                                     whenDegenerate);
+                    if (discriminant.Evaled is Real { IsNegative: true }
+                        || roots.Any(root => root is Complex and not Real))
+                        return NeverZero();
                     roots = TreeAnalyzer.SortRealsAndNonReals(roots);
-                    var (root1, root2) = AscendingEndpoints(roots.First(), roots.Last());
-                    if (a is Real { IsNegative: true })
-                        return new Interval(root1, false, root2, false);
-                    return new Interval(Real.NegativeInfinity, false, root1, false)
+                    var (root1, root2, endpointCondition) = AscendingEndpoints(roots.First(), roots.Last());
+                    // A parabola is above zero between its roots when it opens downwards and
+                    // outside them when it opens upwards, and which of those it does is the
+                    // sign of the leading coefficient. That test read `a is Real { IsNegative:
+                    // true }`, which a symbol fails -- so every symbolic leading coefficient
+                    // was answered as though it were positive, and a*x^2 - 1 < 0 came back with
+                    // the complement of its solution set.
+                    Set between = new Interval(root1, false, root2, false);
+                    Set outside = new Interval(Real.NegativeInfinity, false, root1, false)
                         .Unite(new Interval(root2, false, Real.PositiveInfinity, false));
+                    var crossingZero = ByLeadingSign(a, x, outside, between, whenDegenerate);
+                    // The discriminant's sign is a second undecidable question, and an
+                    // independent one: (x + 1)(x + 2) < a negates to a leading coefficient of
+                    // -1, concrete and negative, while its discriminant 1 + 4a is symbolic. So
+                    // this split is made on its own evidence rather than only where the leading
+                    // coefficient is a symbol.
+                    if (discriminant.Evaled is Real)
+                        return Assuming(endpointCondition, crossingZero, x);
+                    return Assuming(endpointCondition,
+                        crossingZero.Filter(discriminant >= 0, x)
+                            .Unite(NeverZero().Filter(discriminant < 0, x)),
+                        x);
                 }
             }
             throw FutureReleaseException.Raised("Inequalities are not implemented yet", "1.2.1");
         }
+
+        /// <summary>
+        /// The three answers a coefficient of unknown sign may have, joined into one set that
+        /// is whichever of them the sign turns out to select.
+        /// </summary>
+        /// <remarks>
+        /// The conditions are mutually exclusive and cover every case, so the union of the
+        /// three conditional sets is the case split -- each is empty except the one whose
+        /// condition holds. This is what a piecewise would say, said in a way that is still a
+        /// <see cref="Set"/>: <see cref="Piecewise"/> is an <see cref="Entity"/>, so
+        /// <see cref="Solve"/> cannot hand one back.
+        /// <para/>
+        /// Unlike the ordering of the endpoints, which has a closed form
+        /// (<see cref="AscendingEndpoints"/>), this genuinely needs the split: lying between
+        /// the roots and lying outside them differ topologically and not arithmetically, so no
+        /// single interval covers both.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/762">#762</a>
+        /// </remarks>
+        private static Set BySignOf(Entity coefficient, Variable x,
+                                    Set whenPositive, Set whenNegative, Set whenZero)
+            => whenPositive.Filter(coefficient > 0, x)
+                .Unite(whenNegative.Filter(coefficient < 0, x))
+                .Unite(whenZero.Filter(coefficient.Equalizes(0), x));
+
+        /// <summary>
+        /// Whichever of the two the leading coefficient selects, read off directly where its
+        /// sign is known and left as a case split where it is not, so that a concrete
+        /// coefficient produces exactly the interval it always did.
+        /// </summary>
+        private static Set ByLeadingSign(Entity a, Variable x,
+                                         Set whenPositive, Set whenNegative, Set whenZero)
+            => a is Real { IsNegative: true } ? whenNegative
+             : a is Real ? whenPositive
+             : BySignOf(a, x, whenPositive, whenNegative, whenZero);
+
+        /// <summary>
+        /// The solutions of a statement that does not mention <paramref name="x"/> at all:
+        /// every real number where it holds, and none where it does not.
+        /// </summary>
+        private static Set Everywhere(Entity constant, Variable x)
+            => SpecialSet.Create(Domain.Real).Filter(constant > 0, x);
+
+        /// <summary>
+        /// The answer under a condition it needed, or the answer itself where there was none.
+        /// </summary>
+        private static Set Assuming(Entity? condition, Set answer, Variable x)
+            => condition is null ? answer : answer.Filter(condition, x);
 
         /// <summary>
         /// The two roots as (smaller, larger).
@@ -81,32 +173,41 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
         /// changes shape.
         /// <a href="https://github.com/asc-community/AngouriMath/issues/757">#757</a>
         /// </remarks>
-        private static (Entity Lower, Entity Upper) AscendingEndpoints(Entity first, Entity second)
+        private static (Entity Lower, Entity Upper, Entity? Condition) AscendingEndpoints(Entity first, Entity second)
         {
             if (first is Real && second is Real)
-                return (first, second);
+                return (first, second, null);
             var spread = MathS.Abs(first - second);
-            return (Tidied((first + second - spread) / 2), Tidied((first + second + spread) / 2));
+            var (lower, lowerCondition) = WithoutCondition(((first + second - spread) / 2).Simplify());
+            var (upper, upperCondition) = WithoutCondition(((first + second + spread) / 2).Simplify());
+            return (lower, upper, Both(lowerCondition, upperCondition));
         }
 
         /// <summary>
-        /// An endpoint in the shortest form that is still an endpoint.
+        /// An endpoint split into its value and whatever the simplification had to assume to
+        /// reach it, since a <see cref="Providedf"/> where an endpoint belongs makes the
+        /// interval an <see cref="Entity"/> rather than a <see cref="Set"/>.
         /// </summary>
         /// <remarks>
-        /// <see cref="Entity.Simplify"/> is what turns the arithmetic above back into something
-        /// readable, but it may cancel a symbol against itself on the way -- which holds only
-        /// away from zero, and so comes back as a <see cref="Providedf"/>. A condition where an
-        /// endpoint belongs makes the interval an <see cref="Entity"/> rather than a
-        /// <see cref="Set"/>, and threw on the cast for <c>a*x^2 - 1 &lt;= 0</c>. The
-        /// unsimplified form is the same number and assumes nothing, so it is what is kept
-        /// there. Those are the expressions whose *leading* coefficient is symbolic, which this
-        /// does not claim to answer correctly in any case -- whether the solution lies inside
-        /// the roots or outside them turns on the sign of that coefficient, and that is a
-        /// second question from the one here.
+        /// Ordering the roots of <c>a*x^2 - 1</c> cancels an <c>a</c> against itself, which
+        /// holds only away from zero, so the condition is real and is carried into the answer
+        /// rather than dropped from it -- by the same <see cref="Set.Filter"/> that carries the
+        /// sign of the leading coefficient.
         /// </remarks>
-        private static Entity Tidied(Entity endpoint)
-            => endpoint.Simplify() is var simplified && simplified is not Providedf
-                ? simplified
-                : endpoint.InnerSimplified;
+        private static (Entity Value, Entity? Condition) WithoutCondition(Entity expr)
+        {
+            Entity? condition = null;
+            while (expr is Providedf(var inner, var predicate))
+            {
+                condition = Both(condition, predicate);
+                expr = inner;
+            }
+            return (expr, condition);
+        }
+
+        private static Entity? Both(Entity? left, Entity? right)
+            => left is null ? right
+             : right is null || left == right ? left
+             : left & right;
     }
 }

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/SolveInequality.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/SolveInequality.cs
@@ -132,20 +132,94 @@ namespace AngouriMath.Tests.Algebra
         }
 
         /// <summary>
-        /// What ordering the endpoints does not reach. A symbol on the right-hand side moves
-        /// the roots rather than merely permuting them, so whether the quadratic has real roots
-        /// at all turns on the sign of <c>a + 1/4</c> -- and where it has none the answer is the
-        /// whole line or nothing, which is not an interval between endpoints in any order.
-        /// That wants the case split this solver still does not make, as does a symbolic
-        /// *leading* coefficient:
-        /// <a href="https://github.com/asc-community/AngouriMath/issues/762">#762</a>.
+        /// A symbol on the right-hand side moves the roots rather than merely permuting them,
+        /// so whether the quadratic has real roots at all turns on the sign of <c>a + 1/4</c>,
+        /// and where it has none the answer is the whole line or nothing rather than an
+        /// interval between endpoints. These were skipped as "Piecewise required" since 1.2 and
+        /// are answered by the case split on the signs of the leading coefficient and the
+        /// discriminant.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/762">#762</a>
         /// </summary>
-        [Theory(Skip = "a case split on the sign of the discriminant is required")]
+        [Theory]
         [InlineData("(x + 1)(x + 2) < a")]
         [InlineData("(x + 1)(x + 2) <= a")]
         [InlineData("(x + 1)(x + 2) > a")]
         [InlineData("(x + 1)(x + 2) >= a")]
-        public void AutoTestSkip(string inequality, string setToCheck = "{ -5, -3, 0, 3, 5 }")
+        public void AShiftedRightHandSideIsAnsweredToo(string inequality, string setToCheck = "{ -5, -3, 0, 3, 5 }")
             => AutoTest(inequality, setToCheck);
+
+        /// <summary>
+        /// Whether a parabola lies above zero between its roots or outside them is the sign of
+        /// its leading coefficient, and the solver tested <c>a is Real { IsNegative: true }</c>
+        /// -- which a symbol fails, so every symbolic leading coefficient was read as positive
+        /// and <c>a*x^2 - 1 &lt; 0</c> came back with the complement of its solution set. Where
+        /// the coefficient is symbolic, so is the discriminant's sign, and a negative one means
+        /// no real roots at all and no endpoints to lie between.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/762">#762</a>
+        /// </summary>
+        [Theory]
+        [InlineData("a*x^2 - 1 < 0", "3")]
+        [InlineData("a*x^2 - 1 < 0", "-3")]
+        [InlineData("a*x^2 - 1 < 0", "1/2")]
+        [InlineData("a*x^2 - 1 < 0", "-1/2")]
+        [InlineData("a*x^2 - 1 <= 0", "3")]
+        [InlineData("a*x^2 - 1 <= 0", "-3")]
+        [InlineData("a*x^2 - 1 > 0", "3")]
+        [InlineData("a*x^2 - 1 > 0", "-3")]
+        [InlineData("a*x^2 - 1 >= 0", "3")]
+        [InlineData("a*x^2 - 1 >= 0", "-3")]
+        [InlineData("a*x^2 - a < 0", "3")]
+        [InlineData("a*x^2 - a < 0", "-3")]
+        [InlineData("a*x^2 - a > 0", "3")]
+        [InlineData("a*x^2 - a > 0", "-3")]
+        [InlineData("a*x^2 - a >= 0", "1/2")]
+        [InlineData("a*x^2 - a >= 0", "-1/2")]
+        public void ASymbolicLeadingCoefficientPicksItsOwnBranch(string inequality, string value)
+            => AssertSolvesLike(inequality, value);
+
+        /// <summary>
+        /// A symbolic coefficient on a linear inequality has the same defect in miniature:
+        /// <c>a*x + b &gt; 0</c> is <c>x &gt; -b/a</c> for a positive <c>a</c> and
+        /// <c>x &lt; -b/a</c> for a negative one, and for <c>a = 0</c> it is not an inequality
+        /// in <c>x</c> at all.
+        /// </summary>
+        [Theory]
+        [InlineData("a*x - 1 > 0", "3")]
+        [InlineData("a*x - 1 > 0", "-3")]
+        [InlineData("a*x + 2 < 0", "3")]
+        [InlineData("a*x + 2 < 0", "-3")]
+        [InlineData("a*x - 1 >= 0", "1/2")]
+        [InlineData("a*x - 1 >= 0", "-1/2")]
+        public void ASymbolicLinearCoefficientPicksItsOwnDirection(string inequality, string value)
+            => AssertSolvesLike(inequality, value);
+
+        /// <summary>
+        /// A quadratic that never reaches zero is above it everywhere or below it everywhere,
+        /// and which of those is again the sign of the leading coefficient. Returning the empty
+        /// set regardless answered <c>x^2 + 1 &gt; 0</c> with nothing, where it holds at every
+        /// real x. Whether this was noticed at all depended on how far the radical simplified:
+        /// <c>sqrt(-4)</c> is the literal <c>2i</c> and <c>sqrt(-12)</c> is a product that is
+        /// not, so <c>x^2 + 1</c> was recognised and <c>3*x^2 + 1</c> was not -- the
+        /// discriminant is read directly now.
+        /// </summary>
+        [Theory]
+        [InlineData("x^2 + 1 > 0", true)]
+        [InlineData("3*x^2 + 1 > 0", true)]
+        [InlineData("x^2 + x + 1 > 0", true)]
+        [InlineData("x^2 + 1 >= 0", true)]
+        [InlineData("x^2 + 1 < 0", false)]
+        [InlineData("3*x^2 + 1 <= 0", false)]
+        [InlineData("-x^2 - 1 < 0", true)]
+        [InlineData("-x^2 - 1 > 0", false)]
+        [InlineData("-3*x^2 - 1 <= 0", true)]
+        public void AQuadraticThatNeverReachesZeroHoldsEverywhereOrNowhere(string inequality, bool everywhere)
+        {
+            Variable x = "x";
+            var solutions = (Set)((Entity)inequality).Solve(x).Simplify();
+            foreach (var point in new Entity[] { -7, -1, 0, "1/2".ToEntity(), 3, 7 })
+                Assert.True(solutions.Contains(point) == everywhere,
+                    $"{inequality} was solved as {solutions}, which "
+                    + (everywhere ? "does not hold" : "holds") + $" at x = {point}");
+        }
     }
 }


### PR DESCRIPTION
Closes #762. Builds on #761, which is merged.

## What was wrong

Three things decided a quadratic inequality's answer that the solver was not asking about, each of them the sign of something it could not evaluate.

**1. The leading coefficient.** A parabola lies above zero *between* its roots when it opens downwards and *outside* them when it opens upwards. The test for that read `a is Real { IsNegative: true }`, which a symbol fails — so every symbolic leading coefficient was read as positive:

```
a*x^2 - 1 < 0   at a = 3   ->  (-oo; -1/sqrt(3)) \/ (1/sqrt(3); +oo)
                               the answer is  (-1/sqrt(3); 1/sqrt(3))
```

Wrong at **all eleven** sample points, not merely imprecise. The linear branch had it in miniature: `a*x + b > 0` is `x > -b/a` for a positive `a` and `x < -b/a` for a negative one. And for `a = 0` neither is an inequality in `x` at all.

**2. A quadratic with no real roots** was answered with the empty set whichever side of zero it sat on:

```
x^2 + 1 > 0     ->  { }        it holds at every real x
```

**3. Whether "no real roots" was noticed** depended on how far the radical simplified. `sqrt(-4)` is the literal `2i` and `sqrt(-12)` is a product that is not one, so the test `root is Complex and not Real` caught `x^2 + 1` and missed `3*x^2 + 1`. The discriminant is read directly now rather than inferred from the shape of a root.

## The fix

Split on the sign where it is not known, using `Set.Filter` — which the solver already uses at the top of the same method to carry a `Providedf` condition. The conditions are mutually exclusive and exhaustive, so the union of the conditional sets *is* the case split, and the answer stays a `Set`. (A `Piecewise` is an `Entity`, so `Solve` cannot return one.)

Unlike #757's endpoint ordering, this one genuinely needs the split: lying between the roots and lying outside them differ **topologically**, not arithmetically, so no single interval covers both. That is the distinction the two PRs are worth reading together for.

**The discriminant is an independent condition, and assuming otherwise cost a round.** My first attempt split only where the *leading coefficient* was symbolic — and `(x + 1)(x + 2) < a` negates to a leading coefficient of `-1`, concrete and negative, while its discriminant `1 + 4a` is symbolic. Those four cases came out exactly as wrong as before. It is now split on its own evidence.

## What changes for callers

A **concrete** coefficient is untouched — `(x - 2)(x + 2) <= 0` is still `[-2; 2]`, `x^2 - 4 < 0` still `(-2; 2)`. Where a coefficient is symbolic the answer is a union of conditional sets rather than a single interval:

```
{ x : a > 0 and x in ... or a < 0 and x in ... or a = 0 and x in ... }
```

Code that assumed `Solve` on an inequality returns an `Interval` may now get a `ConditionalSet` or a `Unionf`. It was getting a wrong `Interval` before. Recorded in `BREAKING-CHANGES.md`.

## Measured

Correctness is checked by **membership**, not by the printed form: solve with the symbol, substitute a value of each sign, and compare what the resulting set holds at eleven points against the inequality itself. 128 specialisations — 8 shapes × 4 directions × `a ∈ {3, -3, 1/2, -1/2}`:

| | correct |
|---|--:|
| 1.4.0 solver | 81/128 |
| after #761 (endpoint ordering) | 108/128 |
| **this PR** | **128/128** |

`SolveInequality` now has **no skipped cases at all** — the four `(x + 1)(x + 2) <op> a` skipped as *"Piecewise required"* since 1.2 pass.

Suites and harnesses, from a clean build:

- unit tests **5291 passed, 0 failed** (5254 on master; 37 added)
- F# wrapper tests **130 passed**
- `casbench` **112/117, 0 wrong, 0 error, 0 timeout** — unchanged
- `propcheck` **0 failures**, `rootcheck` **596/596**, `simpsweep` **0 disagreements** of 10463