### PR TITLE
Replace net7.0 with net8.0 and net10.0

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -47,6 +47,44 @@ read first.
 | **silent** | two integrals | answered correctly | unevaluated — a deliberate loss |
 | **silent** | `k/(a x^2 + c)` and `k/sqrt(a x^2 + c)` for symbolic `a` | `NaN` | a piecewise on the sign of the discriminant |
 | loud | `Compile` over a missing variable | `KeyNotFoundException` | `UncompilableNodeException` |
+| loud | the target frameworks | `net7.0;netstandard2.0` | `netstandard2.0;net8.0;net10.0` |
+
+---
+
+## Target frameworks
+
+`net7.0` is replaced by `net8.0` and `net10.0`. `netstandard2.0` is unchanged, so consumers on
+.NET Framework and the older runtimes are unaffected.
+
+| | was | is |
+|---|---|---|
+| `TargetFrameworks` | `net7.0;netstandard2.0` | `netstandard2.0;net8.0;net10.0` |
+
+.NET 7 left support in May 2024, so the old list named one framework nobody should still be
+targeting and no supported modern one. A consumer on net8.0 or net10.0 previously resolved the
+`netstandard2.0` asset and silently lost the generic-math surface with it; they now get a real
+target.
+
+**What breaks.** Anything that pins the framework of its reference:
+
+```xml
+<ProjectReference Include="...\AngouriMath.csproj">
+  <SetTargetFramework>TargetFramework=net7.0</SetTargetFramework>   <!-- no longer resolves -->
+</ProjectReference>
+```
+
+fails with `NETSDK1005: Assets file ... doesn't have a target for 'net7.0'`. Change it to `net10.0`
+or `net8.0`. This is not hypothetical -- every one of the nine measurement harnesses in this
+workspace pinned `net7.0` and had to be repointed.
+
+A consumer that references the NuGet package rather than the project picks its asset by its own
+framework and needs no change, unless it targets `net7.0` itself, in which case it now resolves
+`netstandard2.0` and loses the generic-math types.
+
+**Generic math is unchanged in reach.** `Core/Entity/GenericMath` needs `INumber<T>` and so is
+still compiled only into the net7.0-and-later targets -- now written as a compatibility test
+rather than a literal `!= 'net7.0'`, so adding a framework does not silently drop it. Verified on
+the built assemblies: present in `net8.0` and `net10.0`, absent from `netstandard2.0`.
 
 ---
 

--- a/Sources/AngouriMath/AngouriMath.csproj
+++ b/Sources/AngouriMath/AngouriMath.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>net7.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <PackageId>AngouriMath</PackageId>
     <Product>AngouriMath</Product>
   </PropertyGroup>
@@ -88,6 +88,11 @@
     </None>
   
     <None Include="extension.dib" Pack="true" PackagePath="interactive-extensions/dotnet" />
-    <Compile Remove="Core/Entity/GenericMath/**" Condition="'$(TargetFramework)' != 'net7.0'" />
+    <!--
+    Generic math needs INumber<T>, which is net7.0 and later. Written as a compatibility
+    test rather than a list of frameworks so that adding one to TargetFrameworks above
+    does not silently drop this folder from it.
+    -->
+    <Compile Remove="Core/Entity/GenericMath/**" Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net7.0'))" />
   </ItemGroup>
 </Project>

--- a/Sources/Tests/UnitTests/UnitTests.csproj
+++ b/Sources/Tests/UnitTests/UnitTests.csproj
@@ -34,7 +34,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\AngouriMath\AngouriMath.csproj">
-      <SetTargetFramework>TargetFramework=net7.0</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=net10.0</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
 


### PR DESCRIPTION
**.NET 7 left support in May 2024.** The target list named it and no supported modern framework:

```
was   net7.0;netstandard2.0
is    netstandard2.0;net8.0;net10.0
```

`netstandard2.0` stays, so .NET Framework and the older runtimes are unaffected. Both replacements are LTS.

There is a quiet second effect worth stating: a consumer on net8.0 or net10.0 previously resolved the **`netstandard2.0`** asset, and silently lost the generic-math surface with it. They now get a real target.

## Generic math

`Core/Entity/GenericMath` needs `INumber<T>`, so it must still be excluded below net7.0. Its condition was a literal:

```xml
Condition="'$(TargetFramework)' != 'net7.0'"
```

which would have dropped it from **every new framework silently**. It is now a compatibility test, so adding a target keeps it.

Verified on the built assemblies rather than assumed:

| | `IClosedArithmetics` | `Sumf` (control) |
|---|---|---|
| `netstandard2.0` | absent ✅ | present |
| `net8.0` | present ✅ | present |
| `net10.0` | present ✅ | present |

## What this breaks

Anything that **pins** the framework of its reference:

```xml
<ProjectReference Include="...\AngouriMath.csproj">
  <SetTargetFramework>TargetFramework=net7.0</SetTargetFramework>
</ProjectReference>
```

now fails with `NETSDK1005: Assets file ... doesn't have a target for 'net7.0'` — an unhelpful message for the actual cause, which is why it is written up in `BREAKING-CHANGES.md`. `UnitTests` is repointed here; **all nine measurement harnesses outside this repository hit it too**, so it is not hypothetical.

Consumers using the NuGet package pick their asset by their own framework and need no change — unless they target `net7.0` themselves, in which case they now resolve `netstandard2.0` and lose the generic-math types.

## Side effect: #808 is no longer blocked

This removes `NETSDK1204` — *"ahead-of-time compilation is not supported on the current platform 'osx-arm64'"* — which is what stopped `AngouriMath.CPP.Exporting` from building against the source beside it instead of a `1.4.0-preview.2` package.

**Not fixed here** — two further changes are needed, both measured and now known. I got a working 4.4 MB native `.so` locally with them applied on top of this branch; details on #808.

## Verification

5551 unit tests, 130 F# tests. All four packable projects build. casbench 113/117 with **0 wrong**, propcheck 0 failures, rootcheck 596/596, simpsweep 10463/10463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)