### PR TITLE
Report the syntax error instead of dying on the half-built tree (#813)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -48,6 +48,7 @@ read first.
 | **silent** | `k/(a x^2 + c)` and `k/sqrt(a x^2 + c)` for symbolic `a` | `NaN` | a piecewise on the sign of the discriminant |
 | loud | `Compile` over a missing variable | `KeyNotFoundException` | `UncompilableNodeException` |
 | loud | `Expand` of a quotient of factorials | `AngouriBugException` | the expanded polynomial |
+| loud | parsing a `provided` in a parenthesised comma list | `NullReferenceException` | `UnhandledParseException` |
 | loud | the target frameworks | `net7.0;netstandard2.0` | `netstandard2.0;net8.0;net10.0` |
 | **silent** | `abs(x) = c` for a negative `c` | a set of non-solutions | the empty set |
 
@@ -1288,6 +1289,30 @@ depending on this; the entry is here because the same call now returns a value w
 throw. `Simplify` was never affected — it answered `1 + x` throughout.
 
 Issue [#817](https://github.com/asc-community/AngouriMath/issues/817).
+
+### A parse failure no longer escapes as a `NullReferenceException`
+
+```csharp
+"(1 provided x > 0, 2)".ToEntity();
+// was  NullReferenceException
+// is   UnhandledParseException: line 1:17 no viable alternative at input '(1providedx>0,'
+```
+
+ANTLR reports a syntax error to the listener and then *recovers*, carrying on with a rule context
+whose value was never assigned. The grammar's action for `provided` runs anyway and dereferences it,
+so the parse came down before the error already recorded against the input was read.
+
+**Change your `catch` clause if you were catching `NullReferenceException` around user input** — but
+the point of the fix is that you should not have had to.
+[`Docs/Usage/Exceptions.md`](Sources/AngouriMath/Docs/Usage/Exceptions.md) says every parse failure
+arrives under `AngouriMathBaseException`, and a caller who wrote the one correct `catch` was not
+catching this.
+
+The construct is unaffected: `1 provided x > 0` parses, and so does the piecewise form
+`piecewise(1 provided x > 0, 2 provided x < 0, 3)`. What is refused is the comma list with no
+`piecewise` in front of it, which has no rule.
+
+Issue [#813](https://github.com/asc-community/AngouriMath/issues/813).
 
 ### Compiled arcsine was the conjugate of the arcsine
 

--- a/Sources/AngouriMath/Core/Parser.cs
+++ b/Sources/AngouriMath/Core/Parser.cs
@@ -14,6 +14,7 @@ Any modifications to other source files will be overwritten when the parser is r
 */
 
 using Antlr4.Runtime;
+using System;
 using System.IO;
 using System.Text;
 
@@ -148,11 +149,31 @@ namespace AngouriMath.Core
 
             
             var parser = new AngouriMathParser(tokenStream, null, writer);
-            parser.Parse();
-            
+
+            // ANTLR reports a syntax error to the listener and then *recovers*, carrying on
+            // with a rule context whose value was never assigned. The grammar's actions run
+            // anyway and dereference it, so an invalid input can bring the parse down before
+            // the error already sitting in `writer.errors` is ever read. Reading it is the
+            // honest answer: the input really was invalid, and that is what the caller is
+            // owed -- an exception under AngouriMathBaseException, as Docs/Usage/Exceptions.md
+            // promises, rather than whatever the half-built tree happened to throw.
+            //
+            // Guarded on an error having been reported, so this cannot swallow a genuine bug:
+            // where the parser throws with nothing recorded against the input, the exception
+            // is ours and it keeps propagating.
+            // https://github.com/asc-community/AngouriMath/issues/813
+            try
+            {
+                parser.Parse();
+            }
+            catch (Exception) when (writer.errors.Count > 0)
+            {
+                return new Failure<ReasonWhyParsingFailed>(writer.errors[0]);
+            }
+
             if (writer.errors.Count > 0)
                 return new Failure<ReasonWhyParsingFailed>(writer.errors[0]);
-            
+
             return parser.Result;
         }
 

--- a/Sources/Tests/UnitTests/Convenience/FromStringTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/FromStringTest.cs
@@ -41,9 +41,62 @@ namespace AngouriMath.Tests.Convenience
         [InlineData("+!", "line 1:1")]
         [InlineData("_", "line 1:0")]
         [InlineData("()", "line 1:1")]
+        // A `provided` in a parenthesised comma list. ANTLR reports the syntax error and
+        // then recovers, and the grammar's action for `provided` runs anyway on a rule
+        // context whose value was never assigned -- so these used to bring the parse down
+        // with a raw NullReferenceException, which a caller catching AngouriMathBaseException
+        // around user input does not catch.
+        // https://github.com/asc-community/AngouriMath/issues/813
+        [InlineData("(1 provided x > 0, 2)", "line 1:17")]
+        [InlineData("(a provided b, c)", "line 1:13")]
+        [InlineData("(1 provided x > 0, 2, 3)", "line 1:17")]
+        [InlineData("(1, 2 provided x > 0)", "line 1:2")]
+        [InlineData("(1 provided x > 0, 2 provided x < 0)", "line 1:17")]
         public void Error(string input, string errorPrefix) =>
             Assert.StartsWith(errorPrefix,
                 Assert.Throws<UnhandledParseException>(() => (Entity)input).Message);
+
+        // The construct itself is untouched: what is refused is the invalid input, not
+        // `provided`. https://github.com/asc-community/AngouriMath/issues/813
+        [Theory]
+        [InlineData("1 provided x > 0")]
+        [InlineData("(1 provided x > 0)")]
+        [InlineData("(1 provided x > 0) + 2")]
+        [InlineData("a provided b provided c")]
+        public void AProvidedStillParses(string input)
+            => Assert.Contains(((Entity)input).Nodes, node => node is Providedf);
+
+        // A comma list of `provided` is the piecewise syntax, and it parses -- so the fix
+        // must not refuse it. The list without a piecewise in front of it is what has no
+        // rule, which is what the crash was hiding.
+        // https://github.com/asc-community/AngouriMath/issues/813
+        [Theory]
+        [InlineData("piecewise(1 provided x > 0, 2)")]
+        [InlineData("piecewise(1 provided x > 0, 2 provided x < 0)")]
+        [InlineData("piecewise(1 provided x > 0, 2 provided x < 0, 3)")]
+        public void APiecewiseOverAProvidedListStillParses(string input)
+            => Assert.IsType<Piecewise>((Entity)input);
+
+        // Every way an input can be refused must arrive as this library's own exception --
+        // Docs/Usage/Exceptions.md says so, and a caller wrapping user input in one catch
+        // is relying on it. Nothing here may come back as a raw framework exception.
+        // https://github.com/asc-community/AngouriMath/issues/813
+        [Theory]
+        [InlineData("(1 provided x > 0, 2)")]
+        [InlineData("(provided, )")]
+        [InlineData("(1 provided, 2)")]
+        [InlineData("(1 provided x > 0,)")]
+        [InlineData("(, 1 provided x)")]
+        [InlineData("{1 provided x > 0, 2")]
+        [InlineData("[1 provided x > 0, 2)")]
+        [InlineData("piecewise(1 provided x > 0")]
+        public void AnInvalidInputIsRefusedByThisLibrarysOwnException(string input)
+        {
+            var thrown = Record.Exception(() => (Entity)input);
+            Assert.NotNull(thrown);
+            Assert.True(thrown is AngouriMathBaseException,
+                $"{input} was refused with {thrown!.GetType().FullName} rather than an AngouriMathBaseException");
+        }
         [Theory]
         [InlineData("limitleft()", "limitleft should have exactly 3 arguments but 0 arguments are provided")]
         [InlineData("derivative(3)", "derivative should have exactly 3 arguments or 2 arguments but 1 argument is provided")]


### PR DESCRIPTION
Closes #813.

## What was wrong

ANTLR reports a syntax error to the listener and then **recovers**, carrying on with a rule context whose `value` was never assigned. The grammar's action for `provided` runs anyway:

```csharp
_localctx.value = _localctx.value.Provided(_localctx.pred.value);   // AngouriMathParser.cs:1549
```

so the parse came down with a raw `NullReferenceException` before `ParseSilent` ever read the error **already sitting in `writer.errors`**.

That last part is the whole fix. The error was detected the entire time; the parser just died before anyone looked at it.

```csharp
try { parser.Parse(); }
catch (Exception) when (writer.errors.Count > 0)
{
    return new Failure<ReasonWhyParsingFailed>(writer.errors[0]);
}
```

Reading the recorded error is the honest answer — the input really was invalid, and a caller is owed an exception under `AngouriMathBaseException`, as [`Docs/Usage/Exceptions.md`](Sources/AngouriMath/Docs/Usage/Exceptions.md) promises. **The guard is what makes this safe rather than a blanket swallow:** where the parser throws with *nothing* recorded against the input, the exception is ours and it keeps propagating. A bug of ours cannot be laundered into a syntax error.

## Measured

Each of these was a `NullReferenceException` on `61de353b`:

| input | now |
|---|---|
| `(1 provided x > 0, 2)` | `UnhandledParseException: line 1:17 no viable alternative` |
| `(a provided b, c)` | `line 1:13` |
| `(1 provided x > 0, 2, 3)` | `line 1:17` |
| `(1, 2 provided x > 0)` | `line 1:2` |
| `(1 provided x > 0, 2 provided x < 0)` | `line 1:17` |

The last two are **wider than the issue reported**: a `provided` *after* the comma crashes too, so the trigger is a `provided` anywhere in a parenthesised comma list, not only one followed by a comma.

## A correction to the issue

#813 says the piecewise forms from #326 "do not parse either". **That is wrong, and I wrote it.** All three documented shapes parse:

```
piecewise(1 provided x > 0, 2)                     ->  piecewise(1 provided (x > 0), 2 provided True)
piecewise(1 provided x > 0, 2 provided x < 0)      ->  parses
piecewise(1 provided x > 0, 2 provided x < 0, 3)   ->  piecewise(..., 3 provided True)
```

Only the **capitalised** `Piecewise(` fails, as an unknown name followed by a bracket — which is #733, not this. I tested with the capitalisation used in #326's prose and drew the wrong conclusion from it.

So the grammar does have a rule for the comma list of `provided`; what has no rule is that list **without a `piecewise` in front of it**, and that is exactly what the crash was hiding. The tests now pin the working forms so the fix cannot be mistaken for refusing the construct.

## Tests

**5828 passing, 0 failed, 14 skipped.** F# **130 passing**.

Three groups added to `FromStringTest`: the five crashing inputs with their error positions; the `provided` and `piecewise` forms that must keep parsing; and a broader check that a malformed input is refused by *this library's own* exception rather than a framework one — which is the property the issue is actually about, and which nothing was asserting.

## Not in scope

What the piecewise syntax *should* be is #326, still open and marked *Opinions wanted*. Fixing the crash did not need that settled, and this does not settle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
