### PR TITLE
Minimise boolean expressions rather than only factoring them (#768, #769)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -41,6 +41,7 @@ read first.
 | **silent** | a limit assembling `oo^0` or `1^oo` | that form's value, `1` | the real answer, or unevaluated |
 | **silent** | a factorial under a vanishing exponent | unevaluated | a value, by Stirling |
 | **silent** | `ln(x!)` in a limit | unevaluated, and `ln(x!)/ln(x)` was `NaN` | a value |
+| **silent** | a boolean expression | factored, not minimised | minimised where that is shorter |
 | **silent** | some integrals | not antiderivatives | closed forms |
 | **silent** | two integrals | answered correctly | unevaluated — a deliberate loss |
 | loud | `Compile` over a missing variable | `KeyNotFoundException` | `UncompilableNodeException` |
@@ -537,6 +538,47 @@ hundred decimal places.
 [#677](https://github.com/asc-community/AngouriMath/pull/677).
 
 ---
+
+## Boolean simplification
+
+### A boolean expression is minimised rather than merely factored
+
+The rewrite rules reached absorption and stopped there, so the factoring worked and had nothing to
+finish it — there is no rule taking `b or not b` to `true`:
+
+```
+a and b or a and not b                          was  a and (b or not b)   is  a
+a or not a                                      was  a or not a           is  true
+a and not a                                     was  a and not a          is  false
+(a and b) or (a and not b) or (not a and b)      was  not a and b or a and (b or not b)
+                                                 is  a or b
+(not a and not b and not c) or (not a and not b and c)
+                                                 was  a or b or c implies not (a or b) and c
+                                                 is  not (a or b)
+```
+
+Two-level minimisation by Quine–McCluskey now runs over the truth table, covering excluded middle,
+non-contradiction and every larger cover in one procedure rather than as separate rules.
+
+**It is offered to `Simplify` as one more candidate, not as a replacement for its answer.**
+Candidates are ranked by node count and the shortest is returned, so this can only change an
+expression where the minimal form is shorter than everything else already on offer. That is what
+keeps `not (a and b)` as it is — 4 nodes against its sum-of-products form `not a or not b` at 5 — and
+it means no expression's answer gets longer.
+
+The last row above is [#769](https://github.com/asc-community/AngouriMath/issues/769), where an
+`implies` rewrite won at 12 nodes against the 16-node input. That rewrite was not misbehaving; the
+4-node answer was simply never generated for it to lose to.
+
+Bounded at **10 variables**, since the table is `2^n` rows. Beyond that it declines rather than
+hangs. A cover of k terms is at least `2k-1` nodes, so where that already exceeds the input the
+search is abandoned before it starts — parity over ten variables has 512 minterms, none of which
+combine, and finding its 512-term minimal form took 1.5 s to produce a candidate that loses to the
+input. With the check, 34 ms.
+
+[#768](https://github.com/asc-community/AngouriMath/issues/768) and
+[#769](https://github.com/asc-community/AngouriMath/issues/769), PR
+[#770](https://github.com/asc-community/AngouriMath/pull/770).
 
 ## Solving
 

--- a/Sources/AngouriMath/Functions/Boolean/Minimiser.cs
+++ b/Sources/AngouriMath/Functions/Boolean/Minimiser.cs
@@ -1,0 +1,255 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath.Core.Multithreading;
+
+namespace AngouriMath.Functions.Boolean
+{
+    using static Entity;
+
+    /// <summary>
+    /// Two-level minimisation of a boolean expression by Quine-McCluskey: the minterms where
+    /// it holds are combined into prime implicants, and a cover is chosen from those.
+    /// </summary>
+    /// <remarks>
+    /// The rewrite rules reach absorption and nothing past it, so
+    /// <c>a and b or a and not b</c> stopped at <c>a and (b or not b)</c> -- the factoring is
+    /// right and there is no rule to finish it, because <c>b or not b</c> has none reducing it
+    /// to <c>true</c>. One classical algorithm covers that, excluded middle, non-contradiction
+    /// and every larger cover at once, where each would otherwise be its own rule.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/768">#768</a>
+    /// </remarks>
+    internal static class Minimiser
+    {
+        /// <summary>
+        /// Above this many variables the table is not built at all. The cost is
+        /// <c>2^n</c> evaluations of the expression before any minimising starts, and the
+        /// expression is substituted into once per row -- so this is a bound on work that is
+        /// already lost by the time it is found to be wasted.
+        /// </summary>
+        /// <remarks>
+        /// Ten variables is 1024 rows, and the worst case is parity -- <c>a xor b xor ...</c>,
+        /// where no two minterms combine. Measured on that: 13 ms at eight variables, 22 at
+        /// nine, 34 at ten, roughly doubling per variable. Without the early exit below the
+        /// same three were 196 ms, 803 ms and 1517 ms, so most of what the bound is protecting
+        /// against is handled by not searching rather than by refusing.
+        /// <para/>
+        /// What remains is the table itself, which has to be built before anything can be said
+        /// about it. The bound is where that stops being worth paying blind, and it exists so
+        /// a wide expression declines rather than hangs -- the behaviour every other guard
+        /// here has.
+        /// </remarks>
+        internal const int MaxVariables = 10;
+
+        /// <summary>
+        /// The expression as a minimal sum of products, or <see langword="null"/> where it is
+        /// not a purely boolean expression, has too many variables, or is already what this
+        /// would produce.
+        /// </summary>
+        /// <remarks>
+        /// **Offered as one more candidate rather than taken.** `Simplify` ranks what it is
+        /// given by node count and returns the shortest, so handing it this can only change an
+        /// answer where it is shorter than everything else on offer -- which is what makes it
+        /// safe to add to a pipeline that already answers most expressions well. It is also
+        /// what fixes
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/769">#769</a>: there
+        /// the winning candidate was an `implies` form at 12 nodes, beating the 16-node input,
+        /// and the minimal `not (a or b)` at 4 was never generated for it to lose to.
+        /// </remarks>
+        internal static Entity? Minimise(Entity expr)
+        {
+            // Declaring the variable boolean is how a caller says what this is about, so
+            // `a and b or a and not b provided a in BB` had better reach the same answer the
+            // bare expression does. The condition says nothing about which minterms hold, so
+            // it travels with the result rather than blocking it.
+            if (expr is Providedf(var body, var condition))
+                return Minimise(body) is { } minimisedBody ? minimisedBody.Provided(condition) : null;
+            if (!IsPurelyBoolean(expr))
+                return null;
+            var variables = expr.Vars.ToArray();
+            if (variables.Length is 0 || variables.Length > MaxVariables)
+                return null;
+            // `e` and `pi` are Variable nodes that evaluate to numbers, so they pass the check
+            // above and are then absent from Vars -- which is how `a and (e or not e)` reached
+            // the table with a variable it could not assign. A boolean expression has no
+            // business holding one, and VarsAndConsts is what tells them apart.
+            if (expr.VarsAndConsts.Count() != variables.Length)
+                return null;
+
+            var rows = 1 << variables.Length;
+            var minterms = new List<int>();
+            var assignment = new Dictionary<Variable, Entity>(variables.Length);
+            for (var row = 0; row < rows; row++)
+            {
+                for (var bit = 0; bit < variables.Length; bit++)
+                    assignment[variables[bit]] = Bit(row, bit, variables.Length);
+                bool holds;
+                try { holds = expr.Substitute(assignment).EvalBoolean(); }
+                catch (Core.Exceptions.AngouriBugException) { throw; }
+                catch (Exception) { return null; }
+                if (holds)
+                    minterms.Add(row);
+            }
+            MultithreadingFunctional.ExitIfCancelled();
+
+            if (minterms.Count == 0)
+                return Entity.Boolean.False;
+            if (minterms.Count == rows)
+                return Entity.Boolean.True;
+            // A sum of k products is at least 2k-1 nodes -- k terms of at least one node,
+            // joined by k-1 disjunctions -- so where that already exceeds what came in, no
+            // cover this could find will be chosen, and the search is work thrown away.
+            // Parity is the case that matters: `a xor b xor ... ` over ten variables has 512
+            // minterms and no two of them combine, so every one is a prime implicant and the
+            // minimal form is 512 terms long. Finding that took 1.5 s to produce a candidate
+            // that loses to the input at 19 nodes.
+            if (2 * minterms.Count - 1 >= expr.Complexity)
+                return null;
+
+            var cover = Cover(PrimeImplicants(minterms, variables.Length), minterms);
+            return SumOfProducts(cover, variables);
+        }
+
+        /// <summary>
+        /// Whether every node is a boolean connective, a variable or a boolean constant.
+        /// </summary>
+        /// <remarks>
+        /// Substituting <see langword="true"/> for the variable of <c>x &gt; 1</c> is not a
+        /// question this can ask, so anything carrying arithmetic is declined before the table
+        /// is built rather than by catching what the evaluation throws.
+        /// </remarks>
+        private static bool IsPurelyBoolean(Entity expr)
+            => expr.Nodes.All(node =>
+                node is Andf or Orf or Notf or Xorf or Impliesf or Variable or Entity.Boolean);
+
+        /// <summary>
+        /// The value of the variable at <paramref name="bit"/> in the row numbered
+        /// <paramref name="row"/>, counting from the most significant so that the rows read in
+        /// the order a truth table is written.
+        /// </summary>
+        private static Entity Bit(int row, int bit, int count)
+            => (row >> (count - 1 - bit) & 1) == 1;
+
+        /// <summary>
+        /// An implicant: the bits that are fixed, and which positions those are.
+        /// </summary>
+        /// <param name="Bits">The fixed values, with the free positions zeroed.</param>
+        /// <param name="Fixed">One bit set per position that is fixed.</param>
+        private readonly record struct Implicant(int Bits, int Fixed);
+
+        /// <summary>
+        /// The prime implicants: every minterm, combined with its neighbours as far as it will
+        /// go. Two implicants combine when they fix the same positions and differ in exactly
+        /// one of them, and what comes out is the pair with that position freed. Whatever is
+        /// never combined is prime.
+        /// </summary>
+        private static List<Implicant> PrimeImplicants(List<int> minterms, int count)
+        {
+            var all = (1 << count) - 1;
+            var current = new HashSet<Implicant>(minterms.Select(m => new Implicant(m, all)));
+            var primes = new List<Implicant>();
+            while (current.Count > 0)
+            {
+                var combined = new HashSet<Implicant>();
+                var used = new HashSet<Implicant>();
+                foreach (var left in current)
+                    foreach (var right in current)
+                    {
+                        if (left.Fixed != right.Fixed)
+                            continue;
+                        var difference = left.Bits ^ right.Bits;
+                        // Exactly one fixed position differs -- and a power of two with its
+                        // low bit cleared is zero, which is the cheapest way to say so.
+                        if (difference == 0 || (difference & (difference - 1)) != 0
+                                            || (difference & left.Fixed) == 0)
+                            continue;
+                        combined.Add(new Implicant(left.Bits & ~difference, left.Fixed & ~difference));
+                        used.Add(left);
+                        used.Add(right);
+                    }
+                primes.AddRange(current.Where(implicant => !used.Contains(implicant)));
+                current = combined;
+                MultithreadingFunctional.ExitIfCancelled();
+            }
+            return primes;
+        }
+
+        /// <summary>
+        /// A cover of the minterms by the prime implicants: every implicant that alone covers
+        /// some minterm has to be in it, and what those leave uncovered is taken greedily,
+        /// widest first.
+        /// </summary>
+        /// <remarks>
+        /// Greedy rather than Petrick's method, which is exact and exponential in the number
+        /// of implicants. The essential pass alone settles every case in <c>work/boolmin</c>,
+        /// and where it does not, a cover that is one term wider than the optimum still has to
+        /// beat every other candidate on node count before `Simplify` will return it.
+        /// </remarks>
+        private static List<Implicant> Cover(List<Implicant> primes, List<int> minterms)
+        {
+            var covers = primes.ToDictionary(
+                implicant => implicant,
+                implicant => new HashSet<int>(minterms.Where(m => Covers(implicant, m))));
+            var chosen = new List<Implicant>();
+            var remaining = new HashSet<int>(minterms);
+
+            foreach (var minterm in minterms)
+            {
+                var only = primes.Where(implicant => covers[implicant].Contains(minterm)).ToList();
+                if (only.Count == 1 && !chosen.Contains(only[0]))
+                {
+                    chosen.Add(only[0]);
+                    remaining.ExceptWith(covers[only[0]]);
+                }
+            }
+            while (remaining.Count > 0)
+            {
+                var best = primes.Where(implicant => !chosen.Contains(implicant))
+                    .OrderByDescending(implicant => covers[implicant].Count(remaining.Contains))
+                    .ThenBy(implicant => FixedCount(implicant))
+                    .First();
+                chosen.Add(best);
+                remaining.ExceptWith(covers[best]);
+            }
+            return chosen;
+        }
+
+        /// <summary>
+        /// How many positions an implicant fixes -- its width, counted by hand because
+        /// <c>BitOperations</c> is not in netstandard2.0, which this library still targets.
+        /// </summary>
+        private static int FixedCount(Implicant implicant)
+        {
+            var count = 0;
+            for (var bits = implicant.Fixed; bits != 0; bits &= bits - 1)
+                count++;
+            return count;
+        }
+
+        private static bool Covers(Implicant implicant, int minterm)
+            => (minterm & implicant.Fixed) == implicant.Bits;
+
+        /// <summary>
+        /// The implicants written back out as a disjunction of conjunctions.
+        /// </summary>
+        private static Entity SumOfProducts(List<Implicant> cover, Variable[] variables)
+            => cover
+                .Select(implicant => Product(implicant, variables))
+                .Aggregate((left, right) => left | right);
+
+        private static Entity Product(Implicant implicant, Variable[] variables)
+            => Enumerable.Range(0, variables.Length)
+                .Where(bit => (implicant.Fixed >> (variables.Length - 1 - bit) & 1) == 1)
+                .Select(bit => (implicant.Bits >> (variables.Length - 1 - bit) & 1) == 1
+                    ? (Entity)variables[bit]
+                    : !variables[bit])
+                .Aggregate((left, right) => left & right);
+    }
+}

--- a/Sources/AngouriMath/Functions/Simplification/Simplificator.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Simplificator.cs
@@ -76,6 +76,21 @@ namespace AngouriMath.Functions
             AddHistory(stage1);
             var res = stage1;
 
+            // A boolean expression minimised properly, offered as one more candidate rather
+            // than taken. The rewrite rules reach absorption and stop there, so
+            // `a and b or a and not b` factored to `a and (b or not b)` and had no rule to
+            // finish it. Quine-McCluskey covers that, excluded middle, non-contradiction and
+            // every larger cover in one procedure.
+            //
+            // A candidate can only be returned where it is the shortest on offer, so this
+            // cannot make any expression's answer longer -- which is also what settles
+            // https://github.com/asc-community/AngouriMath/issues/769, where an `implies`
+            // rewrite won at 12 nodes against the 16-node input because the 4-node minimal
+            // form was never generated for it to lose to.
+            // https://github.com/asc-community/AngouriMath/issues/768
+            if (Functions.Boolean.Minimiser.Minimise(stage1) is { } minimised)
+                AddHistory(minimised);
+
             for (int i = 0; i < Math.Abs(level); i++)
             {
                 var sortLevel = i switch

--- a/Sources/Tests/UnitTests/PatternsTest/BooleanMinimisationTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/BooleanMinimisationTest.cs
@@ -1,0 +1,133 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.PatternsTest
+{
+    /// <summary>
+    /// The rewrite rules reached absorption and stopped there, so <c>a and b or a and not b</c>
+    /// factored correctly to <c>a and (b or not b)</c> and had nothing to finish it -- there is
+    /// no rule taking <c>b or not b</c> to <c>true</c>. Two-level minimisation by
+    /// Quine-McCluskey covers that, excluded middle, non-contradiction and every larger cover
+    /// in one procedure.
+    /// https://github.com/asc-community/AngouriMath/issues/768
+    ///
+    /// It is offered to <c>Simplify</c> as one more candidate rather than as a replacement for
+    /// its answer. Candidates are ranked by node count and the shortest is returned, so this
+    /// can only change an expression's answer where it is shorter than everything else on
+    /// offer -- which is also why it needs no separate entry point.
+    /// </summary>
+    public sealed class BooleanMinimisationTest
+    {
+        private static void AssertSimplifiesTo(string input, string expected) =>
+            Assert.Equal(expected.ToEntity().InnerSimplified,
+                         input.ToEntity().Simplify().InnerSimplified);
+
+        /// <summary>
+        /// The keystones. Without excluded middle and non-contradiction the factoring that
+        /// already worked could not finish, which is what made case 1 stop one rewrite short.
+        /// </summary>
+        [Theory]
+        [InlineData("a or not a", "true")]
+        [InlineData("a and not a", "false")]
+        [InlineData("a and b or a and not b", "a")]
+        [InlineData("(a or b) and (a or not b)", "a")]
+        public void ExcludedMiddleAndNonContradictionAreReached(string input, string expected) =>
+            AssertSimplifiesTo(input, expected);
+
+        /// <summary>
+        /// Covers over more than one variable, which no single rewrite rule reaches.
+        /// </summary>
+        [Theory]
+        [InlineData("(a and b) or (a and not b) or (not a and b)", "a or b")]
+        [InlineData("(a and b and c) or (a and b and not c)", "a and b")]
+        [InlineData("(a and b and c and d) or (a and b and c and not d)", "a and b and c")]
+        public void ALargerCoverIsFound(string input, string expected) =>
+            AssertSimplifiesTo(input, expected);
+
+        /// <summary>
+        /// #769's report: <c>Simplify</c> returned an <c>implies</c> form at 12 nodes, which
+        /// beat the 16-node input honestly -- the 4-node answer was simply never generated for
+        /// it to lose to. Supplying it settles that without touching the rule that produced the
+        /// <c>implies</c>, which is what a naive reading of that issue would have removed.
+        /// https://github.com/asc-community/AngouriMath/issues/769
+        /// </summary>
+        [Theory]
+        [InlineData("(not a and not b and not c) or (not a and not b and c)", "not (a or b)")]
+        [InlineData("(not a and not b and c) or (not a and b and c)", "not a and c")]
+        [InlineData("(not a and not b and not c) or (a and not b and not c)", "not (b or c)")]
+        public void TheMinimalFormBeatsTheImpliesRewrite(string input, string expected) =>
+            AssertSimplifiesTo(input, expected);
+
+        /// <summary>
+        /// Declaring the variable boolean must reach the same answer the bare expression does.
+        /// The condition says nothing about which minterms hold, so it travels with the result
+        /// rather than blocking it.
+        /// </summary>
+        [Theory]
+        [InlineData("a or not a provided a in BB", "true provided a in BB")]
+        [InlineData("a and b or a and not b provided a in BB", "a provided a in BB")]
+        public void ADeclaredBooleanIsMinimisedToo(string input, string expected) =>
+            AssertSimplifiesTo(input, expected);
+
+        /// <summary>
+        /// **Where the minimiser must not win.** Its output is a sum of products, and that is
+        /// not always the shortest way to write a function: <c>not (a and b)</c> is 4 nodes
+        /// against the SOP form <c>not a or not b</c> at 5. Offering it as a candidate rather
+        /// than taking it is what keeps these as they are, without any rule deciding which
+        /// shape is preferable.
+        /// </summary>
+        [Theory]
+        [InlineData("not (a and b)")]
+        [InlineData("not (a or b)")]
+        [InlineData("a and b")]
+        [InlineData("a or b")]
+        [InlineData("a xor b")]
+        [InlineData("a implies b")]
+        public void AnExpressionAlreadyShorterThanItsSumOfProductsIsLeftAlone(string input) =>
+            AssertSimplifiesTo(input, input);
+
+        /// <summary>
+        /// Nothing that is not a boolean expression may reach the truth table at all --
+        /// substituting <see langword="true"/> for the variable of <c>x &gt; 1</c> is not a
+        /// question this can ask. <c>e</c> is the case worth pinning: it is a
+        /// <c>Variable</c> node that evaluates to a number, so it passes a check on node types
+        /// and is then absent from <c>Vars</c>.
+        /// </summary>
+        [Theory]
+        [InlineData("x > 1 or x <= 1")]
+        [InlineData("a and (e or not e)")]
+        [InlineData("x + 1 = 2 or x + 1 != 2")]
+        public void ANonBooleanExpressionIsDeclined(string input)
+        {
+            var simplified = input.ToEntity().Simplify();
+            Assert.NotEqual(Entity.Boolean.True, simplified);
+            Assert.NotEqual(Entity.Boolean.False, simplified);
+        }
+
+        /// <summary>
+        /// **The cost guard.** A sum of k products is at least 2k-1 nodes, so where that
+        /// already exceeds the input no cover can be chosen and the search is wasted. Parity is
+        /// the case: over ten variables it has 512 minterms, no two of which combine, so every
+        /// one is a prime implicant and the minimal form is 512 terms long. Without this the
+        /// search took 1.5 s to produce a candidate that loses to the input at 19 nodes; with
+        /// it, 34 ms.
+        /// </summary>
+        [Fact]
+        public void ParityIsNotSearchedAndTerminatesQuickly()
+        {
+            var parity = "a xor b xor c xor d xor f xor g xor h xor j xor k xor l".ToEntity();
+            var task = System.Threading.Tasks.Task.Run(() => parity.Simplify());
+            Assert.True(task.Wait(System.TimeSpan.FromSeconds(10)),
+                "minimising a ten-variable parity expression should decline rather than search");
+            Assert.Equal(parity.InnerSimplified, task.Result.InnerSimplified);
+        }
+    }
+}


### PR DESCRIPTION
Closes #768 and #769.

## What was wrong

The rewrite rules reach absorption and stop there. `a and b or a and not b` factors correctly to `a and (b or not b)` and then has nothing to finish it, because no rule takes `b or not b` to `true`. Excluded middle and non-contradiction are the keystones — without them the factoring that already works cannot complete.

```
a and b or a and not b                    was  a and (b or not b)          is  a
a or not a                                was  a or not a                  is  true
a and not a                               was  a and not a                 is  false
(a and b) or (a and not b) or (not a and b)
                                          was  not a and b or a and (b or not b)
                                          is  a or b
```

## The fix

Quine–McCluskey over the truth table: minterms → prime implicants → a cover. One classical algorithm in place of a pile of rules, and it subsumes excluded middle, non-contradiction and every larger cover at once.

**Offered to `Simplify` as one more candidate rather than as a replacement for its answer.** Candidates are ranked by node count and the shortest wins, so this can only change an expression where the minimal form beats everything already on offer. Three consequences worth stating:

- **No answer can get longer.** That is a property of the architecture, not a claim about the algorithm.
- **`not (a and b)` is left alone** — 4 nodes, against its sum-of-products form `not a or not b` at 5. Sum-of-products is not always the shortest way to write a function, and nothing here has to decide that; the metric does.
- **It needs no separate entry point.** #768 suggested `MathS.Boolean.Minimise` first, on the grounds that folding it into `Simplify` risks changing existing answers. Offering a candidate cannot.

## This is also #769, and the obvious fix there would have been a regression

#769 reports `Simplify` rewriting a disjunction into an `implies` form that eliminates nothing. Measured: the input is **16** nodes, the `implies` form **12**, and the correct answer `not (a or b)` is **4**. The rewrite was not misbehaving — it wins honestly, and the 4-node answer was never generated for it to lose to. Removing the rule, which is what that report invites, would leave the **16**-node input as the answer.

```
(not a and not b and not c) or (not a and not b and c)
    was  a or b or c implies not (a or b) and c        (12 nodes)
    is   not (a or b)                                  (4 nodes)
```

## Two guards, measured rather than picked

- **Ten variables.** The table is `2^n` rows and must be built before anything can be said about it.
- **A cover of k terms is at least `2k-1` nodes**, so where that already exceeds the input, no cover can be chosen and the search is abandoned before it starts. Parity is the case: over ten variables it has 512 minterms, no two of which combine, so every one is a prime implicant and the minimal form is 512 terms long.

| parity, 10 vars | time |
|---|--:|
| without the cover bound | **1517 ms** |
| with it | **34 ms** |

The residue is the `2^n` evaluations needed to discover it is parity at all.

## Two things that only showed up by measuring

- **`e` is a `Variable` node that evaluates to a number.** It passes a check on node types and is then absent from `Vars`, so `a and (e or not e)` reached the table with a variable it could not assign. It is declined explicitly now rather than by catching what the evaluation throws — and it is pinned as a test, because it looked exactly like a mysterious cutoff at five variables until I read the trace.
- **netstandard2.0 has neither `ToHashSet` nor `BitOperations`.** The net7.0 build succeeded and said nothing about it; the popcount is written out by hand.

## Measured

- unit tests **5344 passed, 0 failed** (5322 on master; 22 added, **12 of which fail without the wiring**)
- `casbench` **113/117, 0 wrong, 0 error, 0 timeout** — unchanged
- F# wrapper tests **130 passed**
- `propcheck` **0 failures**, `rootcheck` **596/596**, `simpsweep` **0 disagreements** of 10463

`Simplify` has the widest reach of anything in the library, so all four harnesses were re-run rather than trusted.