### PR TITLE
Inner-simplify the indefinite integral's answer (#772)

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
@@ -21,8 +21,17 @@ namespace AngouriMath
         /// <returns>
         /// An integrated expression. It might remain the same or be transformed into nodes with no integrals.
         /// </returns>
+        /// <remarks>
+        /// The antiderivative is inner-simplified before it is returned, as the definite
+        /// overload below has always done. Without it the answer kept branches whose guard
+        /// was a comparison of two literals -- <c>1/sqrt(x^2 - 1)</c> came back as a
+        /// three-branch piecewise on <c>1 * 1 ^ 2</c>, two of them dead -- and a caller that
+        /// inspects the answer rather than evaluating it saw all three. `Piecewise` already
+        /// drops a branch whose guard is decidably false; nothing was asking it to.
+        /// https://github.com/asc-community/AngouriMath/issues/772
+        /// </remarks>
         public Entity Integrate(Variable x) =>
-            Integration.ComputeIndefiniteIntegral(InnerSimplified, x) is { } antiderivative
+            Integration.ComputeIndefiniteIntegral(InnerSimplified, x)?.InnerSimplified is { } antiderivative
             ? antiderivative + (antiderivative.VarsAndConsts.Contains("C") ? Variable.CreateUnique(antiderivative, "C") : "C")
             : new Integralf(this, x, null);
         /// <summary>

