### PR TITLE
Expand a cancelled quotient of factorials instead of throwing (#817)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -47,6 +47,7 @@ read first.
 | **silent** | two integrals | answered correctly | unevaluated — a deliberate loss |
 | **silent** | `k/(a x^2 + c)` and `k/sqrt(a x^2 + c)` for symbolic `a` | `NaN` | a piecewise on the sign of the discriminant |
 | loud | `Compile` over a missing variable | `KeyNotFoundException` | `UncompilableNodeException` |
+| loud | `Expand` of a quotient of factorials | `AngouriBugException` | the expanded polynomial |
 | loud | the target frameworks | `net7.0;netstandard2.0` | `netstandard2.0;net8.0;net10.0` |
 | **silent** | `abs(x) = c` for a negative `c` | a set of non-solutions | the empty set |
 
@@ -1262,6 +1263,31 @@ on. **Change your `catch` clause.** Constants are unaffected: `pi` and `e` are s
 variable is looked up, so `"pi * x"` still compiles over `x` alone.
 
 PR [#688](https://github.com/asc-community/AngouriMath/pull/688).
+
+### `Expand` of a quotient of factorials threw instead of expanding
+
+```csharp
+"(x + 1)! / x!".ToEntity().Expand();
+// was  AngouriBugException: SmartExpandOver must be only called of non-sum expression
+// is   x + 1
+
+"(x + 2)! / x!".ToEntity().Expand();
+// was  AngouriBugException
+// is   x ^ 2 + 3 * x + 2
+```
+
+Expansion cancels a quotient of factorials before it does anything else, and the cancellation can
+leave a sum — `(x + 1)! / x!` is `x + 1`. The result was then handed straight back to the routine
+that expands a *non*-sum, which asserts that it never receives one, so the assertion fired and an
+`AngouriBugException` came out of a public method. Sending the cancelled expression through the
+sum-aware entry point instead costs nothing when it is not a sum, since that is where everything
+else goes anyway.
+
+**`AngouriBugException` is the library reporting that the library is broken**, so nothing was
+depending on this; the entry is here because the same call now returns a value where it used to
+throw. `Simplify` was never affected — it answered `1 + x` throughout.
+
+Issue [#817](https://github.com/asc-community/AngouriMath/issues/817).
 
 ### Compiled arcsine was the conjugate of the arcsine
 

--- a/Sources/AngouriMath/Functions/TreeAnalyzer/Expansion.cs
+++ b/Sources/AngouriMath/Functions/TreeAnalyzer/Expansion.cs
@@ -97,8 +97,13 @@ namespace AngouriMath.Functions
                     throw new AngouriBugException("SmartExpandOver must be only called of non-sum expression");
                 case Divf:
                     expr = expr.Replace(Patterns.ExpandFactorialDivisions);
+                    // Cancelling a quotient of factorials can leave a sum -- (x + 1)! / x!
+                    // is x + 1 -- and this method is documented not to take one. Going back
+                    // in through the sum-aware entry point costs nothing when the result is
+                    // not a sum, since that is where it sends anything else anyway.
+                    // https://github.com/asc-community/AngouriMath/issues/817
                     if (!(expr is Divf(var dividend, var divisor)))
-                        return SmartExpandOver(expr, conditionForUniqueTerms);
+                        return GatherLinearChildrenOverSumAndExpand(expr, conditionForUniqueTerms);
                     var numChildren = GatherLinearChildrenOverSumAndExpand(dividend, conditionForUniqueTerms);
                     if (numChildren is null || numChildren.Count > MathS.Settings.MaxExpansionTermCount)
                         return null;

--- a/Sources/Tests/UnitTests/Common/SimplificationRegressionTest.cs
+++ b/Sources/Tests/UnitTests/Common/SimplificationRegressionTest.cs
@@ -402,17 +402,37 @@ namespace AngouriMath.Tests.Common
                 $"{input} simplified to {simplified.Stringize()}, which is {value.Stringize()} at x = {at}");
         }
 
-        // Expand reaches SmartExpandOver with a sum and that method asserts it never gets
-        // one, so a public call throws AngouriBugException where the honest answer is the
-        // expression back unexpanded. Simplify handles the same input and gives 1 + x.
+        // Cancelling a quotient of factorials can leave a sum -- (x + 1)! / x! is x + 1 --
+        // and SmartExpandOver, which is documented not to take a sum, was handed the result
+        // and threw AngouriBugException out of a public method.
         // https://github.com/asc-community/AngouriMath/issues/817
-        [Theory(Skip = "https://github.com/asc-community/AngouriMath/issues/817")]
-        [InlineData("(x + 1)! / x!")]
-        [InlineData("(x + 2)! / x!")]
-        public void ExpandDoesNotThrowOnAQuotientOfFactorials(string input)
+        //
+        // Asserted as a value rather than as a string: expanding must not change what the
+        // expression is worth, and the point it is checked at is one where the factorials
+        // are defined and the quotient is a whole number.
+        [Theory]
+        [InlineData("(x + 1)! / x!", 4, 5)]
+        [InlineData("(x + 2)! / x!", 4, 30)]
+        [InlineData("(x + 3)! / x!", 4, 210)]
+        [InlineData("x! / (x + 1)!", 4, 0.2)]
+        [InlineData("(x + 1)! / x! + y", 4, 9)]
+        [InlineData("((x + 1)! / x!) * (a + b)", 4, 40)]
+        public void ExpandKeepsTheValueOfAQuotientOfFactorials(string input, int at, double expected)
         {
             var expanded = input.ToEntity().Expand();
-            Assert.NotNull(expanded);
+            var value = expanded.Substitute("x", at).Substitute("y", 4).Substitute("a", 3).Substitute("b", 5).EvalNumerical();
+            var real = ((Entity.Number.Complex)value).RealPart.EDecimal.ToDouble();
+            Assert.True(System.Math.Abs(real - expected) < 1e-9,
+                $"{input} expanded to {expanded.Stringize()}, which is {value.Stringize()} at x = {at} rather than {expected}");
         }
+
+        // The cancellation is what makes the expansion possible at all, so the answer should
+        // no longer mention a factorial where the two cancel completely.
+        [Theory]
+        [InlineData("(x + 1)! / x!")]
+        [InlineData("(x + 2)! / x!")]
+        [InlineData("(x + y + 1)! / (x + y)!")]
+        public void ExpandCancelsAQuotientOfFactorialsRatherThanLeavingIt(string input)
+            => Assert.DoesNotContain(input.ToEntity().Expand().Nodes, node => node is Entity.Factorialf);
     }
 }


