### PR TITLE
Solve a mixed sine-cosine equation in arc functions (#270)

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
@@ -248,6 +248,24 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
                 // // //
             }
 
+            // An equation in both sin(u) and cos(u), where one of them appears only at even
+            // powers, is a polynomial in the other once cos^2 is written as 1 - sin^2 -- and
+            // the replacement machinery above then solves it as one. This has to come before
+            // the trigonometric solver, which writes both in terms of e^(i u) and so answers
+            // a quadratic in sin(a x) with a quartic in e^(i a x).
+            // https://github.com/asc-community/AngouriMath/issues/270
+            // Solved without compensation, whatever this call was given. The rewrite keeps
+            // the whole left-hand side of `... = 0` rather than peeling a constant off it,
+            // so there is nothing to compensate -- and compensating skips the replacement
+            // machinery, which is the only thing that can solve what the rewrite produces.
+            // Passed `true`, this fired, produced `1 - sin(x)^2 + sin(x)` and then answered
+            // it through the exponential solver anyway, which is the route it exists to
+            // avoid. It cannot recurse: what comes back mentions only one of the two
+            // functions, so the rewrite declines it.
+            if (TrigonometricSolver.TryRewriteInOneFunction(expr, x, out var inOneFunction)
+                && Solve(inOneFunction, x) is FiniteSet { IsSetEmpty: false } elsPythagorean)
+                return (Set)elsPythagorean.Select(ent => TryDowncast(expr, x, ent)).ToSet().InnerSimplified;
+
             // if no replacement worked, try trigonometric solver
             if (TrigonometricSolver.TrySolveLinear(expr, x, out var trig) && trig is FiniteSet elsTrig)
                 return (Set)elsTrig.Select(ent => TryDowncast(expr, x, ent)).ToSet().InnerSimplified;

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/TrigonometricSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/TrigonometricSolver.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) 2019-2022 Angouri.
 // AngouriMath is licensed under MIT.
 // Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
