### PR TITLE
Print a complex number so that it parses back to itself (#776)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -28,6 +28,7 @@ read first.
 | **silent** | `sqrt(x^2)`, `sqrt(-x)` and their kind | `x`, `i*sqrt(x)` — wrong for negative x | left as written |
 | loud | `mod` as a variable name | a variable | a keyword, so a parse error |
 | **silent** | `Stringize` of powers, lambdas, applications, piecewises | did not parse back | parses back |
+| **silent** | `Stringize` of a complex number with a fractional imaginary part | read back as its negation, or as a power | parses back |
 | **silent** | numbers below `1e-16` | rounded to `0` | kept |
 | **silent** | `Real` `%` | `-7 % 3` was `-1` | `2` |
 | **silent** | `Simplify` of a cancelling quotient | the quotient | a `Providedf` |
@@ -247,10 +248,23 @@ expression. **If you compare `Stringize` output against fixed strings, these fou
 | `lambda(x, x + 1)` | `x -> x + 1` | `x implies x + 1` | `lambda(x, x + 1)` |
 | `apply(f, 2)` | `f 2` | a power | `apply(f, 2)` |
 | `piecewise(1 provided x > 0)` | `(1 if x > 0)` | a product, `if` being an undeclared variable | `piecewise(1 provided (x > 0))` |
+| `i / 2` evaluated | `1/2i` | `1 / (2i)`, which is its **negation** | `1/2 * i` |
+| `2 + 3 * i / 4` evaluated | `2 + (3/4)i` | `2 + (3/4) ^ i`, a different number | `2 + 3/4 * i` |
 
 Powers group to the right, so it is the base that needs bracketing when it is a power of its own —
-the mirror of the rule the left-associative operators use. The other three have no operator spelling
+the mirror of the rule the left-associative operators use. The next three have no operator spelling
 in the grammar, so they now print as the function call the parser does have.
+
+The last two are one defect. A complex number whose imaginary part is a fraction was printed with
+the fraction pushed up against the `i`, and `1/2i` is read as `1 / (2i)` — the negation of what was
+printed. The case with a real part bracketed the coefficient, which looks like a guard and is not:
+a bracket followed by a name is read as exponentiation, so `(3/4)i` came back as `(3/4) ^ i`. Both
+now multiply explicitly, which needs no bracket since `*` and `/` bind tighter than `+`. Integer
+coefficients never had the problem and are unchanged — `i`, `-i` and `2i` print as before.
+
+This one is worth reading twice if you parse printed output, because the misreading is a perfectly
+ordinary number: every root of a trigonometric equation prints through this path, and
+`cos(x)^2 + sin(x) = 0` returns roots that are exact as entities and were not as text.
 
 `Latexise` is under no such obligation, since nothing parses LaTeX, and is unaffected.
 

--- a/Sources/AngouriMath/Functions/Output/ToString/ToString.Number.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/ToString/ToString.Number.Classes.cs
@@ -31,13 +31,19 @@ namespace AngouriMath
                         else
                             return number.Stringize();
                     }
+                    // A fraction next to the i has to be multiplied by it explicitly. Written
+                    // as 1/2i the parser reads 1/(2i), which is the negation of what was
+                    // printed, and bracketing it as (1/2)i does not help -- a bracket followed
+                    // by a name is read as a power, so 2 + (3/4)i came back as 2 + (3/4)^i.
+                    // Both are silent: the misreading is a valid expression, so nothing
+                    // complains, and every root of a trigonometric equation prints this way.
+                    var times = ImaginaryPart is Rational and not Integer ? " * " : "";
                     if (ImaginaryPart is Integer(0))
                         return RealPart.Stringize();
                     else if (RealPart is Integer(0))
-                        return RenderNum(ImaginaryPart) + "i";
-                    var (l, r) = ImaginaryPart is Rational and not Integer ? ("(", ")") : ("", "");
+                        return RenderNum(ImaginaryPart) + times + "i";
                     var (im, sign) = ImaginaryPart > 0 ? (ImaginaryPart, "+") : (-ImaginaryPart, "-");
-                    return RealPart.Stringize() + " " + sign + " " + l + RenderNum(im) + r + "i";
+                    return RealPart.Stringize() + " " + sign + " " + RenderNum(im) + times + "i";
                 }
                 /// <inheritdoc/>
                 public override string ToString() => Stringize();

--- a/Sources/Tests/UnitTests/Common/CircleTest.cs
+++ b/Sources/Tests/UnitTests/Common/CircleTest.cs
@@ -67,7 +67,10 @@ namespace AngouriMath.Tests.Common
         [Theory]
         [InlineData("23.3", "233/10")]
         [InlineData("5.3", "53/10")]
