### PR TITLE
Answer the condition when the equation has no unknown in it (#278)

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
@@ -92,6 +92,27 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
             if (expr == x)
                 return new Entity[] { 0 }.ToSet();
 
+            // An equation that does not mention x at all has either no solutions or every
+            // solution, and which of the two is decided by whether what is left is zero.
+            // Where that is not decidable the honest answer is the condition itself: `a = b`
+            // answered `{ }`, which asserts that no x satisfies it -- and every x does,
+            // whenever a happens to equal b.
+            // https://github.com/asc-community/AngouriMath/issues/278
+            if (!compensateSolving && !expr.ContainsNode(x))
+            {
+                if (expr.Evaled is Complex evaluated)
+                    return evaluated.IsZero ? (Set)MathS.Sets.C : Set.Empty;
+                // `a - a` is zero and does not look it until the simplifier has been asked,
+                // and answering the condition there would be as wrong as answering the empty
+                // set -- it would say "provided a = a" where the answer is every x. Only an
+                // equation with no x in it at all reaches this, so the simplification is paid
+                // for once and never inside a loop.
+                var residual = expr.Simplify();
+                if (residual.Evaled is Complex simplified)
+                    return simplified.IsZero ? (Set)MathS.Sets.C : Set.Empty;
+                return new ConditionalSet(x, residual.Equalizes(0));
+            }
+
             // Whether a candidate root really is one. The loose tolerance that guesses the
             // rational must not also be what decides this: at 1e-7, x^41 + 6x + 1 accepted
             // -1/6, whose residual is -1.25e-32 -- small, but the difference between an

--- a/Sources/Tests/UnitTests/Algebra/EquationWithoutTheUnknownTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/EquationWithoutTheUnknownTest.cs
@@ -1,0 +1,120 @@
+﻿//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Algebra
+{
+    /// <summary>
+    /// An equation that does not mention the unknown has either no solutions or every
+    /// solution, and which of the two is decided by whether what is left is zero. Where
+    /// that is not decidable, the answer was the empty set -- which asserts that no
+    /// <c>x</c> satisfies it, and every <c>x</c> does whenever the two sides happen to be
+    /// equal. https://github.com/asc-community/AngouriMath/issues/278
+    /// </summary>
+    public sealed class EquationWithoutTheUnknownTest
+    {
+        /// <summary>
+        /// The predicate the answer carries must be true exactly where the equation is.
+        /// Every free symbol is given each of a handful of values and the two are compared
+        /// as booleans; an assignment where either side does not decide is skipped, and the
+        /// count that did decide is asserted to be non-zero so that a vacuous pass is not
+        /// mistaken for agreement.
+        /// </summary>
+        private static void AssertAgreesWithTheEquation(Entity predicate, Entity equation)
+        {
+            var symbols = equation.Vars.Where(v => v != "x").ToList();
+            var compared = 0;
+            foreach (var value in new Entity[] { -2, 0, 1, 2, "1/2".ToEntity() })
+            {
+                Entity left = predicate, right = equation;
+                foreach (var symbol in symbols)
+                {
+                    left = left.Substitute(symbol, value);
+                    right = right.Substitute(symbol, value);
+                }
+                bool expected, actual;
+                try
+                {
+                    expected = right.EvalBoolean();
+                    actual = left.EvalBoolean();
+                }
+                catch { continue; }
+                compared++;
+                Assert.True(expected == actual,
+                    $"{equation.Stringize()} at {value.Stringize()}: the answer's condition "
+                    + $"{predicate.Stringize()} says {actual} where the equation says {expected}");
+            }
+            Assert.True(compared > 0,
+                $"{equation.Stringize()}: no assignment decided, so the condition was not checked");
+        }
+
+        /// <summary>Decidably unequal: no x satisfies it.</summary>
+        [Theory]
+        [InlineData("3 = 5")]
+        [InlineData("2 + 2 = 5")]
+        [InlineData("sqrt(4) = 3")]
+        public void AFalseStatementHasNoSolutions(string equation)
+            => Assert.Equal(Entity.Set.Empty, equation.ToEntity().Solve("x").InnerSimplified);
+
+        /// <summary>
+        /// Decidably equal: every x satisfies it. <c>a = a</c> and <c>a + b = b + a</c> are
+        /// the cases that evaluation alone does not settle -- neither side is a number --
+        /// so the residual is simplified before the question is called undecidable.
+        /// </summary>
+        [Theory]
+        [InlineData("3 = 3")]
+        [InlineData("2 + 2 = 4")]
+        [InlineData("a = a")]
+        [InlineData("a + b = b + a")]
+        public void ATrueStatementIsSatisfiedByEverything(string equation)
+            => Assert.Equal(MathS.Sets.C, equation.ToEntity().Solve("x").InnerSimplified);
+
+        /// <summary>
+        /// Not decidable either way, which is what #278 asks for: the answer is the
+        /// condition itself, as a set of every <c>x</c> subject to it.
+        /// </summary>
+        [Theory]
+        [InlineData("a = b")]
+        [InlineData("sin(a) = 0")]
+        [InlineData("a ^ 2 = 2")]
+        public void AnUndecidableStatementAnswersWithItsCondition(string equation)
+        {
+            var solved = equation.ToEntity().Solve("x").InnerSimplified;
+            var conditional = Assert.IsType<Entity.Set.ConditionalSet>(solved);
+            Assert.Equal((Entity)"x".ToEntity(), conditional.Var);
+            // The condition must agree with the equation, not merely be present: it is what
+            // the answer claims, and a wrong one here is a wrong answer that looks careful.
+            // Compared by truth value at concrete assignments rather than symbolically --
+            // asserting that Simplify can prove two booleans equal would be testing the
+            // simplifier's reach on `and`/`or`, not the solver's answer.
+            AssertAgreesWithTheEquation(conditional.Predicate, equation.ToEntity());
+        }
+
+        /// <summary>
+        /// The unknown is bound by the limit rather than free in it, so this reduces to
+        /// <c>y^2 - 2</c> and is the undecidable case above -- every <c>x</c> is a solution
+        /// when <c>y</c> is a square root of 2, and none otherwise.
+        /// </summary>
+        /// <remarks>
+        /// This case used to sit in <c>SolveOneEquation.TestInvertNodes</c> expecting zero
+        /// roots. It was moved here rather than updated in place because that test verifies
+        /// a *count* of roots through a helper that requires a <c>FiniteSet</c>, and the
+        /// right answer here is not a finite set.
+        /// </remarks>
+        [Fact]
+        public void ALimitBindsTheUnknownAndLeavesTheEquationWithout()
+        {
+            var solved = "limit(x, x, y)2 - 2".ToEntity().SolveEquation("x").InnerSimplified;
+            var conditional = Assert.IsType<Entity.Set.ConditionalSet>(solved);
+            AssertAgreesWithTheEquation(conditional.Predicate, "y ^ 2 = 2".ToEntity());
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/SolveOneEquation.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/SolveOneEquation.cs
@@ -260,7 +260,12 @@ namespace AngouriMath.Tests.Algebra
         [InlineData("(3 - x)^2 - 4", 2)]
         [InlineData("arccos(x)2 - 1", 1)]
         [InlineData("x! - 1", 0)]
-        [InlineData("limit(x, x, y)2 - 2", 0)]
+        // `limit(x, x, y)2 - 2` moved to EquationWithoutTheUnknownTest: the limit binds
+        // x, so the equation reduces to y^2 - 2 and mentions no unknown at all. It now
+        // answers `{ x : y^2 - 2 = 0 }` rather than `{ }` -- every x is a solution when y
+        // is a square root of 2 -- and this helper verifies a count of roots through a
+        // FiniteSet, which that answer is not.
+        // https://github.com/asc-community/AngouriMath/issues/278
         [InlineData("sec(x) - a", 2)]
         [InlineData("csc(x) - a", 2)]
         [InlineData("arcsec(x) - a", 1, 3)]

--- a/Sources/Tests/UnitTests/Common/IntervalSimplificationTest.cs
+++ b/Sources/Tests/UnitTests/Common/IntervalSimplificationTest.cs
@@ -1,0 +1,75 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Common
+{
+    /// <summary>
+    /// Intersections and unions of intervals were left as written.
+    /// https://github.com/asc-community/AngouriMath/issues/415
+    /// </summary>
+    /// <remarks>
+    /// The behaviour was fixed by PR #677, but the example the issue actually reports -- a
+    /// screenshot, which is why it was easy to skip -- was never among the cases tested. An
+    /// intersection of my own choosing was tested instead, and the maintainer said so on the
+    /// issue. This pins the reporter's expression, character for character.
+    /// </remarks>
+    public sealed class IntervalSimplificationTest
+    {
+        /// <summary>
+        /// The expression from the screenshot on #415, in the syntax it was written in.
+        /// <code>
+        ///     (-1; 1) /\ (((-(sqrt(33) + 3)) / 6; (sqrt(33) - 3) / 6) \/ (1; +oo))
+        /// </code>
+        /// The left endpoint of the inner interval is about -1.457 and the right about
+        /// 0.457, so intersecting with (-1; 1) keeps (-1; (sqrt(33) - 3) / 6), and the
+        /// (1; +oo) branch contributes nothing.
+        /// </summary>
+        [Fact]
+        public void TheReportersOwnExample()
+        {
+            var simplified = @"(-1; 1) /\ (((-(sqrt(33) + 3)) / 6; (sqrt(33) - 3) / 6) \/ (1; +oo))"
+                .ToEntity().Simplify();
+            Assert.Equal(@"(-1; (sqrt(33) - 3) / 6)".ToEntity(), simplified);
+        }
+
+        /// <summary>
+        /// The endpoints are surds, and the comparison that decides the intersection has to
+        /// evaluate them rather than compare them as written -- which is what PR #677 fixed.
+        /// Checked by membership rather than by shape, so that a differently spelled but
+        /// equal answer still passes and a wrong one still fails.
+        /// </summary>
+        [Theory]
+        [InlineData("-0.9", true)]
+        [InlineData("0", true)]
+        [InlineData("0.45", true)]
+        [InlineData("0.46", false)]   // just past (sqrt(33) - 3) / 6 = 0.4574...
+        [InlineData("-1", false)]     // open at the left end
+        [InlineData("0.99", false)]
+        [InlineData("2", false)]      // the (1; +oo) branch is cut away by (-1; 1)
+        public void TheAnswerHoldsTheRightPoints(string point, bool expected)
+        {
+            var simplified = (Entity.Set)@"(-1; 1) /\ (((-(sqrt(33) + 3)) / 6; (sqrt(33) - 3) / 6) \/ (1; +oo))"
+                .ToEntity().Simplify();
+            Assert.Equal(expected, simplified.Contains(point.ToEntity()));
+        }
+
+        /// <summary>
+        /// Intersection distributing over a union, which is the other half of what PR #677
+        /// had to add for the example above to reduce at all.
+        /// </summary>
+        [Theory]
+        [InlineData(@"[3; 7] \/ [5; 10]", "[3; 10]")]
+        [InlineData(@"[1; 5] /\ [3; 8]", "[3; 5]")]
+        [InlineData(@"[0; 10] /\ ([1; 2] \/ [3; 4])", @"[1; 2] \/ [3; 4]")]
+        public void IntervalsCombine(string expr, string expected)
+            => Assert.Equal(expected.ToEntity().Simplify(), expr.ToEntity().Simplify());
+    }
+}


### PR DESCRIPTION
Closes #278.

`a = b` solved for `x` answered `{ }` — which asserts that **no** `x` satisfies it, and every `x` does whenever `a` happens to equal `b`. #278's second bullet asks for `{ x : a = b }`, and that is now what comes back.

## The three cases

An equation that does not mention the unknown has either no solutions or every solution, decided by whether what is left is zero. #278's first bullet was already right and stays so; what was missing is the case where the question is not decidable at all.

| equation | before | after |
|---|---|---|
| `3 = 5` | `{ }` | unchanged |
| `3 = 3` | `CC` | unchanged |
| `a = a` | `{ }` | **`CC`** |
| `a + b = b + a` | `{ }` | **`CC`** |
| `a = b` | `{ }` | **`{ x : a - b = 0 }`** |
| `sin(a) = 0` | `{ }` | **`{ x : sin(a) = 0 }`** |

## Evaluation alone does not settle it

`a - a` is zero and does not look it until the simplifier has been asked. Answering the condition there would be as wrong as answering the empty set — it would say "provided `a = a`" where the answer is every `x`. So the residual is simplified before the question is called undecidable.

Only an equation with **no unknown in it at all** reaches this branch, so that simplification is paid for once and never inside a loop.

## One case moved rather than changed

`limit(x, x, y)2 - 2` sat in `SolveOneEquation.TestInvertNodes` expecting zero roots. The limit *binds* `x`, so the equation reduces to `y^2 - 2` and mentions no unknown — it now answers `{ x : y^2 - 2 = 0 }`, which is right: every `x` is a solution when `y` is a square root of 2, and none otherwise.

It moved rather than being updated in place because that helper verifies a **count** of roots through an assertion that the answer is a `FiniteSet`, and the correct answer here is not one. The old `InlineData` is replaced by a comment saying where it went and why.

## The condition is checked, not just its presence

Each answer's predicate is compared against the equation **by truth value at concrete assignments**, not by shape — it is what the answer claims, and a wrong condition is a wrong answer that looks careful. Asserting that `Simplify` can prove two booleans equal would have tested the simplifier instead. The helper also counts the assignments that actually decided, so a vacuous pass cannot read as agreement.

## Harnesses

- unit **5429 pass, 0 fail**; F# **130/130**
- `rootcheck` **596/596** clean; `casbench` **113/117**, 0 wrong; `simpsweep` **10463/10463**; `propcheck` **0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