@@ -14,6 +14,74 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
     using static Entity;
     internal static class TrigonometricSolver
     {
+        /// <summary>
+        /// Rewrites an equation that mixes <c>sin(u)</c> and <c>cos(u)</c> into one written
+        /// in a single function, by way of <c>cos(u)^2 = 1 - sin(u)^2</c> or its mirror.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Without this the equation reaches the exponential solver, which writes both
+        /// functions in terms of <c>e^(i u)</c> -- so <c>cos(a x)^2 + sin(a x) + c = 0</c>,
+        /// which is a quadratic in <c>sin(a x)</c>, becomes a *quartic* in <c>e^(i a x)</c>
+        /// and is answered with pages of nested radicals where there are two arcsines.
+        /// https://github.com/asc-community/AngouriMath/issues/270
+        /// </para>
+        /// <para>
+        /// Nothing new is needed to solve what comes out: the replacement machinery in
+        /// <see cref="AnalyticalEquationSolver"/> already reduces a polynomial in
+        /// <c>sin(u)</c> to a polynomial in a fresh variable and inverts the arcsine
+        /// afterwards, which is why <c>sin(x)^2 + sin(x) = 0</c> has always answered well.
+        /// The mixed form simply never became one.
+        /// </para>
+        /// <para>
+        /// Only whole even powers are rewritten, and the rewrite is kept only if it removes
+        /// the other function entirely. An odd power leaves a square root of a square behind
+        /// -- <c>sin(x) + cos(x)</c> is not a polynomial in either function -- so those are
+        /// declined here and left to the solvers that already handle them.
+        /// </para>
+        /// </remarks>
+        internal static bool TryRewriteInOneFunction(Entity expr, Variable x, out Entity rewritten)
+        {
+            rewritten = expr;
+            static bool Mentions<T>(Entity where, Variable x) where T : Entity
+                => where.Nodes.Any(node => node is T && node.DirectChildren[0].ContainsNode(x));
+
+            if (!Mentions<Sinf>(expr, x) || !Mentions<Cosf>(expr, x))
+                return false;
+
+            var asSine = expr.Replace(node => node switch
+            {
+                Powf(Cosf(var arg), Integer { IsPositive: true } power)
+                    when power.EInteger.IsEven && arg.ContainsNode(x)
+                    => MathS.Pow(1 - MathS.Pow(MathS.Sin(arg), 2),
+                                 Integer.Create(power.EInteger.Divide(2))),
+                _ => node
+            });
+            if (!Mentions<Cosf>(asSine, x))
+            {
+                // Folded, because the halved power is often 1 and `(1 - sin(x)^2)^1` is not
+                // recognised as a polynomial in sin(x) by the replacement machinery that has
+                // to solve it -- the rewrite fired and then bought nothing.
+                rewritten = asSine.InnerSimplified;
+                return true;
+            }
+
+            var asCosine = expr.Replace(node => node switch
+            {
+                Powf(Sinf(var arg), Integer { IsPositive: true } power)
+                    when power.EInteger.IsEven && arg.ContainsNode(x)
+                    => MathS.Pow(1 - MathS.Pow(MathS.Cos(arg), 2),
+                                 Integer.Create(power.EInteger.Divide(2))),
+                _ => node
+            });
+            if (!Mentions<Sinf>(asCosine, x))
+            {
+                rewritten = asCosine.InnerSimplified;
+                return true;
+            }
+            return false;
+        }
+
         // solves equation f(sin(x), cos(x), tan(x), cot(x)) for x
         internal static bool TrySolveLinear(Entity expr, Variable variable, out Set res)
         {

--- a/Sources/Tests/UnitTests/Algebra/PythagoreanEquationRewriteTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/PythagoreanEquationRewriteTest.cs
@@ -1,0 +1,124 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Algebra
+{
+    /// <summary>
+    /// An equation mixing <c>sin(u)</c> and <c>cos(u)</c> went to the exponential solver,
+    /// which rewrites both in terms of <c>e^(i u)</c> and so turns
+    /// <c>cos(a x)^2 + sin(a x) + c = 0</c> into a *quartic* in <c>e^(i a x)</c>. The answer
+    /// was pages of nested radicals where there are two arcsines.
+    /// https://github.com/asc-community/AngouriMath/issues/270
+    /// </summary>
+    /// <remarks>
+    /// Writing <c>cos(u)^2</c> as <c>1 - sin(u)^2</c> makes it a polynomial in
+    /// <c>sin(u)</c> alone, which the replacement machinery already solves --
+    /// <c>sin(x)^2 + sin(x) = 0</c> has always answered in arcsines. The mixed form simply
+    /// never became one.
+    /// </remarks>
+    public sealed class PythagoreanEquationRewriteTest
+    {
+        /// <summary>
+        /// Every root is substituted back into the equation and required to satisfy it.
+        /// That is the property worth asserting: a solver rewrite can just as easily lose a
+        /// root or invent one as shorten the answer, and the printed form says neither.
+        /// </summary>
+        private static void AssertRootsSatisfy(string equation, (string Symbol, double Value)[] constants)
+        {
+            Entity specialised = equation.ToEntity().Solve("x");
+            // The residual, not the equation: substituting into `lhs = rhs` gives a boolean,
+            // which EvalNumerical refuses -- and a helper that swallows that exception counts
+            // every root as unverifiable and passes without checking anything.
+            Entity truth = equation.ToEntity() is Entity.Equalsf(var lhs, var rhs)
+                ? lhs - rhs
+                : equation.ToEntity();
+            foreach (var (symbol, value) in constants)
+            {
+                specialised = specialised.Substitute(symbol, value);
+                truth = truth.Substitute(symbol, value);
+            }
+            var roots = Assert.IsType<Entity.Set.FiniteSet>(specialised.InnerSimplified);
+            Assert.NotEmpty(roots);
+
+            var checkedRoots = 0;
+            foreach (var root in roots)
+            {
+                // The periodic parameter is a free integer; 0 is a root whatever it is.
+                var point = root;
+                foreach (var free in point.Vars.Where(v => v.Name.StartsWith("n_")))
+                    point = point.Substitute(free, 0);
+                if (point.Vars.Any()) continue;
+                double residual;
+                try
+                {
+                    var value = truth.Substitute("x", point).EvalNumerical();
+                    residual = Math.Abs(value.RealPart.EDecimal.ToDouble())
+                             + Math.Abs(value.ImaginaryPart.EDecimal.ToDouble());
+                }
+                catch { continue; }
+                if (double.IsNaN(residual)) continue;
+                checkedRoots++;
+                Assert.True(residual < 1e-6,
+                    $"{equation}: {root.Stringize()} is not a root, residual {residual}");
+            }
+            Assert.True(checkedRoots > 0, $"{equation}: no root could be checked, so nothing was verified");
+        }
+
+        /// <summary>
+        /// The answer must be written in arc functions rather than as radicals in
+        /// <c>e^(i a x)</c>, which is what #270 asks for. Measured as size, because the
+        /// quartic answer runs to thousands of nodes and the arcsine one to tens.
+        /// </summary>
+        [Theory]
+        [InlineData("cos(a * x) ^ 2 + sin(a * x) + c = 0")]
+        [InlineData("cos(x) ^ 2 + sin(x) = 0")]
+        [InlineData("cos(x) ^ 2 + sin(x) + 1 = 0")]
+        [InlineData("sin(x) ^ 2 + cos(x) = 0")]
+        [InlineData("2 * cos(x) ^ 2 - 3 * sin(x) = 0")]
+        public void TheAnswerIsSmallAndInArcFunctions(string equation)
+        {
+            var solved = equation.ToEntity().Solve("x");
+            Assert.True(solved.Complexity < 400,
+                $"{equation} answered with {solved.Complexity} nodes, which is the quartic route");
+            Assert.Contains(solved.Nodes, node => node is Entity.Arcsinf or Entity.Arccosf);
+        }
+
+        [Theory]
+        [InlineData("cos(x) ^ 2 + sin(x) = 0")]
+        [InlineData("cos(x) ^ 2 + sin(x) + 1 = 0")]
+        [InlineData("sin(x) ^ 2 + cos(x) = 0")]
+        [InlineData("2 * cos(x) ^ 2 - 3 * sin(x) = 0")]
+        public void EveryRootSatisfiesTheEquation(string equation)
+            => AssertRootsSatisfy(equation, Array.Empty<(string, double)>());
+
+        [Fact]
+        public void TheIssuesOwnEquationIsSolved()
+            => AssertRootsSatisfy("cos(a * x) ^ 2 + sin(a * x) + c = 0",
+                new[] { ("a", 2.0), ("c", -0.5) });
+
+        /// <summary>
+        /// An equation with an odd power of cosine is not a polynomial in sine, and the
+        /// rewrite must decline rather than produce a square root of a square. These are the
+        /// cases that must keep whatever answer they had.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x) + cos(x) = 0")]
+        [InlineData("sin(x) * cos(x) = 0")]
+        public void AnOddPowerIsLeftToTheOtherSolvers(string equation)
+        {
+            var solved = equation.ToEntity().Solve("x");
+            Assert.False(solved is Entity.Set.FiniteSet { IsSetEmpty: true },
+                $"{equation} lost its answer: {solved.Stringize()}");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #270.

`cos(a x)^2 + sin(a x) + c = 0` is a quadratic in `sin(a x)` with two arcsine answers. It was reaching the exponential solver, which writes both functions in terms of `e^(i a x)` — turning it into a **quartic**, answered with roughly four thousand nodes of nested radicals. That is exactly what the issue reports.

## Nothing new was needed to solve it

Writing `cos(u)^2` as `1 - sin(u)^2` makes it a polynomial in `sin(u)` alone, and the replacement machinery already reduces such a polynomial to one in a fresh variable and inverts the arcsine afterwards — which is why `sin(x)^2 + sin(x) = 0` has always answered well. The mixed form simply never became one.

```
cos(a x)^2 + sin(a x) + c = 0
  ->  { (arcsin((-1 - sqrt(1 + 4(1 + c))) / (-2)) + 2 pi n_1) / a,
        (pi - arcsin((-1 - sqrt(1 + 4(1 + c))) / (-2)) + 2 pi n_1) / a,  ... }
```

## Two things it had to get right, both found by measuring

Each made the rewrite fire and then buy nothing, which is worse than not firing — the tell was that the answer was unchanged while a trace showed the rewrite succeeding.

1. **The rewrite is folded before it is handed on.** The halved power is usually 1, and `(1 - sin(x)^2)^1` is not recognised as a polynomial in `sin(x)` by the machinery that has to solve it.
2. **What comes out is solved *without* compensation**, whatever the enclosing call was given. Compensating skips the replacement machinery entirely — and `.Solve` arrives here with it already set, so passing it on produced `1 - sin(x)^2 + sin(x)` and then answered it through the exponential solver anyway, the exact route this exists to avoid.

## Scope

Only whole even powers are rewritten, and only when the result is free of the other function. `sin(x) + cos(x) = 0` is not a polynomial in either, so it is declined and keeps the answer it had — pinned by a test. It cannot recurse: what comes back mentions one function only, so the rewrite declines it on the way in.

## Every root is substituted back

The tests do not compare printed forms. Each root has its periodic parameter set to 0 and is substituted into the equation, and the residual is required to be zero — a solver rewrite can lose a root or invent one as easily as it can shorten an answer, and the printed form says neither.

The helper also asserts that **at least one root was actually checked**, which caught it silently verifying nothing: the equation is an `Equalsf`, so substituting into it yields a boolean that `EvalNumerical` refuses, and the `catch` counted every root as unverifiable. Without that assertion the test would have passed while checking zero roots.

## Harnesses

- unit **5420 pass, 0 fail**; F# **130/130**
- `rootcheck` **596/596** clean — 0 incomplete, 0 unsound; this is the one that would catch a lost or invented root at scale
- `casbench` **113/117**, 0 wrong; `simpsweep` **10463/10463**; `propcheck` **0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
