### PR TITLE
Clear a surd out of a two-term denominator (#205)

### DIFF
--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -5632,6 +5632,14 @@ namespace AngouriMath
                             cases.Sum(@case =>
                                 DefaultCriteria(@case.Expression) + 0.1 * DefaultCriteria(@case.Predicate) + ExtraHeavyWeight * (@case.Expression.Nodes.Count(n => n is Providedf) + @case.Predicate.Nodes.Count(n => n is Providedf))),
                         Variable => Weight, // Number of variables
+                        // A root in a denominator, which the rationalising rule clears out.
+                        // Without a weight here the two forms tie -- 1 / (sqrt(3) + 5) and
+                        // (sqrt(3) - 5) / (-22) are the same rate -- and a tie is settled by
+                        // whichever candidate was generated first, which is not a preference
+                        // so much as an accident. This states the preference instead.
+                        // https://github.com/asc-community/AngouriMath/issues/205
+                        Divf(_, var divisor) when divisor.Nodes.Any(node => node is Powf(_, Rational and not Integer))
+                            => MinorWeight + Weight + expr.DirectChildren.Sum(DefaultCriteria),
                         Divf => MinorWeight + expr.DirectChildren.Sum(DefaultCriteria), // Number of divides
                         Rational(Integer(1 or -1), _) and not Integer => Weight + expr.DirectChildren.Sum(DefaultCriteria), // Number of rationals with unit numerator
                         Powf(_, Real { IsNegative: true }) => HeavyWeight + expr.DirectChildren.Sum(DefaultCriteria), // Number of negative powers

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Rational.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Rational.cs
@@ -5,6 +5,7 @@
 // Website: https://am.angouri.org.
 //
 
+using PeterO.Numbers;
 using AngouriMath.Extensions;
 using static AngouriMath.Entity;
 
@@ -66,6 +67,98 @@ namespace AngouriMath.Functions
                     => PairwiseGrouping(num, den, level).Select(PowerRules).MultiplyAll().InnerSimplified.Replace(CollapseMultipleFractions),
                 _ => expr
             };
