### PR TITLE
Name the version under development, and stop stamping 0.1.3.0

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -15,7 +15,7 @@ read first.
 
 ---
 
-## Unreleased — since 1.4.0
+## 2.0.0 (unreleased) — since 1.4.0
 
 ### At a glance
 

--- a/Sources/AngouriMath/AngouriMath.csproj
+++ b/Sources/AngouriMath/AngouriMath.csproj
@@ -10,8 +10,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <LangVersion>preview</LangVersion>
-    <AssemblyVersion>0.1.3.0</AssemblyVersion>
-    <FileVersion>0.1.3.0</FileVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTags>$(PackageTags), csharp</PackageTags>
     <Description>Enables to work with formulas built in the code or from a string. Computing, derivating, latex rendering, compilation, solving equations and systems of equations analytycally, simplification, and much more. Read more on https://am.angouri.org.</Description>

--- a/Sources/Package.Build.props
+++ b/Sources/Package.Build.props
@@ -12,7 +12,22 @@
   -->
   
   <PropertyGroup>
-    <Version>1.4.0-preview.4</Version>
+    <!--
+    The version under development. The NuGet workflow overrides PackageVersion from the
+    release tag, so what ships is named by the tag; this is what a local build and the
+    assembly metadata carry.
+    -->
+    <Version>2.0.0-preview.1</Version>
+
+    <!--
+    Pinned to the major for the whole of 2.x, and deliberately not tracking Version.
+    The assembly is strong-named (see AngouriMath.csproj), and for a signed assembly
+    every AssemblyVersion change breaks binding on consumers that do not add a redirect.
+    Holding it at 2.0.0.0 makes every 2.x release a drop-in replacement. FileVersion
+    carries the release for anyone reading the file properties.
+    -->
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
 
     <Authors>WhiteBlackGoose and contributors</Authors>
     <Company>Angouri</Company>


### PR DESCRIPTION
Three version fields disagreed with each other and with what actually shipped.

## What was wrong

| where | said | should have said |
|---|---|---|
| `Sources/Package.Build.props` | `1.4.0-preview.4` | 1.4.0 was released in January |
| `Sources/AngouriMath/AngouriMath.csproj` | `AssemblyVersion` / `FileVersion` = `0.1.3.0` | a number from long before 1.4 |

Nothing **published** was wrong — `Nuget.yml` packs with `-p:PackageVersion` taken from the release tag, so NuGet has always been named by the tag. But a local build and the assembly metadata carried these.

Worse, they disagreed *with each other*. The csproj override sits after the `Package.Build.props` import, so it won: `AngouriMath.dll` reported `0.1.3.0` while `AngouriMath.FSharp.dll`, which has no override, reported `1.4.0.0`. Four packages built from one repository did not agree on their own version.

## Now

The props carry it for all four packable projects, and the csproj override is gone:

```
Version           2.0.0-preview.1
AssemblyVersion   2.0.0.0
FileVersion       2.0.0.0
```

Measured on the built assembly rather than read off the diff:

```
AssemblyVersion   2.0.0.0
FileVersion       2.0.0.0
Informational     2.0.0-preview.1+21f0d16f
PublicKeyToken    bccdab90849ccf86     <- unchanged
```

## Why `AssemblyVersion` is pinned, and does not track `Version`

The assembly is **strong-named** (`SignAssembly`, `key.snk`). For a signed assembly, every `AssemblyVersion` change breaks binding on any consumer that does not add a redirect. Holding it at `2.0.0.0` for the whole of 2.x makes each 2.x release a drop-in replacement; `FileVersion` and the informational version carry the actual release.

## Why 2.0 and not 1.5

The changes since 1.4.0 include ones no minor version may carry:

- `Minusf.Minuend` / `.Subtrahend` **exchanged names** — code using them still compiles and now means the *other* operand
- `Compile` over a missing variable throws `UncompilableNodeException` where it threw `KeyNotFoundException`
- `mod`, `floor` and ten other names that used to parse as products now raise

`BREAKING-CHANGES.md`'s section is renamed to the version it will ship as, and still says **unreleased** — more is landing before the release.

## Not included, on purpose

`AngouriMath.CPP.Exporting` references **`PackageReference AngouriMath 1.4.0-preview.2`** — it builds the C++ bindings against a published package rather than the source beside it, and `CPPBuild`/`CPPTest` run on that. I verified it builds clean against a `ProjectReference`, but that changes *what code is compiled and tested* rather than just metadata, so it belongs in its own PR where CPPTest can adjudicate it. Raised separately.

## Verification

5551 unit tests, 130 F# tests pass. All four packable projects build (AngouriMath, `.FSharp`, `.Interactive`, `.Terminal`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)