### PR TITLE
Read a factorial's logarithm by Stirling's expansion (#754)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -39,6 +39,7 @@ read first.
 | **silent** | many limits | `NaN`, or unevaluated | a value |
 | **silent** | a vanishing sine behind a constant factor | `NaN` | a value — but `sin(x)*ln(x)*2` loses its `0` |
 | **silent** | a limit assembling `oo^0` or `1^oo` | that form's value, `1` | the real answer, or unevaluated |
+| **silent** | a factorial under a vanishing exponent | unevaluated | a value, by Stirling |
 | **silent** | some integrals | not antiderivatives | closed forms |
 | **silent** | two integrals | answered correctly | unevaluated — a deliberate loss |
 | loud | `Compile` over a missing variable | `KeyNotFoundException` | `UncompilableNodeException` |
@@ -871,18 +872,18 @@ answer off one. `0^0` is deliberately untouched for the opposite reason: its `Na
 says `lim x->0 x^x` does not exist, which `LimitTest.TestNoLimit` pins, and declining it would turn a
 considered "does not exist" into "not settled".
 
-**What it costs.** Three limits that were answered `1` are now unevaluated, because the substitution
+**What it costs.** Two limits that were answered `1` are now unevaluated, because the substitution
 that used to land on them is gone and nothing else has a reading:
 
 ```
-lim x->+oo (x!)  ^ (1/x^2)      was  1     is  unevaluated   (it is 1)
 lim x->0   (1/x) ^ x            was  1     is  unevaluated
 lim x->0   (1/x) ^ (x^2)        was  1     is  unevaluated
 ```
 
-The first was right by luck: the same substitution gave `1` for `(x!)^(1/x)`, where the answer is
-`+oo`, and the two cannot be told apart at the point where the value is read off. Answering it
-properly wants Stirling's expansion of `ln(x!)`, which is the second half of #754. The other two are
+A third, `lim x->+oo (x!)^(1/x^2)`, was withdrawn here and is answered `1` again by the entry
+below — it was right by luck when this landed, since the same substitution gave `1` for
+`(x!)^(1/x)` where the answer is `+oo`, and the two cannot be told apart at the point where the
+value is read off. Stirling's expansion answers it by reading instead. The other two are
 two-sided limits at `0` whose base has no two-sided limit at all and which are not real to the left
 of `0`, so the `1` came from the complex continuation; **their one-sided readings are unchanged** —
 `lim x->0+ (1/x)^x` is still `1`.
@@ -892,6 +893,41 @@ became unevaluated, 1 `NaN` became unevaluated, and 3 right values became uneval
 
 [#754](https://github.com/asc-community/AngouriMath/issues/754), PR
 [#760](https://github.com/asc-community/AngouriMath/pull/760).
+
+### A factorial under a vanishing exponent has a limit
+
+A power whose base holds a factorial had none at all. Every route out of `ln(f)` runs through
+differentiating `f`, and a factorial's derivative wants the digamma function, which this library does
+not have — so the rule that reads `f^g` as `e^(g * ln f)` declined and nothing behind it had a
+reading either:
+
+```
+lim x->+oo (x! / x^x) ^ (1/x)   was  unevaluated   is  1/e
+lim x->+oo (x!) ^ (1/x)         was  unevaluated   is  +oo
+lim x->+oo (x!) ^ (1/ln(x))     was  unevaluated   is  +oo
+lim x->+oo (x!) ^ (1/x^2)       was  unevaluated   is  1
+lim x->+oo (x! / e^x) ^ (1/x)   was  unevaluated   is  +oo
+lim x->+oo ((x+1)! / x!) ^ (1/x)  was unevaluated  is  1
+```
+
+Stirling's expansion is stated for exactly that logarithm — `ln(f!)` is
+`f*ln(f) - f + ln(2*pi*f)/2 + 1/(12f) + O(1/f^3)` — and it is applied to the **exponent** rather than
+substituted for the factorial in the base. That is what makes it sound: what is dropped here
+*vanishes*, where the asymptotic for `f!` itself has an error that is merely relative and survives
+being raised to a power. Vanishing is still not enough on its own, since the dropped term is
+multiplied by the exponent it sits under, so `power / f -> 0` is required; `(x!)^x` fails that and is
+left alone.
+
+Every one of these values was checked numerically before being claimed — `(x!/x^x)^(1/x)` is
+`0.3678794453` at `x = 1e9` against `1/e = 0.3678794412`. Note that **SymPy 1.14.0 answers that one
+`0`**, so it is not a usable oracle here.
+
+Nothing without a factorial in it changes: over 225 generated powers, six results differ and all six
+are one of these, every one of them an unevaluated node becoming a value. `casbench` 112/117 →
+113/117.
+
+[#754](https://github.com/asc-community/AngouriMath/issues/754), PR
+[#764](https://github.com/asc-community/AngouriMath/pull/764).
 
 ### `lim x->2 signum(x)` no longer kills the process
 

--- a/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Transformations.cs
@@ -247,29 +247,102 @@ namespace AngouriMath.Functions.Algebra
                 return null;
             if (EvalAssumingContinuous(power.Limit(x, dest, side)) != 0)
                 return null;
-            var baseLimit = EvalAssumingContinuous(@base.Limit(x, dest, side));
-            if (baseLimit != 0 && !IsInfiniteNode(baseLimit))
-                return null;
-            // Every route out of ln(f) runs through differentiating f, so a base this library
-            // cannot differentiate is one the rewrite cannot finish on: it would only hand the
-            // rules an expression with a hole in it and let them work at it. A factorial is the
-            // case that matters -- its derivative wants the digamma function, which is not here,
-            // and comes back as NaN -- and lim x->+oo ((x!) / x^x)^(1/x) is the expression. It
-            // has no answer either way, and without this it takes a long time not to find one.
-            var derivative = @base.Differentiate(x).InnerSimplified;
-            if (derivative.Nodes.Any(node => node is Derivativef || node == MathS.NaN))
-                return null;
+
+            // f^g is e^(g * ln f), and this rule computes the limit of the exponent. Where the
+            // base holds a diverging factorial, that logarithm is what Stirling's expansion is
+            // stated for -- so the expansion is applied here, to the exponent, rather than to
+            // the base, where it would have to reproduce the factorial itself and its merely
+            // *relative* error. https://github.com/asc-community/AngouriMath/issues/754
+            var byStirling = StirlingExponent(@base, power, x, dest);
+
+            if (byStirling is null)
+            {
+                var baseLimit = EvalAssumingContinuous(@base.Limit(x, dest, side));
+                if (baseLimit != 0 && !IsInfiniteNode(baseLimit))
+                    return null;
+                // Every route out of ln(f) runs through differentiating f, so a base this
+                // library cannot differentiate is one the rewrite cannot finish on: it would
+                // only hand the rules an expression with a hole in it and let them work at it.
+                // A factorial is the case that matters -- its derivative wants the digamma
+                // function, which is not here, and comes back as NaN. That is why the expansion
+                // above is tried first: where it applies there is no factorial left to
+                // differentiate, and this guard is asking about an expression the rule is no
+                // longer going to use.
+                var derivative = @base.Differentiate(x).InnerSimplified;
+                if (derivative.Nodes.Any(node => node is Derivativef || node == MathS.NaN))
+                    return null;
+            }
 
             indeterminatePowerDepth++;
             try
             {
-                if (ComputeLimit((power * MathS.Ln(@base)).InnerSimplified, x, dest, side) is not { } exponent
+                var exponentExpr = byStirling ?? (power * MathS.Ln(@base)).InnerSimplified;
+                if (ComputeLimit(exponentExpr, x, dest, side) is not { } exponent
                     || exponent.Evaled == MathS.NaN)
                     return null;
                 return MathS.e.Pow(exponent).InnerSimplified;
             }
             finally { indeterminatePowerDepth--; }
         }
+
+        /// <summary>
+        /// <c>power * ln(base)</c> with the logarithm of every diverging factorial in it
+        /// replaced by Stirling's expansion, or <see langword="null"/> where there is no such
+        /// factorial or the expansion would not be sound here.
+        /// </summary>
+        /// <remarks>
+        /// <c>ln(f!)</c> is <c>f*ln(f) - f + ln(2*pi*f)/2 + 1/(12f) + O(1/f^3)</c>, and what is
+        /// dropped **vanishes** -- where the asymptotic for <c>f!</c> itself has an error that
+        /// is merely relative. That is why the expansion is written for the logarithm and
+        /// applied to this exponent rather than substituted for the factorial in the base.
+        /// <para/>
+        /// Vanishing is still not sufficient, because the dropped term is multiplied by the
+        /// exponent the rewrite sits under: the answer is <c>e^(power * ln(base))</c>, so an
+        /// error of <c>1/(12f)</c> in the logarithm contributes <c>power/(12f)</c> to the
+        /// exponent. Requiring <c>power / f -> 0</c> is what makes it disappear. For
+        /// <c>((x!) / x^x)^(1/x)</c> that ratio is <c>1/x^2</c>.
+        /// <para/>
+        /// The logarithm has to be taken apart before the factorial's own is visible:
+        /// <c>ln(x!/x^x)</c> is one node, and nothing here simplifies it. Splitting it over
+        /// products, quotients and powers assumes the parts are positive on the approach, which
+        /// is the same assumption the simplifier's <c>ln(a) + ln(b) = ln(a*b)</c> already
+        /// makes; it is confined to logarithms that actually hold a diverging factorial, so it
+        /// is reached only by expressions that have no answer at all without it.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/754">#754</a>
+        /// </remarks>
+        private static Entity? StirlingExponent(Entity @base, Entity power, Variable x, Entity dest)
+        {
+            var factorials = @base.Nodes.OfType<Factorialf>()
+                .Where(f => f.Argument.ContainsNode(x)
+                            && EvalAssumingContinuous(f.Argument.Limit(x, dest)) == Real.PositiveInfinity)
+                .ToList();
+            if (factorials.Count == 0)
+                return null;
+            // The dropped 1/(12f) is multiplied by the exponent this sits under, so it only
+            // disappears where power/f does.
+            foreach (var factorial in factorials)
+                if (EvalAssumingContinuous((power / factorial.Argument).Limit(x, dest)) != 0)
+                    return null;
+            return (power * LogarithmExpanded(@base, x, dest)).InnerSimplified;
+        }
+
+        /// <summary>
+        /// <c>ln(antilogarithm)</c> taken apart over products, quotients and powers, with
+        /// Stirling's expansion written for the logarithm of a diverging factorial.
+        /// </summary>
+        private static Entity LogarithmExpanded(Entity antilogarithm, Variable x, Entity dest)
+            => antilogarithm switch
+            {
+                Factorialf(var argument)
+                    when EvalAssumingContinuous(argument.Limit(x, dest)) == Real.PositiveInfinity
+                        => argument * MathS.Ln(argument) - argument
+                           + MathS.Ln(2 * MathS.pi * argument) / 2,
+                Mulf(var a, var b) => LogarithmExpanded(a, x, dest) + LogarithmExpanded(b, x, dest),
+                Divf(var a, var b) => LogarithmExpanded(a, x, dest) - LogarithmExpanded(b, x, dest),
+                Powf(var b, var e) when !e.ContainsNode(x) || b.ContainsNode(x)
+                    => e * LogarithmExpanded(b, x, dest),
+                _ => MathS.Ln(antilogarithm)
+            };
 
         /// <summary>
         /// How deep the rewriting of one power into another may go. The exponent it asks about

--- a/Sources/Tests/UnitTests/Calculus/IndeterminatePowerSubstitutionTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/IndeterminatePowerSubstitutionTest.cs
@@ -94,31 +94,28 @@ namespace AngouriMath.Tests.Calculus
             AssertDiverges("(e^x) ^ (1/ln(x))", "+oo");
 
         /// <summary>
-        /// The factorial cases from the report. A factorial's derivative wants the digamma
-        /// function, which this library does not have, so <c>SolveAsIndeterminatePower</c>
-        /// declines and nothing else has a reading either -- they are left unsettled rather
-        /// than answered wrongly. <c>(x!)^(1/x)</c> is <c>+oo</c>: by Stirling it grows like
-        /// <c>x/e</c>, and <c>(100!)^(1/100)</c> is already 37.99.
+        /// The factorial cases from the report, which were left unsettled when this guard
+        /// landed and are answered now that Stirling's expansion of <c>ln(f!)</c> reaches them.
+        /// <c>(x!)^(1/x)</c> grows like <c>x/e</c> -- <c>(100!)^(1/100)</c> is already 37.99 --
+        /// and it is the value the substitution used to read off as <c>1</c>.
         /// </summary>
         [Theory]
         [InlineData("(x!) ^ (1/x)")]
         [InlineData("(x!) ^ (1/ln(x))")]
-        public void AFactorialUnderAVanishingExponentIsLeftUnsettled(string expression) =>
-            AssertNotSettled(expression, "+oo");
+        public void AFactorialUnderAVanishingExponentDiverges(string expression) =>
+            AssertDiverges(expression, "+oo");
 
         /// <summary>
-        /// **What this costs.** <c>(x!)^(1/x^2)</c> is 1 -- its logarithm is
-        /// <c>ln(x!)/x^2 ~ ln(x)/x</c>, which vanishes -- and the old substitution happened to
-        /// land on that 1 for the same reason it landed on 1 for <c>(x!)^(1/x)</c>, where the
-        /// answer is <c>+oo</c>. It was right by luck rather than by reading, and the two
-        /// cannot be told apart at the point where the value is read off.
-        /// <para/>
-        /// Answering it properly wants Stirling's expansion of <c>ln(x!)</c>, which is the
-        /// second half of #754 and is not attempted here.
+        /// **What this used to cost, and no longer does.** <c>(x!)^(1/x^2)</c> is 1 -- its
+        /// logarithm is <c>ln(x!)/x^2 ~ ln(x)/x</c>, which vanishes -- and the old substitution
+        /// landed on that 1 for the same reason it landed on 1 for <c>(x!)^(1/x)</c>, where the
+        /// answer is <c>+oo</c>. It was right by luck rather than by reading, so it was
+        /// withdrawn along with the case that was wrong. Stirling's expansion answers it by
+        /// reading, which is what makes keeping it worth anything.
         /// </summary>
         [Fact]
-        public void TheFactorialCaseThatWasAccidentallyRightIsAlsoLeftUnsettled() =>
-            AssertNotSettled("(x!) ^ (1/x^2)", "+oo");
+        public void TheFactorialCaseThatWasAccidentallyRightIsAnsweredByReading() =>
+            AssertLimit("(x!) ^ (1/x^2)", "+oo", "1");
 
         /// <summary>
         /// <c>0^0</c> is deliberately **not** guarded. It evaluates to NaN, and that NaN is

--- a/Sources/Tests/UnitTests/Calculus/StirlingFactorialLimitTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/StirlingFactorialLimitTest.cs
@@ -1,0 +1,113 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// A power whose base holds a factorial had no limit at all, because every route out of
+    /// <c>ln(f)</c> runs through differentiating <c>f</c> and a factorial's derivative wants the
+    /// digamma function, which this library does not have.
+    ///
+    /// <c>f^g</c> is <c>e^(g * ln f)</c>, and Stirling's expansion is stated for exactly that
+    /// logarithm: <c>ln(f!) = f*ln(f) - f + ln(2*pi*f)/2 + 1/(12f) + O(1/f^3)</c>. Applying it
+    /// to the exponent rather than substituting for the factorial in the base is what makes it
+    /// sound -- what is dropped here **vanishes**, where the asymptotic for <c>f!</c> itself has
+    /// an error that is merely relative and survives being raised to a power.
+    ///
+    /// Vanishing is still not enough on its own: the dropped term is multiplied by the exponent
+    /// the rewrite sits under, so <c>power / f -> 0</c> is required. For <c>(x!/x^x)^(1/x)</c>
+    /// that ratio is <c>1/x^2</c>.
+    ///
+    /// https://github.com/asc-community/AngouriMath/issues/754
+    /// </summary>
+    public sealed class StirlingFactorialLimitTest
+    {
+        private static Entity LimitOf(string expression) =>
+            expression.ToEntity().Limit("x", Entity.Number.Real.PositiveInfinity).Simplify();
+
+        private static void AssertLimit(string expression, string expected)
+        {
+            var difference = (LimitOf(expression) - expected.ToEntity()).Simplify();
+            while (difference is Entity.Providedf(var inner, _)) difference = inner;
+            Assert.Equal(Entity.Number.Integer.Create(0), difference);
+        }
+
+        private static void AssertDiverges(string expression) =>
+            Assert.Equal(Entity.Number.Real.PositiveInfinity, LimitOf(expression).Evaled);
+
+        /// <summary>
+        /// The reported case, and the last <c>lim:factorial</c> miss in the corpus.
+        /// <c>x!/x^x</c> is <c>sqrt(2*pi*x) * e^(-x)</c> to leading order, so its x-th root is
+        /// <c>1/e</c> -- checked numerically at <c>x = 1e9</c>, where the quotient's root is
+        /// 0.3678794453 against <c>1/e = 0.3678794412</c>.
+        /// </summary>
+        [Fact]
+        public void TheCorpusMissIsAnswered() =>
+            AssertLimit("(x! / x^x) ^ (1/x)", "1/e");
+
+        /// <summary>
+        /// The wrong answer the same issue reported, which was <c>1</c> and then unevaluated,
+        /// and is a value now. <c>(x!)^(1/x)</c> is asymptotic to <c>x/e</c>: at <c>x = 1e9</c>
+        /// it is 367879445, against <c>x/e = 367879441</c>.
+        /// </summary>
+        [Theory]
+        [InlineData("(x!) ^ (1/x)")]
+        [InlineData("(x!) ^ (2/x)")]
+        [InlineData("(x!) ^ (1/ln(x))")]
+        [InlineData("(x! * x) ^ (1/x)")]
+        [InlineData("(x! / e^x) ^ (1/x)")]
+        public void AFactorialUnderAVanishingExponentDiverges(string expression) =>
+            AssertDiverges(expression);
+
+        /// <summary>
+        /// Where the exponent vanishes fast enough to hold the factorial's growth down. Each of
+        /// these was checked numerically before being written here.
+        /// </summary>
+        [Theory]
+        [InlineData("(x!) ^ (1/x^2)", "1")]
+        [InlineData("(x! / x^x) ^ (1/x^2)", "1")]
+        [InlineData("((x+1)! / x!) ^ (1/x)", "1")]
+        public void AnExponentThatVanishesFasterHoldsItDown(string expression, string expected) =>
+            AssertLimit(expression, expected);
+
+        /// <summary>
+        /// The guard, and the reason the expansion is not simply applied wherever a factorial
+        /// appears. What Stirling drops is <c>1/(12f)</c>, and the answer is
+        /// <c>e^(power * ln(base))</c> -- so that error contributes <c>power/(12f)</c> to the
+        /// exponent and only disappears where <c>power/f</c> does. <c>(x!)^x</c> fails that
+        /// (the ratio is <c>x/x</c>, which is 1), and it is left unanswered rather than
+        /// answered from an expansion that does not hold there.
+        /// </summary>
+        [Theory]
+        [InlineData("(x!) ^ x")]
+        [InlineData("(x!) ^ (x^2)")]
+        public void AnExponentThatDoesNotVanishAgainstTheFactorialIsNotRewritten(string expression)
+        {
+            var limit = expression.ToEntity().Limit("x", Entity.Number.Real.PositiveInfinity);
+            Assert.True(limit.Evaled is Entity.Limitf or Entity.Number.Real { IsFinite: false },
+                $"{expression} should be left unsettled or diverge, and came back {limit.Evaled}");
+        }
+
+        /// <summary>
+        /// The powers with no factorial in them, which must reach the same answers by the same
+        /// route they always did -- the expansion is only reached where a diverging factorial
+        /// is actually present.
+        /// </summary>
+        [Theory]
+        [InlineData("x ^ (1/x)", "1")]
+        [InlineData("(1 + 1/x) ^ x", "e")]
+        [InlineData("(x - 5) ^ x / x ^ x", "e^(-5)")]
+        [InlineData("(x^2) ^ (1/ln(x))", "e^2")]
+        [InlineData("(1 - 1/x^2) ^ (x^2)", "1/e")]
+        public void APowerWithoutAFactorialIsUntouched(string expression, string expected) =>
+            AssertLimit(expression, expected);
+    }
+}


### PR DESCRIPTION
Closes #754 — its remaining half. The wrong answer it also reported was fixed in #760.

## What was wrong

A power whose base holds a factorial had no limit at all. `f^g` is `e^(g * ln f)`, and `SolveAsIndeterminatePower` computes the limit of that exponent — but every route out of `ln(f)` runs through differentiating `f`, and a factorial's derivative wants the digamma function, which this library does not have. The rule declined, nothing behind it had a reading either, and `lim x->+oo ((x!)/x^x)^(1/x)` was the last `lim:factorial` miss in the corpus.

```
lim x->+oo (x! / x^x) ^ (1/x)     was  unevaluated   is  1/e
lim x->+oo (x!) ^ (1/x)           was  unevaluated   is  +oo
lim x->+oo (x!) ^ (1/ln(x))       was  unevaluated   is  +oo
lim x->+oo (x!) ^ (1/x^2)         was  unevaluated   is  1
lim x->+oo (x! / e^x) ^ (1/x)     was  unevaluated   is  +oo
lim x->+oo ((x+1)! / x!) ^ (1/x)  was  unevaluated   is  1
```

## Why the expansion goes on the exponent

`ln(f!)` is `f*ln(f) - f + ln(2*pi*f)/2 + 1/(12f) + O(1/f^3)`. Applying it to the **exponent** rather than substituting for the factorial in the base is the whole of what makes it sound: what is dropped here **vanishes**, where the asymptotic for `f!` itself has an error that is merely *relative* and survives being raised to a power.

**Vanishing is still not sufficient**, because the dropped term is multiplied by the exponent the rewrite sits under — an error of `1/(12f)` in the logarithm contributes `power/(12f)` to the exponent. So `power / f -> 0` is required. For `((x!)/x^x)^(1/x)` that ratio is `1/x^2`; `(x!)^x` fails it and is left alone, which is pinned as a test.

The factorial's logarithm is not visible until the base's logarithm is taken apart — `ln(x!/x^x)` is one node and nothing simplifies it — so `ln` is split over products, quotients and powers, **confined to logarithms that actually hold a diverging factorial**. That split assumes the parts are positive on the approach, which is the same assumption the simplifier's `ln(a) + ln(b) = ln(a*b)` already makes, and it is reached only by expressions that have no answer at all without it.

## Three tests from #760 are updated, not loosened

#760 pinned `(x!)^(1/x)`, `(x!)^(1/ln x)` and `(x!)^(1/x^2)` as *left unsettled*. Each is answered now. The third is the one #760 recorded as the thing it cost — right by luck rather than by reading, since the same substitution gave `1` for `(x!)^(1/x)` where the answer is `+oo`. It comes back as `1` **by reading**, and `BREAKING-CHANGES.md` is corrected accordingly.

## Measured

Every value checked numerically with mpmath at 50 digits before being claimed, at up to `x = 1e9`:

```
x        (x!/x^x)^(1/x)      (x!)^(1/x^2)
1e6      0.36788232          1.000012816
1e9      0.36787945          1.000000020
         1/e = 0.36787944    -> 1
```

This matters here: **SymPy 1.14.0 answers `limit((factorial(x)/x**x)**(1/x), x, oo)` with `0`**, which is wrong, so it is not a usable oracle for this one.

Over the 225 generated powers from #760, diffed against master: **six results differ, all six are one of the limits above, and every one is an unevaluated node becoming a value.** No answer changed into a different answer.

- `casbench` **112/117 → 113/117**, 0 wrong, 0 error, 0 timeout — the `lim:factorial` problem is solved
- unit tests **5307 passed, 0 failed** (5291 on master; 16 added)
- F# wrapper tests **130 passed**
- `propcheck` **0 failures**, `rootcheck` **596/596**, `simpsweep` **0 disagreements** of 10463