+
+        /// <summary>n^(p/q) for a q of 2 or more -- a root that is not a whole power.</summary>
+        private static bool IsSurd(Entity node)
+            => node is Powf(_, Rational and not Integer);
+
+        /// <summary>
+        /// <c>num / (a + b)</c> becomes <c>num * (a - b) / (a^2 - b^2)</c>, which clears a
+        /// square root out of a two-term denominator:
+        /// <c>(5 - sqrt(3)) / (5 + sqrt(3))</c> is <c>14/11 - 5/11 * sqrt(3)</c>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The library already prefers a denominator without a surd -- <c>1/sqrt(2)</c> has
+        /// always come back as <c>sqrt(2)/2</c> -- so this extends an existing preference to
+        /// the binomial case. https://github.com/asc-community/AngouriMath/issues/205
+        /// </para>
+        /// <para>
+        /// Three conditions, and each is load-bearing. The denominator must be constant,
+        /// because multiplying numerator and denominator by <c>a - b</c> is only valid where
+        /// that is non-zero, and for a symbolic denominator it is not decidable -- rewriting
+        /// there would either lose a value or attach a condition to every such quotient.
+        /// <c>a^2 - b^2</c> must fold to a rational, which is what says the root was
+        /// actually cleared: a conjugate does nothing for a cube root, where
+        /// <c>1 - 2^(2/3)</c> is no better than <c>1 + 2^(1/3)</c>. And it must be non-zero,
+        /// which rules out <c>a = b</c> and, since it is <c>(a-b)(a+b)</c>, guarantees the
+        /// original denominator was non-zero too.
+        /// </para>
+        /// <para>
+        /// Terminates because the rewritten denominator is a rational and this rule requires
+        /// a surd in the denominator to fire at all.
+        /// </para>
+        /// </remarks>
+        /// <summary>
+        /// <c>p * value / q</c> for a rational <c>p/q</c>, written so that the rational is
+        /// split across the quotient rather than left as a factor: a unit-numerator rational
+        /// carries its own weight in the complexity criteria, so <c>(1/2) * value</c> would
+        /// rate worse than <c>value / 2</c> and hand back the comparison this is trying to win.
+        /// </summary>
+        private static Entity ScaleBy(ERational ratio, Entity value)
+        {
+            var scaled = ratio.Numerator.Equals(EInteger.One)
+                ? value
+                : (Integer.Create(ratio.Numerator) * value).InnerSimplified;
+            return ratio.Denominator.Equals(EInteger.One)
+                ? scaled
+                : scaled / Integer.Create(ratio.Denominator);
+        }
+
+        internal static Entity RationaliseDenominator(Entity expr)
+        {
+            // k * (value / d) -> (k * value) / d, reduced, where the numerator carries a surd
+            // this rule moved up out of a denominator. Without it a numeric coefficient never
+            // meets the divisor: `k / (p + sqrt(q))` is split into `k * (1 / (p + sqrt(q)))`
+            // before this rule runs, so the quotient it rewrites has a numerator of 1 and the
+            // k stays outside. 2 / (3 - sqrt(5)) came out as `2 * (3 + sqrt(5)) / 4`, which is
+            // longer than what it replaced -- while 1 / (3 - sqrt(5)), with no coefficient to
+            // strand, answered correctly all along.
+            if (expr is Mulf(Rational coefficient, Divf(var inner, Rational { IsZero: false } innerDivisor))
+                && inner.Nodes.Any(IsSurd))
+                return ScaleBy(coefficient.ERational.Divide(innerDivisor.ERational), inner);
+
+            if (expr is not Divf(var num, var den))
+                return expr;
+            var (a, b) = den switch
+            {
+                Sumf(var left, var right) => (left, right),
+                Minusf(var left, var right) => (left, -right),
+                _ => (null, null)
+            };
+            if (a is null || b is null)
+                return expr;
+            if (den.Vars.Any() || !den.Nodes.Any(IsSurd))
+                return expr;
+
+            var product = (a * a - b * b).InnerSimplified;
+            if (product is not Rational { IsZero: false } rational)
+                return expr;
+            // Orient the conjugate so the rational denominator comes out positive. Taking
+            // it the other way round leaves a double negative -- 1/(5 + sqrt(3)) became
+            // (sqrt(3) - 5) / (-22) -- which nothing downstream folds back, so the candidate
+            // stayed longer than the form it replaced and lost on the metric it was supposed
+            // to win. Negating both halves is the same number.
+            var negative = rational.IsNegative;
+            var conjugate = negative ? b - a : a - b;
+            var divisor = negative ? (Rational)(-rational).InnerSimplified : rational;
+
+            // A rational numerator is cancelled against the divisor rather than left to meet
+            // it later, which it does not: InnerSimplify leaves `2 * (3 + sqrt(5)) * 1/4`.
+            if (num is Rational numerator)
+                return ScaleBy(numerator.ERational.Divide(divisor.ERational), conjugate);
+            return ((num * conjugate) / divisor).InnerSimplified;
+        }
 
         internal static Entity CollapseMultipleFractions(Entity expr)
             => expr switch

--- a/Sources/AngouriMath/Functions/Simplification/Simplificator.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Simplificator.cs
@@ -99,6 +99,15 @@ namespace AngouriMath.Functions
                     2 => TreeAnalyzer.SortLevel.LOW_LEVEL,
                     _ => TreeAnalyzer.SortLevel.HIGH_LEVEL
                 };
+                // Clearing a surd out of a two-term denominator, before anything else has
+                // rearranged the quotient. Taken rather than offered as a candidate: the
+                // complexity metric ties on it -- 1/(sqrt(3)+5) and (sqrt(3)-5)/(-22) rate
+                // the same -- and a tie is settled by whichever candidate came first, which
+                // is an accident rather than a preference.
+                // https://github.com/asc-community/AngouriMath/issues/205
+                if (res.Nodes.Any(child => child is Divf))
+                    AddHistory(res = res.Replace(Patterns.RationaliseDenominator).InnerSimplified);
+
                 res = res.Replace(Patterns.SortRules(sortLevel)).InnerSimplified;
                 if (res.Nodes.Any(child => child is Powf))
                     AddHistory(res = res.Replace(Patterns.PowerRules).InnerSimplified);
@@ -117,6 +126,7 @@ namespace AngouriMath.Functions
                     AddHistory(res.Replace(Patterns.PolynomialGcdCancellation).InnerSimplified);
 
                 AddHistory(res = res.Replace(Patterns.PolynomialLongDivision).InnerSimplified);
+
 
                 AddHistory(res = res.Replace(Patterns.NormalTrigonometricForm).InnerSimplified);
                 AddHistory(res = res.Replace(Patterns.CollapseMultipleFractions).InnerSimplified);

