### PR TITLE
Distribute over a sum before searching by parts (#779)

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
@@ -59,9 +59,21 @@ namespace AngouriMath.Functions.Algebra
             if ((answer = IndefiniteIntegralSolver.SolveLogarithmic(expr, x, integrateByParts)) is { }) return answer;
             if ((answer = IndefiniteIntegralSolver.SolveBySubstitution(expr, x, integrateByParts)) is { }) return answer;
             if ((answer = IndefiniteIntegralSolver.SolveByPartialFractions(expr, x, integrateByParts)) is { }) return answer;
-            if (integrateByParts && (answer = IndefiniteIntegralSolver.SolveIntegratingByParts(expr, x)) is { }) return answer;
-            // this may expand to too many terms
+            // Linearity comes before integration by parts, because it decomposes the problem
+            // into strictly simpler ones where by parts searches. It cannot cost an answer:
+            // splitting returns null unless *every* term integrates, so a sum that only comes
+            // out whole still falls through to by parts below.
+            //
+            // A product with a sum in it -- sin(a+f*x)^4 * (5 - 6*sin(a+f*x)^2) -- reaches
+            // this as a product, so only the expansion here finds the two terms it is. Behind
+            // by parts it never did: the search spent the whole budget first and the caller
+            // waited over 20 seconds to be told nothing, where the split answers in 0.16.
+            // https://github.com/asc-community/AngouriMath/issues/779
+            //
+            // Expansion is bounded by MaxExpansionTermCount, which returns null rather than
+            // building the terms, so putting it earlier cannot blow the tree up either.
             if ((answer = IndefiniteIntegralSolver.SolveBySplittingSum(expr, x, integrateByParts)) is { }) return answer;
+            if (integrateByParts && (answer = IndefiniteIntegralSolver.SolveIntegratingByParts(expr, x)) is { }) return answer;
             return null;
         }
         /// <summary>

--- a/Sources/Tests/UnitTests/Calculus/LinearityBeforeByPartsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/LinearityBeforeByPartsTest.cs
@@ -1,0 +1,118 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Threading.Tasks;
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// A product with a sum inside it -- <c>sin(a+f*x)^4 * (5 - 6*sin(a+f*x)^2)</c> -- is the
+    /// same function as the expanded difference, which answers in milliseconds. Written
+    /// factored it did not finish in twenty seconds, because the only rule that would
+    /// distribute it ran behind integration by parts and the search spent the whole budget
+    /// first. https://github.com/asc-community/AngouriMath/issues/779
+    /// <para/>
+    /// Every answer is checked by differentiating it back and comparing at points: what
+    /// matters is that it is an antiderivative, not what form it is written in.
+    /// </summary>
+    public sealed class LinearityBeforeByPartsTest
+    {
+        /// <summary>
+        /// Generous enough that a slow machine will not fail it, and far below the twenty
+        /// seconds this shape used to spend. Asserts termination rather than speed -- a
+        /// regression here is a hang, and a hang would otherwise wedge the run instead of
+        /// failing it.
+        /// </summary>
+        private static readonly TimeSpan Budget = TimeSpan.FromSeconds(15);
+
+        private static Entity IntegrateWithinBudget(string integrand)
+        {
+            Entity? answer = null;
+            var task = Task.Run(() => answer = integrand.ToEntity().Integrate("x"));
+            Assert.True(task.Wait(Budget), $"{integrand} did not finish within {Budget}");
+            return answer!;
+        }
+
+        private static void AssertIsAntiderivative(string integrand, params double[] points)
+        {
+            var antiderivative = IntegrateWithinBudget(integrand);
+            Assert.DoesNotContain("integral(", antiderivative.Stringize());
+            var f = integrand.ToEntity().Substitute("a", 0.7).Substitute("f", 1.3);
+            var derivative = antiderivative
+                .Substitute("C", 0).Substitute("a", 0.7).Substitute("f", 1.3)
+                .Differentiate("x");
+            foreach (var point in points)
+            {
+                var expected = f.Substitute("x", point).EvalNumerical().RealPart.EDecimal.ToDouble();
+                var actual = derivative.Substitute("x", point).EvalNumerical().RealPart.EDecimal.ToDouble();
+                Assert.Equal(expected, actual, 7);
+            }
+        }
+
+        /// <summary>
+        /// The integrand from the issue, and the neighbours that make the point: written as a
+        /// difference it always answered, and the factored form is the same function.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(a + f * x) ^ 4 * (5 - 6 * sin(a + f * x) ^ 2)", new[] { 0.4, 1.6, -0.9 })]
+        [InlineData("5 * sin(a + f * x) ^ 4 - 6 * sin(a + f * x) ^ 6", new[] { 0.4, 1.6, -0.9 })]
+        [InlineData("sin(a + f * x) ^ 2 * (1 + sin(a + f * x) ^ 2)", new[] { 0.4, 1.6 })]
+        public void AProductWithASumInsideIsDistributed(string integrand, double[] points) =>
+            AssertIsAntiderivative(integrand, points);
+
+        /// <summary>
+        /// Linearity is not specific to trigonometry, and these are the shapes most likely to
+        /// be disturbed by moving it in front of integration by parts.
+        /// </summary>
+        [Theory]
+        [InlineData("x * (1 + x)", new[] { 0.4, 1.6, -2.2 })]
+        [InlineData("(x + 1) * (x + 2)", new[] { 0.4, 1.6, -2.2 })]
+        [InlineData("cos(x) * (1 + x)", new[] { 0.4, 1.6, -2.2 })]
+        [InlineData("e ^ x * (1 + x)", new[] { 0.4, 1.6, -2.2 })]
+        public void OrdinaryProductsOverSumsStillAnswer(string integrand, double[] points) =>
+            AssertIsAntiderivative(integrand, points);
+
+        /// <summary>
+        /// Integration by parts is still reached. Splitting returns nothing unless *every*
+        /// term integrates, so a sum that only comes out whole falls through to it -- which is
+        /// what makes putting linearity first unable to cost an answer.
+        /// </summary>
+        [Theory]
+        [InlineData("x * cos(x)", new[] { 0.4, 1.6, -2.2 })]
+        [InlineData("x * ln(x)", new[] { 0.4, 1.6 })]
+        [InlineData("x ^ 2 * e ^ x", new[] { 0.4, 1.6, -2.2 })]
+        public void ByPartsIsStillReached(string integrand, double[] points) =>
+            AssertIsAntiderivative(integrand, points);
+
+        /// <summary>
+        /// **A separate known gap, pinned here so it is not read as this one.** Two powers of
+        /// one base are never merged: <c>x^2 / x</c> is declined though it is <c>x</c>, and
+        /// distributing the first case below gives <c>sin(x)^4 * (-6) * sin(x)^2</c>, which
+        /// is declined though it is <c>-6 sin(x)^6</c>.
+        /// <para/>
+        /// It is only ever fixed by accident. A substitution rebuilds the tree on its way
+        /// past, and that rebuild is what merges the powers -- which is why every argument
+        /// other than a bare <c>x</c> (<c>2*x</c>, <c>x+1</c>, <c>a+f*x</c>) answers and a
+        /// bare <c>x</c> does not.
+        /// <para/>
+        /// These are declined in milliseconds rather than hung, so this is a missing answer
+        /// and not the defect this file is about. Measured on master before the reordering,
+        /// so it is pre-existing rather than caused by it.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x) ^ 4 * (5 - 6 * sin(x) ^ 2)")]
+        [InlineData("sin(x) ^ 4 * (-6) * sin(x) ^ 2")]
+        [InlineData("x ^ 2 * (x + 1 / x)")]
+        [InlineData("x ^ 2 / x")]
+        public void PowersOfOneBaseAreNotMerged(string integrand) =>
+            Assert.Contains("integral(", IntegrateWithinBudget(integrand).Stringize());
+    }
+}


