### PR TITLE
Make a mathematical operation a value, and put the 1.x entry points on it (#746)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,6 +201,38 @@ with the measurements against it.
 product is contraction, not convolution), and operators or gates — those act *on* states rather than
 being states, and they belong to a quantum computing library rather than to a CAS.
 
+## An operation is a value, not only a method
+
+`Simplify`, `Expand`, `Factorize`, `Differentiate`, `Integrate` and `Limit` are adapters over
+`AngouriMath.Core.Transformations` — a `Transformation` is the operation itself, carrying a name,
+what it claims about its output, and how well justified the claim is. The algorithms underneath are
+untouched; what changed is that a step can be named, composed and enumerated rather than only
+called. See [`Contributing/Transformations.md`](Sources/AngouriMath/Docs/Contributing/Transformations.md),
+and [#746](https://github.com/asc-community/AngouriMath/issues/746) for where it is going.
+
+Three habits it asks for, and each is the honesty rule above in a different place:
+
+**Say which relation you are claiming.** `Equivalence` means the output is another way of writing the
+input; `Derivation` means it is a different object. A derivative and an antiderivative are
+`Derivation`, and a test that subtracts one from its input and asserts zero is testing nothing.
+
+**Do not label a rewrite `Sound` without an argument.** Every rule set shipped today is
+`SoundUnderAssumptions`, and a test over `RewriteRules.All` holds it there. The tier is declared, not
+verified — so promoting one means changing that test, and saying in the same change why the rewrite
+needs no assumptions. Loosening a tier needs nothing.
+
+**Say "no answer" with `null`, here too.** `ApplyCore` returning `null` is the layer's way of saying
+"I could not settle this", and it is the one place where the new layer is *more* honest than the 1.x
+method it backs: `Transformation.Integration` has no answer where `Entity.Integrate` returns an
+unevaluated `Integralf`. Both are the same claim; neither is `NaN`.
+
+And what not to do with it. `Solve` is not a transformation — it consumes a goal and produces a
+solution set, and it belongs in a tactic layer that does not exist yet. `Entity.Set` being an
+`Entity` means it would type-check as `Entity -> Entity`, which is the reason to keep it out rather
+than a reason to put it in. Nor is there any inverse machinery: `Expand` and `Factor` are not
+inverses and `Unsolve` is not well defined, so the API does not invent a symmetry the mathematics
+does not have.
+
 ## Keep up with the mathematics
 
 Algorithms here are decades of literature deep, and the good ones are written down. Before inventing
@@ -294,6 +326,7 @@ are short, and a stale one is worse than none — if you change what a file desc
 | [`Contributing/General.md`](Sources/AngouriMath/Docs/Contributing/General.md) | the `Entity` hierarchy, in a paragraph |
 | [`Contributing/AddingNode.cs`](Sources/AngouriMath/Docs/Contributing/AddingNode.cs) | every place a new node has to be taught about. Read it *before* adding one |
 | [`Contributing/ImproveParser.md`](Sources/AngouriMath/Docs/Contributing/ImproveParser.md) | how to change the grammar and regenerate |
+| [`Contributing/Transformations.md`](Sources/AngouriMath/Docs/Contributing/Transformations.md) | the transformation layer the 1.x entry points sit on, and how to add the next rule set |
 | [`Contributing/coding_rules.md`](Sources/AngouriMath/Docs/Contributing/coding_rules.md) | sealed-or-abstract, and immutability of `Entity` |
 | [`WhatsNew/version_performance_control.md`](Sources/AngouriMath/Docs/WhatsNew/version_performance_control.md) | the inter-version performance table, and how to add a column |
 | `Sources/Analyzers/` | the custom analyzers, including the static-field one behind `[ConstantField]` |

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -19,3 +19,13 @@ dotnet_diagnostic.IDE0090.severity = none
 # dotnet_diagnostic.CA2252.severity = none
 
 file_header_template=\nCopyright (c) 2019-2022 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+# Files written after 2022 say so. Bumping the year on the template above would make
+# IDE0073 fail on all 367 files that already carry the old one, which is a rewrite of every
+# header folded into whatever branch happened to need a new file -- so the year moves per
+# directory as directories are added, not all at once.
+[AngouriMath/Core/Transformations/*.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Core/Transformations/*.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Core/Transformations/RewriteRuleSet.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRuleSet.cs
@@ -1,0 +1,104 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+
+namespace AngouriMath.Core.Transformations
+{
+    /// <summary>
+    /// A named, attributable group of rewrites — the unit this library has always written
+    /// them in — carrying what it is called, what it claims and how well justified the
+    /// claim is, so that the set can be enumerated, tested and referred to by name instead
+    /// of only being called.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The set, rather than the single <c>pattern -&gt; replacement</c> line, is the unit
+    /// here on purpose. Every rewrite in this library is a case of one <c>switch</c>
+    /// matched against a node, and the C# compiler turns that switch into a type test and a
+    /// jump. Splitting each case into its own object would replace one dispatch per node
+    /// with one delegate call per rule per node on the hottest path in the library, and buy
+    /// nothing that a caller can use today. What a caller can use today is the set:
+    /// <see cref="RewriteRules.All"/> is enumerable, each entry is applicable on its own,
+    /// and the tests iterate it.
+    /// </para>
+    /// <para>
+    /// The finer grain is the next step rather than the abandoned one — see
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> on rules
+    /// as data — and nothing here forecloses it: a set whose rewrites become individually
+    /// addressable keeps the same name and the same entry in the registry.
+    /// </para>
+    /// </remarks>
+    public sealed class RewriteRuleSet
+    {
+        private readonly Func<Entity, Entity> rules;
+
+        internal RewriteRuleSet(string name, string description, TransformationRelation relation, Soundness soundness, Func<Entity, Entity> rules)
+            => (Name, Description, Relation, Soundness, this.rules) = (name, description, relation, soundness, rules);
+
+        /// <summary>A stable identity for this set.</summary>
+        public string Name { get; }
+
+        /// <summary>What the set is for, in a sentence.</summary>
+        public string Description { get; }
+
+        /// <summary>What the rewrites in this set claim about the expressions they produce.</summary>
+        public TransformationRelation Relation { get; }
+
+        /// <summary>How well justified that claim is. See <see cref="Soundness"/> on what a tier here is and is not.</summary>
+        public Soundness Soundness { get; }
+
+        /// <summary>
+        /// Applies the set once, bottom-up over every node, exactly as
+        /// <see cref="Entity.Replace(Func{Entity, Entity})"/> does. One pass: a rewrite
+        /// that opens up an opportunity for another rewrite in the same set will not see it
+        /// taken until the next pass.
+        /// </summary>
+        /// <param name="expression">The expression to rewrite.</param>
+        public Entity ApplyOnce(Entity expression)
+            => expression is null
+                ? throw new ArgumentNullException(nameof(expression))
+                : expression.Replace(rules);
+
+        /// <summary>
+        /// This set as a <see cref="Transformation"/>, so that it composes with the rest of
+        /// the catalogue.
+        /// </summary>
+        /// <remarks>
+        /// Built on demand, and it has to be. <see cref="RewritingTransformation"/> derives
+        /// from <see cref="Transformation"/>, so constructing one runs that type's static
+        /// initialiser -- which reads <see cref="RewriteRules"/>. Doing it in this
+        /// constructor instead would make the two types depend on each other's
+        /// initialisation and hand whichever one lost the race a null rule set. Two threads
+        /// arriving together may each build one; they are equivalent and immutable, so
+        /// whichever reference lands is the one everyone then uses.
+        /// </remarks>
+        public Transformation AsTransformation() => asTransformation ??= new RewritingTransformation(this);
+        private Transformation? asTransformation;
+
+        /// <inheritdoc/>
+        public override string ToString() => Name;
+
+        private sealed class RewritingTransformation : Transformation
+        {
+            private readonly RewriteRuleSet ruleSet;
+
+            internal RewritingTransformation(RewriteRuleSet ruleSet) => this.ruleSet = ruleSet;
+
+            public override string Name => $"rewrite[{ruleSet.Name}]";
+
+            public override TransformationRelation Relation => ruleSet.Relation;
+
+            public override Soundness Soundness => ruleSet.Soundness;
+
+            // A rewrite pass always has an answer: where nothing matched, the answer is the
+            // expression it was given. That is a fixed point, not a failure, and
+            // TransformationResult.Changed is what tells the two apart.
+            protected override Entity? ApplyCore(Entity input) => ruleSet.ApplyOnce(input);
+        }
+    }
+}

--- a/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
@@ -1,0 +1,161 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath.Functions;
+
+namespace AngouriMath.Core.Transformations
+{
+    /// <summary>
+    /// The rewrite rule sets this library ships, as data: named, described, attributed with
+    /// what they claim, and enumerable through <see cref="All"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Registration is explicit and static — there is no assembly scanning and no
+    /// <c>Activator</c>, so the registry survives trimming and NativeAOT, and
+    /// <see cref="All"/> is in a fixed order that does not depend on hashing, reflection or
+    /// which type happened to be loaded first.
+    /// </para>
+    /// <para>
+    /// This is a slice, not the whole pattern table. The sets below are the ones the
+    /// transformations in <see cref="Transformation"/> are built from; the rest of
+    /// <c>Functions/Simplification/Patterns</c> is still reached only from
+    /// <c>Simplificator</c>. Adding one here is five lines and gets it enumeration, a
+    /// soundness label and the tests over <see cref="All"/> for free.
+    /// </para>
+    /// </remarks>
+    public static class RewriteRules
+    {
+        /// <summary>
+        /// Puts the operands of commutative chains into a canonical order and groups equal
+        /// ones together, so that <c>x + y</c> and <c>y + x</c> stop being different trees.
+        /// </summary>
+        public static RewriteRuleSet CanonicalOrder { get; } = new(
+            nameof(CanonicalOrder),
+            "Sorts and groups the operands of sums, products, conjunctions, disjunctions and set operations.",
+            TransformationRelation.Equivalence,
+            // Regrouping reads a quotient as a product with a negative power, which is the
+            // same value wherever the divisor is not zero.
+            Soundness.SoundUnderAssumptions,
+            Patterns.SortRules(TreeAnalyzer.SortLevel.HIGH_LEVEL));
+
+        /// <summary>
+        /// Turns a negative power into a quotient: <c>a * b ^ (-1)</c> becomes <c>a / b</c>.
+        /// </summary>
+        public static RewriteRuleSet InvertNegativePowers { get; } = new(
+            nameof(InvertNegativePowers),
+            "Rewrites negative powers as quotients.",
+            TransformationRelation.Equivalence,
+            Soundness.SoundUnderAssumptions,
+            Patterns.InvertNegativePowers);
+
+        /// <summary>
+        /// Brings a negative numeric factor out in front of the term it multiplies.
+        /// </summary>
+        public static RewriteRuleSet InvertNegativeMultipliers { get; } = new(
+            nameof(InvertNegativeMultipliers),
+            "Moves a negative numeric factor out of a product into the sign of the term.",
+            TransformationRelation.Equivalence,
+            Soundness.SoundUnderAssumptions,
+            Patterns.InvertNegativeMultipliers);
+
+        /// <summary>
+        /// The arithmetic housekeeping rules — collecting like terms, flattening nested
+        /// quotients, moving numeric coefficients to the front.
+        /// </summary>
+        public static RewriteRuleSet Common { get; } = new(
+            nameof(Common),
+            "Collects like terms and normalises the arrangement of products and quotients.",
+            TransformationRelation.Equivalence,
+            Soundness.SoundUnderAssumptions,
+            Patterns.CommonRules);
+
+        /// <summary>
+        /// Rules about powers, roots and logarithms.
+        /// </summary>
+        public static RewriteRuleSet Power { get; } = new(
+            nameof(Power),
+            "Gathers and splits powers, roots and logarithms.",
+            TransformationRelation.Equivalence,
+            // (a ^ b) ^ c is a ^ (b c) only on a branch; the rules guard for it, and the
+            // guard is what the tier is stating.
+            Soundness.SoundUnderAssumptions,
+            Patterns.PowerRules);
+
+        /// <summary>
+        /// The trigonometric identities.
+        /// </summary>
+        public static RewriteRuleSet Trigonometric { get; } = new(
+            nameof(Trigonometric),
+            "Applies trigonometric identities to sines, cosines and their relatives.",
+            TransformationRelation.Equivalence,
+            // tan and cot bring poles with them, so an identity that introduces one holds
+            // away from those points rather than everywhere.
+            Soundness.SoundUnderAssumptions,
+            Patterns.TrigonometricRules);
+
+        /// <summary>
+        /// Multiplies products over sums out.
+        /// </summary>
+        public static RewriteRuleSet Expansion { get; } = new(
+            nameof(Expansion),
+            "Distributes products and powers over sums.",
+            TransformationRelation.Equivalence,
+            Soundness.SoundUnderAssumptions,
+            Patterns.ExpandRules);
+
+        /// <summary>
+        /// Takes common factors back out of a sum.
+        /// </summary>
+        public static RewriteRuleSet Factorization { get; } = new(
+            nameof(Factorization),
+            "Gathers common factors out of sums.",
+            TransformationRelation.Equivalence,
+            Soundness.SoundUnderAssumptions,
+            Patterns.FactorizeRules);
+
+        /// <summary>
+        /// Recognises a perfect square written out, so that factorisation has something to
+        /// gather.
+        /// </summary>
+        public static RewriteRuleSet PerfectSquare { get; } = new(
+            nameof(PerfectSquare),
+            "Collapses a written-out perfect square into a squared binomial.",
+            TransformationRelation.Equivalence,
+            Soundness.SoundUnderAssumptions,
+            Patterns.PerfectSquareRules);
+
+        /// <summary>
+        /// Clears a surd out of a two-term denominator.
+        /// </summary>
+        public static RewriteRuleSet RationaliseDenominator { get; } = new(
+            nameof(RationaliseDenominator),
+            "Multiplies a quotient by the conjugate of its denominator to clear a surd from it.",
+            TransformationRelation.Equivalence,
+            Soundness.SoundUnderAssumptions,
+            Patterns.RationaliseDenominator);
+
+        /// <summary>
+        /// Every rule set registered above, in a fixed order. Enumerable so that a property
+        /// that should hold of all of them can be tested over all of them rather than over
+        /// whichever ones somebody remembered.
+        /// </summary>
+        public static IReadOnlyList<RewriteRuleSet> All { get; } = new[]
+        {
+            CanonicalOrder,
+            InvertNegativePowers,
+            InvertNegativeMultipliers,
+            Common,
+            Power,
+            Trigonometric,
+            Expansion,
+            Factorization,
+            PerfectSquare,
+            RationaliseDenominator,
+        };
+    }
+}

--- a/Sources/AngouriMath/Core/Transformations/Soundness.cs
+++ b/Sources/AngouriMath/Core/Transformations/Soundness.cs
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+namespace AngouriMath.Core.Transformations
+{
+    /// <summary>
+    /// How well justified the relation a <see cref="Transformation"/> claims between its
+    /// input and its output is. The three tiers are never blurred: a heuristic labelled as
+    /// a proof is a wrong answer with a friendly face.
+    /// </summary>
+    /// <remarks>
+    /// The tier is <b>declared</b> by whoever wrote the transformation, not derived from it.
+    /// Nothing in the library checks a declaration today, so a tier is a claim to be argued
+    /// with rather than a guarantee to be relied on, and the registry starts conservative
+    /// on purpose: tightening a label needs an argument, loosening one does not.
+    /// </remarks>
+    public enum Soundness
+    {
+        /// <summary>
+        /// The claimed relation holds for every value of the free variables, with no side
+        /// conditions and no choice of branch.
+        /// </summary>
+        Sound,
+
+        /// <summary>
+        /// The claimed relation holds only where the stated assumptions do: wherever both
+        /// sides are defined, under the conditions the output carries as
+        /// <see cref="Entity.Providedf"/>, or under a branch-cut convention. This is the
+        /// honest tier for most of the rewrite rules in this library.
+        /// </summary>
+        SoundUnderAssumptions,
+
+        /// <summary>
+        /// Worth trying; proves nothing. A heuristic result has to be checked by something
+        /// else before it may be returned as an answer.
+        /// </summary>
+        Heuristic
+    }
+}

--- a/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
+++ b/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
@@ -1,0 +1,297 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Functions;
+using AngouriMath.Functions.Algebra;
+using static AngouriMath.Entity;
+
+namespace AngouriMath.Core.Transformations
+{
+    partial class Transformation
+    {
+        /// <summary>
+        /// Applies a rewrite rule set once over every node.
+        /// </summary>
+        /// <param name="ruleSet">The set to apply; see <see cref="RewriteRules"/>.</param>
+        public static Transformation Rewriting(RewriteRuleSet ruleSet)
+            => (ruleSet ?? throw new ArgumentNullException(nameof(ruleSet))).AsTransformation();
+
+        /// <summary>
+        /// One structural tidying pass — <see cref="Entity.InnerSimplified"/>. Cheap, and
+        /// no pattern search.
+        /// </summary>
+        public static Transformation InnerSimplification { get; } = new InnerSimplificationTransformation();
+
+        /// <summary>
+        /// The full simplification pipeline at the default level, as
+        /// <see cref="Entity.Simplify(int)"/> runs it.
+        /// </summary>
+        public static Transformation Simplification { get; } = SimplificationAtLevel(2);
+
+        /// <summary>
+        /// The full simplification pipeline at a chosen level.
+        /// </summary>
+        /// <param name="level">
+        /// How hard to look; the same argument <see cref="Entity.Simplify(int)"/> takes.
+        /// </param>
+        public static Transformation SimplificationAtLevel(int level)
+            => LevelledCache.Simplification.For(level, static l => new SimplificationTransformation(l));
+
+        /// <summary>
+        /// Multiplies products over sums out, as <see cref="Entity.Expand(int)"/> does.
+        /// </summary>
+        public static Transformation Expansion { get; } = ExpansionAtLevel(2);
+
+        /// <summary>
+        /// Multiplies products over sums out, for a chosen number of passes.
+        /// </summary>
+        /// <param name="level">The number of passes; the argument <see cref="Entity.Expand(int)"/> takes.</param>
+        public static Transformation ExpansionAtLevel(int level)
+            => LevelledCache.Expansion.For(level, static l => new ExpansionTransformation(l));
+
+        /// <summary>
+        /// Gathers common factors back out, as <see cref="Entity.Factorize(int)"/> does.
+        /// </summary>
+        public static Transformation Factorization { get; } = FactorizationAtLevel(2);
+
+        /// <summary>
+        /// Gathers common factors back out, for a chosen number of passes.
+        /// </summary>
+        /// <param name="level">The number of passes; the argument <see cref="Entity.Factorize(int)"/> takes.</param>
+        /// <remarks>
+        /// Built out of the registry rather than written again: one pass is the perfect
+        /// square rules, then the factorisation rules, then a tidying pass, and the level is
+        /// how many times that runs.
+        /// </remarks>
+        public static Transformation FactorizationAtLevel(int level)
+            => LevelledCache.Factorization.For(level, static l =>
+                Rewriting(RewriteRules.PerfectSquare)
+                    .Then(Rewriting(RewriteRules.Factorization))
+                    .Then(InnerSimplification)
+                    // Entity.Factorize has always run at least one pass, whatever it was asked for.
+                    .Repeat(Math.Max(l, 1)));
+
+        /// <summary>
+        /// Puts commutative chains into a canonical order, so that expressions which differ
+        /// only in the arrangement of their operands become the same tree.
+        /// </summary>
+        /// <remarks>
+        /// Not a simplification: it makes an expression comparable, not shorter. It has
+        /// always been available inside <c>Simplify</c> and had no name of its own until
+        /// this layer gave the rule set one.
+        /// </remarks>
+        public static Transformation Normalization { get; }
+            = Rewriting(RewriteRules.CanonicalOrder).Then(InnerSimplification);
+
+        /// <summary>
+        /// Clears a surd out of a two-term denominator: <c>1 / (sqrt(3) + 5)</c> becomes
+        /// <c>(sqrt(3) - 5) / (-22)</c>.
+        /// </summary>
+        public static Transformation Rationalisation { get; }
+            = Rewriting(RewriteRules.RationaliseDenominator).Then(InnerSimplification);
+
+        /// <summary>
+        /// Replaces every occurrence of <paramref name="what"/> with
+        /// <paramref name="with"/>, as <see cref="Entity.Substitute(Entity, Entity)"/> does.
+        /// </summary>
+        /// <param name="what">The subexpression to replace.</param>
+        /// <param name="with">What to put in its place.</param>
+        public static Transformation Substitution(Entity what, Entity with)
+            => new SubstitutionTransformation(
+                what ?? throw new ArgumentNullException(nameof(what)),
+                with ?? throw new ArgumentNullException(nameof(with)));
+
+        /// <summary>
+        /// The symbolic derivative over <paramref name="variable"/>, as
+        /// <see cref="Entity.Differentiate(Variable)"/> computes it.
+        /// </summary>
+        /// <param name="variable">The variable to differentiate over.</param>
+        public static Transformation Differentiation(Variable variable)
+            => new DifferentiationTransformation(variable ?? throw new ArgumentNullException(nameof(variable)));
+
+        /// <summary>
+        /// The antiderivative over <paramref name="variable"/>, <b>without</b> the constant
+        /// of integration — <see cref="Entity.Integrate(Variable)"/> is what adds it.
+        /// </summary>
+        /// <param name="variable">The variable to integrate over.</param>
+        /// <remarks>
+        /// Where no antiderivative is found this says so, by having no answer.
+        /// <see cref="Entity.Integrate(Variable)"/> hands back an unevaluated
+        /// <see cref="Entity.Integralf"/> instead, which is the same claim in the shape 1.x
+        /// callers expect.
+        /// </remarks>
+        public static Transformation Integration(Variable variable)
+            => new IntegrationTransformation(variable ?? throw new ArgumentNullException(nameof(variable)));
+
+        /// <summary>
+        /// The limit over <paramref name="variable"/> as it approaches
+        /// <paramref name="destination"/> from <paramref name="side"/>.
+        /// </summary>
+        /// <param name="variable">The variable that approaches.</param>
+        /// <param name="destination">Where it approaches.</param>
+        /// <param name="side">From which side.</param>
+        /// <remarks>
+        /// The limit as computed, not further simplified — <see cref="Entity.Limit(Variable, Entity, ApproachFrom)"/>
+        /// is what tidies it. Where the limit cannot be settled this has no answer, rather
+        /// than the unevaluated <see cref="Entity.Limitf"/> node the 1.x method returns;
+        /// neither is a claim that the limit does not exist.
+        /// </remarks>
+        public static Transformation LimitAt(Variable variable, Entity destination, ApproachFrom side)
+            => new LimitTransformation(
+                variable ?? throw new ArgumentNullException(nameof(variable)),
+                destination ?? throw new ArgumentNullException(nameof(destination)),
+                side);
+
+        /// <summary>
+        /// The transformations that differ only by a level, built once, so that an ordinary
+        /// <c>Simplify()</c> allocates nothing to reach its transformation.
+        /// </summary>
+        /// <remarks>
+        /// Filled on demand rather than in the static initialiser, and it has to be. Building
+        /// the factorisation entry reads <see cref="RewriteRules"/>, whose sets in turn build
+        /// transformations of their own; doing that while this type is still initialising
+        /// makes the two types depend on each other's initialisation, and one of them then
+        /// reads the other's fields before they are set. Two threads arriving together may
+        /// each build the same entry; the entries are equivalent and immutable, so whichever
+        /// reference lands is the one everyone then uses.
+        /// </remarks>
+        private sealed class LevelledCache
+        {
+            // The levels Simplify, Expand and Factorize are actually asked for: the default
+            // 2, the negated -level Simplify passes itself, and a little room either side.
+            private const int Lowest = -4;
+            private const int Highest = 4;
+
+            [ConcurrentField]
+            internal static readonly LevelledCache Simplification = new();
+            [ConcurrentField]
+            internal static readonly LevelledCache Expansion = new();
+            [ConcurrentField]
+            internal static readonly LevelledCache Factorization = new();
+
+            private readonly Transformation?[] cached = new Transformation?[Highest - Lowest + 1];
+
+            internal Transformation For(int level, Func<int, Transformation> make)
+                => level < Lowest || level > Highest
+                    ? make(level)
+                    : cached[level - Lowest] ??= make(level);
+        }
+
+        private sealed class InnerSimplificationTransformation : Transformation
+        {
+            public override string Name => "inner-simplify";
+
+            public override TransformationRelation Relation => TransformationRelation.Equivalence;
+
+            public override Soundness Soundness => Soundness.SoundUnderAssumptions;
+
+            protected override Entity? ApplyCore(Entity input) => input.InnerSimplified;
+        }
+
+        private sealed class SimplificationTransformation : Transformation
+        {
+            private readonly int level;
+
+            internal SimplificationTransformation(int level) => this.level = level;
+
+            public override string Name => $"simplify[{level}]";
+
+            public override TransformationRelation Relation => TransformationRelation.Equivalence;
+
+            public override Soundness Soundness => Soundness.SoundUnderAssumptions;
+
+            protected override Entity? ApplyCore(Entity input) => Simplificator.Simplify(input, level);
+        }
+
+        private sealed class ExpansionTransformation : Transformation
+        {
+            private readonly int level;
+
+            internal ExpansionTransformation(int level) => this.level = level;
+
+            public override string Name => $"expand[{level}]";
+
+            public override TransformationRelation Relation => TransformationRelation.Equivalence;
+
+            public override Soundness Soundness => Soundness.SoundUnderAssumptions;
+
+            protected override Entity? ApplyCore(Entity input) => input.ExpandOverSum(level);
+        }
+
+        private sealed class SubstitutionTransformation : Transformation
+        {
+            private readonly Entity what, with;
+
+            internal SubstitutionTransformation(Entity what, Entity with) => (this.what, this.with) = (what, with);
+
+            public override string Name => $"substitute[{what.Stringize()} := {with.Stringize()}]";
+
+            // The output is a different expression from the input, not another way of
+            // writing it, so subtracting the two means nothing.
+            public override TransformationRelation Relation => TransformationRelation.Derivation;
+
+            // Replacing every occurrence of a subexpression by another is valid whatever
+            // the two are; nothing about it is conditional.
+            public override Soundness Soundness => Soundness.Sound;
+
+            protected override Entity? ApplyCore(Entity input) => input.Substitute(what, with);
+        }
+
+        private sealed class DifferentiationTransformation : Transformation
+        {
+            private readonly Variable variable;
+
+            internal DifferentiationTransformation(Variable variable) => this.variable = variable;
+
+            public override string Name => $"differentiate[{variable.Name}]";
+
+            public override TransformationRelation Relation => TransformationRelation.Derivation;
+
+            // The derivative is the derivative where the expression is differentiable, and
+            // an unevaluated Derivativef node where this library does not know a rule.
+            public override Soundness Soundness => Soundness.SoundUnderAssumptions;
+
+            protected override Entity? ApplyCore(Entity input) => input.DifferentiateOnce(variable);
+        }
+
+        private sealed class IntegrationTransformation : Transformation
+        {
+            private readonly Variable variable;
+
+            internal IntegrationTransformation(Variable variable) => this.variable = variable;
+
+            public override string Name => $"integrate[{variable.Name}]";
+
+            public override TransformationRelation Relation => TransformationRelation.Derivation;
+
+            public override Soundness Soundness => Soundness.SoundUnderAssumptions;
+
+            protected override Entity? ApplyCore(Entity input)
+                => Functions.Algebra.Integration.ComputeIndefiniteIntegral(input.InnerSimplified, variable)?.InnerSimplified;
+        }
+
+        private sealed class LimitTransformation : Transformation
+        {
+            private readonly Variable variable;
+            private readonly Entity destination;
+            private readonly ApproachFrom side;
+
+            internal LimitTransformation(Variable variable, Entity destination, ApproachFrom side)
+                => (this.variable, this.destination, this.side) = (variable, destination, side);
+
+            public override string Name => $"limit[{variable.Name} -> {destination.Stringize()}, {side}]";
+
+            public override TransformationRelation Relation => TransformationRelation.Derivation;
+
+            public override Soundness Soundness => Soundness.SoundUnderAssumptions;
+
+            protected override Entity? ApplyCore(Entity input)
+                => LimitFunctional.ComputeLimit(input, variable, destination, side);
+        }
+    }
+}

--- a/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
+++ b/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
@@ -148,8 +148,8 @@ namespace AngouriMath.Core.Transformations
                 side);
 
         /// <summary>
-        /// The transformations that differ only by a level, built once, so that an ordinary
-        /// <c>Simplify()</c> allocates nothing to reach its transformation.
+        /// The transformations that differ only by a level, each built at most once, so that
+        /// an ordinary <c>Simplify()</c> allocates nothing to reach its transformation.
         /// </summary>
         /// <remarks>
         /// Filled on demand rather than in the static initialiser, and it has to be. Building

--- a/Sources/AngouriMath/Core/Transformations/Transformation.Combinators.cs
+++ b/Sources/AngouriMath/Core/Transformations/Transformation.Combinators.cs
@@ -1,0 +1,141 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+
+namespace AngouriMath.Core.Transformations
+{
+    partial class Transformation
+    {
+        /// <summary>
+        /// Runs this transformation and then <paramref name="next"/> on what it produced.
+        /// Where either step has no answer, the composition has none: a step that could not
+        /// be settled is not silently skipped.
+        /// </summary>
+        /// <param name="next">The transformation to apply to this one's output.</param>
+        public Transformation Then(Transformation next)
+            => new SequentialTransformation(this, next ?? throw new ArgumentNullException(nameof(next)));
+
+        /// <summary>
+        /// Runs this transformation <paramref name="times"/> times in a row. The bound is
+        /// the caller's, which is what keeps repetition terminating by construction rather
+        /// than by the good behaviour of whatever is being repeated.
+        /// </summary>
+        /// <param name="times">How many applications; must not be negative.</param>
+        public Transformation Repeat(int times)
+            => times < 0
+                ? throw new ArgumentOutOfRangeException(nameof(times))
+                : new RepeatedTransformation(this, times);
+
+        /// <summary>
+        /// Runs this transformation until its output stops changing, giving up after
+        /// <paramref name="maxIterations"/> applications.
+        /// </summary>
+        /// <param name="maxIterations">The bound on applications; must be positive.</param>
+        /// <remarks>
+        /// Hitting the bound is reported as <b>no answer</b> rather than as the last value
+        /// reached. An unbounded rewrite loop is the failure mode this layer is supposed to
+        /// make visible, and handing back a value from the middle of one would hide exactly
+        /// the case worth seeing. It is also what lets a test assert that a rule set has a
+        /// fixed point on a given expression instead of assuming it.
+        /// </remarks>
+        public Transformation UntilStable(int maxIterations)
+            => maxIterations < 1
+                ? throw new ArgumentOutOfRangeException(nameof(maxIterations))
+                : new StableTransformation(this, maxIterations);
+
+        /// <summary>
+        /// The weaker of two justifications. Composing anything with a heuristic gives a
+        /// heuristic; nothing composes upwards into a stronger claim.
+        /// </summary>
+        private static Soundness Weaker(Soundness one, Soundness another)
+            => one > another ? one : another;
+
+        /// <summary>
+        /// A chain is an equivalence only if every link is. One derivation anywhere in it
+        /// means the end no longer denotes the same value as the start.
+        /// </summary>
+        private static TransformationRelation Combine(TransformationRelation one, TransformationRelation another)
+            => one is TransformationRelation.Equivalence && another is TransformationRelation.Equivalence
+                ? TransformationRelation.Equivalence
+                : TransformationRelation.Derivation;
+
+        private sealed class SequentialTransformation : Transformation
+        {
+            private readonly Transformation first, second;
+
+            internal SequentialTransformation(Transformation first, Transformation second)
+                => (this.first, this.second) = (first, second);
+
+            public override string Name => $"{first.Name} then {second.Name}";
+
+            public override TransformationRelation Relation => Combine(first.Relation, second.Relation);
+
+            public override Soundness Soundness => Weaker(first.Soundness, second.Soundness);
+
+            protected override Entity? ApplyCore(Entity input)
+                => first.Apply(input).Output is { } intermediate
+                    ? second.Apply(intermediate).Output
+                    : null;
+        }
+
+        private sealed class RepeatedTransformation : Transformation
+        {
+            private readonly Transformation inner;
+            private readonly int times;
+
+            internal RepeatedTransformation(Transformation inner, int times)
+                => (this.inner, this.times) = (inner, times);
+
+            public override string Name => $"{inner.Name} x{times}";
+
+            public override TransformationRelation Relation => inner.Relation;
+
+            public override Soundness Soundness => inner.Soundness;
+
+            protected override Entity? ApplyCore(Entity input)
+            {
+                var current = input;
+                for (var i = 0; i < times; i++)
+                    if (inner.Apply(current).Output is { } next)
+                        current = next;
+                    else
+                        return null;
+                return current;
+            }
+        }
+
+        private sealed class StableTransformation : Transformation
+        {
+            private readonly Transformation inner;
+            private readonly int maxIterations;
+
+            internal StableTransformation(Transformation inner, int maxIterations)
+                => (this.inner, this.maxIterations) = (inner, maxIterations);
+
+            public override string Name => $"{inner.Name} until stable (<={maxIterations})";
+
+            public override TransformationRelation Relation => inner.Relation;
+
+            public override Soundness Soundness => inner.Soundness;
+
+            protected override Entity? ApplyCore(Entity input)
+            {
+                var current = input;
+                for (var i = 0; i < maxIterations; i++)
+                {
+                    if (inner.Apply(current).Output is not { } next)
+                        return null;
+                    if (next == current)
+                        return current;
+                    current = next;
+                }
+                return null;
+            }
+        }
+    }
+}

--- a/Sources/AngouriMath/Core/Transformations/Transformation.cs
+++ b/Sources/AngouriMath/Core/Transformations/Transformation.cs
@@ -1,0 +1,105 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+
+namespace AngouriMath.Core.Transformations
+{
+    /// <summary>
+    /// A named mathematical operation that consumes an <see cref="Entity"/> and produces
+    /// one, together with enough about itself — what it claims, how well justified the
+    /// claim is — to be inspected and composed rather than only invoked.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the layer the 1.x entry points sit on:
+    /// <see cref="Entity.Simplify(int)"/>, <see cref="Entity.Expand(int)"/> and
+    /// <see cref="Entity.Factorize(int)"/> are adapters over the transformations named
+    /// below, and the algorithms underneath are unchanged. Callers who only want an answer
+    /// should keep using those methods; this type is for callers who want to know which
+    /// operation produced it, or to build an operation out of others.
+    /// </para>
+    /// <para>
+    /// Deterministic: the same transformation applied to the same expression under the same
+    /// <see cref="MathS.Settings"/> gives the same result. Composition is by explicit
+    /// ordering — there is no registry that decides what to run next, and nothing here
+    /// consults reflection, so the layer stays trimmable and AOT-publishable.
+    /// </para>
+    /// <para>
+    /// <b>Experimental.</b> The three concepts — a transformation, its relation, its
+    /// soundness tier — are meant to last; the catalogue of factories will grow and the
+    /// signatures here may still move. The stable surface is <see cref="MathS"/> and the
+    /// methods on <see cref="Entity"/>.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// using System;
+    /// using AngouriMath;
+    /// using AngouriMath.Core.Transformations;
+    ///
+    /// Entity expr = "(x + 1) ^ 2";
+    /// var result = Transformation.Expansion.Apply(expr);
+    /// Console.WriteLine(result.Output);
+    /// Console.WriteLine(result.Relation);
+    /// Console.WriteLine(result.Soundness);
+    /// </code>
+    /// Prints
+    /// <code>
+    /// 1 + 2 * x + x ^ 2
+    /// Equivalence
+    /// SoundUnderAssumptions
+    /// </code>
+    /// </example>
+    public abstract partial class Transformation
+    {
+        /// <summary>
+        /// A stable identity for this operation, used in diagnostics and in the failure a
+        /// caller is handed. Composed transformations name their parts.
+        /// </summary>
+        public abstract string Name { get; }
+
+        /// <summary>What this operation claims about its output relative to its input.</summary>
+        public abstract TransformationRelation Relation { get; }
+
+        /// <summary>How well justified that claim is.</summary>
+        public abstract Soundness Soundness { get; }
+
+        /// <summary>
+        /// Does the work. Returns <see langword="null"/> to mean "I could not settle this" —
+        /// never an unevaluated node of the input, and never <see cref="MathS.NaN"/> for a
+        /// question that merely went unanswered.
+        /// </summary>
+        /// <param name="input">The expression to transform.</param>
+        protected abstract Entity? ApplyCore(Entity input);
+
+        /// <summary>
+        /// Applies the transformation, reporting what happened rather than only the value.
+        /// </summary>
+        /// <param name="input">The expression to transform.</param>
+        /// <returns>
+        /// The input, the output where there is one, and this transformation. See
+        /// <see cref="TransformationResult.Succeeded"/> for the case where there is none.
+        /// </returns>
+        public TransformationResult Apply(Entity input)
+        {
+            if (input is null)
+                throw new ArgumentNullException(nameof(input));
+            return new TransformationResult(this, input, ApplyCore(input));
+        }
+
+        /// <summary>
+        /// Applies the transformation and hands back the input untouched where it produced
+        /// no answer — the convention the 1.x methods have always followed.
+        /// </summary>
+        /// <param name="input">The expression to transform.</param>
+        public Entity ApplyOrKeep(Entity input) => Apply(input).OutputOrInput;
+
+        /// <inheritdoc/>
+        public override string ToString() => Name;
+    }
+}

--- a/Sources/AngouriMath/Core/Transformations/TransformationRelation.cs
+++ b/Sources/AngouriMath/Core/Transformations/TransformationRelation.cs
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+namespace AngouriMath.Core.Transformations
+{
+    /// <summary>
+    /// What a <see cref="Transformation"/> claims about its output relative to its input.
+    /// Without this, <see cref="Soundness"/> would be meaningless: "sound" is only a
+    /// statement about some relation, and the relation is not the same one for every
+    /// operation.
+    /// </summary>
+    public enum TransformationRelation
+    {
+        /// <summary>
+        /// The output denotes the same mathematical value as the input, so
+        /// <c>input - output</c> is zero wherever both are defined. Simplification,
+        /// expansion, factorisation and rewriting all claim this.
+        /// </summary>
+        Equivalence,
+
+        /// <summary>
+        /// The output is a different mathematical object computed from the input — a
+        /// derivative, an antiderivative, a limit, an instance under a substitution.
+        /// Subtracting it from the input means nothing, and a test that does so is testing
+        /// nothing.
+        /// </summary>
+        Derivation
+    }
+}

--- a/Sources/AngouriMath/Core/Transformations/TransformationResult.cs
+++ b/Sources/AngouriMath/Core/Transformations/TransformationResult.cs
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+namespace AngouriMath.Core.Transformations
+{
+    /// <summary>
+    /// What one application of a <see cref="Transformation"/> produced: the input, the
+    /// output if there was one, and which transformation was asked.
+    /// </summary>
+    /// <remarks>
+    /// A struct, so that routing an ordinary <c>Simplify</c> or <c>Differentiate</c> call
+    /// through this layer costs no allocation.
+    /// </remarks>
+    public readonly struct TransformationResult
+    {
+        internal TransformationResult(Transformation transformation, Entity input, Entity? output)
+            => (Transformation, Input, Output) = (transformation, input, output);
+
+        /// <summary>The transformation that was applied.</summary>
+        public Transformation Transformation { get; }
+
+        /// <summary>The expression it was applied to.</summary>
+        public Entity Input { get; }
+
+        /// <summary>
+        /// The result, or <see langword="null"/> where the transformation could not settle
+        /// the question. Null means "no answer" and nothing more — in particular it does not
+        /// mean the answer does not exist.
+        /// </summary>
+        public Entity? Output { get; }
+
+        /// <summary>Whether there is an answer at all.</summary>
+        public bool Succeeded => Output is not null;
+
+        /// <summary>
+        /// Whether there is an answer and it differs from the input. A transformation that
+        /// succeeded without changing anything has reached a fixed point, which is what
+        /// <see cref="Transformation.UntilStable(int)"/> looks for.
+        /// </summary>
+        public bool Changed => Output is not null && Output != Input;
+
+        /// <summary>
+        /// The answer where there is one, the untouched input otherwise. This is what the
+        /// 1.x API surface wants: those methods have always returned the original
+        /// expression rather than nothing when they could not improve on it.
+        /// </summary>
+        public Entity OutputOrInput => Output ?? Input;
+
+        /// <summary>What the transformation claims relates <see cref="Input"/> to <see cref="Output"/>.</summary>
+        public TransformationRelation Relation => Transformation.Relation;
+
+        /// <summary>How well justified that claim is.</summary>
+        public Soundness Soundness => Transformation.Soundness;
+
+        /// <inheritdoc/>
+        public override string ToString()
+            => Output is null
+                ? $"{Transformation.Name}: no answer for {Input.Stringize()}"
+                : $"{Transformation.Name}: {Input.Stringize()} -> {Output.Stringize()}";
+    }
+}

--- a/Sources/AngouriMath/Docs/Contributing/README.md
+++ b/Sources/AngouriMath/Docs/Contributing/README.md
@@ -10,7 +10,9 @@ If you aren't sure about what to add, you may want to check the current projects
 1. <a href="./General.md">General information</a>
 2. <a href="./AddingNode.cs">Adding a new node (function, operator)</a>
 3. <a href="./ImproveParser.md">Improve parser</a>
-4. <a href="./RS1617Errors.md">Adding a public member</a> — out of date; the `PublicApi.*.txt` files
+4. <a href="./Transformations.md">Transformations</a> — the layer the 1.x entry points sit on, and
+   how to add the next rule set or transformation
+5. <a href="./RS1617Errors.md">Adding a public member</a> — out of date; the `PublicApi.*.txt` files
    and the analyzer that required them are no longer in the tree
 
 See also <a href="../../../../BREAKING-CHANGES.md">BREAKING-CHANGES.md</a>, where a change that makes

--- a/Sources/AngouriMath/Docs/Contributing/Transformations.md
+++ b/Sources/AngouriMath/Docs/Contributing/Transformations.md
@@ -1,0 +1,132 @@
+# Transformations
+
+`AngouriMath.Core.Transformations` is the layer the 1.x mathematical entry points sit on. It exists
+so that an operation is a **value** — something with a name, a stated claim, and a way to be
+composed — instead of only a method you call.
+
+It is the first step of the rewrite-engine layer in
+[#746](https://github.com/asc-community/AngouriMath/issues/746). It is deliberately small, and it is
+**experimental**: the three concepts are meant to last, the catalogue will grow, and the signatures
+may still move. The stable surface is `MathS` and the methods on `Entity`.
+
+## Why it is not just an interface with `Apply`
+
+Three things have to be said about a mathematical operation before it can be composed with another
+one, and none of them fit in `Entity -> Entity`:
+
+**What it claims.** `Simplify` returns another way of writing the same value. `Differentiate` returns
+a different object. Both are `Entity -> Entity` and confusing them is how you get a test that
+subtracts a derivative from its integrand and asserts zero. `TransformationRelation` is `Equivalence`
+or `Derivation`, and a chain is an equivalence only if every link is.
+
+**How well justified the claim is.** `Soundness` is `Sound`, `SoundUnderAssumptions` or `Heuristic`,
+and composing takes the weaker of two — nothing composes upwards. The tier is **declared, not
+checked**: it is a claim to argue with, not a guarantee, which is why the registry starts
+conservative and why tightening a label needs an argument while loosening one does not.
+
+**Whether it answered at all.** `ApplyCore` returns `null` for "I could not settle this", which is
+the same distinction [AGENTS.md](../../../../AGENTS.md) draws between an unevaluated node and `NaN`.
+`Transformation.Integration("x")` applied to `e ^ (x ^ 2)` has no answer; `Entity.Integrate` makes the
+same claim in the shape its callers expect, by handing back an unevaluated `Integralf`.
+
+## The pieces
+
+| | |
+|---|---|
+| `Transformation` | the operation: `Name`, `Relation`, `Soundness`, `Apply`, and the static catalogue |
+| `TransformationResult` | input, output-or-nothing, and which transformation ran. A struct, so routing an ordinary call through this layer allocates nothing |
+| `RewriteRuleSet` | a named, attributed group of rewrites — `Name`, `Description`, `Relation`, `Soundness`, `ApplyOnce` |
+| `RewriteRules` | the registry: every shipped set, explicitly listed, enumerable through `All` in a fixed order |
+
+Composition is `Then`, `Repeat(n)` and `UntilStable(max)`. All three take their bound from the
+caller: there is no unbounded rewrite loop anywhere in the layer, and `UntilStable` reports hitting
+its bound as **no answer** rather than as the value it happened to be holding, so that a rule set
+which does not converge is visible instead of silently truncated.
+
+Registration is static and explicit. No assembly scanning, no `Activator`, no reflection — the layer
+stays trimmable and NativeAOT-publishable, and `RewriteRules.All` is in an order that does not depend
+on hashing or on which type loaded first.
+
+## What already uses it
+
+```
+Entity.Simplify(level)     ->  Transformation.SimplificationAtLevel(level)  ->  Simplificator.Simplify
+Entity.Expand(level)       ->  Transformation.ExpansionAtLevel(level)       ->  Entity.ExpandOverSum
+Entity.Factorize(level)    ->  Transformation.FactorizationAtLevel(level)   ->  RewriteRules, composed
+Entity.Differentiate(x)    ->  Transformation.Differentiation(x)            ->  Entity.DifferentiateOnce
+Entity.Integrate(x)        ->  Transformation.Integration(x)                ->  Integration.ComputeIndefiniteIntegral
+Entity.Limit(x, to, side)  ->  Transformation.LimitAt(x, to, side)          ->  LimitFunctional.ComputeLimit
+Simplificator.SimplifyChildren  ->  a composed chain of four registry entries
+```
+
+Two of these are real ports rather than wrappers. `Factorize` is no longer a method that names its
+own rules: it is `PerfectSquare`, then `Factorization`, then a tidying pass, repeated `level` times,
+built out of the registry. `SimplifyChildren` — which every stage of the simplification pipeline runs
+— is a chain composed once, statically, out of four registry entries instead of a hand-written run of
+`Replace` calls. Both produce exactly what they produced before.
+
+Everything else is a thin adapter over the algorithm that was already there. **Nothing that worked
+was rewritten to make the architecture tidier.**
+
+## What is deliberately not here
+
+**`Solve` is not a transformation.** It consumes a *goal* — an equation, with a variable to solve for
+— and produces a solution set, and the honest place for it is a tactic layer where a goal can become
+subgoals. `Entity.Set` being an `Entity` means `Solve` would type-check as `Entity -> Entity`; that
+is exactly why forcing it in would be a mistake, since it would compile while saying nothing true
+about what the operation does. Same for `Isolate`, `Eliminate` and `Parametrize` when they arrive.
+
+**There are no inverse transformations.** `Expand` and `Factor` are not inverses, and `Unsolve` is not
+a well-defined operation. Where an inverse is mathematically meaningful there is room to add one; the
+API does not invent symmetry that the mathematics does not have.
+
+**`Heuristic` currently has no instance in the catalogue.** That is a statement about what is
+registered so far, not a claim that nothing in the library guesses.
+
+**Most of the pattern table is still only reachable from `Simplificator`.** `RewriteRules` registers
+the ten sets the catalogue is built from. The rest are unchanged and unregistered.
+
+## Adding the next one
+
+A new transformation built from rules that already exist is one line:
+
+```csharp
+public static Transformation Rationalisation { get; }
+    = Rewriting(RewriteRules.RationaliseDenominator).Then(InnerSimplification);
+```
+
+A new rule set is five, and registering it gets it enumeration, an identity, a soundness label, and
+the tests that run over `RewriteRules.All` — including the one that asserts it reaches a fixed point
+rather than rewriting in a cycle:
+
+```csharp
+public static RewriteRuleSet Power { get; } = new(
+    nameof(Power),
+    "Gathers and splits powers, roots and logarithms.",
+    TransformationRelation.Equivalence,
+    Soundness.SoundUnderAssumptions,
+    Patterns.PowerRules);
+```
+
+Add it to `RewriteRules.All` in the same change — the list is explicit so that its order is a
+decision rather than an accident.
+
+Two things to get right:
+
+- **State the relation honestly.** If the output is not another way of writing the input, it is
+  `Derivation`, and the equivalence property test will correctly leave it alone.
+- **Do not claim `Sound` without an argument.** Every rule set shipped today is
+  `SoundUnderAssumptions`, and the test over `RewriteRules.All` enforces that, so promoting one means
+  changing that test and saying why in the same change.
+
+## What the next step is
+
+The unit here is the rule *set*, not the single `pattern -> replacement` line, because every rewrite
+in this library is a case of one `switch` and the compiler turns that into a type test and a jump —
+splitting each case into an object would trade one dispatch per node for one delegate call per rule
+per node, on the hottest path there is. Making the individual rewrites addressable without paying
+that is the next piece of work, and nothing here forecloses it: a set whose rewrites become
+individually reachable keeps its name and its entry in the registry.
+
+After that, in dependency order: the goal/tactic layer that `Solve` belongs in, and then derivations,
+which want every step to be attributable — which is what naming the steps was for.

--- a/Sources/AngouriMath/Functions/Continuous/Differentiation.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Differentiation.cs
@@ -5,6 +5,7 @@
 // Website: https://am.angouri.org.
 //
 
+using AngouriMath.Core.Transformations;
 using PeterO.Numbers;
 
 namespace AngouriMath
@@ -43,6 +44,14 @@ namespace AngouriMath
         /// </code>
         /// </example>
         public Entity Differentiate(Variable variable)
+            => Transformation.Differentiation(variable).ApplyOrKeep(this);
+
+        /// <summary>
+        /// What <see cref="Differentiate(Variable)"/> does, reachable by
+        /// <see cref="Transformation.Differentiation(Variable)"/> without going back
+        /// through the public method and round again.
+        /// </summary>
+        internal Entity DifferentiateOnce(Variable variable)
             => InnerDifferentiate(variable).InnerSimplified;
 
         /// <summary>

--- a/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
@@ -5,6 +5,7 @@
 // Website: https://am.angouri.org.
 //
 
+using AngouriMath.Core.Transformations;
 using AngouriMath.Extensions;
 using AngouriMath.Functions.Algebra;
 using PeterO.Numbers;
@@ -31,7 +32,7 @@ namespace AngouriMath
         /// https://github.com/asc-community/AngouriMath/issues/772
         /// </remarks>
         public Entity Integrate(Variable x) =>
-            Integration.ComputeIndefiniteIntegral(InnerSimplified, x)?.InnerSimplified is { } antiderivative
+            Transformation.Integration(x).Apply(this).Output is { } antiderivative
             ? antiderivative + (antiderivative.VarsAndConsts.Contains("C") ? Variable.CreateUnique(antiderivative, "C") : "C")
             : new Integralf(this, x, null);
         /// <summary>
@@ -45,7 +46,7 @@ namespace AngouriMath
         /// An integrated expression. It might remain the same or be transformed into nodes with no integrals.
         /// </returns>
         public Entity Integrate(Variable x, Entity from, Entity to) =>
-            Integration.ComputeIndefiniteIntegral(InnerSimplified, x)?.InnerSimplified is { } antiderivative
+            Transformation.Integration(x).Apply(this).Output is { } antiderivative
             ? antiderivative.Substitute(x, to) - antiderivative.Substitute(x, from)
             : new Integralf(this, x, (from, to));
     }

--- a/Sources/AngouriMath/Functions/Continuous/Limits/Limit.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Limits/Limit.Definition.cs
@@ -34,6 +34,7 @@ namespace AngouriMath.Core
 namespace AngouriMath
 {
     using Core;
+    using Core.Transformations;
     using static Functions.Algebra.LimitFunctional;
     partial record Entity
     {
@@ -58,8 +59,8 @@ namespace AngouriMath
         /// cannot be determined
         /// </returns>
         public Entity Limit(Variable x, Entity destination, ApproachFrom side)
-        { 
-            var res = ComputeLimit(this, x, destination, side); 
+        {
+            var res = Transformation.LimitAt(x, destination, side).Apply(this).Output;
             if (res is null) return new Limitf(this, x, destination, side);
             return res.InnerSimplified;
         }
@@ -118,7 +119,9 @@ namespace AngouriMath
         /// </example>
         public Entity Limit(Variable x, Entity destination)
         {
-            var res = ComputeLimit(this, x, destination, ApproachFrom.BothSides);
+            // The NaN test is on the limit as computed, before it is tidied: an expression
+            // that inner-simplifies to NaN is not the same claim as one that came back NaN.
+            var res = Transformation.LimitAt(x, destination, ApproachFrom.BothSides).Apply(this).Output;
             if (res is null || res == MathS.NaN)
                 return new Limitf(this, x, destination, ApproachFrom.BothSides).InnerSimplified;
             return res.InnerSimplified;

--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Definition.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Definition.cs
@@ -5,6 +5,7 @@
 // Website: https://am.angouri.org.
 //
 
+using AngouriMath.Core.Transformations;
 using HonkSharp.Laziness;
 
 namespace AngouriMath
@@ -204,6 +205,14 @@ namespace AngouriMath
         /// </example> 
 
         public Entity Expand(int level = 2)
+            => Transformation.ExpansionAtLevel(level).ApplyOrKeep(this);
+
+        /// <summary>
+        /// What <see cref="Expand(int)"/> does, reachable by
+        /// <see cref="Transformation.ExpansionAtLevel(int)"/> without going back through
+        /// the public method and round again.
+        /// </summary>
+        internal Entity ExpandOverSum(int level)
         {
             static Entity Expand_(Entity e, int level) =>
                 level <= 1
@@ -330,11 +339,16 @@ namespace AngouriMath
         /// (1 + x) * (1 + y)
         /// </code>
         /// </example>
-        public Entity Factorize(int level = 2) => level <= 1
-            // InnerSimplified, so that the factors come back finished: the rules leave
-            // x ^ 1 where they mean x, and sqrt(4) where they mean 2.
-            ? this.Replace(Patterns.PerfectSquareRules).Replace(Patterns.FactorizeRules).InnerSimplified
-            : this.Replace(Patterns.PerfectSquareRules).Replace(Patterns.FactorizeRules).InnerSimplified.Factorize(level - 1);
+        /// <remarks>
+        /// One pass is the perfect-square rules, then the factorisation rules, then
+        /// <see cref="InnerSimplified"/> -- so that the factors come back finished, since
+        /// the rules leave <c>x ^ 1</c> where they mean <c>x</c> and <c>sqrt(4)</c> where
+        /// they mean <c>2</c> -- and <paramref name="level"/> is how many times that runs.
+        /// Built out of <see cref="RewriteRules"/> by
+        /// <see cref="Transformation.FactorizationAtLevel(int)"/>.
+        /// </remarks>
+        public Entity Factorize(int level = 2)
+            => Transformation.FactorizationAtLevel(level).ApplyOrKeep(this);
 
         /// <summary>
         /// Simplifies an equation ( e.g. (x - y) * (x + y) -> x^2 - y^2, but 3 * x + y * x = (3 + y) * x )
@@ -386,7 +400,8 @@ namespace AngouriMath
         /// cos((x * y) ^ 2 + x * y) * (2 * x * y ^ 2 + y)
         /// </code>
         /// </example>
-        public Entity Simplify(int level = 2) => Simplificator.Simplify(this, level);
+        public Entity Simplify(int level = 2)
+            => Transformation.SimplificationAtLevel(level).ApplyOrKeep(this);
 
         /// <summary>Finds all alternative forms of an expression sorted by their complexity</summary>
         /// <example>

--- a/Sources/AngouriMath/Functions/Simplification/Simplificator.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Simplificator.cs
@@ -6,7 +6,9 @@
 //
 
 using System;
+using AngouriMath.Core;
 using AngouriMath.Core.Multithreading;
+using AngouriMath.Core.Transformations;
 using PeterO.Numbers;
 
 namespace AngouriMath.Functions
@@ -22,14 +24,27 @@ namespace AngouriMath.Functions
         /// <summary>See more details in <see cref="Entity.Simplify(int)"/></summary>
         internal static Entity Simplify(Entity expr, int level) => Alternate(expr, level).First().InnerSimplified;
 
-        internal static Entity SimplifyChildren(Entity expr)
-        {
-            return expr.Replace(Patterns.InvertNegativePowers)
-                       .Replace(Patterns.InvertNegativeMultipliers).Replace(
-                        Patterns.SortRules(TreeAnalyzer.SortLevel.HIGH_LEVEL)
-                        )
-                .InnerSimplified.Replace(Patterns.CommonRules).InnerSimplified;
-        }
+        /// <summary>
+        /// The tidying pass every stage of <see cref="Alternate(Entity, int)"/> runs: get
+        /// the quotients and the signs into their usual shape, put the operands in order,
+        /// then collect like terms.
+        /// </summary>
+        /// <remarks>
+        /// Composed once, statically, out of <see cref="RewriteRules"/> rather than written
+        /// out as a chain of <c>Replace</c> calls -- so the sequence is a value that can be
+        /// named, printed and tested, and so each stage of it is a registry entry other
+        /// code can reach on its own. The passes and their order are unchanged.
+        /// </remarks>
+        [ConstantField]
+        private static readonly Transformation simplifyChildren =
+            Transformation.Rewriting(RewriteRules.InvertNegativePowers)
+                .Then(Transformation.Rewriting(RewriteRules.InvertNegativeMultipliers))
+                .Then(Transformation.Rewriting(RewriteRules.CanonicalOrder))
+                .Then(Transformation.InnerSimplification)
+                .Then(Transformation.Rewriting(RewriteRules.Common))
+                .Then(Transformation.InnerSimplification);
+
+        internal static Entity SimplifyChildren(Entity expr) => simplifyChildren.ApplyOrKeep(expr);
 
         /// <summary>Finds all alternative forms of an expression</summary>
         internal static IEnumerable<Entity> Alternate(Entity src, int level)

--- a/Sources/Tests/UnitTests/Core/Transformations/TransformationTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/TransformationTest.cs
@@ -1,0 +1,416 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Core;
+using AngouriMath.Core.Transformations;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// The transformation layer: that it does what it says, that the 1.x methods built on
+    /// it still answer what they answered, and that it is honest about what it could not do.
+    /// </summary>
+    [Trait("Area", "Transformations")]
+    public sealed class TransformationTest
+    {
+        /// <summary>
+        /// Ordinary textbook-sized expressions, of the kinds the rule sets below are about.
+        /// </summary>
+        public static readonly IEnumerable<object[]> Corpus = new[]
+        {
+            "x + 0",
+            "x * 1",
+            "x - x",
+            "(x + 1) ^ 2",
+            "(x + y) * (x - y)",
+            "x * y + y + x + 1",
+            "sin(x) ^ 2 + cos(x) ^ 2",
+            "a / b / c",
+            "1 / (sqrt(3) + 5)",
+            "(x ^ 3 + 3 * x ^ 2 * y + 3 * x * y ^ 2 + y ^ 3) / (x + y)",
+            "2 * x + 3 * x",
+            "sqrt(12) + sqrt(27)",
+        }.Select(x => new object[] { x }).ToArray();
+
+        private static Entity Parse(string raw) => MathS.FromString(raw);
+
+        #region The abstraction itself
+
+        [Fact]
+        public void ATransformationReportsWhatItIsAndWhatItDid()
+        {
+            var result = Transformation.Expansion.Apply(Parse("(x + 1) ^ 2"));
+
+            Assert.True(result.Succeeded);
+            Assert.True(result.Changed);
+            Assert.Equal(Transformation.Expansion, result.Transformation);
+            Assert.Equal(TransformationRelation.Equivalence, result.Relation);
+            Assert.Equal(Soundness.SoundUnderAssumptions, result.Soundness);
+            Assert.Equal(Parse("(x + 1) ^ 2"), result.Input);
+        }
+
+        [Fact]
+        public void AFixedPointSucceedsWithoutChangingAnything()
+        {
+            // Nothing in the common rules matches a bare variable, so the pass answers with
+            // what it was given. That is a fixed point, not a failure.
+            var result = Transformation.Rewriting(RewriteRules.Common).Apply(Parse("x"));
+
+            Assert.True(result.Succeeded);
+            Assert.False(result.Changed);
+            Assert.Equal(Parse("x"), result.Output);
+        }
+
+        [Fact]
+        public void ApplyOrKeepHandsBackTheInputWhereThereIsNoAnswer()
+        {
+            var unanswerable = Transformation.Integration("x").Apply(Parse("e ^ (x ^ 2)"));
+            Assert.False(unanswerable.Succeeded);
+            Assert.Equal(Parse("e ^ (x ^ 2)"), unanswerable.OutputOrInput);
+        }
+
+        [Fact]
+        public void ATransformationRefusesANullInput()
+            => Assert.Throws<ArgumentNullException>(() => Transformation.Simplification.Apply(null!));
+
+        #endregion
+
+        #region Composition
+
+        [Fact]
+        public void AChainRunsItsPartsInOrder()
+        {
+            var expandThenFactor = Transformation.Expansion.Then(Transformation.Factorization);
+            var factorThenExpand = Transformation.Factorization.Then(Transformation.Expansion);
+
+            // Not an inverse pair, and the names say which way round each one is.
+            Assert.Equal("expand[2] then factorize", Shorten(expandThenFactor.Name));
+            Assert.Equal("factorize then expand[2]", Shorten(factorThenExpand.Name));
+
+            static string Shorten(string name)
+                => name.Replace("rewrite[PerfectSquare] then rewrite[Factorization] then inner-simplify x2", "factorize");
+        }
+
+        [Fact]
+        public void AChainWithADerivationInItIsNotAnEquivalence()
+        {
+            var chain = Transformation.Expansion.Then(Transformation.Differentiation("x"));
+
+            Assert.Equal(TransformationRelation.Equivalence, Transformation.Expansion.Relation);
+            Assert.Equal(TransformationRelation.Derivation, chain.Relation);
+        }
+
+        [Fact]
+        public void AChainCarriesTheWeakerOfTheTwoJustifications()
+        {
+            // Substitution is unconditional; expansion is not. Composing them cannot make
+            // the pair unconditional again.
+            var chain = Transformation.Substitution("x", 3).Then(Transformation.Expansion);
+
+            Assert.Equal(Soundness.Sound, Transformation.Substitution("x", 3).Soundness);
+            Assert.Equal(Soundness.SoundUnderAssumptions, chain.Soundness);
+        }
+
+        [Fact]
+        public void ANoAnswerAnywhereInAChainIsANoAnswerForTheChain()
+        {
+            // The integral has no closed form, so nothing downstream of it can have run.
+            var chain = Transformation.Integration("x").Then(Transformation.Simplification);
+
+            Assert.False(chain.Apply(Parse("e ^ (x ^ 2)")).Succeeded);
+        }
+
+        [Fact]
+        public void RepeatingSomethingZeroTimesChangesNothing()
+            => Assert.Equal(
+                Parse("(x + 1) ^ 2"),
+                Transformation.Expansion.Repeat(0).Apply(Parse("(x + 1) ^ 2")).Output);
+
+        [Fact]
+        public void HittingTheBoundBeforeStabilisingIsReportedAsNoAnswer()
+        {
+            // One iteration expands the square, so a single application cannot yet show
+            // that another one would change nothing.
+            var tooFewIterations = Transformation.Expansion.UntilStable(1);
+            Assert.False(tooFewIterations.Apply(Parse("(x + 1) ^ 2")).Succeeded);
+
+            // Given room, it settles.
+            var enough = Transformation.Expansion.UntilStable(16);
+            Assert.True(enough.Apply(Parse("(x + 1) ^ 2")).Succeeded);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void UntilStableRefusesAnUnboundedLoop(int bound)
+            => Assert.Throws<ArgumentOutOfRangeException>(() => Transformation.Simplification.UntilStable(bound));
+
+        #endregion
+
+        #region The rule registry
+
+        [Fact]
+        public void TheRegistryIsEnumerableAndItsOrderIsFixed()
+        {
+            Assert.NotEmpty(RewriteRules.All);
+            Assert.Equal(RewriteRules.All.Select(r => r.Name), RewriteRules.All.Select(r => r.Name));
+            Assert.Equal(RewriteRules.CanonicalOrder, RewriteRules.All[0]);
+            Assert.Equal(RewriteRules.All.Count, RewriteRules.All.Select(r => r.Name).Distinct().Count());
+        }
+
+        [Fact]
+        public void EveryRuleSetSaysWhatItIsAndWhatItClaims()
+        {
+            foreach (var ruleSet in RewriteRules.All)
+            {
+                Assert.False(string.IsNullOrWhiteSpace(ruleSet.Name));
+                Assert.False(string.IsNullOrWhiteSpace(ruleSet.Description));
+                // Nothing in the registry may quietly claim a proof it has not got.
+                Assert.NotEqual(Soundness.Sound, ruleSet.Soundness);
+            }
+        }
+
+        [Fact]
+        public void TheRegistryAndTheCatalogueAreBothFullyBuilt()
+        {
+            // A smoke check, and it is here because the failure it catches is not a failing
+            // assertion: RewriteRuleSet builds its transformation on demand precisely so
+            // that constructing a rule set does not run Transformation's static
+            // initialiser, which reads the registry back. Tie those two together and
+            // whichever type is touched second reads the other's fields before they are
+            // set, so the entries below come out null and every call that reaches them
+            // dies -- in whichever order the process happened to load them.
+            foreach (var ruleSet in RewriteRules.All)
+                Assert.NotNull(ruleSet.AsTransformation());
+
+            Assert.NotNull(Transformation.Simplification);
+            Assert.NotNull(Transformation.Expansion);
+            Assert.NotNull(Transformation.Factorization);
+            Assert.NotNull(Transformation.Normalization);
+            Assert.NotNull(Transformation.Rationalisation);
+            Assert.NotNull(Transformation.InnerSimplification);
+        }
+
+        [Theory]
+        [MemberData(nameof(Corpus))]
+        public void NoRuleSetRewritesInACycle(string raw)
+        {
+            var expr = Parse(raw);
+            foreach (var ruleSet in RewriteRules.All)
+                Assert.True(
+                    ruleSet.AsTransformation().UntilStable(32).Apply(expr).Succeeded,
+                    $"{ruleSet.Name} did not reach a fixed point on {raw} within 32 passes");
+        }
+
+        [Theory]
+        [MemberData(nameof(Corpus))]
+        public void ARuleSetGivesTheSameAnswerEveryTime(string raw)
+        {
+            var expr = Parse(raw);
+            foreach (var ruleSet in RewriteRules.All)
+                Assert.Equal(ruleSet.ApplyOnce(expr), ruleSet.ApplyOnce(expr));
+        }
+
+        #endregion
+
+        #region The 1.x methods answer what they answered
+
+        [Theory]
+        [MemberData(nameof(Corpus))]
+        public void SimplifyIsItsTransformation(string raw)
+            => Assert.Equal(Parse(raw).Simplify(), Transformation.Simplification.Apply(Parse(raw)).Output);
+
+        [Theory]
+        [MemberData(nameof(Corpus))]
+        public void ExpandIsItsTransformation(string raw)
+            => Assert.Equal(Parse(raw).Expand(), Transformation.Expansion.Apply(Parse(raw)).Output);
+
+        [Theory]
+        [MemberData(nameof(Corpus))]
+        public void FactorizeIsItsTransformation(string raw)
+            => Assert.Equal(Parse(raw).Factorize(), Transformation.Factorization.Apply(Parse(raw)).Output);
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void FactorizeRunsThePassAsManyTimesAsItIsAsked(int level)
+            => Assert.Equal(
+                Parse("x * y + y + 1 + x").Factorize(level),
+                Transformation.FactorizationAtLevel(level).Apply(Parse("x * y + y + 1 + x")).Output);
+
+        [Theory]
+        [MemberData(nameof(Corpus))]
+        public void DifferentiateIsItsTransformation(string raw)
+            => Assert.Equal(
+                Parse(raw).Differentiate("x"),
+                Transformation.Differentiation("x").Apply(Parse(raw)).Output);
+
+        [Theory]
+        [InlineData("x")]
+        [InlineData("sin(x)")]
+        [InlineData("1 / x")]
+        public void IntegrateIsItsTransformationPlusTheConstant(string raw)
+        {
+            var antiderivative = Transformation.Integration("x").Apply(Parse(raw)).Output;
+            Assert.NotNull(antiderivative);
+            Assert.Equal(Parse(raw).Integrate("x"), antiderivative! + (Entity)"C");
+        }
+
+        [Theory]
+        [InlineData("sin(x) / x", "0")]
+        [InlineData("(1 + 1 / x) ^ x", "+oo")]
+        public void LimitIsItsTransformationTidiedUp(string raw, string destination)
+        {
+            var computed = Transformation.LimitAt("x", destination, ApproachFrom.BothSides).Apply(Parse(raw)).Output;
+            Assert.NotNull(computed);
+            Assert.Equal(Parse(raw).Limit("x", destination, ApproachFrom.BothSides), computed!.InnerSimplified);
+        }
+
+        [Theory]
+        [MemberData(nameof(Corpus))]
+        public void SubstituteIsItsTransformation(string raw)
+            => Assert.Equal(
+                Parse(raw).Substitute("x", 3),
+                Transformation.Substitution("x", 3).Apply(Parse(raw)).Output);
+
+        #endregion
+
+        #region Honesty
+
+        [Fact]
+        public void AnIntegralWithNoClosedFormHasNoAnswerRatherThanAWrongOne()
+        {
+            var result = Transformation.Integration("x").Apply(Parse("e ^ (x ^ 2)"));
+
+            Assert.False(result.Succeeded);
+            Assert.Null(result.Output);
+
+            // The 1.x method makes the same claim in the shape its callers expect: an
+            // unevaluated node, which is "I could not settle this" and not NaN.
+            var legacy = Parse("e ^ (x ^ 2)").Integrate("x");
+            Assert.IsType<Entity.Integralf>(legacy);
+            Assert.False(legacy.IsNaN);
+        }
+
+        [Fact]
+        public void ALimitThatCannotBeSettledHasNoAnswerRatherThanNaN()
+        {
+            // The documented unevaluated case: see the example on Entity.Limit(Variable, Entity).
+            var expr = Parse("sin(x * a) / x");
+            var result = Transformation.LimitAt("x", "+oo", ApproachFrom.BothSides).Apply(expr);
+
+            Assert.False(result.Succeeded);
+
+            var legacy = expr.Limit("x", "+oo", ApproachFrom.BothSides);
+            Assert.IsType<Entity.Limitf>(legacy);
+            Assert.False(legacy.IsNaN);
+        }
+
+        #endregion
+
+        #region Determinism and the relation each transformation claims
+
+        [Theory]
+        [MemberData(nameof(Corpus))]
+        public void TheSameTransformationOnTheSameInputGivesTheSameAnswer(string raw)
+        {
+            var expr = Parse(raw);
+            foreach (var transformation in new[]
+                     {
+                         Transformation.Simplification,
+                         Transformation.Expansion,
+                         Transformation.Factorization,
+                         Transformation.Normalization,
+                         Transformation.Rationalisation,
+                         Transformation.InnerSimplification,
+                     })
+                Assert.Equal(transformation.Apply(expr).Output, transformation.Apply(expr).Output);
+        }
+
+        [Theory]
+        [MemberData(nameof(Corpus))]
+        public void AnEquivalenceTransformationDoesNotChangeTheValue(string raw)
+        {
+            var expr = Parse(raw);
+            foreach (var transformation in new[]
+                     {
+                         Transformation.Expansion,
+                         Transformation.Factorization,
+                         Transformation.Normalization,
+                         Transformation.Rationalisation,
+                         Transformation.InnerSimplification,
+                     })
+            {
+                Assert.Equal(TransformationRelation.Equivalence, transformation.Relation);
+                if (transformation.Apply(expr).Output is not { } output)
+                    continue;
+                // The property, not the printed form: subtract the two sides and simplify.
+                // A domain condition may survive that -- the two sides agree only where both
+                // are defined, which is exactly what SoundUnderAssumptions says -- so the
+                // condition is stripped before the value is read.
+                var difference = (expr - output).Simplify();
+                if (difference is Entity.Providedf(var value, _))
+                    difference = value;
+                Assert.True(
+                    difference == 0,
+                    $"{transformation.Name} changed the value of {raw}: difference simplified to {difference}");
+            }
+        }
+
+        [Fact]
+        public void SubstitutionIsTheOneThingHereThatNeedsNoAssumptions()
+        {
+            var substitution = Transformation.Substitution("x", 3);
+            Assert.Equal(Soundness.Sound, substitution.Soundness);
+            // and it is a different object, not another way of writing the same one
+            Assert.Equal(TransformationRelation.Derivation, substitution.Relation);
+        }
+
+        [Theory]
+        [MemberData(nameof(Corpus))]
+        public void SimplifyingAnAlreadySimplifiedExpressionChangesNothing(string raw)
+        {
+            var once = Parse(raw).Simplify();
+            Assert.Equal(once, once.Simplify());
+        }
+
+        #endregion
+
+        #region The transformations this layer added
+
+        [Fact]
+        public void NormalizationMakesTwoArrangementsOfOneExpressionTheSameTree()
+        {
+            var oneWay = Transformation.Normalization.Apply(Parse("x + y + z")).Output;
+            var another = Transformation.Normalization.Apply(Parse("z + y + x")).Output;
+
+            Assert.Equal(oneWay, another);
+            // and it is not simplification: the two were already as short as they get
+            Assert.NotEqual(Parse("x + y + z"), Parse("z + y + x"));
+        }
+
+        [Fact]
+        public void RationalisationClearsASurdOutOfADenominator()
+        {
+            var result = Transformation.Rationalisation.Apply(Parse("1 / (sqrt(3) + 5)"));
+
+            Assert.True(result.Succeeded);
+            Assert.DoesNotContain(
+                result.Output!.Nodes,
+                node => node is Entity.Divf(_, var denominator) && denominator.Nodes.Any(n => n is Entity.Powf));
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Closes nothing on its own; this is the first layer of #746, with consumers in the same change.

## What was wrong

The top-level mathematical operations are procedures you invoke. There is nowhere to say what one of them **claims** about its output, how well **justified** the claim is, or that it **could not settle** the question — and nowhere to compose two of them, because a `Func<Entity, Entity>` carries none of that. #746's argument is that this interface is the ceiling on everything built above it.

## What this adds

`AngouriMath.Core.Transformations`, public and documented as experimental:

| | |
|---|---|
| `Transformation` | `Name`, `Relation`, `Soundness`, `Apply` — plus `Then`, `Repeat(n)`, `UntilStable(max)` |
| `TransformationResult` | input, output-or-nothing, which transformation ran. A struct, so routing an ordinary call allocates nothing |
| `RewriteRuleSet` | a named, attributed group of rewrites |
| `RewriteRules` | the registry: ten shipped sets, explicitly listed, enumerable in a fixed order |

Three things it insists on, each the honesty rule in a different place:

- **`TransformationRelation`** is `Equivalence` or `Derivation`. "Sound" is only a statement about *some* relation, and a derivative is not another way of writing its integrand — so the property test that subtracts output from input only runs against the transformations that claim equivalence.
- **`Soundness`** is declared, not checked. Every shipped rule set is `SoundUnderAssumptions`, and a test over `RewriteRules.All` holds it there: promoting one means changing that test and saying why in the same change. Nothing in the catalogue claims `Heuristic` — that is a statement about what is registered so far, not about the library.
- **No answer is `null`.** This is the one place the new layer is *more* honest than the method it backs: `Transformation.Integration("x")` has no answer for `e^(x^2)`, where `Entity.Integrate` returns an unevaluated `Integralf`. Same claim, different shape; neither is `NaN`.

`UntilStable` reports hitting its bound as **no answer** rather than as whatever value it was holding, so a rule set that does not converge is visible instead of silently truncated.

## What now uses it

```
Entity.Simplify(level)     ->  Transformation.SimplificationAtLevel(level)  ->  Simplificator.Simplify
Entity.Expand(level)       ->  Transformation.ExpansionAtLevel(level)       ->  Entity.ExpandOverSum
Entity.Factorize(level)    ->  Transformation.FactorizationAtLevel(level)   ->  RewriteRules, composed
Entity.Differentiate(x)    ->  Transformation.Differentiation(x)            ->  Entity.DifferentiateOnce
Entity.Integrate(x)        ->  Transformation.Integration(x)                ->  Integration.ComputeIndefiniteIntegral
Entity.Limit(x, to, side)  ->  Transformation.LimitAt(x, to, side)          ->  LimitFunctional.ComputeLimit
Simplificator.SimplifyChildren  ->  a chain composed from four registry entries
```

Two of these are real ports. `Factorize` no longer names its own rules — it is `PerfectSquare`, then `Factorization`, then a tidying pass, repeated `level` times, built out of the registry. `SimplifyChildren`, which every stage of the simplification pipeline runs, is a chain composed once, statically, from four registry entries instead of a hand-written run of `Replace` calls. The rest are thin adapters. **Nothing that worked was rewritten to make the architecture tidier.**

## What is deliberately not here

- **`Solve` is not a transformation.** It consumes a goal and produces a solution set, and belongs in a tactic layer that does not exist yet. `Entity.Set` being an `Entity` means `Solve` would type-check as `Entity -> Entity` — which is the reason to keep it out, since it would compile while saying nothing true.
- **No inverse machinery.** `Expand` and `Factor` are not inverses and `Unsolve` is not well defined.
- **Most of the pattern table is untouched** and still reachable only from `Simplificator`. Ten sets are registered — the ones the catalogue is built from.

## Extensibility constraints

Registration is static and explicit — no assembly scanning, no `Activator` — so the layer stays trimmable and NativeAOT-publishable, and `RewriteRules.All` is in an order that does not depend on hashing or on which type loaded first.

One trap is worth naming, because it cost a full-suite abort during development: `RewriteRuleSet` builds its `Transformation` **on demand**. Doing it in the constructor makes the registry and the catalogue depend on each other's static initialisation, and whichever type is touched second reads the other's fields before they are set — so the failure is a null field in whichever order the process happened to load them, not a failing assertion. There is a comment on the field and a smoke test pinning it.

## Measurements

Release, net7.0, against master `21f0d16f`, two samples each, same expressions as `DotnetBenchmark/CommonFunctionsInterVersion`. Every timing range overlaps the baseline's. Allocation is deterministic and is the reliable comparison:

| | master | this branch |
|---|---|---|
| ParseEasy | 17.6 KB | 17.6 KB |
| ParseHard | 3405.8 KB | 3405.4 KB |
| SimplifyEasy | 158.6 KB | 157.6 KB |
| SimplifyCommon | 6976.8 KB | 6973.6 KB |
| SimplifyHard | 3616232 KB | 3616197 KB |
| Differentiate | 51.6 KB | 51.6 KB |
| SolveEasy | 19789.6 KB | 19789.6 KB |
| Limit | 7664.8 KB | 7660.8 KB |

Identical or slightly lower. `Patterns.SortRules(level)` returns a fresh closure on every call and `SimplifyChildren` used to build one per invocation; it is now built once, which is where the difference comes from.

## Tests

`dotnet test Sources/Tests/UnitTests` — **5699 passed, 0 failed, 14 skipped** (5551 + 149 new, the same 14 skips as master).
`dotnet test Sources/Tests/FSharpWrapperUnitTests` — **130 passed, 0 failed**.

The new tests cover the abstraction; that each 1.x method answers exactly what its transformation answers, including `Factorize` at levels 0–3; determinism; that an equivalence transformation does not change the value of the expression, checked by simplifying the difference and stripping the domain condition rather than by comparing printed forms; that unsupported integrals and limits stay honest; and that no registered rule set rewrites in a cycle.

## Compatibility

No behavioural change, so no `BREAKING-CHANGES.md` entry — the suite is byte-identical in outcome and the public signatures are untouched. The new surface is additive.

`Sources/.editorconfig` gains a path-scoped `file_header_template` so the new directories carry the current year; the existing 367 files keep the header they were written with rather than having a year bump folded into this diff.

Documentation: [`Docs/Contributing/Transformations.md`](Sources/AngouriMath/Docs/Contributing/Transformations.md), linked from the contributor index, with a section in `AGENTS.md` on the three habits the layer asks for.

## What comes next

The unit here is the rule *set*, not the single `pattern -> replacement` line, because every rewrite in this library is a case of one `switch` and the compiler turns that into a type test and a jump — splitting each case into an object would trade one dispatch per node for one delegate call per rule per node, on the hottest path there is. Making individual rewrites addressable without paying that is the next piece of work, and nothing here forecloses it. After that: the goal/tactic layer `Solve` belongs in, then derivations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