### PR DESCRIPTION
Closes #817.

## What was wrong

`Entity.Expand` cancels a quotient of factorials before it does anything else, and the cancellation can leave a **sum** — `(x + 1)! / x!` is `x + 1`. The result went straight back into `SmartExpandOver`, which is documented `<summary>expr is NEITHER Sumf NOR Minusf</summary>` and asserts that it never receives one. So the assertion fired and an `AngouriBugException` — the library reporting that the library is broken — came out of a public method, on an expression `Simplify` answered as `1 + x` throughout.

```csharp
case Divf:
    expr = expr.Replace(Patterns.ExpandFactorialDivisions);   // (x + 1)! / x!  ->  x + 1
    if (!(expr is Divf(var dividend, var divisor)))
        return SmartExpandOver(expr, ...);                    // ... which must not take a sum
```

Thrown rather than returned, so a caller mapping `Expand` over a corpus loses the whole run instead of one entry.

## Why this fix is right

`GatherLinearChildrenOverSumAndExpand` is the sum-aware entry point, and it already delegates to `SmartExpandOver` for anything that is not a sum. Calling it here is one identifier and a **strict superset** of the old behaviour: identical where the cancelled expression is not a sum, and correct instead of fatal where it is.

The other two recursive calls are unaffected — one is handed a product, and the public `MathS.SmartExpandOver` splits by `Sumf.LinearChildren` before descending, which is exactly the guard that was missing here.

## Measured

On this build, each of these threw `AngouriBugException` before:

| input | now |
|---|---|
| `(x + 1)! / x!` | `x + 1` |
| `(x + 2)! / x!` | `x ^ 2 + 3 * x + 2` |
| `(x + 3)! / x!` | `x ^ 3 + 6 * x ^ 2 + 11 * x + 6` |
| `x! / (x + 1)!` | `1 / (x + 1)` |
| `(x + 1)! / x! + y` | `x + 1 + y` |
| `((x + 1)! / x!) * (a + b)` | `a * x + b * x + a + b` |
| `(x + y + 1)! / (x + y)!` | `x + y + 1` |

Checked as values, not strings, at a point where the factorials are defined: 5!/4! = 5, 6!/4! = 30, 7!/4! = 210 — and the expanded form agrees with the original at that point in every case.

`sin(x)! / x!` is unchanged and still comes back as written, which is correct: nothing cancels.

## Tests

**5808 passing, 0 failed, 14 skipped** — the skip this issue was holding is gone. F# **130 passing**.

Two regression tests: one asserting the value is preserved, one asserting no factorial survives where the two cancel completely. **Both were checked against the unfixed code** — five cases fail without the change, including the nested (`+ y`) and multiplied (`* (a + b)`) ones, so the tests are not passing vacuously.

## Compatibility

`BREAKING-CHANGES.md` records it: the same call returns a value where it used to throw. Nothing could have depended on the old behaviour — `AngouriBugException` is not a contract — but the entry belongs there anyway since the answer changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
