### PR TITLE
Point the kernel benchmark at a path that exists (#775)

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -1,16 +1,37 @@
 name: 'Kernel Benchmark'
 
+# The path filters below used to read "./Sources/AngouriMath/AngouriMath", which is not a
+# path in this tree: the kernel is Sources/AngouriMath/ and its project file is
+# Sources/AngouriMath/AngouriMath.csproj, with no nested AngouriMath directory. The pattern
+# has no wildcard, so it could only ever match that one literal non-existent path, and the
+# workflow last ran on 2026-01-02 -- two minutes before the filter was re-added in f51c7e03.
+# Ninety-eight PRs merged after that without being benchmarked.
+#
+# Path filters are globs matched against paths relative to the repository root, so the
+# leading "./" was wrong as well, though it made no difference while the target did not
+# exist. https://github.com/asc-community/AngouriMath/issues/775
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
+    # Written out twice rather than shared through a YAML anchor: anchors are not a
+    # supported part of the workflow syntax, and a benchmark that fails to parse is a
+    # worse outcome than the one being fixed here.
     paths:
-      - "./Sources/AngouriMath/AngouriMath"
+      - "Sources/AngouriMath/**"
+      # A change to the benchmark itself is worth benchmarking.
+      - "Sources/Tests/DotnetBenchmark/**"
+      # And so is a change to this file -- which is also what lets a fix to these filters
+      # demonstrate that it works, rather than being reasoned about.
+      - ".github/workflows/Benchmark.yml"
   pull_request:
     branches:
       - '*'
     paths:
-      - "./Sources/AngouriMath/AngouriMath"
+      - "Sources/AngouriMath/**"
+      - "Sources/Tests/DotnetBenchmark/**"
+      - ".github/workflows/Benchmark.yml"
 
 jobs:
   Benchmark:


### PR DESCRIPTION
Fixes #775.

Both triggers filtered on `"./Sources/AngouriMath/AngouriMath"`, which is not a path in this tree. The kernel is `Sources/AngouriMath/` and its project file is `Sources/AngouriMath/AngouriMath.csproj` — there is no nested `AngouriMath` directory, and the pattern has no wildcard, so it could only ever match that one literal non-existent path.

The workflow **last ran on 2026-01-02T14:24Z**. The filter was re-added in `f51c7e03` at **14:26Z — two minutes later**. The January runs happened during the #640 CI work while the filter was temporarily absent, which is why the history looks alive up to that point and then stops dead.

**Ninety-eight PRs have merged since.** None were benchmarked, so a PR could have regressed `Simplify` by any factor with CI entirely green. These are the inter-version CPU and RAM benchmarks behind #529 and #500, and the only automated guard on not losing speed or memory on popular use cases.

## The change

```diff
-      - "./Sources/AngouriMath/AngouriMath"
+      - "Sources/AngouriMath/**"
+      - "Sources/Tests/DotnetBenchmark/**"
+      - ".github/workflows/Benchmark.yml"
```

Two paths beyond the kernel, each for a reason:

- **the benchmark harness** — a change to what is measured is worth measuring;
- **this file** — which is also what makes the fix *self-demonstrating*. #775 asks that whoever takes this "confirm the trigger fires rather than reasoning about the glob", and a PR that changes only a workflow file otherwise cannot. Because `Benchmark.yml` is now in its own path list, **Kernel Benchmark should appear on this PR's checks** — if it does not, the fix is wrong and you can see that without merging it.

`workflow_dispatch` added as well, so the benchmark can be run against a branch on demand. It could not be before.

The leading `./` was separately wrong — path filters are globs matched against repository-root-relative paths — though it made no difference while the target did not exist either way.

## Two notes for review

**The list is written out twice rather than shared through a YAML anchor.** Anchors are not a supported part of the workflow syntax, and a benchmark that fails to parse is a worse outcome than the one being fixed.

**Whether the `pull_request` leg should filter at all is still open**, as #775 says: the job takes 9–11 minutes. This PR keeps the filter and makes it correct rather than deciding that question — but now that it works, dropping the filter is a one-line follow-up if the maintainers would rather every PR be benchmarked.

## Checked

- the file parses, and both triggers resolve to the three paths above
- `Sources/Tests/DotnetBenchmark` builds clean on .NET 10, and `CommonFunctionsInterVersion` and `RAMUsageTest` — the two names the job passes on the command line — both still resolve in `Program.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