--- a/Sources/Tests/UnitTests/PatternsTest/RationaliseDenominatorTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/RationaliseDenominatorTest.cs
@@ -1,0 +1,105 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.PatternsTest
+{
+    /// <summary>
+    /// A surd in a two-term denominator was left where it stood:
+    /// <code>
+    ///     (5 - sqrt(3)) / (5 + sqrt(3))   unchanged, where it is 14/11 - 5/11 * sqrt(3)
+    /// </code>
+    /// https://github.com/asc-community/AngouriMath/issues/205
+    /// </summary>
+    /// <remarks>
+    /// The library already prefers a denominator without a surd -- <c>1/sqrt(2)</c> has
+    /// always come back as <c>sqrt(2)/2</c> -- so this extends an existing preference to
+    /// the binomial case rather than introducing one, which is the half of #205 that does
+    /// not need a maintainer's ruling.
+    /// </remarks>
+    public sealed class RationaliseDenominatorTest
+    {
+        private static bool IsSurd(Entity node)
+            => node is Entity.Powf(_, Entity.Number.Rational and not Entity.Number.Integer);
+
+        /// <summary>Every denominator anywhere in the tree.</summary>
+        private static bool HasASurdDenominator(Entity expr)
+            => expr.Nodes.OfType<Entity.Divf>().Any(div => div.Divisor.Nodes.Any(IsSurd));
+
+        private static void AssertSameValue(string original, Entity simplified)
+        {
+            var before = original.ToEntity().EvalNumerical();
+            var after = simplified.EvalNumerical();
+            var expected = before.RealPart.EDecimal.ToDouble();
+            var actual = after.RealPart.EDecimal.ToDouble();
+            var scale = Math.Max(Math.Max(Math.Abs(expected), Math.Abs(actual)), 1e-12);
+            Assert.True(Math.Abs(expected - actual) <= 1e-12 * scale,
+                $"{original} simplified to {simplified.Stringize()}, which is {actual} rather than {expected}");
+        }
+
+        [Theory]
+        [InlineData("(5 - sqrt(3)) / (5 + sqrt(3))")]
+        [InlineData("1 / (5 + sqrt(3))")]
+        [InlineData("1 / (sqrt(2) + sqrt(3))")]
+        [InlineData("(1 + sqrt(2)) / (1 - sqrt(2))")]
+        [InlineData("2 / (3 - sqrt(5))")]
+        [InlineData("1 / (2 * sqrt(3) - 1)")]
+        public void TheSurdLeavesTheDenominator(string expr)
+        {
+            var simplified = expr.ToEntity().Simplify();
+            Assert.False(HasASurdDenominator(simplified),
+                $"{expr} still has a surd in a denominator: {simplified.Stringize()}");
+            AssertSameValue(expr, simplified);
+        }
+
+        /// <summary>
+        /// The rule multiplies by the conjugate, which clears a square root and nothing
+        /// else. A cube root is untouched by it -- <c>1 - 2^(2/3)</c> is no better than
+        /// <c>1 + 2^(1/3)</c> -- so the rule must decline rather than churn, and the answer
+        /// must still be the same number.
+        /// </summary>
+        [Theory]
+        [InlineData("1 / (1 + 2 ^ (1/3))")]
+        [InlineData("1 / (1 + 5 ^ (1/4))")]
+        public void ARootItCannotClearIsLeftAlone(string expr)
+            => AssertSameValue(expr, expr.ToEntity().Simplify());
+
+        /// <summary>
+        /// A symbolic denominator is out of scope: whether the conjugate is non-zero is not
+        /// decidable, and multiplying by something that may be zero is how a value gets
+        /// lost. These must keep their surd rather than be rewritten under a condition
+        /// nobody asked for.
+        /// </summary>
+        [Theory]
+        [InlineData("1 / (a + sqrt(3))")]
+        [InlineData("1 / (x - sqrt(x))")]
+        public void ASymbolicDenominatorIsLeftAlone(string expr)
+        {
+            var simplified = expr.ToEntity().Simplify();
+            foreach (var point in new[] { 1.7, 2.3, 4.1 })
+            {
+                var before = expr.ToEntity().Substitute("a", point).Substitute("x", point).EvalNumerical();
+                var after = simplified.Substitute("a", point).Substitute("x", point).EvalNumerical();
+                Assert.True(Math.Abs(before.RealPart.EDecimal.ToDouble() - after.RealPart.EDecimal.ToDouble()) < 1e-9,
+                    $"{expr} at {point}: {simplified.Stringize()} is a different number");
+            }
+        }
+
+        /// <summary>
+        /// The one case the library already handled, which must keep working -- it goes
+        /// through a different route and this rule does not fire on it at all.
+        /// </summary>
+        [Fact]
+        public void ASingleSurdDenominatorStillRationalises()
+            => Assert.Equal("sqrt(2) / 2".ToEntity().Simplify(), "1 / sqrt(2)".ToEntity().Simplify());
+    }
+}


