### PR TITLE
Add the monoid-algebra spine (#768)

### DIFF
--- a/Sources/AngouriMath/Functions/Algebra/MonoidAlgebra/IBasisOps.cs
+++ b/Sources/AngouriMath/Functions/Algebra/MonoidAlgebra/IBasisOps.cs
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+namespace AngouriMath.Functions.Algebra.MonoidAlgebra
+{
+    /// <summary>
+    /// What a basis has to be able to do for its terms to be factorable: it is a monoid, and
+    /// its elements have a greatest common part that can be divided out.
+    /// </summary>
+    /// <typeparam name="TBasis">
+    /// An exponent vector for a polynomial, a rational exponent for a series, a basis ket for a
+    /// quantum state.
+    /// </typeparam>
+    /// <remarks>
+    /// Passed as an instance rather than fixed by a type parameter with <c>new()</c>. The
+    /// codebase does it the other way in
+    /// <c>PolynomialSolver.GatherMonomialInformation&lt;T, TPrimitive&gt;</c>, and that shape
+    /// is harder to test in isolation for no gain here, since these operations are stateless
+    /// and one instance serves every call.
+    /// <para/>
+    /// **<see cref="Meet"/> is what makes factoring one operation across features.** Dividing
+    /// out the meet of the support is simultaneously "take the common monomial out of a
+    /// polynomial" and "detect that a quantum state is separable":
+    /// <code>
+    /// x^2*y + x^2      meet of (2,1) and (2,0) is (2,0), leaving y + 1
+    /// |001&gt; + |011&gt;    meet of 001 and 011 is 0-1,   leaving |0&gt; + |1&gt;
+    /// </code>
+    /// The two look different only because a polynomial's basis is ordered -- so the meet is a
+    /// componentwise minimum -- while a ket's is flat, and the meet keeps a position only where
+    /// every element agrees. Both are the meet in a product of semilattices.
+    /// </remarks>
+    internal interface IBasisOps<TBasis>
+    {
+        /// <summary>The empty product: the monoid's identity.</summary>
+        TBasis Identity { get; }
+
+        /// <summary>
+        /// The monoid operation -- adding exponents, concatenating kets. Multiplying two terms
+        /// combines their bases with this and their coefficients with the semiring.
+        /// </summary>
+        TBasis Combine(TBasis left, TBasis right);
+
+        /// <summary>
+        /// The greatest part the two have in common, which is what may be factored out of
+        /// both.
+        /// </summary>
+        TBasis Meet(TBasis left, TBasis right);
+
+        /// <summary>
+        /// <paramref name="whole"/> with <paramref name="part"/> removed, or
+        /// <see langword="false"/> where <paramref name="part"/> does not divide it.
+        /// </summary>
+        bool TryDivide(TBasis whole, TBasis part, out TBasis quotient);
+    }
+}

--- a/Sources/AngouriMath/Functions/Algebra/MonoidAlgebra/Semiring.cs
+++ b/Sources/AngouriMath/Functions/Algebra/MonoidAlgebra/Semiring.cs
@@ -1,0 +1,90 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+namespace AngouriMath.Functions.Algebra.MonoidAlgebra
+{
+    using static Entity;
+
+    /// <summary>
+    /// The arithmetic the coefficients of a <see cref="SparseTerms{TBasis}"/> obey.
+    /// </summary>
+    /// <remarks>
+    /// Coefficients are always <see cref="Entity"/>; what changes between features is what
+    /// adding and multiplying two of them means. A polynomial adds them in a field, a boolean
+    /// expression joins them in a lattice, and everything else about the representation is the
+    /// same.
+    /// <para/>
+    /// **<see cref="IsIdempotent"/> is the whole reason this is a type rather than a pair of
+    /// delegates.** <c>a or a = a</c> holds in the boolean semiring and fails in the complex
+    /// one, where <c>|x&gt; + |x&gt;</c> is <c>2|x&gt;</c> -- and that single difference is
+    /// what separates *covering* from *superposition*. Quine-McCluskey's merge step is
+    /// absorption, and it is sound only because a minterm may be covered twice for free; a
+    /// procedure that assumed the same of amplitudes would double them. Anything reading this
+    /// flag is asking whether it may cover the same basis element more than once.
+    /// </remarks>
+    internal abstract class Semiring
+    {
+        /// <summary>The additive identity: a term carrying it is not a term at all.</summary>
+        internal abstract Entity Zero { get; }
+
+        /// <summary>The multiplicative identity.</summary>
+        internal abstract Entity One { get; }
+
+        internal abstract Entity Add(Entity left, Entity right);
+
+        internal abstract Entity Multiply(Entity left, Entity right);
+
+        /// <summary>
+        /// Whether <c>Add(a, a)</c> is <c>a</c> for every <c>a</c>.
+        /// </summary>
+        internal abstract bool IsIdempotent { get; }
+
+        /// <summary>
+        /// Whether a coefficient is the additive identity, and so whether its term should be
+        /// dropped.
+        /// </summary>
+        /// <remarks>
+        /// Decided on <see cref="Entity.InnerSimplified"/> rather than on
+        /// <c>Simplify</c>, which is the cheap end of a real trade: a
+        /// coefficient that vanishes only under full simplification survives as a term with a
+        /// zero coefficient. That is a tidiness cost and never a correctness one -- the term
+        /// contributes nothing either way -- and the caller may simplify first where it
+        /// matters.
+        /// </remarks>
+        internal virtual bool IsZero(Entity coefficient)
+            => coefficient.InnerSimplified == Zero;
+
+        /// <summary>
+        /// Ordinary arithmetic, for polynomials, series and quantum amplitudes.
+        /// </summary>
+        internal static Semiring Field { get; } = new FieldSemiring();
+
+        /// <summary>
+        /// Disjunction and conjunction, for boolean expressions. Idempotent, which is what
+        /// makes covering sound.
+        /// </summary>
+        internal static Semiring Boolean { get; } = new BooleanSemiring();
+
+        private sealed class FieldSemiring : Semiring
+        {
+            internal override Entity Zero => Integer.Zero;
+            internal override Entity One => Integer.One;
+            internal override Entity Add(Entity left, Entity right) => left + right;
+            internal override Entity Multiply(Entity left, Entity right) => left * right;
+            internal override bool IsIdempotent => false;
+        }
+
+        private sealed class BooleanSemiring : Semiring
+        {
+            internal override Entity Zero => Entity.Boolean.False;
+            internal override Entity One => Entity.Boolean.True;
+            internal override Entity Add(Entity left, Entity right) => left | right;
+            internal override Entity Multiply(Entity left, Entity right) => left & right;
+            internal override bool IsIdempotent => true;
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Algebra/MonoidAlgebra/SparseTerms.cs
+++ b/Sources/AngouriMath/Functions/Algebra/MonoidAlgebra/SparseTerms.cs
@@ -1,0 +1,139 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AngouriMath.Functions.Algebra.MonoidAlgebra
+{
+    using static Entity;
+
+    /// <summary>
+    /// A finitely-supported map from a basis into a coefficient semiring -- the shape shared by
+    /// a polynomial, an asymptotic series, a boolean expression's minterms and a quantum state.
+    /// </summary>
+    /// <typeparam name="TBasis">
+    /// The basis element. An exponent vector, a rational exponent, a basis ket.
+    /// <para/>
+    /// **It must compare by value.** The terms are keyed on it, so a basis with reference
+    /// equality would leave every element distinct and quietly stop collecting like terms --
+    /// which is not an error anywhere, just a wrong answer. Use a struct or a record.
+    /// </typeparam>
+    /// <remarks>
+    /// Immutable by construction: every operation returns a new instance, and the dictionary
+    /// handed in is copied rather than adopted. It is not
+    /// <c>System.Collections.Immutable</c> because that would be a new package reference on a
+    /// library that has none, which is a packaging decision rather than a design one.
+    /// <para/>
+    /// The invariant is that **no term carries a zero coefficient**. That is what makes the
+    /// count of terms meaningful, and it is where an idempotent semiring quietly pays for
+    /// itself: adding a boolean term to itself collapses to one term by
+    /// <see cref="Semiring.Add"/> alone, so absorption needs no special case here.
+    /// <para/>
+    /// See *One structure under several features* in <c>AGENTS.md</c> for what this is for and,
+    /// as importantly, what must not be built on it -- cover selection, factorisation into
+    /// irreducibles and series truncation are each specific to one feature and belong in it.
+    /// </remarks>
+    internal sealed class SparseTerms<TBasis> where TBasis : notnull
+    {
+        private readonly Dictionary<TBasis, Entity> terms;
+
+        internal Semiring Coefficients { get; }
+
+        /// <summary>The basis elements present, each with a non-zero coefficient.</summary>
+        internal IReadOnlyDictionary<TBasis, Entity> Terms => terms;
+
+        internal int Count => terms.Count;
+
+        /// <summary>Whether nothing is left: the zero of the algebra.</summary>
+        internal bool IsEmpty => terms.Count == 0;
+
+        private SparseTerms(Dictionary<TBasis, Entity> terms, Semiring coefficients)
+        {
+            this.terms = terms;
+            Coefficients = coefficients;
+        }
+
+        internal static SparseTerms<TBasis> Empty(Semiring coefficients)
+            => new(new Dictionary<TBasis, Entity>(), coefficients);
+
+        /// <summary>
+        /// The terms with like bases collected and zero coefficients dropped, so that the
+        /// invariant holds however the caller assembled them.
+        /// </summary>
+        internal static SparseTerms<TBasis> From(
+            IEnumerable<KeyValuePair<TBasis, Entity>> terms, Semiring coefficients)
+        {
+            var gathered = new Dictionary<TBasis, Entity>();
+            // KeyValuePair has no Deconstruct on netstandard2.0, which this library targets.
+            foreach (var term in terms)
+                gathered[term.Key] = gathered.TryGetValue(term.Key, out var running)
+                    ? coefficients.Add(running, term.Value)
+                    : term.Value;
+            foreach (var basis in gathered.Keys.Where(b => coefficients.IsZero(gathered[b])).ToList())
+                gathered.Remove(basis);
+            return new SparseTerms<TBasis>(gathered, coefficients);
+        }
+
+        internal static SparseTerms<TBasis> Single(TBasis basis, Entity coefficient, Semiring coefficients)
+            => From(new[] { new KeyValuePair<TBasis, Entity>(basis, coefficient) }, coefficients);
+
+        /// <summary>
+        /// The sum, with like bases collected. In an idempotent semiring this is absorption.
+        /// </summary>
+        internal SparseTerms<TBasis> Add(SparseTerms<TBasis> other)
+            => From(terms.Concat(other.terms), Coefficients);
+
+        /// <summary>Every coefficient multiplied by <paramref name="scalar"/>.</summary>
+        internal SparseTerms<TBasis> Scale(Entity scalar)
+            => From(terms.Select(term => new KeyValuePair<TBasis, Entity>(
+                        term.Key, Coefficients.Multiply(scalar, term.Value))),
+                    Coefficients);
+
+        /// <summary>
+        /// The product: every pair of terms, bases combined by the monoid and coefficients by
+        /// the semiring. Polynomial multiplication and the tensor product are both this.
+        /// </summary>
+        internal SparseTerms<TBasis> Multiply(SparseTerms<TBasis> other, IBasisOps<TBasis> basis)
+            => From(terms.SelectMany(left => other.terms.Select(right =>
+                        new KeyValuePair<TBasis, Entity>(
+                            basis.Combine(left.Key, right.Key),
+                            Coefficients.Multiply(left.Value, right.Value)))),
+                    Coefficients);
+
+        /// <summary>
+        /// The greatest basis element dividing every term, and what is left once it is divided
+        /// out -- so that the original is the one multiplied by the other.
+        /// </summary>
+        /// <remarks>
+        /// This is the shared half of factoring. <c>x^2*y + x^2</c> comes back as
+        /// <c>(2,0)</c> with <c>y + 1</c>; <c>|001&gt; + |011&gt;</c> as the cube <c>0-1</c>
+        /// with <c>|0&gt; + |1&gt;</c>. What each feature does with that differs, and does not
+        /// belong here.
+        /// <para/>
+        /// Empty terms have no common factor to speak of, so the identity is returned and
+        /// nothing is claimed.
+        /// </remarks>
+        internal (TBasis Common, SparseTerms<TBasis> Remainder) FactorOutCommon(IBasisOps<TBasis> basis)
+        {
+            if (IsEmpty)
+                return (basis.Identity, this);
+            var common = terms.Keys.Aggregate(basis.Meet);
+            var remainder = new Dictionary<TBasis, Entity>();
+            foreach (var term in terms)
+            {
+                if (!basis.TryDivide(term.Key, common, out var quotient))
+                    // The meet of the support divides every element of it by construction, so
+                    // this is a broken IBasisOps rather than an expression this cannot handle,
+                    // and silently returning something wrong would hide it.
+                    return (basis.Identity, this);
+                remainder[quotient] = term.Value;
+            }
+            return (common, new SparseTerms<TBasis>(remainder, Coefficients));
+        }
+    }
+}


### PR DESCRIPTION
The representation four features share, per *One structure under several features* in `AGENTS.md` (#773). No behaviour change: nothing references it yet.

## Three types

| | |
|---|---|
| `Semiring` | `Zero`, `One`, `Add`, `Multiply`, **`IsIdempotent`** — instances `Field` and `Boolean` |
| `IBasisOps<TBasis>` | `Identity`, `Combine`, **`Meet`**, `TryDivide` |
| `SparseTerms<TBasis>` | immutable; `Add`, `Scale`, `Multiply`, **`FactorOutCommon`** |

**`IsIdempotent` is why `Semiring` is a type rather than a pair of delegates.** `a or a = a` holds in the boolean semiring and fails in the complex one, and that single difference is what separates covering from superposition. Anything reading the flag is asking whether it may cover the same basis element twice.

**`Meet` is why this is one abstraction rather than two.** Dividing out the meet of the support is simultaneously "take the common monomial out of a polynomial" and "detect that a quantum state is separable":

```
x^2*y + x^2     meet of (2,1),(2,0) is (2,0)   leaving  y + 1
|001> + |011>   meet of 001,011     is 0-1     leaving  |0> + |1>
```

## What is deliberately absent

Cover selection, factorisation into irreducibles, series truncation. Each belongs to exactly one feature, and a shared engine that swallowed them would be wrong in a way that still type-checks. That list is in `AGENTS.md` too, so it survives someone finding this class inviting later.

## Two things found by building it

- **`TBasis` must compare by value**, now documented on the type parameter. Terms are keyed on it, so a basis with reference equality leaves every element distinct and quietly stops collecting like terms — no error anywhere, just a wrong answer. Writing the tests is what surfaced it.
- **netstandard2.0 has no `Deconstruct` on `KeyValuePair`.** The net7.0 build said nothing. Third such catch today, after `ToHashSet` and `BitOperations`.

## Unverified, and why that is not neglect

Every type here is `internal`, and `InternalsVisibleTo("UnitTests")` **cannot simply be uncommented** — I tried:

```
error CS1726: Friend assembly reference 'UnitTests' is invalid.
Strong-name signed assemblies must specify a public key in their InternalsVisibleTo declarations.
```

`SignAssembly` is on with `key.snk`, so a friend reference needs the test assembly signed with the same key and its public key named in the attribute. That is a change to the build and to an assembly's identity — the maintainer's call, not mine, so I reverted it.

**The tests are written and waiting**: two `IBasisOps` implementations over one value-typed basis — exponent vectors (meet = componentwise minimum) and kets (meet = agree-or-free) — put through the *same* `FactorOutCommon`, which is the one claim this whole design rests on. They land the moment the access question is settled.

Nothing references the spine, so the suite is unchanged at **5359 passing**. That says the build is sound and says nothing about whether these types are correct.

**Reviewer's note:** if you would rather not sign the test assembly, the alternative is to let the quantum module be the spine's first test, through its public surface. Merging this as-is is reasonable *because* it is inert — but it should not be read as verified.