### PR TITLE
An absolute value cannot equal a negative (#812)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -48,6 +48,7 @@ read first.
 | **silent** | `k/(a x^2 + c)` and `k/sqrt(a x^2 + c)` for symbolic `a` | `NaN` | a piecewise on the sign of the discriminant |
 | loud | `Compile` over a missing variable | `KeyNotFoundException` | `UncompilableNodeException` |
 | loud | the target frameworks | `net7.0;netstandard2.0` | `netstandard2.0;net8.0;net10.0` |
+| **silent** | `abs(x) = c` for a negative `c` | a set of non-solutions | the empty set |
 
 ---
 

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/InvertNode.Classes.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/InvertNode.Classes.cs
@@ -259,11 +259,17 @@ namespace AngouriMath
             // abs(f(x)) = value
             // f(x) = value * e ^ (i * n)
             // x = f(x).InvertNode(value * e ^ (i * n), x)
+            //
+            // value * e ^ (i * r) has modulus |value|, not value, so it solves the equation
+            // only where the two agree -- that is, where value is real and not negative.
+            // Without that condition abs(x) = -1 came back as { -e ^ (i * r) provided r in RR },
+            // whose members have modulus 1 and solve nothing.
+            // https://github.com/asc-community/AngouriMath/issues/812
             private protected override IEnumerable<Entity> InvertNode(Entity value, Entity x)
             {
                 var @var = Variable.CreateUnique(value + Argument, "r");
                 return Argument.Invert(value * MathS.e.Pow(MathS.i * @var), x)
-                    .Select(c => c.Provided(@var.In(MathS.Sets.R)));
+                    .Select(c => c.Provided(@var.In(MathS.Sets.R) & new GreaterOrEqualf(value, 0)));
             }
         }
 

--- a/Sources/Tests/UnitTests/Common/SolverRegressionTest.cs
+++ b/Sources/Tests/UnitTests/Common/SolverRegressionTest.cs
@@ -199,5 +199,49 @@ namespace AngouriMath.Tests.Common
             // The omega constant: the root of x = -ln(x).
             Assert.Equal(0.5671432904097838, root.EvalNumerical().RealPart.EDecimal.ToDouble(), 9);
         }
+
+        // abs(x) = a was inverted to the circle a * e ^ (i * r), which has modulus |a| and
+        // so only solves the equation where a is real and not negative. The condition was
+        // missing, so a negative right-hand side came back with a set of non-solutions
+        // rather than with nothing. https://github.com/asc-community/AngouriMath/issues/812
+        [Theory]
+        [InlineData("abs(x) = -1")]
+        [InlineData("abs(x) = -3/2")]
+        [InlineData("abs(x) + 1 = 0")]
+        public void Issue812_AnAbsoluteValueCannotEqualANegative(string equation)
+        {
+            var solutions = (Entity.Set.FiniteSet)equation.ToEntity().Solve("x");
+            Assert.Empty(solutions);
+        }
+
+        // The guard must not cost the answers that were right. Each solution is checked by
+        // substituting it back, with the free parameter of the circle given a value, rather
+        // than by comparing the printed form.
+        [Theory]
+        [InlineData("3", 3.0)]
+        [InlineData("1/2", 0.5)]
+        [InlineData("0", 0.0)]
+        public void Issue812_ANonNegativeRightHandSideStillSolves(string rhs, double modulus)
+        {
+            var solutions = (Entity.Set.FiniteSet)$"abs(x) = {rhs}".ToEntity().Solve("x");
+            var solution = Assert.Single(solutions);
+            var parameter = solution.Vars.Single(v => v.Name != "x");
+            foreach (var point in new[] { 0.0, 1.0, -2.5 })
+            {
+                var candidate = solution.Substitute(parameter, point);
+                while (candidate is Entity.Providedf(var inner, _)) candidate = inner;
+                Assert.Equal(modulus,
+                    MathS.Abs(candidate).EvalNumerical().RealPart.EDecimal.ToDouble(), 9);
+            }
+        }
+
+        // A symbolic right-hand side cannot be decided either way, so the condition is
+        // carried rather than resolved -- which is what #318 asked this inversion to do.
+        [Fact]
+        public void Issue812_ASymbolicRightHandSideCarriesTheCondition()
+        {
+            var printed = "abs(x) = a".ToEntity().Solve("x").Stringize();
+            Assert.Contains("a >= 0", printed);
+        }
     }
 }


### PR DESCRIPTION
Closes #812. Partly closes #318 — see below.

```csharp
"abs(x) = -1".ToEntity().Solve("x")
// was   { -e ^ (i * r_1) provided r_1 in RR }
// is    { }
```

## The old answer was wrong, not merely loose

At `r_1 = 0` its member is `-1`, and `abs(-1)` is `1`, not `-1`. Every member has modulus 1 and solves nothing.

## Cause

`abs(f(x)) = value` is inverted by writing `f(x)` as `value * e ^ (i * r)` over real `r` — the circle of radius `|value|`. That solves the equation only where `|value|` and `value` agree, which is where `value` is real and not negative. The condition saying so was missing.

It is now carried alongside the one on `r`:

| | |
|---|---|
| `abs(x) = -1` | `{ }` ← **fixed** |
| `abs(x) = 3` | `{ 3 * e ^ (i * r_1) provided r_1 in RR }` ← unchanged |
| `abs(x) = 0` | `{ 0 provided r_1 in RR }` ← unchanged |
| `abs(x) = a` | `{ a * e ^ (i * r_1) provided r_1 in RR and a >= 0 }` ← **new condition** |

A decidable negative collapses the set to empty; a decidable non-negative drops the condition and leaves the previous answer untouched; a symbolic one is kept rather than guessed at.

## This is the missing half of #318

#318 asks for exactly this inversion and names both halves in one sentence:

> `|x| = a` should return `{ a e ^ (i * r) : r in RR **and a >= 0** }`

The `r in RR` half was already implemented. This is the `a >= 0` half. What remains of #318 after this is only the internal return type — `Invert` is `internal` and `InvertNode` is `private protected`, so that part breaks nobody and is not urgent. Detail in [this comment](https://github.com/asc-community/AngouriMath/issues/318#issuecomment-5226016236).

## Tests

Solutions are checked by **substituting them back** with the circle's parameter given a value, not by comparing printed form.

**Checked for teeth** against `origin/master`: four of the seven fail without the fix. The three that pass on both sides are the ones asserting the previously-correct answers are unchanged, which is what they are for.

## Verification

5558 unit tests, 130 F# tests. casbench 113/117 with **0 wrong**, propcheck 0 failures, rootcheck 596/596, simpsweep 10463/10463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)