### PR TITLE
Give every unit test an Area trait (#784)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,22 @@ dotnet test UnitTests
 dotnet test FSharpWrapperUnitTests
 ```
 
+Every test in `UnitTests` carries an `Area` trait naming the directory it lives in, so while
+you are working on one part of the library you can run just that part:
+
+```
+dotnet test UnitTests --filter "Area=Calculus"
+```
+
+The areas are `Algebra`, `Calculus`, `Common`, `Convenience`, `Core`, `Discrete` and
+`PatternsTest`, and every test has exactly one -- the seven of them add up to the whole
+suite, so nothing is missed by running them all separately.
+
+**Run the whole suite before opening a pull request.** The traits are for the loop you run
+while writing the change, not for what you check before proposing it: this library is full
+of rules that interact, and a change to simplification has broken solving and integration
+here more than once.
+
 Use `Sources/Samples/Samples/Playground.csproj` as a sandbox project, where you can manually test anything you want.
 
 ### Tips for working with git

--- a/Sources/Tests/UnitTests/Algebra/FunctionTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/FunctionTest.cs
@@ -12,6 +12,7 @@ using System.Globalization;
 
 namespace AngouriMath.Tests.Algebra
 {
+    [Trait("Area", "Algebra")]
     public sealed class FunctionTest
     {
         // Testing function GetAllRoots

--- a/Sources/Tests/UnitTests/Algebra/MatrixRangeTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/MatrixRangeTest.cs
@@ -16,6 +16,7 @@ namespace AngouriMath.Tests.Algebra
     /// Taking part of a matrix by range, as asked for in
     /// https://github.com/asc-community/AngouriMath/issues/443.
     /// </summary>
+    [Trait("Area", "Algebra")]
     public sealed class MatrixRangeTest
     {
         private static readonly Entity.Matrix ThreeByThree = MathS.Matrices.Matrix(3, 3,

--- a/Sources/Tests/UnitTests/Algebra/MatrixTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/MatrixTest.cs
@@ -13,6 +13,7 @@ using AngouriMath.Extensions;
 
 namespace AngouriMath.Tests.Algebra
 {
+    [Trait("Area", "Algebra")]
     public sealed class MatrixTest
     {
         public static readonly Entity.Matrix A = MathS.Matrices.Matrix(4, 2,

--- a/Sources/Tests/UnitTests/Algebra/NumberTheoryTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/NumberTheoryTest.cs
@@ -13,6 +13,7 @@ using AngouriMath.Extensions;
 
 namespace AngouriMath.Tests.Algebra
 {
+    [Trait("Area", "Algebra")]
     public sealed class NumberTheoryTest
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Algebra/QuantumStateTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/QuantumStateTest.cs
@@ -19,6 +19,7 @@ namespace AngouriMath.Tests.Algebra
     /// Everything is compared symbolically. No amplitude is evaluated to a double anywhere in
     /// this file, which is what makes <c>1/sqrt(2)</c> an exact answer rather than 0.7071.
     /// </summary>
+    [Trait("Area", "Algebra")]
     public sealed class QuantumStateTest
     {
         private static Entity Ket(params int[] qubits) => MathS.Quantum.Ket(qubits);

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/DuplicateRootTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/DuplicateRootTest.cs
@@ -18,6 +18,7 @@ namespace AngouriMath.Tests.Algebra.SolveTest
     /// not with one entry per starting point the search happened to use. No issue is filed
     /// for this; it was found while checking the answers of another fix.
     /// </summary>
+    [Trait("Area", "Algebra")]
     public sealed class DuplicateRootTest
     {
         /// <summary>

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/FactoredPolynomialSolveTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/FactoredPolynomialSolveTest.cs
@@ -18,6 +18,7 @@ namespace AngouriMath.Tests.Algebra
     /// general formula for its degree -- or, above degree four, to the numeric solver.
     /// https://github.com/asc-community/AngouriMath/issues/272
     /// </summary>
+    [Trait("Area", "Algebra")]
     public sealed class FactoredPolynomialSolveTest
     {
         private static Entity.Set.FiniteSet Roots(string equation) =>

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/IdentityEquationTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/IdentityEquationTest.cs
@@ -18,6 +18,7 @@ namespace AngouriMath.Tests.Algebra
     /// <see cref="Core.EquationSystem.Solve"/> --
     /// https://github.com/asc-community/AngouriMath/issues/550.
     /// </summary>
+    [Trait("Area", "Algebra")]
     public sealed class IdentityEquationTest
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/LinearSystemTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/LinearSystemTest.cs
@@ -16,6 +16,7 @@ namespace AngouriMath.Tests.Algebra
     /// occurrences of the next that cancel, and the solver used to commit to the first
     /// equation those occurrences appeared in.
     /// </summary>
+    [Trait("Area", "Algebra")]
     public sealed class LinearSystemTest
     {
         /// <summary>

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/NewtonGridTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/NewtonGridTest.cs
@@ -21,6 +21,7 @@ namespace AngouriMath.Tests.Algebra.PolynomialSolverTests
     /// starting point and a grid of NaN, so the search covered a single corner of the region
     /// it was asked for and quietly returned fewer roots the finer it was told to look.
     /// </summary>
+    [Trait("Area", "Algebra")]
     public sealed class NewtonGridTest
     {
         private static HashSet<Entity.Number.Complex> Roots(string expression, int steps)

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/RepeatedVariableSolveTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/RepeatedVariableSolveTest.cs
@@ -21,6 +21,7 @@ namespace AngouriMath.Tests.Algebra
     /// left where it stood.
     /// https://github.com/asc-community/AngouriMath/issues/744
     /// </summary>
+    [Trait("Area", "Algebra")]
     public sealed class RepeatedVariableSolveTest
     {
         private static Entity.Set.FiniteSet Roots(string equation) =>

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/RootDowncastTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/RootDowncastTest.cs
@@ -15,6 +15,7 @@ namespace AngouriMath.Tests.Algebra
     /// A numeric root that lands near a simple ratio is rewritten as that ratio. These
     /// pin when that is allowed to happen, since a ratio is read as an exact answer.
     /// </summary>
+    [Trait("Area", "Algebra")]
     public sealed class RootDowncastTest
     {
         private static Entity SingleRoot(string equation) =>

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/SolveEquationWithConstraints.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/SolveEquationWithConstraints.cs
@@ -15,6 +15,7 @@ using static AngouriMath.Entity.Set;
 
 namespace AngouriMath.Tests.Algebra
 {
+    [Trait("Area", "Algebra")]
     public sealed class SolveEquationWithConstraints
     {
         /// <summary>Numerically checks if a root fits an equation</summary>

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/SolveEquationWithPiecewise.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/SolveEquationWithPiecewise.cs
@@ -12,6 +12,7 @@ using static AngouriMath.Entity.Set;
 
 namespace AngouriMath.Tests.Algebra
 {
+    [Trait("Area", "Algebra")]
     public sealed class SolveEquationWithPiecewise
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/SolveInequality.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/SolveInequality.cs
@@ -13,6 +13,7 @@ using static AngouriMath.Entity.Set;
 
 namespace AngouriMath.Tests.Algebra
 {
+    [Trait("Area", "Algebra")]
     public sealed class SolveInequality
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/SolveOneEquation.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/SolveOneEquation.cs
@@ -14,6 +14,7 @@ using static AngouriMath.Entity.Set;
 
 namespace AngouriMath.Tests.Algebra
 {
+    [Trait("Area", "Algebra")]
     public sealed class SolveOneEquation
     {
         public static Variable x = nameof(x);

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/SolveStatement.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/SolveStatement.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.Algebra.SolveTest
 {
+    [Trait("Area", "Algebra")]
     public sealed class SolveStatement
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/SolveSystem.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/SolveSystem.cs
@@ -12,6 +12,7 @@ using static AngouriMath.Entity.Number;
 
 namespace AngouriMath.Tests.Algebra
 {
+    [Trait("Area", "Algebra")]
     public sealed class SolveSystem
     {
         internal static void AssertSystemSolvable(Entity[] equations, Entity.Variable[] vars, int rootCount, Integer? ToSub = null)

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/SolverNumericalTests.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/SolverNumericalTests.cs
@@ -13,6 +13,7 @@ namespace AngouriMath.Tests.Algebra.PolynomialSolverTests
     using static AngouriMath.Entity;
     using static AngouriMath.Entity.Set;
     using static Entity.Number;
+    [Trait("Area", "Algebra")]
     public sealed class NumericalEquationsSolve
     {
         private readonly Entity.Variable x = nameof(x);

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/SpuriousRootTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/SpuriousRootTest.cs
@@ -19,6 +19,7 @@ namespace AngouriMath.Tests.Algebra.SolveTest
     /// filed for this; it was found while checking whether
     /// https://github.com/asc-community/AngouriMath/issues/214 could be closed.
     /// </summary>
+    [Trait("Area", "Algebra")]
     public sealed class SpuriousRootTest
     {
         /// <summary>

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/UnderdeterminedSystemTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/UnderdeterminedSystemTest.cs
@@ -17,6 +17,7 @@ namespace AngouriMath.Tests.Algebra
     /// not pin every unknown down still has solutions; there are just infinitely many of them.
     /// The solver used to answer either null or a single tuple that is not the whole answer.
     /// </summary>
+    [Trait("Area", "Algebra")]
     public sealed class UnderdeterminedSystemTest
     {
         private const string h =

--- a/Sources/Tests/UnitTests/Calculus/BoundedTimesVanishingTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/BoundedTimesVanishingTest.cs
@@ -21,6 +21,7 @@ namespace AngouriMath.Tests.Calculus
     /// and left the product indeterminate in the shape (no limit) * 0.
     /// https://github.com/asc-community/AngouriMath/issues/723
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class BoundedTimesVanishingTest
     {
         private static void AssertLimit(string expression, string destination, string expected)

--- a/Sources/Tests/UnitTests/Calculus/DerivativeGapsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/DerivativeGapsTest.cs
@@ -16,6 +16,7 @@ namespace AngouriMath.Tests.Calculus
     /// condition on it that does not belong. Both were found by differentiating
     /// antiderivatives back and checking them at points.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class DerivativeGapsTest
     {
         [Fact]

--- a/Sources/Tests/UnitTests/Calculus/DerivativeTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/DerivativeTest.cs
@@ -13,6 +13,7 @@ using static AngouriMath.Entity;
 
 namespace AngouriMath.Tests.Calculus
 {
+    [Trait("Area", "Calculus")]
     public sealed class DerivativeTest
     {
         private static readonly Variable x = "x";

--- a/Sources/Tests/UnitTests/Calculus/DeterminateCombinationLimitTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/DeterminateCombinationLimitTest.cs
@@ -20,6 +20,7 @@ namespace AngouriMath.Tests.Calculus
     /// how it was written: cos(x) / sin(x) at 0+ was +oo and cos(x) * (1 / sin(x)) was
     /// unevaluated.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class DeterminateCombinationLimitTest
     {
         private static void AssertLimit(string expression, string destination, ApproachFrom side, string expected) =>

--- a/Sources/Tests/UnitTests/Calculus/DifferenceAtInfinityTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/DifferenceAtInfinityTest.cs
@@ -18,6 +18,7 @@ namespace AngouriMath.Tests.Calculus
     /// either a polynomial or a substitution of +oo, and a root of a sum is neither, so a
     /// difference of two of them was left unevaluated however plainly it converged.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class DifferenceAtInfinityTest
     {
         // Compared as numbers, since "1/2" parses as a division of two integers rather than as

--- a/Sources/Tests/UnitTests/Calculus/DifferenceOfFractionsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/DifferenceOfFractionsTest.cs
@@ -19,6 +19,7 @@ namespace AngouriMath.Tests.Calculus
     /// expression is (sin(x) - x) / (x * sin(x)), which is an ordinary 0/0 that l'Hopital's
     /// rule settles.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class DifferenceOfFractionsTest
     {
         // Compared as numbers, since "1/2" parses as a division of two integers rather than as

--- a/Sources/Tests/UnitTests/Calculus/EquivalentInfinitesimalTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/EquivalentInfinitesimalTest.cs
@@ -20,6 +20,7 @@ namespace AngouriMath.Tests.Calculus
     /// Only the quotient had the substitution, and it was made on the function vanishing rather
     /// than on its argument vanishing, which are two different conditions.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class EquivalentInfinitesimalTest
     {
         private static Entity Limit(string expression, string destination, ApproachFrom side)

--- a/Sources/Tests/UnitTests/Calculus/FirstRemarkableOverFactorsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/FirstRemarkableOverFactorsTest.cs
@@ -27,6 +27,7 @@ namespace AngouriMath.Tests.Calculus
     /// and not for a term of a sum, where the difference between the two forms is the entire
     /// answer. <see cref="ASumIsNotRewritten"/> is what holds that line.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class FirstRemarkableOverFactorsTest
     {
         private static Entity LimitOf(string expression, string destination) =>

--- a/Sources/Tests/UnitTests/Calculus/GruntzMovingExponentTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/GruntzMovingExponentTest.cs
@@ -25,6 +25,7 @@ namespace AngouriMath.Tests.Calculus
     /// No issue exists for this; it was found while measuring what a factorial's Stirling
     /// expansion would need, where x^x is the term the factorial is compared against.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class GruntzMovingExponentTest
     {
         private static void AssertLimit(string expression, string expected) =>

--- a/Sources/Tests/UnitTests/Calculus/GruntzTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/GruntzTest.cs
@@ -19,6 +19,7 @@ namespace AngouriMath.Tests.Calculus
     /// it are the expressions whose parts cancel to every order, which no amount of
     /// differentiating both halves reaches.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class GruntzTest
     {
         private static void AssertLimit(string expression, string destination, string expected) =>

--- a/Sources/Tests/UnitTests/Calculus/IndeterminatePowerSubstitutionTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/IndeterminatePowerSubstitutionTest.cs
@@ -30,6 +30,7 @@ namespace AngouriMath.Tests.Calculus
     ///
     /// https://github.com/asc-community/AngouriMath/issues/754
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class IndeterminatePowerSubstitutionTest
     {
         private static Entity LimitOf(string expression, string destination) =>

--- a/Sources/Tests/UnitTests/Calculus/IndeterminatePowerTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/IndeterminatePowerTest.cs
@@ -19,6 +19,7 @@ namespace AngouriMath.Tests.Calculus
     /// something vanishing with something diverging had no reading either unless one of the
     /// factors happened to be written as a reciprocal.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class IndeterminatePowerTest
     {
         private static Entity Limit(string expression, string destination, ApproachFrom side) =>

--- a/Sources/Tests/UnitTests/Calculus/IntegrationTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/IntegrationTest.cs
@@ -11,6 +11,7 @@ using AngouriMath.Extensions;
 
 namespace AngouriMath.Tests.Calculus
 {
+    [Trait("Area", "Calculus")]
     public sealed class IntegrationTest
     {
         // TODO: add more tests

--- a/Sources/Tests/UnitTests/Calculus/InverseTrigonometryLimitTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/InverseTrigonometryLimitTest.cs
@@ -18,6 +18,7 @@ namespace AngouriMath.Tests.Calculus
     /// below the real axis, so along the reals it goes off to infinity in the imaginary direction
     /// with its real part settling at a right angle.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class InverseTrigonometryLimitTest
     {
         private static Entity Limit(string expression, string destination) =>

--- a/Sources/Tests/UnitTests/Calculus/LimitAtInfinityTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/LimitAtInfinityTest.cs
@@ -17,6 +17,7 @@ namespace AngouriMath.Tests.Calculus
     /// l'Hopital's rule was only applied when the destination was finite, so the ordinary
     /// competing-growth limits at infinity came back unevaluated.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class LimitAtInfinityTest
     {
         private static Entity Limit(string expression, string destination) =>

--- a/Sources/Tests/UnitTests/Calculus/LimitTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/LimitTest.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.Calculus
 {
+    [Trait("Area", "Calculus")]
     public sealed class Limits
     {
         void TestLimit(Entity expr, Entity where, ApproachFrom appr, Entity desiredOutput)

--- a/Sources/Tests/UnitTests/Calculus/OneSidedLimitTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/OneSidedLimitTest.cs
@@ -19,6 +19,7 @@ namespace AngouriMath.Tests.Calculus
     /// part's own limit in place of the part. x * ln(x) at 0+ becomes 0 * ln(x), so 0 * -oo,
     /// so NaN, and NaN is the claim that the limit does not exist.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class OneSidedLimitTest
     {
         private static Entity Limit(string expression, string destination, ApproachFrom side) =>

--- a/Sources/Tests/UnitTests/Calculus/PartialFractionsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/PartialFractionsTest.cs
@@ -19,6 +19,7 @@ namespace AngouriMath.Tests.Calculus
     /// Each answer is checked by differentiating it back and comparing at points, since
     /// what matters is that it is an antiderivative and not what form it is written in.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class PartialFractionsTest
     {
         private static void AssertIsAntiderivative(string integrand, params double[] points)

--- a/Sources/Tests/UnitTests/Calculus/PiecewiseLimitTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/PiecewiseLimitTest.cs
@@ -19,6 +19,7 @@ namespace AngouriMath.Tests.Calculus
     /// expression came back unevaluated wherever it was taken, including at points nowhere
     /// near a seam.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class PiecewiseLimitTest
     {
         private const string Sign = "piecewise(-1 provided x < 0, 1 provided x > 0, 0)";

--- a/Sources/Tests/UnitTests/Calculus/RationalIntegralsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/RationalIntegralsTest.cs
@@ -17,6 +17,7 @@ namespace AngouriMath.Tests.Calculus
     /// differentiating it back and comparing at points, since what matters is that it is an
     /// antiderivative and not what form it is written in.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class RationalIntegralsTest
     {
         private static void AssertIsAntiderivative(string integrand, params double[] points)

--- a/Sources/Tests/UnitTests/Calculus/RealCodomainLimitTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/RealCodomainLimitTest.cs
@@ -23,6 +23,7 @@ namespace AngouriMath.Tests.Calculus
     /// <see cref="MathS.Settings.Codomain"/> is that information.
     /// https://github.com/asc-community/AngouriMath/issues/719
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class RealCodomainLimitTest
     {
         private static Entity Limit(string expr, string destination, ApproachFrom side) =>

--- a/Sources/Tests/UnitTests/Calculus/RemarkableLimitAfterSimplificationTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/RemarkableLimitAfterSimplificationTest.cs
@@ -31,6 +31,7 @@ namespace AngouriMath.Tests.Calculus
     /// rather than in the limits -- the same quotient written <c>((x^2 + 1) / x^2)^x</c> is
     /// answered 1 without any of this.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class RemarkableLimitAfterSimplificationTest
     {
         private static Entity LimitOf(string expression, string destination = "+oo") =>

--- a/Sources/Tests/UnitTests/Calculus/RootOverSquareIntegralsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/RootOverSquareIntegralsTest.cs
@@ -18,6 +18,7 @@ namespace AngouriMath.Tests.Calculus
     /// Each answer is checked by differentiating it back and comparing at points, since
     /// what matters is that it is an antiderivative and not what form it is written in.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class RootOverSquareIntegralsTest
     {
         private static void AssertIsAntiderivative(string integrand, params double[] points)

--- a/Sources/Tests/UnitTests/Calculus/SeriesTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/SeriesTest.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.Calculus
 {
+    [Trait("Area", "Calculus")]
     public sealed class SeriesTest
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Calculus/SignumLimitTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/SignumLimitTest.cs
@@ -22,6 +22,7 @@ namespace AngouriMath.Tests.Calculus
     /// overflowing the stack, which kills the process rather than raising anything a caller
     /// could catch -- https://github.com/asc-community/AngouriMath/issues/704.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class SignumLimitTest
     {
         private static Entity Limit(string expression, string destination) =>

--- a/Sources/Tests/UnitTests/Calculus/StandardIntegralsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/StandardIntegralsTest.cs
@@ -16,6 +16,7 @@ namespace AngouriMath.Tests.Calculus
     /// checked by differentiating the answer back and comparing at points, since what
     /// matters is that it is an antiderivative, not what form it is written in.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class StandardIntegralsTest
     {
         /// <param name="points">

--- a/Sources/Tests/UnitTests/Calculus/StirlingFactorialItselfTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/StirlingFactorialItselfTest.cs
@@ -31,6 +31,7 @@ namespace AngouriMath.Tests.Calculus
     ///
     /// https://github.com/asc-community/AngouriMath/issues/754
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class StirlingFactorialItselfTest
     {
         private static Entity LimitOf(string expression) =>

--- a/Sources/Tests/UnitTests/Calculus/StirlingFactorialLimitTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/StirlingFactorialLimitTest.cs
@@ -28,6 +28,7 @@ namespace AngouriMath.Tests.Calculus
     ///
     /// https://github.com/asc-community/AngouriMath/issues/754
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class StirlingFactorialLimitTest
     {
         private static Entity LimitOf(string expression) =>

--- a/Sources/Tests/UnitTests/Calculus/StirlingLogarithmLimitTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/StirlingLogarithmLimitTest.cs
@@ -21,6 +21,7 @@ namespace AngouriMath.Tests.Calculus
     /// that is reached only once nothing else has a reading.
     /// https://github.com/asc-community/AngouriMath/issues/765
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class StirlingLogarithmLimitTest
     {
         private static Entity LimitOf(string expression) =>

--- a/Sources/Tests/UnitTests/Calculus/SymbolicCoefficientIntegralsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/SymbolicCoefficientIntegralsTest.cs
@@ -23,6 +23,7 @@ namespace AngouriMath.Tests.Calculus
     /// No issue is filed for this; it was found by work/intbench against Rubi's suite, where
     /// it accounted for six of the seven wrong answers.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class SymbolicCoefficientIntegralsTest
     {
         /// <summary>

--- a/Sources/Tests/UnitTests/Calculus/VanishingDenominatorTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/VanishingDenominatorTest.cs
@@ -20,6 +20,7 @@ namespace AngouriMath.Tests.Calculus
     /// the other quotients of polynomials escaped it, because those the solvers read outright
     /// once x has been moved out to infinity.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class VanishingDenominatorTest
     {
         private static void AssertLimit(string expression, string destination, ApproachFrom side, string expected) =>

--- a/Sources/Tests/UnitTests/Calculus/VanishingTimesDivergingTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/VanishingTimesDivergingTest.cs
@@ -22,6 +22,7 @@ namespace AngouriMath.Tests.Calculus
     /// straight back and the rule was handed its own input. Split into the denominator instead,
     /// x * ln(x) / cos(x) is answered rather than run at until it times out.
     /// </summary>
+    [Trait("Area", "Calculus")]
     public sealed class VanishingTimesDivergingTest
     {
         private static void AssertLimit(string expression, string expected)

--- a/Sources/Tests/UnitTests/Common/AlreadyFixedIssuesTest.cs
+++ b/Sources/Tests/UnitTests/Common/AlreadyFixedIssuesTest.cs
@@ -18,6 +18,7 @@ namespace AngouriMath.Tests.Common
     /// without leaving the fix that closed it unprotected. Every case is the reporter's
     /// own, taken from the issue.
     /// </summary>
+    [Trait("Area", "Common")]
     public sealed class AlreadyFixedIssuesTest
     {
         private static readonly System.TimeSpan Budget = System.TimeSpan.FromSeconds(30);

--- a/Sources/Tests/UnitTests/Common/ArctanIdentitiesTest.cs
+++ b/Sources/Tests/UnitTests/Common/ArctanIdentitiesTest.cs
@@ -17,6 +17,7 @@ namespace AngouriMath.Tests.Common
     /// the two could not be added, and arctan(1) stayed as it was. No issue is filed for
     /// this; it comes from the gaps a solver corpus showed.
     /// </summary>
+    [Trait("Area", "Common")]
     public sealed class ArctanIdentitiesTest
     {
         private static Entity Simplified(string expression) => expression.ToEntity().Simplify();

--- a/Sources/Tests/UnitTests/Common/BuiltinFunctionsAppliedTest.cs
+++ b/Sources/Tests/UnitTests/Common/BuiltinFunctionsAppliedTest.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.Common
 {
+    [Trait("Area", "Common")]
     public class BuiltinFunctionsAppliedTest
     {
         public static readonly Entity.Variable x = MathS.Var(nameof(x));

--- a/Sources/Tests/UnitTests/Common/CircleTest.cs
+++ b/Sources/Tests/UnitTests/Common/CircleTest.cs
@@ -12,6 +12,7 @@ using AngouriMath.Extensions;
 
 namespace AngouriMath.Tests.Common
 {
+    [Trait("Area", "Common")]
     public sealed class CircleTest
     {
         public static readonly Entity.Variable x = MathS.Var(nameof(x));

--- a/Sources/Tests/UnitTests/Common/CompilationFETest.cs
+++ b/Sources/Tests/UnitTests/Common/CompilationFETest.cs
@@ -12,6 +12,7 @@ using AngouriMath.Extensions;
 
 namespace AngouriMath.Tests.Common
 {
+    [Trait("Area", "Common")]
     public sealed class CompilationFETest
     {
         private static readonly Entity.Variable x = MathS.Var(nameof(x));

--- a/Sources/Tests/UnitTests/Common/CompilationIntoLinqTest.cs
+++ b/Sources/Tests/UnitTests/Common/CompilationIntoLinqTest.cs
@@ -15,6 +15,7 @@ using HonkSharp.Fluency;
 
 namespace AngouriMath.Tests.Common
 {
+    [Trait("Area", "Common")]
     public sealed class CompilationIntoLinqTest
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Common/CompileUnboundVariableTest.cs
+++ b/Sources/Tests/UnitTests/Common/CompileUnboundVariableTest.cs
@@ -18,6 +18,7 @@ namespace AngouriMath.Tests.Common
     /// filed for this; it was found sweeping the compilers for expressions that fail in a
     /// way that says nothing.
     /// </summary>
+    [Trait("Area", "Common")]
     public sealed class CompileUnboundVariableTest
     {
         /// <summary>

--- a/Sources/Tests/UnitTests/Common/CompiledArcsinBranchTest.cs
+++ b/Sources/Tests/UnitTests/Common/CompiledArcsinBranchTest.cs
@@ -21,6 +21,7 @@ namespace AngouriMath.Tests.Common
     /// the only test of it looked -- and wrong everywhere else, so compiled arcsine was the
     /// conjugate of the arcsine over the whole rest of the plane.
     /// </summary>
+    [Trait("Area", "Common")]
     public sealed class CompiledArcsinBranchTest
     {
         private static readonly Entity.Variable x = MathS.Var(nameof(x));

--- a/Sources/Tests/UnitTests/Common/ExpandCollapseTest.cs
+++ b/Sources/Tests/UnitTests/Common/ExpandCollapseTest.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.Common
 {
+    [Trait("Area", "Common")]
     public sealed class ExpandFactorizeTest
     {
         public static readonly Entity.Variable x = MathS.Var(nameof(x));

--- a/Sources/Tests/UnitTests/Common/ExpandCollectsTermsTest.cs
+++ b/Sources/Tests/UnitTests/Common/ExpandCollectsTermsTest.cs
@@ -14,6 +14,7 @@ namespace AngouriMath.Tests.Common
     /// <summary>
     /// Expand adds up the terms it produces that differ only by a numeric factor.
     /// </summary>
+    [Trait("Area", "Common")]
     public sealed class ExpandCollectsTermsTest
     {
         // https://github.com/asc-community/AngouriMath/issues/164

--- a/Sources/Tests/UnitTests/Common/FreeVariablesTest.cs
+++ b/Sources/Tests/UnitTests/Common/FreeVariablesTest.cs
@@ -14,6 +14,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.Common
 {
+    [Trait("Area", "Common")]
     public class FreeVariablesTest
     {
         private IEnumerable<Entity.Variable> SeqVar(params string[] vars)

--- a/Sources/Tests/UnitTests/Common/HierarchyTest.cs
+++ b/Sources/Tests/UnitTests/Common/HierarchyTest.cs
@@ -20,6 +20,7 @@ namespace AngouriMath.Tests.Common
         }
     }
 
+    [Trait("Area", "Common")]
     public sealed class HierarchyTest
     {
         [Theory, CombinatorialData]

--- a/Sources/Tests/UnitTests/Common/ImplicitOperators.cs
+++ b/Sources/Tests/UnitTests/Common/ImplicitOperators.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.Common
 {
+    [Trait("Area", "Common")]
     public sealed class ImplicitOperators
     {
         internal void Test(Entity expr, Entity expected) => Assert.Equal(expected, expr);

--- a/Sources/Tests/UnitTests/Common/InnerSimplifyTest.cs
+++ b/Sources/Tests/UnitTests/Common/InnerSimplifyTest.cs
@@ -13,6 +13,7 @@ using static AngouriMath.Entity.Number;
 
 namespace AngouriMath.Tests.Common
 {
+    [Trait("Area", "Common")]
     public class InnerSimplifyTest
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Common/LambdaCalculusTest.cs
+++ b/Sources/Tests/UnitTests/Common/LambdaCalculusTest.cs
@@ -16,6 +16,7 @@ using static AngouriMath.Entity;
 
 namespace AngouriMath.Tests.Common
 {
+    [Trait("Area", "Common")]
     public class LambdaCalculusTest
     {
         private readonly Variable x = "x";

--- a/Sources/Tests/UnitTests/Common/LongDivisionPowerKeysTest.cs
+++ b/Sources/Tests/UnitTests/Common/LongDivisionPowerKeysTest.cs
@@ -23,6 +23,7 @@ namespace AngouriMath.Tests.Common
     /// <c>2 * a / sqrt(a)</c> simplified to <c>-2 * sqrt(a)</c>.
     /// https://github.com/asc-community/AngouriMath/issues/751
     /// </summary>
+    [Trait("Area", "Common")]
     public sealed class LongDivisionPowerKeysTest
     {
         /// <summary>

--- a/Sources/Tests/UnitTests/Common/MatrixCompilationTest.cs
+++ b/Sources/Tests/UnitTests/Common/MatrixCompilationTest.cs
@@ -16,6 +16,7 @@ namespace AngouriMath.Tests.Common
     /// Compiling expressions that mention matrices. A matrix has no compiled form, but an
     /// expression built out of matrices often has a value that is an ordinary number.
     /// </summary>
+    [Trait("Area", "Common")]
     public sealed class MatrixCompilationTest
     {
         // https://github.com/asc-community/AngouriMath/issues/425

--- a/Sources/Tests/UnitTests/Common/NonStrictTest.cs
+++ b/Sources/Tests/UnitTests/Common/NonStrictTest.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.Common
 {
+    [Trait("Area", "Common")]
     public sealed class NonStrictTest
     {
         static readonly Entity.Variable x = nameof(x);

--- a/Sources/Tests/UnitTests/Common/NumericModulusTest.cs
+++ b/Sources/Tests/UnitTests/Common/NumericModulusTest.cs
@@ -19,6 +19,7 @@ namespace AngouriMath.Tests.Common
     /// at the call site rather than on the values.
     /// See https://github.com/asc-community/AngouriMath/issues/708.
     /// </summary>
+    [Trait("Area", "Common")]
     public sealed class NumericModulusTest
     {
         /// <summary>

--- a/Sources/Tests/UnitTests/Common/NumericsRegressionTest.cs
+++ b/Sources/Tests/UnitTests/Common/NumericsRegressionTest.cs
@@ -17,6 +17,7 @@ namespace AngouriMath.Tests.Common
     /// Each test names the issue it locks down, so a future refactor that
     /// reintroduces the bug fails loudly.
     /// </summary>
+    [Trait("Area", "Common")]
     public sealed class NumericsRegressionTest
     {
         // https://github.com/asc-community/AngouriMath/issues/625

--- a/Sources/Tests/UnitTests/Common/OperatorTest.cs
+++ b/Sources/Tests/UnitTests/Common/OperatorTest.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.Common
 {
+    [Trait("Area", "Common")]
     public sealed class OperatorTest
     {
         [Fact] public void TestEq() => Assert.Equal(MathS.Var("x"), MathS.Var("x"));

--- a/Sources/Tests/UnitTests/Common/ParallelCompiledCallTest.cs
+++ b/Sources/Tests/UnitTests/Common/ParallelCompiledCallTest.cs
@@ -21,6 +21,7 @@ namespace AngouriMath.Tests.Common
     /// https://github.com/asc-community/AngouriMath/issues/637, which reports it as a
     /// compilation problem -- compiling in parallel is fine, it is calling that was not.
     /// </summary>
+    [Trait("Area", "Common")]
     public sealed class ParallelCompiledCallTest
     {
         private const int Threads = 16;

--- a/Sources/Tests/UnitTests/Common/PowerOfPowerBranchTest.cs
+++ b/Sources/Tests/UnitTests/Common/PowerOfPowerBranchTest.cs
@@ -21,6 +21,7 @@ namespace AngouriMath.Tests.Common
     /// each the negation of the right answer where x is negative.
     /// https://github.com/asc-community/AngouriMath/issues/752
     /// </summary>
+    [Trait("Area", "Common")]
     public sealed class PowerOfPowerBranchTest
     {
         /// <summary>

--- a/Sources/Tests/UnitTests/Common/PowerQuotientGatheringTest.cs
+++ b/Sources/Tests/UnitTests/Common/PowerQuotientGatheringTest.cs
@@ -20,6 +20,7 @@ namespace AngouriMath.Tests.Common
     /// has already happened -- and where it applies to only one of the two, the exponents
     /// no longer match. https://github.com/asc-community/AngouriMath/issues/740
     /// </summary>
+    [Trait("Area", "Common")]
     public sealed class PowerQuotientGatheringTest
     {
         private static Entity Simplified(string expr) => expr.ToEntity().Simplify();

--- a/Sources/Tests/UnitTests/Common/PythagoreanIdentityTest.cs
+++ b/Sources/Tests/UnitTests/Common/PythagoreanIdentityTest.cs
@@ -16,6 +16,7 @@ namespace AngouriMath.Tests.Common
     /// two forms got by dividing it through by sin^2 and by cos^2.
     /// https://github.com/asc-community/AngouriMath/issues/725
     /// </summary>
+    [Trait("Area", "Common")]
     public sealed class PythagoreanIdentityTest
     {
         /// <summary>

--- a/Sources/Tests/UnitTests/Common/SimplificationRegressionTest.cs
+++ b/Sources/Tests/UnitTests/Common/SimplificationRegressionTest.cs
@@ -18,6 +18,7 @@ namespace AngouriMath.Tests.Common
     /// Each test names the issue it locks down, so a future refactor that
     /// reintroduces the bug fails loudly.
     /// </summary>
+    [Trait("Area", "Common")]
     public sealed class SimplificationRegressionTest
     {
         // https://github.com/asc-community/AngouriMath/issues/205

--- a/Sources/Tests/UnitTests/Common/SolverRegressionTest.cs
+++ b/Sources/Tests/UnitTests/Common/SolverRegressionTest.cs
@@ -17,6 +17,7 @@ namespace AngouriMath.Tests.Common
     /// Each test names the issue it locks down, so a future refactor that
     /// reintroduces the bug fails loudly.
     /// </summary>
+    [Trait("Area", "Common")]
     public sealed class SolverRegressionTest
     {
         // https://github.com/asc-community/AngouriMath/issues/442

--- a/Sources/Tests/UnitTests/Common/SubstituteTest.cs
+++ b/Sources/Tests/UnitTests/Common/SubstituteTest.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.Common
 {
+    [Trait("Area", "Common")]
     public sealed class SubstituteTest
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Common/TrigonometricTableTest.cs
+++ b/Sources/Tests/UnitTests/Common/TrigonometricTableTest.cs
@@ -22,6 +22,7 @@ namespace AngouriMath.Tests.Common
     /// <c>1/2 + i*sin(5/3*pi)</c>, its own conjugate spelled differently.
     /// https://github.com/asc-community/AngouriMath/issues/743
     /// </summary>
+    [Trait("Area", "Common")]
     public sealed class TrigonometricTableTest
     {
         /// <summary>The denominators the table has entries for, plus a few it has not.</summary>

--- a/Sources/Tests/UnitTests/Convenience/ArcHyperbolicRefusedTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/ArcHyperbolicRefusedTest.cs
@@ -18,6 +18,7 @@ namespace AngouriMath.Tests.Convenience
     /// read as a product of an undeclared variable and its argument and nothing was said
     /// about it. No issue is filed for this.
     /// </summary>
+    [Trait("Area", "Convenience")]
     public sealed class ArcHyperbolicRefusedTest
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Convenience/Casts.cs
+++ b/Sources/Tests/UnitTests/Convenience/Casts.cs
@@ -12,6 +12,7 @@ using AngouriMath.Core.Exceptions;
 
 namespace AngouriMath.Tests.Convenience
 {
+    [Trait("Area", "Convenience")]
     public sealed class Casts
     {
         [Fact] public void ToDoubleSuccess1() => Assert.Equal(3d, (double)"3".EvalNumerical());

--- a/Sources/Tests/UnitTests/Convenience/ExpParsedTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/ExpParsedTest.cs
@@ -20,6 +20,7 @@ namespace AngouriMath.Tests.Convenience
     /// said about it, so exp(x) - 3x = 0 answered { 0 }: a wrong answer to a question the
     /// library had misread, rather than a refusal to answer. No issue is filed for this.
     /// </summary>
+    [Trait("Area", "Convenience")]
     public sealed class ExpParsedTest
     {
         // e^x, not a distinct node: the library already differentiates, integrates and

--- a/Sources/Tests/UnitTests/Convenience/ExtensionTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/ExtensionTest.cs
@@ -12,6 +12,7 @@ using static AngouriMath.Entity.Number;
 
 namespace AngouriMath.Tests.Convenience
 {
+    [Trait("Area", "Convenience")]
     public class ExtensionTest
     {
         [Fact]

--- a/Sources/Tests/UnitTests/Convenience/FactorialNameParsedTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/FactorialNameParsedTest.cs
@@ -20,6 +20,7 @@ namespace AngouriMath.Tests.Convenience
     /// so factorial(5) came out as the product factorial * 5, silently, where it is 120.
     /// https://github.com/asc-community/AngouriMath/issues/733
     /// </summary>
+    [Trait("Area", "Convenience")]
     public sealed class FactorialNameParsedTest
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Convenience/FromStringTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/FromStringTest.cs
@@ -20,6 +20,7 @@ using FluentAssertions;
 
 namespace AngouriMath.Tests.Convenience
 {
+    [Trait("Area", "Convenience")]
     public sealed class FromStringTest
     {
         public static readonly Entity.Variable x = Var(nameof(x));

--- a/Sources/Tests/UnitTests/Convenience/LatexTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/LatexTest.cs
@@ -13,6 +13,7 @@ using static AngouriMath.Entity.Set;
 
 namespace AngouriMath.Tests.Convenience
 {
+    [Trait("Area", "Convenience")]
     public sealed class LatexTests
     {
         private static readonly Entity x = MathS.Var(nameof(x));

--- a/Sources/Tests/UnitTests/Convenience/LogBaseNamesParsedTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/LogBaseNamesParsedTest.cs
@@ -19,6 +19,7 @@ namespace AngouriMath.Tests.Convenience
     /// and x2 means x^2 by design, so log10(100) came out as log^10 * 100.
     /// https://github.com/asc-community/AngouriMath/issues/733
     /// </summary>
+    [Trait("Area", "Convenience")]
     public sealed class LogBaseNamesParsedTest
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Convenience/MissingFunctionNamesRefusedTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/MissingFunctionNamesRefusedTest.cs
@@ -23,6 +23,7 @@ namespace AngouriMath.Tests.Convenience
     /// so these are refused one at a time, as <c>arcsinh</c> already is.
     /// https://github.com/asc-community/AngouriMath/issues/733
     /// </summary>
+    [Trait("Area", "Convenience")]
     public sealed class MissingFunctionNamesRefusedTest
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Convenience/ModulusTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/ModulusTest.cs
@@ -21,6 +21,7 @@ namespace AngouriMath.Tests.Convenience
     /// https://github.com/asc-community/AngouriMath/issues/618. There was no node for it at
     /// all: there was no <c>mod</c> and no <c>MathS.Mod</c>.
     /// </summary>
+    [Trait("Area", "Convenience")]
     public sealed class ModulusTest
     {
         private static readonly Entity.Variable x = MathS.Var("x");

--- a/Sources/Tests/UnitTests/Convenience/PriorityTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/PriorityTest.cs
@@ -10,6 +10,7 @@ using AngouriMath.Extensions;
 
 namespace AngouriMath.Tests.Common
 {
+    [Trait("Area", "Convenience")]
     public class PriorityTest
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Convenience/StringizeRoundTripTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/StringizeRoundTripTest.cs
@@ -16,6 +16,7 @@ namespace AngouriMath.Tests.Common
     /// expression it printed. Anything else makes the printed form a lie, and a silent one,
     /// since a wrong reading is still a valid expression.
     /// </summary>
+    [Trait("Area", "Convenience")]
     public sealed class StringizeRoundTripTest
     {
         private static void AssertRoundTrip(string source)

--- a/Sources/Tests/UnitTests/Convenience/SynonymFunctionTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/SynonymFunctionTest.cs
@@ -14,6 +14,7 @@ using AngouriMath.Extensions;
 
 namespace AngouriMath.Tests.Convenience
 {
+    [Trait("Area", "Convenience")]
     public sealed class SynonymFunctionTest
     {
         private readonly Entity x = MathS.Var(nameof(x));

--- a/Sources/Tests/UnitTests/Convenience/ToSymPyTEst.cs
+++ b/Sources/Tests/UnitTests/Convenience/ToSymPyTEst.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.Convenience
 {
+    [Trait("Area", "Convenience")]
     public class ToSymPyTest
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Convenience/TupleToIntervalTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/TupleToIntervalTest.cs
@@ -27,6 +27,7 @@ using AngouriMath.Extensions;
 
 namespace AngouriMath.Tests.Extensions
 {
+    [Trait("Area", "Convenience")]
     public class IntervalExtensionTest
     {
         [Fact] public void Test0()

--- a/Sources/Tests/UnitTests/Core/Domains.cs
+++ b/Sources/Tests/UnitTests/Core/Domains.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.Core
 {
+    [Trait("Area", "Core")]
     public sealed class Domains
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Core/Multithreading/CancelTest.cs
+++ b/Sources/Tests/UnitTests/Core/Multithreading/CancelTest.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 
 namespace AngouriMath.Tests.Core.Multithreading
 {
+    [Trait("Area", "Core")]
     public sealed class CancelTest
     {
         const int ShouldLastAtLeast = 10000;

--- a/Sources/Tests/UnitTests/Core/Multithreading/MultithreadedTest.cs
+++ b/Sources/Tests/UnitTests/Core/Multithreading/MultithreadedTest.cs
@@ -13,6 +13,7 @@ using System.Threading;
 
 namespace AngouriMath.Tests.Core.Multithreading
 {
+    [Trait("Area", "Core")]
     public sealed class MultithreadedTest
     {
         [Fact]

--- a/Sources/Tests/UnitTests/Core/Multithreading/MultithreadingCancel.cs
+++ b/Sources/Tests/UnitTests/Core/Multithreading/MultithreadingCancel.cs
@@ -16,6 +16,7 @@ using System.Linq;
 
 namespace AngouriMath.Tests.Core.Multithreading
 {
+    [Trait("Area", "Core")]
     public sealed class MultithreadingCancel
     {
         private static void SomeLongLastingTask()

--- a/Sources/Tests/UnitTests/Core/Multithreading/SettingsAndThreads.cs
+++ b/Sources/Tests/UnitTests/Core/Multithreading/SettingsAndThreads.cs
@@ -13,6 +13,7 @@ using static AngouriMath.Entity;
 
 namespace AngouriMath.Tests.Core.Multithreading
 {
+    [Trait("Area", "Core")]
     public sealed class SettingsAndThreads
     {
         #region Obsolete settings

--- a/Sources/Tests/UnitTests/Core/Numeric.cs
+++ b/Sources/Tests/UnitTests/Core/Numeric.cs
@@ -14,6 +14,7 @@ using System;
 
 namespace AngouriMath.Tests.Core
 {
+    [Trait("Area", "Core")]
     public sealed class Numeric
     {
         [Fact]

--- a/Sources/Tests/UnitTests/Core/NumericDigits.cs
+++ b/Sources/Tests/UnitTests/Core/NumericDigits.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.Core
 {
+    [Trait("Area", "Core")]
     public sealed class NumericDigits
     {
         void Test(Entity.Number n, string expected) => Assert.Equal(expected, n.Stringize());

--- a/Sources/Tests/UnitTests/Core/NumericDowncasting.cs
+++ b/Sources/Tests/UnitTests/Core/NumericDowncasting.cs
@@ -14,6 +14,7 @@ using static AngouriMath.Entity.Number;
 
 namespace AngouriMath.Tests.Core
 {
+    [Trait("Area", "Core")]
     public sealed class NumericDowncastingTest
     {
         #region Test from complex to...

--- a/Sources/Tests/UnitTests/Core/PolyParser.cs
+++ b/Sources/Tests/UnitTests/Core/PolyParser.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.Core
 {
+    [Trait("Area", "Core")]
     public class PolyParser
     {
         // Workaround to avoid ToString which results in SO in RC1

--- a/Sources/Tests/UnitTests/Core/Sets/Arithmetics.cs
+++ b/Sources/Tests/UnitTests/Core/Sets/Arithmetics.cs
@@ -10,6 +10,7 @@ using AngouriMath.Extensions;
 
 namespace AngouriMath.Tests.Core.Sets
 {
+    [Trait("Area", "Core")]
     public sealed class Arithmetics
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Core/Sets/CSetAndCSet.cs
+++ b/Sources/Tests/UnitTests/Core/Sets/CSetAndCSet.cs
@@ -11,6 +11,7 @@ using static AngouriMath.Entity;
 using static AngouriMath.Entity.Set;
 namespace AngouriMath.Tests.Core.Sets
 {
+    [Trait("Area", "Core")]
     public sealed class CSetAndCSet
     {
         private readonly Set A = new ConditionalSet("x", "x > 0");

--- a/Sources/Tests/UnitTests/Core/Sets/Contains.cs
+++ b/Sources/Tests/UnitTests/Core/Sets/Contains.cs
@@ -11,6 +11,7 @@ using AngouriMath.Extensions;
 
 namespace AngouriMath.Tests.Core.Sets
 {
+    [Trait("Area", "Core")]
     public sealed class Contains
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Core/Sets/FiniteAndFinite.cs
+++ b/Sources/Tests/UnitTests/Core/Sets/FiniteAndFinite.cs
@@ -12,6 +12,7 @@ using static AngouriMath.Entity.Set;
 
 namespace AngouriMath.Tests.Core.Sets
 {
+    [Trait("Area", "Core")]
     public sealed class FiniteAndFinite
     {
         private readonly Set A = new FiniteSet(1,   3, 5);

--- a/Sources/Tests/UnitTests/Core/Sets/General.cs
+++ b/Sources/Tests/UnitTests/Core/Sets/General.cs
@@ -10,6 +10,7 @@ using AngouriMath.Extensions;
 
 namespace AngouriMath.Tests.Core.Sets
 {
+    [Trait("Area", "Core")]
     public sealed class General
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Core/Sets/IntervalAndInterval.cs
+++ b/Sources/Tests/UnitTests/Core/Sets/IntervalAndInterval.cs
@@ -13,6 +13,7 @@ using static AngouriMath.MathS.Sets;
 
 namespace AngouriMath.Tests.Core.Sets
 {
+    [Trait("Area", "Core")]
     public sealed class IntervalAndInterval
     {
         private readonly Set A = Interval(2, true, 5, true);

--- a/Sources/Tests/UnitTests/Core/Sets/SetsTest.cs
+++ b/Sources/Tests/UnitTests/Core/Sets/SetsTest.cs
@@ -12,6 +12,7 @@ using static AngouriMath.Entity.Set;
 
 namespace AngouriMath.Tests.Core
 {
+    [Trait("Area", "Core")]
     public sealed class SetsTest
     {
         private static Set A = MathS.Sets.Empty;

--- a/Sources/Tests/UnitTests/Core/Settings.cs
+++ b/Sources/Tests/UnitTests/Core/Settings.cs
@@ -10,6 +10,7 @@ using static AngouriMath.MathS.Settings;
 
 namespace AngouriMath.Tests.Core
 {
+    [Trait("Area", "Core")]
     public sealed class Settings
     {
         [Fact]

--- a/Sources/Tests/UnitTests/Core/TreeEqualityPrecision.cs
+++ b/Sources/Tests/UnitTests/Core/TreeEqualityPrecision.cs
@@ -15,6 +15,7 @@ using System;
 
 namespace AngouriMath.Tests.Core
 {
+    [Trait("Area", "Core")]
     public class TreeEqualityPrecision
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Core/UniqueVariableTest.cs
+++ b/Sources/Tests/UnitTests/Core/UniqueVariableTest.cs
@@ -17,6 +17,7 @@ namespace AngouriMath.Tests.Core
     /// integration, which is where the collision showed up, because the machinery that
     /// makes them is internal.
     /// </summary>
+    [Trait("Area", "Core")]
     public sealed class UniqueVariableTest
     {
         private static void AssertIsAntiderivative(string integrand)

--- a/Sources/Tests/UnitTests/Core/UserInvalidExceptions.cs
+++ b/Sources/Tests/UnitTests/Core/UserInvalidExceptions.cs
@@ -15,6 +15,7 @@ using static AngouriMath.Entity;
 
 namespace AngouriMath.Tests.Core
 {
+    [Trait("Area", "Core")]
     public sealed class UserInvalidExceptions
     {
         [Fact] public void PrecisionTooHigh() => 

--- a/Sources/Tests/UnitTests/Discrete/BooleanEval.cs
+++ b/Sources/Tests/UnitTests/Discrete/BooleanEval.cs
@@ -12,6 +12,7 @@ namespace AngouriMath.Tests.Discrete
 {
     using static Entity.Boolean;
 
+    [Trait("Area", "Discrete")]
     public sealed class BooleanEval
     {
         private void Test(Entity expr, Entity.Boolean expected)

--- a/Sources/Tests/UnitTests/Discrete/BooleanSolver.cs
+++ b/Sources/Tests/UnitTests/Discrete/BooleanSolver.cs
@@ -13,6 +13,7 @@ using Xunit;
 namespace AngouriMath.Tests.Discrete
 {
     using static AngouriMath.Entity;
+    [Trait("Area", "Discrete")]
     public sealed class BooleanSolver
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Discrete/EqualityInequalityEval.cs
+++ b/Sources/Tests/UnitTests/Discrete/EqualityInequalityEval.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.Discrete
 {
+    [Trait("Area", "Discrete")]
     public sealed class EqualityInequalityEval
     {
         [Theory]

--- a/Sources/Tests/UnitTests/Discrete/InSet.cs
+++ b/Sources/Tests/UnitTests/Discrete/InSet.cs
@@ -11,6 +11,7 @@ using AngouriMath;
 
 namespace AngouriMath.Tests.Discrete
 {
+    [Trait("Area", "Discrete")]
     public sealed class InSet
     {
         [Theory]

--- a/Sources/Tests/UnitTests/GenericMath.cs
+++ b/Sources/Tests/UnitTests/GenericMath.cs
@@ -15,6 +15,7 @@ using Complex = AngouriMath.Entity.Number.Complex;
 
 namespace AngouriMath.Tests;
 
+[Trait("Area", "Core")]
 public class GenericMath
 {
     [Fact]

--- a/Sources/Tests/UnitTests/PatternsTest/BooleanMinimisationTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/BooleanMinimisationTest.cs
@@ -24,6 +24,7 @@ namespace AngouriMath.Tests.PatternsTest
     /// can only change an expression's answer where it is shorter than everything else on
     /// offer -- which is also why it needs no separate entry point.
     /// </summary>
+    [Trait("Area", "PatternsTest")]
     public sealed class BooleanMinimisationTest
     {
         private static void AssertSimplifiesTo(string input, string expected) =>

--- a/Sources/Tests/UnitTests/PatternsTest/BooleanSimplify.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/BooleanSimplify.cs
@@ -24,6 +24,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.PatternsTest
 {
+    [Trait("Area", "PatternsTest")]
     public sealed class BooleanSimplify
     {
         [Theory]

--- a/Sources/Tests/UnitTests/PatternsTest/DoubleAngleOverSineTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/DoubleAngleOverSineTest.cs
@@ -19,6 +19,7 @@ namespace AngouriMath.Tests.PatternsTest
     /// (sin(2t) csc(t))^2/4 - cos(2t) - sin(t)^2 stopped one step short of zero, which is
     /// what https://github.com/asc-community/AngouriMath/issues/557 asks for.
     /// </summary>
+    [Trait("Area", "PatternsTest")]
     public sealed class DoubleAngleOverSineTest
     {
         private static Entity Bare(string expression)

--- a/Sources/Tests/UnitTests/PatternsTest/FractionSimplify.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/FractionSimplify.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.PatternsTest
 {
+    [Trait("Area", "PatternsTest")]
     public sealed class FractionSimplify
     {
         [Theory]

--- a/Sources/Tests/UnitTests/PatternsTest/MultipleAngleTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/MultipleAngleTest.cs
@@ -16,6 +16,7 @@ namespace AngouriMath.Tests.PatternsTest
     /// offered to the simplifier as a candidate, so what these pin is both that it is
     /// produced and that it is only preferred where the pieces cancel.
     /// </summary>
+    [Trait("Area", "PatternsTest")]
     public sealed class MultipleAngleTest
     {
         // Identities that only close once the multiple angle is opened up.

--- a/Sources/Tests/UnitTests/PatternsTest/PatternTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/PatternTest.cs
@@ -10,6 +10,7 @@ using AngouriMath.Extensions;
 
 namespace AngouriMath.Tests.PatternsTest
 {
+    [Trait("Area", "PatternsTest")]
     public sealed class PatternTest
     {
         private const int GithubIssue170Timeout = 1600; // we don't know the target machines

--- a/Sources/Tests/UnitTests/PatternsTest/PhiSimplify.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/PhiSimplify.cs
@@ -24,6 +24,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.PatternsTest
 {
+    [Trait("Area", "PatternsTest")]
     public sealed class PhiSimplify
     {
         [Theory]

--- a/Sources/Tests/UnitTests/PatternsTest/PolynomialFactoringTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/PolynomialFactoringTest.cs
@@ -16,6 +16,7 @@ namespace AngouriMath.Tests.PatternsTest
     /// The factored form is offered to the simplifier as a candidate, so what these pin
     /// is both that it is produced and that it is preferred where it should be.
     /// </summary>
+    [Trait("Area", "PatternsTest")]
     public sealed class PolynomialFactoringTest
     {
         // https://github.com/asc-community/AngouriMath/issues/177

--- a/Sources/Tests/UnitTests/PatternsTest/SetSimplify.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/SetSimplify.cs
@@ -24,6 +24,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.PatternsTest
 {
+    [Trait("Area", "PatternsTest")]
     public sealed class SetSimplify
     {
         [Theory]

--- a/Sources/Tests/UnitTests/PatternsTest/SimplifyTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/SimplifyTest.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.PatternsTest
 {
+    [Trait("Area", "PatternsTest")]
     public sealed class SimplifyTest
     {
         static readonly Entity a = MathS.Var(nameof(a));

--- a/Sources/Tests/UnitTests/PatternsTest/SmartExpander.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/SmartExpander.cs
@@ -12,6 +12,7 @@ using PeterO.Numbers;
 
 namespace AngouriMath.Tests.PatternsTest
 {
+    [Trait("Area", "PatternsTest")]
     public sealed class SmartExpander
     {
         public (bool equal, Complex eval1, Complex eval2, Real err) AreEqual(Entity expr1, Entity expr2, Complex toSub)

--- a/Sources/Tests/UnitTests/PatternsTest/SortSimplifyTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/SortSimplifyTest.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.PatternsTest
 {
+    [Trait("Area", "PatternsTest")]
     public sealed class SortSimplifyTest
     {
         [Theory]

--- a/Sources/Tests/UnitTests/PatternsTest/TrigTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/TrigTest.cs
@@ -27,6 +27,7 @@ using Xunit;
 
 namespace AngouriMath.Tests.PatternsTest
 {
+    [Trait("Area", "PatternsTest")]
     public sealed class TestTrigTableConsts
     {
         // TODO: Remove when we implement extra precision for rounding


### PR DESCRIPTION
Closes #784.

`UnitTests` carried no `[Trait]` attributes, so `dotnet test --filter` could select only by name or namespace. Each test class now carries an `Area` trait naming the directory it lives in:

```
dotnet test UnitTests --filter "Area=Calculus"       862 tests,  55 s
dotnet test UnitTests --filter "Area=PatternsTest"   691 tests,   3 s
dotnet test UnitTests --filter "Area=Discrete"       132 tests, 0.2 s
```

against **5,422 tests and 3m52s** for the whole thing.

## The check that matters is the sum, not the attribute count

| area | tests |
|---|--:|
| Algebra | 791 |
| Calculus | 862 |
| Common | 1,189 |
| Convenience | 1,172 |
| Core | 585 |
| Discrete | 132 |
| PatternsTest | 691 |
| **sum** | **5,422** |
| full suite | **5,422** |

The first pass left **258 tests untraited**, and the sum is what said so. Four files declare their tests as `[Theory, CombinatorialData]` or `[Fact(Skip = ...)]` rather than a bare `[Fact]`, and `GenericMath.cs` sits at the project root outside every area directory.

That gap mattered more than it looks: a contributor running all seven areas would have silently skipped 258 tests, and the subset would have *looked* complete. Worse than having no traits at all. Every test now has exactly one area.

## CONTRIBUTING.md

Gains the filter, the list of areas, and one caution — the traits are for the loop you run **while writing** a change, not for what you check before proposing one. This library is full of rules that interact, and a change to simplification has broken solving and integration here more than once.

## Notes for review

- Mechanical change: 135 test files gain one attribute line each, plus CONTRIBUTING.md. **151 insertions, 0 deletions.**
- An earlier revision of this branch also rewrote 73 files' byte-order marks as a side effect of the script that inserted the attributes. That is reverted — the diff now touches nothing but the lines it means to.
- **5408 pass, 14 skipped, 0 fail** — unchanged from master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
