### PR TITLE
Clear the vulnerable transitive dependency from the terminal (#542)

### DIFF
--- a/Sources/Terminal/AngouriMath.Terminal.Lib/AngouriMath.Terminal.Lib.fsproj
+++ b/Sources/Terminal/AngouriMath.Terminal.Lib/AngouriMath.Terminal.Lib.fsproj
@@ -15,6 +15,22 @@
   <ItemGroup>
     <PackageReference Include="FSharp.SystemTextJson" Version="0.17.4" />
     <PackageReference Include="Microsoft.DotNet.Interactive.FSharp" Version="1.0.0-beta.25323.1" />
+
+    <!--
+    Pinned to pull the patched build of a transitive dependency forward.
+    Microsoft.DotNet.Interactive.FSharp brings System.Security.Cryptography.Xml 9.0.6, which
+    carries eight known high severity advisories (NU1903): GHSA-23rf-6693-g89p,
+    GHSA-37gx-xxp4-5rgx, GHSA-6588-8gv4-xfgh, GHSA-8q5v-6pqq-x66h, GHSA-cvvh-rhrc-wg4q,
+    GHSA-g8r8-53c2-pm3f, GHSA-mmjf-rqrv-855v and GHSA-w3x6-4m5h-cxqf. 9.0.18 is the patched
+    build on the same major line.
+
+    A direct reference rather than an upgrade of the package that brings it in: moving
+    Microsoft.DotNet.Interactive.FSharp to its newest beta, 1.0.0-beta.26120.1, fails to
+    build with 452 errors and does not clear the advisories either. Measured, not assumed.
+    Remove this line once that package ships a build whose own dependency is patched.
+    https://github.com/asc-community/AngouriMath/issues/542
+    -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.18" />
     <!--
     <PackageReference Include="AngouriMath.Interactive" Version="1.4.0-preview.3" />
     -->


### PR DESCRIPTION
Addresses #542.

Building `AngouriMath.Terminal` produced **48 `NU1903`** warnings and **6 `NU1608`**. The `NU1903`s turn out not to be a version mismatch at all but a **security** one: `Microsoft.DotNet.Interactive.FSharp` brings `System.Security.Cryptography.Xml` **9.0.6**, which carries **eight distinct known high-severity advisories**.

```
GHSA-23rf-6693-g89p   GHSA-37gx-xxp4-5rgx   GHSA-6588-8gv4-xfgh
GHSA-8q5v-6pqq-x66h   GHSA-cvvh-rhrc-wg4q   GHSA-g8r8-53c2-pm3f
GHSA-mmjf-rqrv-855v   GHSA-w3x6-4m5h-cxqf
```

```
AngouriMath.Terminal.Lib
└── Microsoft.DotNet.Interactive.FSharp (1.0.0-beta.25323.1)
    └── System.Security.Cryptography.Xml (9.0.6)
```

A direct reference to **9.0.18**, the patched build on the same major line, pulls the transitive one forward. **`NU1903` goes 48 → 0** and the build still succeeds.

## The upgrade was tried first, and measured

Bumping `Microsoft.DotNet.Interactive.FSharp` to its newest beta (`1.0.0-beta.26120.1`) is the tidier-looking fix, so it was attempted before the pin: it **fails with 452 compile errors and leaves all 48 advisories in place**. Hence the pin, with a comment in the project file saying exactly when it can be removed — once that package ships a build whose own dependency is patched.

## `NU1608` is left, deliberately

It says `FSharp.Compiler.Service 43.9.300 requires FSharp.Core (= 9.0.300) but version FSharp.Core 10.1.302 was resolved` — and 10.1.302 is what the **.NET 10 SDK itself ships**.

The resolved version is *newer* than the constraint, which is the ordinary situation for a package pinned against an older F#. Pinning `FSharp.Core` down to satisfy it would mean shipping an older compiler than the SDK's — a worse outcome than the warning. Silencing it with `NoWarn` would hide a real mismatch rather than fix one, and that is a maintainer's call rather than mine.

So this PR closes the half of #542 that is a genuine defect and states plainly why the other half is left. **The issue should stay open for `NU1608`** unless you would rather suppress it.

## Checked

- `NU1903` **48 → 0**; build succeeds
- `TerminalUnitTests` **7/7**; `FSharpWrapperUnitTests` **130/130**

Note: `dotnet build` on the full solution cannot be used to measure this on Linux — two sample projects target Windows and fail with `NETSDK1100`, which is why the warnings are counted per project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