-        [InlineData("-5.3i", "-53/10i")]
+        // Was "-53/10i", which the parser reads as -53/(10i) -- that is +5.3i, the negation
+        // of the number being printed. The expectation was pinning the misprint, so it is
+        // corrected rather than loosened; the multiplication is now explicit.
+        [InlineData("-5.3i", "-53/10 * i")]
         public void DecimalToRational(string @decimal, string rational)
         {
             string expr = $"{@decimal} + 3 / 3 + {@decimal} + i";

--- a/Sources/Tests/UnitTests/Convenience/StringizeRoundTripTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/StringizeRoundTripTest.cs
@@ -161,5 +161,36 @@ namespace AngouriMath.Tests.Common
         [InlineData("e")]
         [InlineData("pi")]
         public void MatricesAndNumbersRoundTrip(string source) => AssertRoundTrip(source);
+
+        /// <summary>
+        /// The cases above round-trip the expression as written, so <c>i / 2</c> stays a
+        /// division and never reaches the printer for a complex <em>number</em>. Evaluating
+        /// first is what exercises that printer, and it printed a pure imaginary with a
+        /// fractional part as <c>1/2i</c> -- which the parser reads as <c>1/(2i)</c>, the
+        /// negation of what was printed. The mixed case was already right, bracketing it as
+        /// <c>2 + (3/4)i</c>; the pure-imaginary arm returned before that bracketing was
+        /// applied.
+        ///
+        /// Silent, and it misleads a reader as much as a parser: every root of a
+        /// trigonometric equation is printed through this.
+        /// </summary>
+        [Theory]
+        [InlineData("i / 2")]
+        [InlineData("-i / 2")]
+        [InlineData("3 * i / 4")]
+        [InlineData("-5 * i / 3")]
+        [InlineData("2 + 3 * i / 4")]
+        [InlineData("2 - 3 * i / 4")]
+        [InlineData("i")]
+        [InlineData("-i")]
+        [InlineData("2 * i")]
+        [InlineData("-2 * i")]
+        [InlineData("1/2")]
+        [InlineData("2 + 3 * i")]
+        public void AnEvaluatedComplexNumberRoundTrips(string source)
+        {
+            var value = source.ToEntity().Evaled;
+            Assert.Equal(value, value.Stringize().ToEntity().Evaled);
+        }
     }
 }


### PR DESCRIPTION
Fixes #776.

`Stringize()` on a complex number whose imaginary part is a fraction printed a string the parser reads as a **different number** — and both of the spellings it could produce were wrong.

```csharp
"i / 2".ToEntity().Evaled.Stringize()             // was "1/2i"       -> parses as 1/(2i), the negation
"2 + 3 * i / 4".ToEntity().Evaled.Stringize()     // was "2 + (3/4)i" -> parses as 2 + (3/4)^i
```

The first is read as `1 / (2i)`, which is `-i/2`. The second looks like it was already guarded — the code brackets a fractional coefficient — but a bracket followed by a name is read as exponentiation, so `(3/4)i` is `(3/4)^i`, giving `0.9589 - 0.2837i` where `0.75i` was printed.

Both are silent. The misreading is a valid expression, so nothing raises anything; the printed form is simply a lie.

## The cause

`Complex.Stringize` computes the bracketing and then returns from the pure-imaginary arm before applying it:

```csharp
else if (RealPart is Integer(0))
    return RenderNum(ImaginaryPart) + "i";          // returns before the bracketing below
var (l, r) = ImaginaryPart is Rational and not Integer ? ("(", ")") : ("", "");
```

and the bracketing itself does not survive the grammar.

## The fix

Multiply explicitly when, and only when, the coefficient is a fraction — the same `Rational and not Integer` condition the bracketing already used, since that is exactly the case whose spelling contains a `/`:

```
i / 2            ->  1/2 * i
-i / 2           ->  -1/2 * i
2 + 3 * i / 4    ->  2 + 3/4 * i
2 - 3 * i / 4    ->  2 - 3/4 * i
```

`*` and `/` bind tighter than `+`, so no bracket is needed in either position. Integer coefficients are untouched and keep printing as `i`, `-i`, `2i` — they always round-tripped, having neither a `/` nor a bracket.

## Where it bites

Every root of a trigonometric equation prints through this. `"cos(x)^2 + sin(x) = 0".Solve("x")` returns four roots that are exactly correct as entities, and whose printed forms contain `1/2i`; paste that output back in and you get four values that solve nothing. That is how I found it — I had convinced myself the trigonometric solver was returning non-roots, and it was the printer.

## Scope

- **Printing only.** No entity, no evaluation, and no parse changes.
- **`Latexise` is unaffected** — it already emits `\frac{...}{...}` and `\mathrm{i}` and has no such ambiguity.
- **`(3/4)i` parsing as `(3/4)^i` is left alone.** It is surprising on its own terms next to `x(y + 1)` being a product, and it is noted in the issue as its own question; the printer must emit unambiguous text either way, so this does not wait on it.

## Tests and measurements

`StringizeRoundTripTest` already existed and did not catch this, because it round-trips the expression *as written* — `i / 2` stays a division node and never reaches the complex-number printer. The added theory evaluates first, which is what exercises it. **12 cases added, 6 of which fail without the change** (every fractional one, pure and mixed); the other 6 are the integer and real controls that must keep working. Counting the corrected expectation below, **7 tests in total fail without it**.

One existing expectation changes, and it was pinning the misprint rather than a behaviour:

```
CircleTest.DecimalToRational: "-5.3i" printed "-53/10i"  ->  now "-53/10 * i"
```

`-53/10i` parses as `-53/(10i)` = `+5.3i`, the negation of the number being printed, so the expectation is corrected rather than loosened, with the reason in the test.

Unit tests 5322 -> 5334 passing with 12 added, F# 130, casbench 113/117 with 0 wrong, propcheck 0 failures, rootcheck 596/596, simpsweep 10463/10463 in agreement.

Printed output changes, so this is a behaviour change for anyone matching on `ToString()` of a complex number with a fractional imaginary part; it is recorded in `BREAKING-CHANGES.md`.

CI note: GitHub Actions has been in a major outage since 15:22 UTC on 6 Aug, failing at `Set up job` before any code is fetched. Red checks here without a run are that.