### PR DESCRIPTION
Closes #779.

## The defect

```csharp
"sin(a+f*x)^4 * (5 - 6 * sin(a+f*x)^2)".ToEntity().Integrate("x")   // >20 s, no answer
"5 * sin(a+f*x)^4 - 6 * sin(a+f*x)^6".ToEntity().Integrate("x")     // 156 ms, answered
```

Those are the same function. Each piece answers on its own in under a millisecond.

## Cause

`SolveBySplittingSum` is the rule that would find those two pieces, and it ran **last** — behind `SolveIntegratingByParts`. So on a product with a sum inside it, the by-parts search ran first and spent the whole budget on an expression that linearity would have taken apart immediately. The caller waited over twenty seconds to be told nothing.

## Fix

Move linearity in front of by parts. One statement swapped.

**It cannot cost an answer.** Splitting returns `null` unless *every* term integrates:

```csharp
return splitted.Select(...).Aggregate((e1, e2) => (e1, e2) switch {
    (null, _) or (_, null) => null,     // <-- one term fails, the whole split fails
    ...
```

so a sum that only comes out whole still falls through to by parts below. There is no input that by parts answers and this now refuses — which is what makes it a reordering rather than a trade.

**It cannot blow the tree up either.** The expansion is bounded by `MaxExpansionTermCount`, which returns `null` rather than building the terms — that is what the old `// this may expand to too many terms` note was guarding, and the guard is inside the expansion, not in the ordering.

## Measured

| | before | after |
|---|--:|--:|
| `sin(a+f*x)^4 * (5 - 6*sin(a+f*x)^2)` | **>20 s, no answer** | **1.4 s, answered** |

Verification, on this branch:

- **5393** unit tests, **130** F# tests — pass
- suite duration **unchanged**, 3 m 53 s before and after
- casbench **113/117**, 0 wrong, 0 timeout
- propcheck **0** failures
- rootcheck **596/596**
- simpsweep **10463/10463**

Every answer in the new test is checked by **differentiating it back** and comparing at sample points, so what is asserted is that it is an antiderivative, not what form it is written in. The reported case is wrapped in a 15-second budget, so a regression fails the run instead of hanging it.

The test also covers the shapes most likely to be disturbed by the move — `x*(1+x)`, `(x+1)*(x+2)`, `cos(x)*(1+x)`, `e^x*(1+x)` — and asserts by parts is **still reached**, via `x*cos(x)`, `x*ln(x)` and `x^2*e^x`.

## A separate gap, pinned rather than fixed

While measuring this I found that two powers of one base in a product are never merged: `sin(x)^4 * (-6) * sin(x)^2` is declined though it is `-6·sin(x)^6`, and `x^2/x` is declined though it is `x`. Measured on master, so it is pre-existing and not caused by this change.

It is filed as #781 and pinned here by `PowersOfOneBaseAreNotMerged`, so that fixing it fails a test expecting the old behaviour rather than passing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
