### PR TITLE
Answer k/(a x^2 + c) instead of NaN when the leading coefficient is symbolic

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -43,6 +43,7 @@ read first.
 | **silent** | `ln(x!)` in a limit | unevaluated, and `ln(x!)/ln(x)` was `NaN` | a value |
 | **silent** | some integrals | not antiderivatives | closed forms |
 | **silent** | two integrals | answered correctly | unevaluated — a deliberate loss |
+| **silent** | `k/(a x^2 + c)` and `k/sqrt(a x^2 + c)` for symbolic `a` | `NaN` | a piecewise on the sign of the discriminant |
 | loud | `Compile` over a missing variable | `KeyNotFoundException` | `UncompilableNodeException` |
 
 ---
@@ -1037,6 +1038,34 @@ one.
 
 PRs [#665](https://github.com/asc-community/AngouriMath/pull/665) and
 [#675](https://github.com/asc-community/AngouriMath/pull/675).
+
+### A quadratic denominator with a symbolic leading coefficient answered `NaN`
+
+`1/(4 + 9*x^2)` has always come back as an arctangent. `1/(a^2 + b^2*x^2)` came back as `NaN` — the
+claim that no antiderivative exists, for one of the most common integrals there is.
+
+```
+int 1/(a^2 + b^2*x^2) dx     was  NaN + C
+                             is   a piecewise, the arctangent where 4*a^2*b^2 > 0
+int 1/sqrt(a*x^2 + c) dx     was  NaN + C
+                             is   a piecewise on the sign of a
+```
+
+Both patterns build their `a = 0` arm as though the denominator still had an `x` term —
+`(k/b) ln|bx + c|` and `2k sqrt(bx + c)/b` — each dividing by a `b` that is zero whenever the
+denominator is written without one. The arm is guarded afterwards by a `Providedf` on `a = 0`, so a
+numeric leading coefficient makes it decidably unreachable and it is dropped before anything looks
+inside; a symbolic one leaves it in place, and a `Providedf` carrying `NaN` takes the whole piecewise
+with it. Every test of these shapes used numbers, where the defect cannot be reached.
+
+The arm was also the wrong formula, not merely undefined: where `a = 0` and `b = 0` the integrand is
+the constant `k/c` and its antiderivative is `kx/c`, which is what it now says.
+
+Measured over the 1774 fair problems of Rubi's independent test suites: answered 536 -> 543, wrong
+7 -> 0. Three problems that were never answered moved from unevaluated to timeout, the `NaN` having
+served as an accidental early exit.
+
+PR [#774](https://github.com/asc-community/AngouriMath/pull/774).
 
 ### Two integrals that were answered are now unevaluated
 

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IntegralPatterns.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IntegralPatterns.cs
@@ -387,8 +387,14 @@ namespace AngouriMath.Functions.Algebra
             var logarithmCase =
                 numerator * MathS.Ln(MathS.Abs(twoAxPlusB + 2 * MathS.Sqrt(a) * MathS.Sqrt(radicand))) / MathS.Sqrt(a);
 
-            // a = 0: sqrt(bx + c), which integrates as an ordinary power
-            var linearCase = 2 * numerator * MathS.Sqrt(b * x + c) / b;
+            // a = 0: sqrt(bx + c), which integrates as an ordinary power, and needs b ≠ 0 for
+            // the same reason the rational case below does. Where the radicand has no x term
+            // the integrand is the constant k/sqrt(c) and its antiderivative is kx/sqrt(c);
+            // the division by zero otherwise left here is what made k/sqrt(a x^2 + c) answer
+            // NaN for every symbolic a, since only a numeric a lets this arm be dropped.
+            var linearCase = TreeAnalyzer.IsZero(b)
+                ? numerator * x / MathS.Sqrt(c)
+                : 2 * numerator * MathS.Sqrt(b * x + c) / b;
 
             return MathS.Piecewise([
                 new Entity.Providedf(linearCase, a.EqualTo(0)),
@@ -412,8 +418,15 @@ namespace AngouriMath.Functions.Algebra
         {
             // The formula depends on whether it's linear (a = 0) or quadratic (a ≠ 0)
             // Case 0: a = 0 (linear, not quadratic)
-            // ∫ k/(bx + c) dx = (k/b) * ln|bx + c|
-            var linearCase = numerator * MathS.Ln(MathS.Abs(b * x + c)) / b;
+            // ∫ k/(bx + c) dx = (k/b) * ln|bx + c|, which needs b ≠ 0. Where the denominator
+            // has no x term the integrand is the constant k/c and its antiderivative is kx/c;
+            // writing the logarithm there divides by zero, and a Providedf carrying NaN takes
+            // the whole piecewise with it. That is only ever reached when a is symbolic, since
+            // a numeric a makes this arm decidably unreachable and it is dropped before the
+            // NaN can propagate -- so k/(a x^2 + c) answered NaN while k/(2 x^2 + c) did not.
+            var linearCase = TreeAnalyzer.IsZero(b)
+                ? numerator * x / c
+                : numerator * MathS.Ln(MathS.Abs(b * x + c)) / b;
             
             // For true quadratics (a ≠ 0), discriminant Δ = 4ac - b^2 determines the form
             var discriminant = 4 * a * c - b * b;

--- a/Sources/Tests/UnitTests/Calculus/SymbolicCoefficientIntegralsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/SymbolicCoefficientIntegralsTest.cs
@@ -1,0 +1,138 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// Quotients whose denominator is a quadratic with a symbolic leading coefficient and no
+    /// x term, such as k/(a x^2 + c). These answered NaN: the a = 0 arm of the piecewise is
+    /// written as (k/b) ln|bx + c|, which divides by zero when the denominator has no x term,
+    /// and the resulting NaN propagates out of the whole piecewise as soon as a is symbolic
+    /// and so the arm cannot be dropped for being unreachable. With a numeric leading
+    /// coefficient a = 0 is decidably false, the arm is dropped, and the same integrals were
+    /// answered correctly -- which is why this was invisible to every test using numbers.
+    ///
+    /// No issue is filed for this; it was found by work/intbench against Rubi's suite, where
+    /// it accounted for six of the seven wrong answers.
+    /// </summary>
+    public sealed class SymbolicCoefficientIntegralsTest
+    {
+        /// <summary>
+        /// Integrates with the coefficients left symbolic, then substitutes values into the
+        /// answer and differentiates it back. Specialising after integrating is the point:
+        /// substituting first would take the numeric path, which never had the defect.
+        /// </summary>
+        private static void AssertIsAntiderivative(
+            string integrand, string coefficients, params double[] points)
+        {
+            var f = integrand.ToEntity();
+            var antiderivative = f.Integrate("x");
+            Assert.DoesNotContain("integral(", antiderivative.Stringize());
+            Assert.DoesNotContain("NaN", antiderivative.Stringize());
+            // The root-of-a-quadratic arm only collapses once the *symbolic* answer is
+            // simplified: the raw form still carries an undivided .../0 that has not been
+            // turned into NaN yet, so checking the raw form alone would miss it.
+            Assert.DoesNotContain("NaN", antiderivative.Simplify().Stringize());
+
+            Entity specialisedIntegrand = f;
+            Entity specialisedAnswer = antiderivative.Substitute("C", 0);
+            foreach (var assignment in coefficients.Split(','))
+            {
+                var parts = assignment.Split('=');
+                var name = parts[0].Trim();
+                var value = double.Parse(parts[1].Trim(),
+                    System.Globalization.CultureInfo.InvariantCulture);
+                specialisedIntegrand = specialisedIntegrand.Substitute(name, value);
+                specialisedAnswer = specialisedAnswer.Substitute(name, value);
+            }
+
+            // Simplify collapses the piecewise once the conditions are decidable; the
+            // derivative of an undecided piecewise would say nothing.
+            var derivative = specialisedAnswer.Simplify().Differentiate("x");
+            foreach (var point in points)
+            {
+                var expected = specialisedIntegrand.Substitute("x", point)
+                    .EvalNumerical().RealPart.EDecimal.ToDouble();
+                var actual = derivative.Substitute("x", point)
+                    .EvalNumerical().RealPart.EDecimal.ToDouble();
+                Assert.Equal(expected, actual, 8);
+            }
+        }
+
+        // The six wrong answers intbench found, in the form Rubi states them. Every one is a
+        // denominator with a symbolic leading coefficient and no x term.
+        [Theory]
+        [InlineData("1 / (a ^ 2 + b ^ 2 * x ^ 2)", "a = 2, b = 3", new[] { 0.3, 1.7, -0.6 })]
+        [InlineData("1 / (a ^ 2 - b ^ 2 * x ^ 2)", "a = 2, b = 3", new[] { 0.3, 1.7, -0.6 })]
+        [InlineData("1 / (a + b * x ^ 2)", "a = 2, b = 3", new[] { 0.3, 1.7, -0.6 })]
+        [InlineData("1 / (a * x ^ 2 + c)", "a = 3, c = 2", new[] { 0.3, 1.7, -0.6 })]
+        [InlineData("1 / (A ^ 4 - A ^ 2 * B ^ 2 + (-A ^ 2 + B ^ 2) * x ^ 2)",
+            "A = 3, B = 2", new[] { 0.3, 1.7, -0.6 })]
+        public void ASymbolicLeadingCoefficientWithNoXTerm(
+            string integrand, string coefficients, double[] points) =>
+            AssertIsAntiderivative(integrand, coefficients, points);
+
+        // A linear numerator over the same shape goes through the same arm, one rewrite later.
+        [Theory]
+        [InlineData("x / (a ^ 2 + b ^ 2 * x ^ 2)", "a = 2, b = 3", new[] { 0.3, 1.7, -0.6 })]
+        [InlineData("(2 * x + 1) / (a + b * x ^ 2)", "a = 2, b = 3", new[] { 0.3, 1.7, -0.6 })]
+        public void ALinearNumeratorOverTheSameShape(
+            string integrand, string coefficients, double[] points) =>
+            AssertIsAntiderivative(integrand, coefficients, points);
+
+        // The neighbouring shapes must keep working: a symbolic leading coefficient *with* an
+        // x term never had the defect, because the a = 0 arm divides by a b that is not zero.
+        [Theory]
+        [InlineData("1 / (a * x ^ 2 + b * x + c)", "a = 1, b = 2, c = 5", new[] { 0.3, 1.7, -0.6 })]
+        [InlineData("1 / (a * x ^ 2 + 2 * x + 3)", "a = 1", new[] { 0.3, 1.7, -0.6 })]
+        [InlineData("1 / (1 + b * x + a * x ^ 2)", "a = 1, b = 2", new[] { 0.3, 1.7, -0.6 })]
+        public void ASymbolicLeadingCoefficientWithAnXTerm(
+            string integrand, string coefficients, double[] points) =>
+            AssertIsAntiderivative(integrand, coefficients, points);
+
+        // k/sqrt(a x^2 + c) has the same arm with the same division by zero in it, and it is
+        // the last of intbench's seven wrong answers: 1/sqrt(-alpha^2 + 2 h r^2) came back as
+        // sqrt(-alpha^2)/0 and Simplify turned the lot into NaN.
+        [Theory]
+        [InlineData("1 / sqrt(a * x ^ 2 + c)", "a = 2, c = 3", new[] { 0.3, 1.7, -0.6 })]
+        [InlineData("1 / sqrt(a * x ^ 2 + c)", "a = -9, c = 4", new[] { 0.3, 0.6, -0.5 })]
+        [InlineData("1 / sqrt(-alpha ^ 2 + 2 * h * x ^ 2)", "alpha = 1, h = 2", new[] { 1.3, 2.4 })]
+        [InlineData("1 / sqrt(a ^ 2 - b ^ 2 * x ^ 2)", "a = 2, b = 3", new[] { 0.3, 0.6, -0.5 })]
+        public void ARootOfAQuadraticWithNoXTerm(
+            string integrand, string coefficients, double[] points) =>
+            AssertIsAntiderivative(integrand, coefficients, points);
+
+        // And the shapes beside it, which have an x term and never had the defect.
+        [Theory]
+        [InlineData("1 / sqrt(a * x ^ 2 + b * x + c)", "a = 1, b = 2, c = 5", new[] { 0.3, 1.7 })]
+        [InlineData("1 / sqrt(2 * x + 3)", "a = 1", new[] { 0.3, 1.7 })]
+        public void ARootOfAQuadraticWithAnXTerm(
+            string integrand, string coefficients, double[] points) =>
+            AssertIsAntiderivative(integrand, coefficients, points);
+
+        /// <summary>
+        /// The degenerate arm is not merely non-NaN, it is the right answer: where the
+        /// leading coefficient really is zero and there is no x term, the integrand is the
+        /// constant k/c and its antiderivative is kx/c. The old code claimed (k/b) ln|bx + c|
+        /// there, which is wrong quite apart from dividing by zero.
+        /// </summary>
+        [Fact]
+        public void TheDegenerateArmIsTheConstantIntegral()
+        {
+            var antiderivative = "1 / (a * x ^ 2 + 5)".ToEntity().Integrate("x")
+                .Substitute("C", 0).Substitute("a", 0).Simplify();
+            var derivative = antiderivative.Differentiate("x").Simplify();
+            foreach (var point in new[] { 0.3, 1.7, -0.6 })
+                Assert.Equal(0.2,
+                    derivative.Substitute("x", point).EvalNumerical().RealPart.EDecimal.ToDouble(), 8);
+        }
+    }
+}


### PR DESCRIPTION
`1/(a^2 + b^2*x^2)` answered `NaN` — the claim that no antiderivative exists — where it is `arctan(b*x/a)/(a*b)`. So did `1/(a + b*x^2)`, `1/(a^2 - b^2*x^2)`, `cos(x)/(a^2 + b^2*sin(x)^2)` and `1/sqrt(-alpha^2 + 2*h*x^2)`.

`1/(4 + 9*x^2)` has always been fine, and that difference is the whole of the bug.

## What was wrong

Both quadratic integral patterns write their `a = 0` arm as though the denominator still had an `x` term:

| pattern | `a = 0` arm |
|---|---|
| `k/(ax^2 + bx + c)` | `(k/b) * ln|bx + c|` |
| `k/sqrt(ax^2 + bx + c)` | `2k * sqrt(bx + c) / b` |

Each divides by `b`, which is exactly zero whenever the denominator is written without an `x` term. The arm is built unconditionally and only guarded afterwards, by a `Providedf` on `a = 0`, so whether that division by zero is ever seen depends on whether the guard can be decided:

- **numeric leading coefficient** — `a = 0` is decidably false, the arm is dropped, and the answer is correct;
- **symbolic leading coefficient** — `a = 0` is undecidable, the arm survives carrying `NaN`, and a `Providedf` carrying `NaN` takes the whole piecewise with it.

Reduced to the mechanism, with no integration involved:

```
piecewise((1/0) provided (a = 0), (5) provided (a > 0))   =>   NaN
```

Every existing test of these shapes uses numbers, and with numbers the defect is unreachable. That is why it survived.

## What the fix does

The arm is not merely `NaN`, it is the **wrong formula**. Where `a = 0` and `b = 0` the integrand is the constant `k/c`, whose antiderivative is `kx/c`; the logarithm claimed there is wrong quite apart from dividing by zero. So this writes the antiderivative that case actually has rather than suppressing the branch, and the piecewise becomes correct on every arm instead of correct only on the arms that can be reached.

`1/(a^2 + b^2*x^2)` now answers, with the degenerate arm carrying its own real value:

```
piecewise((x / a^2) provided (b^2 = 0),
          (2 * arctan(2*b^2*x / sqrt(4*b^2*a^2)) / sqrt(4*b^2*a^2)) provided (4*b^2*a^2 > 0),
          ((-2) / (2*b^2*x)) provided (4*b^2*a^2 = 0),
          (ln(abs(...)) / sqrt(-4*b^2*a^2)) provided (4*b^2*a^2 < 0)) + C
```

## What it does not do

- **Only the syntactically zero coefficient is treated this way.** Where `b` is itself a symbol, `b = 0` is undecidable and the logarithm is what any CAS returns. That case is unchanged, and it never produced a `NaN` — the arm formally overclaims for a `b` that happens to be zero, which is a separate and much smaller question than this one.
- **No change to which shapes are recognised.** This only corrects arms that were already being emitted.
- **`sqrt(a*x^2 + c)` is still unevaluated.** It was before too.

## Measurements

Against Rubi's integration test-suite via a harness that grades by differentiating our answer back and comparing to the integrand numerically — never against Rubi's answer. 1774 fair problems from the independent test suites (Stewart, Apostol, Timofeev, Hearn, Moses and the rest), 5s budget:

| | before | after |
|---|--:|--:|
| answered | 536 | **543** |
| wrong | 7 | **0** |
| of which `NaN` | 6 | **0** |
| unevaluated | 1194 | 1191 |
| timeout | 29 | 32 |

All seven wrong answers in that suite were this defect.

**The cost, stated plainly:** three problems moved from unevaluated to timeout — Hearn 61 (`1/(x^6 - 1)`), Hearn 349, and Moses 124. None of the three was ever answered, so no answer was lost, and no answered problem changed. The `NaN` had been acting as an accidental early exit: a real piecewise now survives where the search used to collapse instantly, so on those three the search runs to the budget before giving up.

Also run: unit tests **5322 -> 5339** passing with 17 added, **11 of which fail without this change** (the other 6 are the neighbouring shapes, which must keep working and do). casbench 113/117 unchanged with 0 wrong, F# 130, propcheck 0 failures, rootcheck 596/596, simpsweep 10463/10463 in agreement.

No issue is filed for this; it was found by a harness rather than reported.

CI note: GitHub Actions has been in a [major outage](https://www.githubstatus.com/) since 15:22 UTC today, and jobs are failing at `Set up job` before any code is fetched. If the checks here are red without having run, that is why.