### PR DESCRIPTION
Closes #205.

`(5 - sqrt(3)) / (5 + sqrt(3))` was left as written, where it is `14/11 - 5/11 * sqrt(3)`. Multiplying through by the conjugate clears the root: `num / (a + b)` is `num * (a - b) / (a² - b²)`.

## The design question #205 asks, answered with a measurement

> Or should we avoid surds in denominators always?

Measured, **the library had no policy**. `1/sqrt(2)` answers `sqrt(2)/2` — but the two forms rate *exactly equal* under the complexity criteria, so that answer is a tie broken by whichever candidate happened to be generated first. It looked like a preference and was an accident.

So this states the preference: a quotient whose divisor contains a root carries one `Weight` more. That is the same kind of clause the criteria already has for `0 < x` being worse than `x > 0`, and it is a documented, user-overridable setting.

## Three conditions, each load-bearing

- **The denominator must be constant.** Multiplying by `a - b` is valid only where that is non-zero, and for a symbolic denominator it is not decidable — rewriting there would either lose a value or attach a condition to every such quotient. `1/(a + sqrt(3))` is left alone.
- **`a² - b²` must fold to a rational**, which is what says the root was actually cleared. A conjugate does nothing for a cube root: `1 - 2^(2/3)` is no better than `1 + 2^(1/3)`, so `1/(1 + 2^(1/3))` is left alone.
- **It must be non-zero**, ruling out `a = b` — and being `(a-b)(a+b)`, it also establishes the original denominator was non-zero.

## Three things found by measuring the candidate pool, not by reading the rule

Each of these produced a *correct but longer* candidate that then lost the comparison it existed to win:

1. **The conjugate is oriented so the rational denominator comes out positive.** Otherwise `1/(5 + sqrt(3))` became `(sqrt(3) - 5) / (-22)` — a double negative nothing downstream folds.
2. **A rational numerator is cancelled against the divisor by hand**, and written as `p * value / q` rather than `(p/q) * value`, since a unit-numerator rational carries its own weight in the criteria.
3. **The pass runs at the top of the loop**, before anything rearranges the quotient. Placed later, `DivisionPreparingRules` had already split `2/(3 - sqrt(5))` into `2 * (1/(3 - sqrt(5)))`, stranding the coefficient outside — which is exactly why `1/(3 - sqrt(5))` worked while `2/(3 - sqrt(5))` did not.

## Measured

| expression | before | after |
|---|---|---|
| `(5 - sqrt(3)) / (5 + sqrt(3))` | unchanged | `14/11 - 5/11 * sqrt(3)` |
| `1 / (5 + sqrt(3))` | unchanged | `(5 - sqrt(3)) / 22` |
| `1 / (sqrt(2) + sqrt(3))` | unchanged | `sqrt(3) - sqrt(2)` |
| `2 / (3 - sqrt(5))` | unchanged | `(3 + sqrt(5)) / 2` |
| `1 / (2 * sqrt(3) - 1)` | unchanged | `2/11 * sqrt(3) + 1/11` |
| `1 / (1 + 2^(1/3))` | unchanged | unchanged — no conjugate clears a cube root |
| `1 / (a + sqrt(3))` | unchanged | unchanged — conjugate not decidably non-zero |
| `1 / sqrt(2)` | `sqrt(2) / 2` | unchanged |

## Blast radius

The complexity criteria is global, so this was the thing to measure rather than reason about:

- unit **5419 pass, 0 fail**; F# **130/130**
- `casbench` **113/117**, 0 wrong / 0 error / 0 timeout
- `rootcheck` **596/596**; `simpsweep` **10463/10463** agree; `propcheck` **1337 checks, 0 failures**
- suite **4m00s**, inside the 3m49s–4m27s range master runs in

Every test asserts the value is preserved numerically as well as the shape, and the two negative cases assert the value too — so a future change that starts rewriting them cannot do it silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
