### PR TITLE
Symbolic quantum states on the monoid-algebra spine

### DIFF
--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -6869,6 +6869,77 @@ namespace AngouriMath
         }
 
         /// <summary>
+        /// Symbolic quantum states: superpositions of basis kets with <see cref="Entity"/>
+        /// amplitudes.
+        /// </summary>
+        /// <remarks>
+        /// A state is an ordinary expression rather than a new kind of node. <c>Ket</c> builds
+        /// <c>apply(ket, 0, 1)</c> for |01&gt;, so a superposition is a sum of products and
+        /// everything that reads expressions reads it -- which is why adding two states,
+        /// scaling one, and collecting <c>a|x&gt; + b|x&gt;</c> into <c>(a+b)|x&gt;</c> need no
+        /// method here. <c>Simplify</c> already does them.
+        /// <para/>
+        /// What is here is what the ordinary machinery has no reason to know: factoring a
+        /// definite qubit out of a superposition, and the two questions that are about states
+        /// as states rather than as expressions.
+        /// <para/>
+        /// There are deliberately no gates. A gate acts *on* a state rather than being one,
+        /// and operators, circuits and measurement belong to a quantum computing library
+        /// rather than to a computer algebra system.
+        /// </remarks>
+        public static class Quantum
+        {
+            /// <summary>
+            /// The basis ket over the given qubits, each 0 or 1: <c>Ket(0, 1)</c> is |01&gt;.
+            /// </summary>
+            /// <example>
+            /// <code>
+            /// var bell = (MathS.Quantum.Ket(0, 0) + MathS.Quantum.Ket(1, 1)) / MathS.Sqrt(2);
+            /// Console.WriteLine(bell.Simplify());
+            /// </code>
+            /// </example>
+            public static Entity Ket(params int[] qubits)
+                => Entity.Variable.CreateVariableUnchecked(Functions.Quantum.QuantumState.KetHead)
+                    .Apply(qubits.Select(q => (Entity)q).ToArray());
+
+            /// <summary>
+            /// The state written as a tensor product where its leading or trailing qubits are
+            /// in a definite basis state, or the expression unchanged where none is.
+            /// </summary>
+            /// <remarks>
+            /// <c>|001&gt; + |011&gt;</c> becomes <c>|0&gt; (|0&gt; + |1&gt;) |1&gt;</c>. A
+            /// state with no definite qubit at either end comes back as it went in -- including
+            /// an entangled one such as <c>|00&gt; + |11&gt;</c>, which has no factorisation at
+            /// all, and a product state such as <c>(|0&gt;+|1&gt;)(|0&gt;+|1&gt;)</c>, whose
+            /// separability this does not yet detect.
+            /// </remarks>
+            public static Entity Factorise(Entity state)
+                => Functions.Quantum.Factorisation.Factorise(state) ?? state;
+
+            /// <summary>
+            /// A product of states over consecutive qubits multiplied back out into a single
+            /// superposition -- the inverse of <c>Factorise</c> -- or the expression unchanged
+            /// where it is not such a product.
+            /// </summary>
+            public static Entity TensorExpand(Entity state)
+                => Functions.Quantum.Factorisation.TensorExpand(state) ?? state;
+
+            /// <summary>
+            /// Whether the amplitudes square-sum to one, or <see langword="null"/> where that
+            /// cannot be settled -- a symbolic amplitude need not have a decidable modulus.
+            /// </summary>
+            public static bool? IsNormalised(Entity state)
+                => Functions.Quantum.Factorisation.IsNormalised(state);
+
+            /// <summary>
+            /// Whether two states differ only by a global phase, which is the difference no
+            /// measurement can see -- or <see langword="null"/> where that cannot be settled.
+            /// </summary>
+            public static bool? EqualUpToGlobalPhase(Entity left, Entity right)
+                => Functions.Quantum.Factorisation.EqualUpToGlobalPhase(left, right);
+        }
+
+        /// <summary>
         /// Some operations on booleans are stored here
         /// </summary>
         public static class Boolean