--- a/Sources/Tests/UnitTests/Calculus/IntegralPiecewiseReducedTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/IntegralPiecewiseReducedTest.cs
@@ -1,0 +1,122 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// <see cref="Entity.Integrate(Entity.Variable)"/> returned piecewise answers whose
+    /// branches were left unreduced, guarded by comparisons of two constants nobody had
+    /// evaluated:
+    /// <code>
+    ///     1/sqrt(x^2 - 1)  ->  piecewise((1 * x / sqrt(-1))          provided (1 * 1 ^ 2 = 0),
+    ///                                    (... arcsin ...)            provided (1 * 1 ^ 2 &lt; 0),
+    ///                                    (... ln ...)                provided (1 * 1 ^ 2 &gt; 0))
+    /// </code>
+    /// The value was right -- the third branch is the live one -- but two dead branches and
+    /// every literal coefficient survived into the answer, so anything that inspects rather
+    /// than evaluates the result saw them.
+    /// https://github.com/asc-community/AngouriMath/issues/772
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Entity.Piecewise"/> already drops a branch whose guard evaluates to false
+    /// and stops at one that evaluates to true. The indefinite integral simply never asked
+    /// it to: it inner-simplifies its *input* and returns its output untouched, while the
+    /// definite overload has always inner-simplified the antiderivative.
+    /// </remarks>
+    public sealed class IntegralPiecewiseReducedTest
+    {
+        /// <summary>
+        /// Every guard here is a comparison of literals, so no branch is in doubt and no
+        /// piecewise should reach the caller at all.
+        /// </summary>
+        [Theory]
+        [InlineData("1/sqrt(x^2 - 1)")]
+        [InlineData("1/sqrt(x^2 - 4)")]
+        [InlineData("10/sqrt(x^2 - 4) + 1/sqrt(x^2 - 1)")]
+        [InlineData("1/sqrt(x^2 - a^2)")]
+        [InlineData("1/(x*sqrt(ln(x)^2 - a^2))")]
+        public void ADecidablePiecewiseDoesNotReachTheCaller(string integrand)
+        {
+            var antiderivative = integrand.ToEntity().Integrate("x");
+            Assert.False(antiderivative is Entity.Integralf,
+                $"{integrand} was declined: {antiderivative.Stringize()}");
+            Assert.DoesNotContain(antiderivative.Nodes, node => node is Entity.Piecewise);
+            Assert.DoesNotContain(antiderivative.Nodes, node => node == MathS.NaN);
+        }
+
+        /// <summary>
+        /// The guard must be *decided*, not merely dropped. A symbolic coefficient leaves
+        /// the sign genuinely open, and those answers have to keep their piecewise -- a
+        /// reduction that threw the branches away here would be answering a question it
+        /// cannot decide. https://github.com/asc-community/AngouriMath/issues/771
+        /// </summary>
+        [Theory]
+        [InlineData("1/(a + b*x^2)")]
+        [InlineData("1/sqrt(b*x^2 - a^2)")]
+        public void AnUndecidablePiecewiseIsKept(string integrand)
+        {
+            var antiderivative = integrand.ToEntity().Integrate("x");
+            Assert.False(antiderivative is Entity.Integralf,
+                $"{integrand} was declined: {antiderivative.Stringize()}");
+            Assert.Contains(antiderivative.Nodes, node => node is Entity.Piecewise);
+        }
+
+        /// <summary>
+        /// The reduced answer must still be the same antiderivative. Checked by
+        /// differentiating it back rather than against a printed form, since the printed
+        /// form is exactly what this changes -- and sampled rather than simplified to a
+        /// symbolic zero: differentiating a logarithm of an absolute value gives
+        /// <c>sgn(u) / abs(u)</c>, which <see cref="Entity.Simplify"/> does not reduce to
+        /// <c>1/u</c>, so a symbolic assertion here would measure the simplifier.
+        /// </summary>
+        [Theory]
+        [InlineData("1/sqrt(x^2 - 1)", new[] { -4.1, -2.5, 1.4, 2.3, 3.9 })]
+        [InlineData("1/sqrt(x^2 - 4)", new[] { -5.2, -3.1, 2.6, 3.4, 4.8 })]
+        [InlineData("1/(1 + x^2)", new[] { -2.2, -0.7, 0.5, 1.3, 3.6 })]
+        public void ReducingDoesNotChangeTheAntiderivative(string integrand, double[] points)
+        {
+            var derivative = integrand.ToEntity().Integrate("x").Substitute("C", 0).Differentiate("x");
+            var compared = 0;
+            foreach (var point in points)
+            {
+                if (!TryEval(derivative, point, out var actual)) continue;
+                if (!TryEval(integrand.ToEntity(), point, out var expected)) continue;
+                compared++;
+                var scale = System.Math.Max(System.Math.Max(
+                    System.Math.Abs(expected), System.Math.Abs(actual)), 1e-12);
+                Assert.True(System.Math.Abs(expected - actual) <= 1e-8 * scale,
+                    $"{integrand} at x = {point}: differentiated back to {actual}, integrand is {expected}");
+            }
+            Assert.True(compared > 0, $"{integrand}: no point was comparable, so nothing was checked");
+        }
+
+        /// <summary>
+        /// A point counts only where both sides are real and finite -- these integrands
+        /// leave the reals over part of the line, and a skipped point is not a failure.
+        /// </summary>
+        private static bool TryEval(Entity expr, double point, out double value)
+        {
+            value = 0;
+            try
+            {
+                var evaluated = expr.Substitute("x", point).EvalNumerical();
+                var real = evaluated.RealPart.EDecimal.ToDouble();
+                if (System.Math.Abs(evaluated.ImaginaryPart.EDecimal.ToDouble())
+                    > 1e-9 * System.Math.Max(1, System.Math.Abs(real))) return false;
+                if (double.IsNaN(real) || double.IsInfinity(real)) return false;
+                value = real;
+                return true;
+            }
+            catch { return false; }
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Common/InnerSimplifyTest.cs
+++ b/Sources/Tests/UnitTests/Common/InnerSimplifyTest.cs
@@ -176,13 +176,19 @@ namespace AngouriMath.Tests.Common
             "derivative(apply(f, x), x, -2)".ToEntity().InnerSimplified.ShouldBe("integral(integral(apply(f, x), x), x)");
         [Fact] public void DerivativeToIntegralEval() =>
             "derivative(apply(f, x) + (sin(3)^2 + cos(3)^2), x, -1)".ToEntity().Evaled.ShouldBe("integral(apply(f, x) + 1, x)");
+        // The multiplication is distributed into the branches now that Integrate
+        // inner-simplifies its answer (https://github.com/asc-community/AngouriMath/issues/772).
+        // Same value, and it is the form the library already produced for the same
+        // question asked through the node -- see PiecewiseIntegrate1NodeInnerSimplified
+        // below, which has always expected `piecewise(2 * x + C provided a, ...)`. The two
+        // paths disagreed; the old expectation here was pinning that disagreement.
         [Fact] public void PiecewiseIntegrate1() =>
             "piecewise(2 provided a, 3)".Integrate("x")
-            .ShouldBe("piecewise(2 provided a, 3) * x + C");
+            .ShouldBe("piecewise(2 * x provided a, 3 * x) + C");
 
         [Fact] public void PiecewiseIntegrate2() =>
             "piecewise(2 provided a, 3)".Integrate("d")
-            .ShouldBe("piecewise(2 provided a, 3) * d + C");
+            .ShouldBe("piecewise(2 * d provided a, 3 * d) + C");
 
         [Fact] public void PiecewiseIntegrate3() =>
             "piecewise(x provided a, 1/x)".Integrate("x")


### PR DESCRIPTION
Fixes #772.

`Integrate` returned piecewise answers whose branches were left unreduced, guarded by comparisons of two constants nobody had evaluated:

```
1/sqrt(x^2 - 1)  ->  piecewise((1 * x / sqrt(-1))  provided (1 * 1 ^ 2 = 0),
                               (... arcsin ...)    provided (1 * 1 ^ 2 < 0),
                               (... ln ...)        provided (1 * 1 ^ 2 > 0)) + C
```

The value was right — the third branch is the live one — but two dead branches and every literal coefficient survived into the answer. Anything that inspects rather than evaluates the result saw all three, and a reader could not tell by looking which branch was guarded away.

## Nothing needed building

`Piecewise.InnerSimplify` **already** drops a branch whose guard evaluates to false and stops at one that evaluates to true. The indefinite integral simply never asked it to — it inner-simplifies its *input* and returns its output untouched:

```csharp
public Entity Integrate(Variable x) =>
    Integration.ComputeIndefiniteIntegral(InnerSimplified, x) is { } antiderivative   // in, not out
```

while the **definite** overload three lines below has always inner-simplified the antiderivative. This one-word change makes the two agree.

## Measured

| integrand | before | after |
|---|---|---|
| `1/sqrt(x^2 - 1)` | 3-branch piecewise on `1 * 1 ^ 2` | `ln(abs(2 * x + 2 * sqrt(x ^ 2 - 1))) + C` |
| `1/sqrt(x^2 - a^2)` | 3-branch piecewise | `ln(abs(2 * x + 2 * sqrt(x ^ 2 - a ^ 2))) + C` |
| `10/sqrt(x^2 - 4) + 1/sqrt(x^2 - 1)` | two of them | `10 * ln(abs(2 * x + 2 * sqrt(x ^ 2 - 4))) + ln(abs(...)) + C` |
| `1/(x*sqrt(ln(x)^2 - a^2))` | 3-branch piecewise | reduced |
| **`1/(a + b*x^2)`** | piecewise | **unchanged** |

That last row is the point of the guard being *decided* rather than dropped. A symbolic coefficient leaves the sign genuinely open, so those answers must keep their piecewise (#771) — pinned by `AnUndecidablePiecewiseIsKept`, so a future reduction cannot start answering a question it cannot decide.

## Two expectations updated — form, not value

`piecewise(2 provided a, 3)` integrated to `piecewise(2 provided a, 3) * x + C` and now distributes to `piecewise(2 * x provided a, 3 * x) + C`. Same value, and it is what the library **already** answered for the same question asked through the node — `PiecewiseIntegrate1NodeInnerSimplified`, in the same file, has always expected `piecewise(2 * x + C provided a, 3 * x + C)`. The two paths disagreed; the old expectations were pinning that disagreement.

## Harnesses

- unit **5418 pass, 0 fail**; F# **130/130**
- `casbench` **113/117**, 0 wrong / 0 error / 0 timeout; `rootcheck` **596/596**; `simpsweep` **10463/10463**; `propcheck` **1337 checks, 0 failures**
- `Tests.Calculus`, two runs each: master 860 tests in 56 s and 57 s; this branch 870 in 59 s and 56 s

The new tests check the shape *and* that the reduced answer is still the same antiderivative — differentiated back and sampled, because differentiating a logarithm of an absolute value gives `sgn(u) / abs(u)`, which `Simplify` does not reduce to `1/u`. A symbolic assertion there would have measured the simplifier rather than the integral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
