### PR TITLE
Declare the coverage flags so they carry forward (#397)

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -8,6 +8,27 @@ coverage:
   patch: no
   changes: no
 
+# Flags are declared so that each one is scoped to the code it actually measures and is
+# carried forward when its leg does not run. Both matter here: every flag is uploaded from
+# exactly one operating system of its matrix (csharp from windows, fsharp and interactive
+# from ubuntu), so on any run where that leg is skipped an undeclared flag reports as
+# missing rather than unchanged, and the report reads as a coverage drop that did not
+# happen. https://github.com/asc-community/AngouriMath/issues/397
+flags:
+  csharp:
+    paths:
+      - Sources/AngouriMath/
+    carryforward: true
+  fsharp:
+    paths:
+      - Sources/Wrappers/AngouriMath.FSharp/
+    carryforward: true
+  interactive:
+    paths:
+      - Sources/Wrappers/AngouriMath.Interactive/
+      - Sources/Terminal/
+    carryforward: true
+
 parsers:
   gcov:
     branch_detection:


### PR DESCRIPTION
Addresses #397.

## The checklist is out of date

#397 lists coverage as done for `AngouriMath` only. Measured against the workflows, three of the four boxes are already done:

| project | flag | uploaded by | since |
|---|---|---|---|
| AngouriMath | `csharp` | `CSharpTest.yml` (windows-latest) | ✅ |
| AngouriMath.FSharp | `fsharp` | `FSharpTest.yml` (ubuntu-latest) | ✅ **already done** |
| AngouriMath.Interactive | `interactive` | `InteractiveTest.yml` (ubuntu-latest) | ✅ **already done** |
| AngouriMath.CPP | — | — | ❌ |

## What was actually missing

**None of the three flags is declared in `codecov.yml`.** That matters more here than it usually would: every flag is uploaded from *exactly one operating system* of its matrix. On a run where that leg does not execute, an undeclared flag reports as **missing rather than unchanged** — and the report reads as a coverage drop that did not happen.

```yaml
flags:
  csharp:
    paths: [Sources/AngouriMath/]
    carryforward: true
  fsharp:
    paths: [Sources/Wrappers/AngouriMath.FSharp/]
    carryforward: true
  interactive:
    paths: [Sources/Wrappers/AngouriMath.Interactive/, Sources/Terminal/]
    carryforward: true
```

`carryforward` fixes the phantom drops; `paths` scopes each flag to the code it actually measures, so the `interactive` flag stops being diluted by the kernel's line count.

## What is left, and why it is not in this PR

The **C++** box is a different kind of work rather than more of the same. Those tests build a **native AOT export** of the library and drive it through `ctest`, so there is no .NET assembly to instrument — coverage there means `gcov` or `llvm-cov` over the test binaries on three platforms, plus feeding the `gcov` parser section this file already carries and nothing currently uses.

There is also no C++ toolchain set up on my side to verify such a change. A CI-only change that cannot be verified before merging is precisely what left the Kernel Benchmark dead for seven months (#775), so I am not going to guess at one here.

**Suggest #397 stays open for the C++ box**, with the other three ticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