--- a/Sources/AngouriMath/Functions/Quantum/Factorisation.cs
+++ b/Sources/AngouriMath/Functions/Quantum/Factorisation.cs
@@ -1,0 +1,195 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath.Functions.Algebra.MonoidAlgebra;
+
+namespace AngouriMath.Functions.Quantum
+{
+    using static Entity;
+
+    /// <summary>
+    /// Writing a state as a tensor product where its leading or trailing qubits are in a
+    /// definite basis state.
+    /// </summary>
+    /// <remarks>
+    /// <c>|001&gt; + |011&gt;</c> is <c>|0&gt; (x) (|0&gt; + |1&gt;) (x) |1&gt;</c>: the first
+    /// and last qubits agree across the whole superposition, so they factor out and only the
+    /// middle carries it.
+    /// <para/>
+    /// **Which positions agree is not computed here.** It is
+    /// <see cref="SparseTerms{TBasis}.FactorOutCommon"/>, the same call that takes the common
+    /// monomial out of a polynomial -- the meet of the support. What is specific to states is
+    /// only how the answer is written down, and that division is the whole point of the spine.
+    /// <para/>
+    /// **What this does not do.** Only a common *prefix or suffix* is factored, because a ket
+    /// says which qubit it describes by its position in the product and there is no notation
+    /// here for "the state of qubits 1 and 3". Nor does it find general separability:
+    /// <c>(|0&gt; + |1&gt;) (x) (|0&gt; + |1&gt;)</c> has no qubit in a definite state at all,
+    /// so the meet is empty and nothing is factored, yet it is a product state. Detecting that
+    /// is a rank-one test on the amplitudes across a bipartition -- a different algorithm,
+    /// belonging to this file rather than to the spine, and not written yet.
+    /// </remarks>
+    internal static class Factorisation
+    {
+        /// <summary>
+        /// The state rewritten as a product, or <see langword="null"/> where it is not a state
+        /// or has no qubit in a definite basis state at either end.
+        /// </summary>
+        internal static Entity? Factorise(Entity expr)
+        {
+            if (QuantumState.TryRead(expr) is not { } state || state.IsEmpty)
+                return null;
+            var width = state.Terms.Keys.First().Width;
+            var (common, remainder) = state.FactorOutCommon(new KetOps(width));
+            if (common.IsAllFree)
+                return null;
+
+            var prefix = common.Cells.TakeWhile(cell => cell != Ket.Free).ToArray();
+            var suffix = common.Cells.Skip(prefix.Length)
+                .Reverse().TakeWhile(cell => cell != Ket.Free).Reverse().ToArray();
+            if (prefix.Length + suffix.Length == 0)
+                return null;
+            if (prefix.Length + suffix.Length == width)
+                // Every position is fixed, so the state is a single basis ket and the whole of
+                // it is the "common" part. Writing that as a product of two kets would be a
+                // longer way of saying the same thing.
+                return null;
+
+            var middle = Slice(remainder, prefix.Length, width - suffix.Length);
+            var factors = new List<Entity>();
+            if (prefix.Length > 0)
+                factors.Add(QuantumState.ToEntity(new Ket(prefix)));
+            factors.Add(QuantumState.ToEntity(middle));
+            if (suffix.Length > 0)
+                factors.Add(QuantumState.ToEntity(new Ket(suffix)));
+            return factors.Aggregate((left, right) => left * right);
+        }
+
+        /// <summary>
+        /// A product of states over consecutive qubits multiplied back out into a single
+        /// superposition, or <see langword="null"/> where the expression is not such a product.
+        /// </summary>
+        /// <remarks>
+        /// The inverse of <see cref="Factorise"/>, and the reason it is here rather than on the
+        /// spine: within one state the qubits are a fixed width and combining two kets overlays
+        /// them, while a *product* of states concatenates their widths. Those are two different
+        /// monoids on the same type, and only the first is what
+        /// <see cref="SparseTerms{TBasis}"/> multiplies with.
+        /// </remarks>
+        internal static Entity? TensorExpand(Entity expr)
+        {
+            var factors = new List<Entity>();
+            Flatten(expr, factors);
+            var states = new List<SparseTerms<Ket>>();
+            Entity scalar = 1;
+            foreach (var factor in factors)
+                if (QuantumState.TryRead(factor) is { } state)
+                    states.Add(state);
+                else if (!factor.Nodes.Any(node => QuantumState.TryReadKet(node) is not null))
+                    scalar *= factor;
+                else
+                    return null;
+            if (states.Count == 0)
+                return null;
+
+            var combined = states.Aggregate(Concatenate);
+            return QuantumState.ToEntity(combined.Scale(scalar));
+        }
+
+        private static void Flatten(Entity expr, List<Entity> into)
+        {
+            if (expr is Mulf(var multiplier, var multiplicand))
+            {
+                Flatten(multiplier, into);
+                Flatten(multiplicand, into);
+            }
+            else into.Add(expr);
+        }
+
+        /// <summary>
+        /// Every ket of the left state joined to every ket of the right, widths added and
+        /// amplitudes multiplied -- the tensor product proper.
+        /// </summary>
+        private static SparseTerms<Ket> Concatenate(SparseTerms<Ket> left, SparseTerms<Ket> right)
+            => SparseTerms<Ket>.From(
+                left.Terms.SelectMany(l => right.Terms.Select(r =>
+                    new KeyValuePair<Ket, Entity>(
+                        new Ket(l.Key.Cells.Concat(r.Key.Cells).ToArray()),
+                        l.Value * r.Value))),
+                left.Coefficients);
+
+        /// <summary>
+        /// The state restricted to the positions in <c>[from, to)</c>, which is what is left
+        /// once the definite qubits at the ends have been taken away.
+        /// </summary>
+        private static SparseTerms<Ket> Slice(SparseTerms<Ket> state, int from, int to)
+            => SparseTerms<Ket>.From(
+                state.Terms.Select(term => new KeyValuePair<Ket, Entity>(
+                    new Ket(term.Key.Cells.Skip(from).Take(to - from).ToArray()), term.Value)),
+                state.Coefficients);
+
+        /// <summary>
+        /// Whether the amplitudes square-sum to one, or <see langword="null"/> where that
+        /// cannot be settled -- a symbolic amplitude need not have a decidable modulus.
+        /// </summary>
+        /// <remarks>
+        /// The sum is over |c|^2, written as <c>abs(c)^2</c> since there is no conjugate in
+        /// the library. Left to <c>Simplify</c> to settle rather than evaluated numerically,
+        /// so <c>1/sqrt(2)</c> is recognised exactly.
+        /// </remarks>
+        internal static bool? IsNormalised(Entity expr)
+        {
+            if (QuantumState.TryRead(expr) is not { } state || state.IsEmpty)
+                return null;
+            var total = state.Terms
+                .Select(term => MathS.Sqr(MathS.Abs(term.Value)))
+                .Aggregate((left, right) => left + right)
+                .Simplify();
+            if (total == 1)
+                return true;
+            return total.Evaled is Number.Complex { IsFinite: true } value
+                ? value == 1
+                : null;
+        }
+
+        /// <summary>
+        /// Whether two states are the same up to a global phase -- that is, whether one is a
+        /// scalar multiple of the other, that scalar having modulus one.
+        /// </summary>
+        /// <remarks>
+        /// Two states with the same physical content may be written differently, and a global
+        /// factor is exactly the difference that no measurement can see. Decided by taking the
+        /// ratio on one shared basis ket and checking every other amplitude against it, which
+        /// is symbolic throughout -- <c>|00&gt; + |11&gt;</c> and
+        /// <c>-|00&gt; - |11&gt;</c> differ by -1 and are the same state.
+        /// </remarks>
+        internal static bool? EqualUpToGlobalPhase(Entity left, Entity right)
+        {
+            if (QuantumState.TryRead(left) is not { } a || QuantumState.TryRead(right) is not { } b)
+                return null;
+            if (a.Count != b.Count || a.Count == 0)
+                return a.IsEmpty && b.IsEmpty;
+            var shared = a.Terms.Keys.First();
+            if (!b.Terms.TryGetValue(shared, out var scale) || scale == 0)
+                return false;
+            var phase = (a.Terms[shared] / scale).Simplify();
+            foreach (var term in a.Terms)
+            {
+                if (!b.Terms.TryGetValue(term.Key, out var other))
+                    return false;
+                if ((term.Value - phase * other).Simplify() != 0)
+                    return false;
+            }
+            // A phase is a unit: rescaling by anything else is a different state, not the same
+            // one seen differently.
+            var modulus = MathS.Sqr(MathS.Abs(phase)).Simplify();
+            return modulus == 1 ? true : modulus.Evaled is Number.Complex value ? value == 1 : null;
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Quantum/Ket.cs
+++ b/Sources/AngouriMath/Functions/Quantum/Ket.cs
@@ -1,0 +1,81 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Linq;
+using AngouriMath.Functions.Algebra.MonoidAlgebra;
+
+namespace AngouriMath.Functions.Quantum
+{
+    /// <summary>
+    /// A computational basis state: a fixed-width word over {0, 1}, with
+    /// <see cref="Free"/> marking a position that has been factored out.
+    /// </summary>
+    /// <remarks>
+    /// Compared by value, which <see cref="SparseTerms{TBasis}"/> requires -- keyed on a
+    /// reference-equal basis it would silently stop collecting like terms.
+    /// </remarks>
+    internal readonly struct Ket : IEquatable<Ket>
+    {
+        /// <summary>A position no longer fixed, because it was divided out.</summary>
+        internal const int Free = -1;
+
+        internal int[] Cells { get; }
+
+        internal Ket(params int[] cells) => Cells = cells;
+
+        internal int Width => Cells.Length;
+
+        internal bool IsAllFree => Cells.All(cell => cell == Free);
+
+        public bool Equals(Ket other) => Cells.SequenceEqual(other.Cells);
+
+        public override bool Equals(object? obj) => obj is Ket other && Equals(other);
+
+        public override int GetHashCode() => Cells.Aggregate(17, (hash, cell) => hash * 31 + cell);
+
+        public override string ToString()
+            => string.Concat(Cells.Select(cell => cell == Free ? "-" : cell.ToString()));
+    }
+
+    /// <summary>
+    /// The monoid and lattice structure on kets: the tensor product joins them, and the meet
+    /// keeps a position only where both agree.
+    /// </summary>
+    /// <remarks>
+    /// The alphabet is unordered, so this is the meet in a product of *flat* lattices -- which
+    /// is the only place it differs from a polynomial's exponent vector, where the meet is a
+    /// componentwise minimum in a product of chains. Everything else about factoring is shared.
+    /// </remarks>
+    internal sealed class KetOps : IBasisOps<Ket>
+    {
+        private readonly int width;
+
+        internal KetOps(int width) => this.width = width;
+
+        public Ket Identity => new(Enumerable.Repeat(Ket.Free, width).ToArray());
+
+        /// <summary>
+        /// The tensor product, for kets that occupy disjoint positions: each takes the value
+        /// the other leaves free.
+        /// </summary>
+        public Ket Combine(Ket left, Ket right)
+            => new(left.Cells.Zip(right.Cells,
+                    (l, r) => l == Ket.Free ? r : l).ToArray());
+
+        public Ket Meet(Ket left, Ket right)
+            => new(left.Cells.Zip(right.Cells,
+                    (l, r) => l == r ? l : Ket.Free).ToArray());
+
+        public bool TryDivide(Ket whole, Ket part, out Ket quotient)
+        {
+            quotient = new Ket(whole.Cells.Zip(part.Cells,
+                    (w, p) => p == Ket.Free ? w : Ket.Free).ToArray());
+            return whole.Cells.Zip(part.Cells, (w, p) => p == Ket.Free || w == p).All(ok => ok);
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Quantum/QuantumState.cs
+++ b/Sources/AngouriMath/Functions/Quantum/QuantumState.cs
@@ -1,0 +1,138 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath.Functions.Algebra.MonoidAlgebra;
+
+namespace AngouriMath.Functions.Quantum
+{
+    using static Entity;
+
+    /// <summary>
+    /// Reading a quantum state out of an ordinary expression, and writing one back.
+    /// </summary>
+    /// <remarks>
+    /// **A state is not a new kind of node.** A ket is written <c>apply(ket, 0, 1)</c> -- an
+    /// application of an undeclared name, which the library already understands -- so a state
+    /// is an ordinary sum of products and everything that reads expressions reads it. That is
+    /// not only tidy: it is why <c>a|x&gt; + b|x&gt; = (a+b)|x&gt;</c> and <c>0|x&gt; = 0</c>
+    /// need no code here at all. <c>Simplify</c> collects like terms over an opaque
+    /// application already, and it factors the amplitude out of a Bell state without being
+    /// told what one is.
+    /// <para/>
+    /// The cost of the choice is that <c>ket</c> is a name rather than a type: nothing stops
+    /// <c>apply(ket, 5, 7)</c>, and a caller with their own variable called <c>ket</c> will
+    /// collide with it. A dedicated node would close both and would forfeit everything in the
+    /// paragraph above, so the loose reading is taken deliberately and is reversible.
+    /// </remarks>
+    internal static class QuantumState
+    {
+        /// <summary>The name an application must have to be read as a ket.</summary>
+        internal const string KetHead = "ket";
+
+        /// <summary>
+        /// The state as a map from basis ket to amplitude, or <see langword="null"/> where the
+        /// expression is not one -- which includes an expression with no ket in it at all, and
+        /// one whose kets are of different widths.
+        /// </summary>
+        internal static SparseTerms<Ket>? TryRead(Entity expr)
+        {
+            var terms = new List<KeyValuePair<Ket, Entity>>();
+            if (!TryReadSum(expr, terms) || terms.Count == 0)
+                return null;
+            var width = terms[0].Key.Width;
+            if (terms.Any(term => term.Key.Width != width))
+                return null;
+            return SparseTerms<Ket>.From(terms, Semiring.Field);
+        }
+
+        private static bool TryReadSum(Entity expr, List<KeyValuePair<Ket, Entity>> into)
+            => TryReadTerm(expr, 1, into);
+
+        /// <summary>
+        /// One term: exactly one ket among its multiplicative factors, and everything else is
+        /// the amplitude. Two kets in a product would be a tensor product of states rather
+        /// than a term of one, and is not read here.
+        /// </summary>
+        /// <remarks>
+        /// Sums are handled here rather than above it because an amplitude may be carried in
+        /// from outside: <c>(|00&gt; + |01&gt;) / sqrt(2)</c> reaches this as a quotient whose
+        /// dividend is a sum, and reading the sum only at the top would refuse it -- which is
+        /// exactly how every normalised state in the tests failed to parse at first.
+        /// </remarks>
+        private static bool TryReadTerm(Entity expr, Entity amplitude, List<KeyValuePair<Ket, Entity>> into)
+        {
+            switch (expr)
+            {
+                case Sumf(var augend, var addend):
+                    return TryReadTerm(augend, amplitude, into)
+                        && TryReadTerm(addend, amplitude, into);
+                case Minusf(var minuend, var subtrahend):
+                    return TryReadTerm(minuend, amplitude, into)
+                        && TryReadTerm(subtrahend, -amplitude, into);
+                case Mulf(var multiplier, var multiplicand):
+                    // Whichever side is free of kets is amplitude, and the other side is the
+                    // state -- chosen by where the ket is rather than by which side it is on,
+                    // so that a|x> and (a)(|x>) read alike. Kets on both sides means a tensor
+                    // product of two states, which is not a term of one and is not read here.
+                    if (NoKetIn(multiplicand))
+                        return TryReadTerm(multiplier, amplitude * multiplicand, into);
+                    if (NoKetIn(multiplier))
+                        return TryReadTerm(multiplicand, amplitude * multiplier, into);
+                    return false;
+                case Divf(var dividend, var divisor):
+                    return NoKetIn(divisor) && TryReadTerm(dividend, amplitude / divisor, into);
+                default:
+                    return TryReadKet(expr) is { } alone && Record(alone, amplitude, into);
+            }
+        }
+
+        private static bool Record(Ket ket, Entity amplitude, List<KeyValuePair<Ket, Entity>> into)
+        {
+            into.Add(new KeyValuePair<Ket, Entity>(ket, amplitude));
+            return true;
+        }
+
+        private static bool NoKetIn(Entity expr) => !expr.Nodes.Any(IsKet);
+
+        private static bool IsKet(Entity node)
+            => node is Application(Variable { Name: KetHead }, _);
+
+        /// <summary>
+        /// The ket an expression denotes, or <see langword="null"/>. Every argument has to be
+        /// 0 or 1: <c>apply(ket, 5)</c> is an application of something called <c>ket</c> and
+        /// is not a basis state.
+        /// </summary>
+        internal static Ket? TryReadKet(Entity expr)
+        {
+            if (expr is not Application(Variable { Name: KetHead }, var arguments))
+                return null;
+            var cells = new List<int>();
+            foreach (var argument in arguments)
+            {
+                if (argument.Evaled is not Number.Integer value || (value != 0 && value != 1))
+                    return null;
+                cells.Add(value == 1 ? 1 : 0);
+            }
+            return cells.Count == 0 ? null : new Ket(cells.ToArray());
+        }
+
+        /// <summary>A ket written back as the expression it came from.</summary>
+        internal static Entity ToEntity(Ket ket)
+            => Variable.CreateVariableUnchecked(KetHead)
+                .Apply(ket.Cells.Where(cell => cell != Ket.Free).Select(cell => (Entity)cell).ToArray());
+
+        /// <summary>The state written back as an ordinary sum of products.</summary>
+        internal static Entity ToEntity(SparseTerms<Ket> state)
+            => state.IsEmpty
+                ? 0
+                : state.Terms
+                    .Select(term => term.Value == 1 ? ToEntity(term.Key) : term.Value * ToEntity(term.Key))
+                    .Aggregate((left, right) => left + right);
+    }
+}

--- a/Sources/Tests/UnitTests/Algebra/QuantumStateTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/QuantumStateTest.cs
@@ -1,0 +1,206 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Algebra
+{
+    /// <summary>
+    /// Symbolic quantum states. A state is an ordinary expression -- a ket is
+    /// <c>apply(ket, 0, 1)</c> -- so most of the state algebra is the existing simplifier and
+    /// is tested here to record that it is, rather than because new code does it.
+    ///
+    /// Everything is compared symbolically. No amplitude is evaluated to a double anywhere in
+    /// this file, which is what makes <c>1/sqrt(2)</c> an exact answer rather than 0.7071.
+    /// </summary>
+    public sealed class QuantumStateTest
+    {
+        private static Entity Ket(params int[] qubits) => MathS.Quantum.Ket(qubits);
+
+        private static readonly Entity Sqrt2 = MathS.Sqrt(2);
+
+        /// <summary>(|00&gt; + |11&gt;)/sqrt(2) -- entangled, and the canonical example of it.</summary>
+        private static Entity Bell => (Ket(0, 0) + Ket(1, 1)) / Sqrt2;
+
+        /// <summary>(|00&gt; + |01&gt;)/sqrt(2) -- a product state: the first qubit is |0&gt;.</summary>
+        private static Entity Product => (Ket(0, 0) + Ket(0, 1)) / Sqrt2;
+
+        /// <summary>(|000&gt; + |111&gt;)/sqrt(2).</summary>
+        private static Entity Ghz => (Ket(0, 0, 0) + Ket(1, 1, 1)) / Sqrt2;
+
+        private static void AssertSame(Entity expected, Entity actual) =>
+            Assert.Equal(0, (expected - actual).Simplify().InnerSimplified);
+
+        // ---- what the existing machinery already does, recorded rather than implemented ----
+
+        [Fact]
+        public void LikeTermsCollectWithoutAnyQuantumCode() =>
+            AssertSame(("a + b").ToEntity() * Ket(0, 1),
+                       ("a".ToEntity() * Ket(0, 1) + "b".ToEntity() * Ket(0, 1)).Simplify());
+
+        [Fact]
+        public void AZeroAmplitudeIsNotATerm() =>
+            AssertSame(0, (0 * Ket(0, 1)).Simplify());
+
+        [Fact]
+        public void OppositeAmplitudesCancel() =>
+            AssertSame(0, (Ket(0, 1) - Ket(0, 1)).Simplify());
+
+        // ---- normalisation ----
+
+        [Theory]
+        [InlineData(true)]
+        public void TheStandardStatesAreNormalised(bool _)
+        {
+            Assert.True(MathS.Quantum.IsNormalised(Bell));
+            Assert.True(MathS.Quantum.IsNormalised(Product));
+            Assert.True(MathS.Quantum.IsNormalised(Ghz));
+            Assert.True(MathS.Quantum.IsNormalised(Ket(0, 1)));
+        }
+
+        /// <summary>
+        /// The same state written with its amplitude in front rather than as a divisor. A
+        /// reader that only looked to the left of a product would refuse this one, and a user
+        /// would hit that on their first Bell state written the other way round.
+        /// </summary>
+        [Fact]
+        public void AnAmplitudeInFrontIsReadTheSameAsADivisor()
+        {
+            Assert.True(MathS.Quantum.IsNormalised(1 / Sqrt2 * (Ket(0, 0) + Ket(1, 1))));
+            AssertSame(Ket(0) * (Ket(0) + Ket(1)) * 2,
+                       MathS.Quantum.Factorise(2 * (Ket(0, 0) + Ket(0, 1))));
+        }
+
+        [Fact]
+        public void AnUnnormalisedStateIsNotNormalised()
+        {
+            Assert.False(MathS.Quantum.IsNormalised(Ket(0, 0) + Ket(1, 1)));
+            Assert.False(MathS.Quantum.IsNormalised(2 * Ket(0)));
+        }
+
+        [Fact]
+        public void SomethingThatIsNotAStateHasNoAnswer()
+        {
+            Assert.Null(MathS.Quantum.IsNormalised("x + 1".ToEntity()));
+            Assert.Null(MathS.Quantum.IsNormalised("apply(ket, 5)".ToEntity()));
+        }
+
+        // ---- factorisation ----
+
+        /// <summary>
+        /// The first and last qubits agree across the superposition, so they factor out and
+        /// only the middle carries it. This is the spine's <c>FactorOutCommon</c> -- the same
+        /// call that takes the common monomial out of a polynomial.
+        /// </summary>
+        [Fact]
+        public void ADefiniteQubitAtEitherEndFactorsOut()
+        {
+            var factored = MathS.Quantum.Factorise(Ket(0, 0, 1) + Ket(0, 1, 1));
+            AssertSame(Ket(0) * (Ket(0) + Ket(1)) * Ket(1), factored);
+        }
+
+        [Fact]
+        public void ADefiniteLeadingQubitFactorsOutAlone() =>
+            AssertSame(Ket(0) * (Ket(0) + Ket(1)) / Sqrt2, MathS.Quantum.Factorise(Product));
+
+        /// <summary>
+        /// **Entanglement is the absence of this.** Neither qubit of a Bell state has a
+        /// definite value, so nothing factors and the state comes back as it went in. Same for
+        /// GHZ. A factoriser that "succeeded" on these would be wrong about physics.
+        /// </summary>
+        [Fact]
+        public void AnEntangledStateDoesNotFactor()
+        {
+            AssertSame(Bell, MathS.Quantum.Factorise(Bell));
+            AssertSame(Ghz, MathS.Quantum.Factorise(Ghz));
+        }
+
+        /// <summary>
+        /// A known gap, pinned so it is not mistaken for a bug later:
+        /// <c>(|0&gt;+|1&gt;)(|0&gt;+|1&gt;)</c> is separable, but no qubit is in a definite
+        /// state, so the meet of the support is empty and nothing is factored. Detecting this
+        /// is a rank-one test across a bipartition, which is not written yet.
+        /// </summary>
+        [Fact]
+        public void SeparabilityWithoutADefiniteQubitIsNotYetDetected()
+        {
+            var uniform = Ket(0, 0) + Ket(0, 1) + Ket(1, 0) + Ket(1, 1);
+            AssertSame(uniform, MathS.Quantum.Factorise(uniform));
+        }
+
+        // ---- round trip ----
+
+        /// <summary>
+        /// Expanding a factorisation returns the state it came from. This is the strongest
+        /// check here: the two directions are written independently -- factoring takes the meet
+        /// of the support, expanding concatenates widths -- so agreement is evidence rather
+        /// than tautology.
+        /// </summary>
+        [Theory]
+        [InlineData("(0,0,1)+(0,1,1)")]
+        [InlineData("(0,0)+(0,1)")]
+        [InlineData("(1,0,0)+(1,0,1)")]
+        public void ExpandingAFactorisationReturnsTheOriginal(string which)
+        {
+            var original = which switch
+            {
+                "(0,0,1)+(0,1,1)" => Ket(0, 0, 1) + Ket(0, 1, 1),
+                "(0,0)+(0,1)" => Ket(0, 0) + Ket(0, 1),
+                _ => Ket(1, 0, 0) + Ket(1, 0, 1),
+            };
+            var roundTripped = MathS.Quantum.TensorExpand(MathS.Quantum.Factorise(original));
+            AssertSame(original, roundTripped);
+        }
+
+        [Fact]
+        public void ExpandingAProductOfStatesMultipliesItOut() =>
+            AssertSame(Ket(0, 0) + Ket(0, 1) + Ket(1, 0) + Ket(1, 1),
+                       MathS.Quantum.TensorExpand((Ket(0) + Ket(1)) * (Ket(0) + Ket(1))));
+
+        // ---- equality up to a global phase ----
+
+        /// <summary>
+        /// A global factor is exactly the difference no measurement can see, so these are the
+        /// same state written two ways.
+        /// </summary>
+        [Fact]
+        public void AGlobalSignIsNotADifference() =>
+            Assert.True(MathS.Quantum.EqualUpToGlobalPhase(
+                Ket(0, 0) + Ket(1, 1), -Ket(0, 0) - Ket(1, 1)));
+
+        [Fact]
+        public void AGlobalImaginaryPhaseIsNotADifference() =>
+            Assert.True(MathS.Quantum.EqualUpToGlobalPhase(
+                Ket(0, 0) + Ket(1, 1),
+                MathS.i * Ket(0, 0) + MathS.i * Ket(1, 1)));
+
+        /// <summary>
+        /// A *relative* phase is a real difference: |00&gt; - |11&gt; is not the Bell state,
+        /// and this is the case a naive ratio check would get wrong.
+        /// </summary>
+        [Fact]
+        public void ARelativePhaseIsADifference() =>
+            Assert.False(MathS.Quantum.EqualUpToGlobalPhase(
+                Ket(0, 0) + Ket(1, 1), Ket(0, 0) - Ket(1, 1)));
+
+        /// <summary>
+        /// Rescaling by something that is not a unit changes the state's norm, so it is not
+        /// the same state seen differently.
+        /// </summary>
+        [Fact]
+        public void ScalingByANonUnitIsADifference() =>
+            Assert.False(MathS.Quantum.EqualUpToGlobalPhase(
+                Ket(0, 0) + Ket(1, 1), 2 * Ket(0, 0) + 2 * Ket(1, 1)));
+
+        [Fact]
+        public void DifferentSupportsAreDifferentStates() =>
+            Assert.False(MathS.Quantum.EqualUpToGlobalPhase(
+                Ket(0, 0) + Ket(1, 1), Ket(0, 0) + Ket(0, 1)));
+    }
+}


### PR DESCRIPTION
Builds on #778 (the monoid-algebra spine), and is the second customer for it.

## The idea

A quantum state is a superposition of basis kets with symbolic amplitudes — a finitely-supported map from basis to coefficient. That is exactly what `SparseTerms` is, so this is the spine instantiated at a new basis rather than a subsystem of its own.

A ket is written `apply(ket, 0, 1)`: an application of an undeclared name, which the library already understands. So **a state is an ordinary expression**, and most of the state algebra needs no code here at all:

| written | `Simplify` gives | new code |
|---|---|---|
| `a·\|01⟩ + b·\|01⟩` | `(a+b)·\|01⟩` | none |
| `0·\|01⟩` | `0` | none |
| `\|01⟩ − \|01⟩` | `0` | none |
| `\|00⟩/√2 + \|11⟩/√2` | amplitude factored out | none |
| `\|001⟩ + \|011⟩` | `\|0⟩ ⊗ (\|0⟩+\|1⟩) ⊗ \|1⟩` | **this PR** |

The first four are tested here to record that they already work, not because anything new does them.

## What the spine actually buys

Tensor factorisation asks which qubit positions agree across the whole superposition. That question is not answered in the quantum code — it is `SparseTerms.FactorOutCommon`, the same call that takes the common monomial out of a polynomial. The meet of the support is the identity that makes the two operations one operation.

A ket's alphabet is unordered, so its meet is in a product of *flat* lattices where an exponent vector's is in a product of *chains*. That single line is the entire difference, and it lives in `KetOps.Meet`.

**Entanglement is then the absence of a factorisation.** The Bell and GHZ states are asserted to come back unchanged — a factoriser that "succeeded" on those would be wrong about the physics.

## No gates

Unitary evolution belongs in a quantum computing library. What belongs in a CAS is the symbolic state algebra — and keeping the boundary there is precisely what lets an amplitude be `1/√2` exactly, or `cos(θ)`, rather than `0.7071`.

## Known and deliberate

- `ket` is a name, not a type: `apply(ket, 5, 7)` parses, and a caller with their own variable named `ket` collides. A dedicated node would close both and forfeit every row of the table above, so the loose reading is taken on purpose and is reversible.
- LaTeX renders `\mathrm{ket}(0)` rather than `|0⟩`.
- Separability without a definite qubit — `(|0⟩+|1⟩) ⊗ (|0⟩+|1⟩)` — is not detected: the meet is empty though the state is a product. That is a rank-one test across a bipartition, a different algorithm. Pinned by a test so it is not later mistaken for a bug.

## Surface

`MathS.Quantum`: `Ket`, `Factorise`, `TensorExpand`, `IsNormalised`, `EqualUpToGlobalPhase`. **Nothing is wired into `Simplify`**, so no existing expression changes.

## Verification

- 5379 unit tests, 130 F# tests — pass
- casbench 113/117, **0 wrong**; propcheck 0 failures
- rootcheck 596/596; simpsweep 10463/10463
- both `net7.0` and `netstandard2.0` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)