### PR TITLE
Withdraw the unmeasured claim about per-rule dispatch (#825)

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/RewriteRuleSet.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRuleSet.cs
@@ -18,18 +18,21 @@ namespace AngouriMath.Core.Transformations
     /// <remarks>
     /// <para>
     /// The set, rather than the single <c>pattern -&gt; replacement</c> line, is the unit
-    /// here on purpose. Every rewrite in this library is a case of one <c>switch</c>
-    /// matched against a node, and the C# compiler turns that switch into a type test and a
-    /// jump. Splitting each case into its own object would replace one dispatch per node
-    /// with one delegate call per rule per node on the hottest path in the library, and buy
-    /// nothing that a caller can use today. What a caller can use today is the set:
-    /// <see cref="RewriteRules.All"/> is enumerable, each entry is applicable on its own,
-    /// and the tests iterate it.
+    /// here because that is what has been built so far — <b>not</b> because the finer grain
+    /// is too expensive. It was asserted here that it would be, on the grounds that each
+    /// rule would cost a delegate call per node; measuring it found the opposite, and the
+    /// measurement is in
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/825">#825</a>: rules
+    /// bucketed by the node type they match run as fast as the hand-written <c>switch</c>
+    /// at realistic set sizes and faster at small ones, because a large <c>switch</c> over
+    /// distinct node types is compiled into that same dispatch anyway.
     /// </para>
     /// <para>
-    /// The finer grain is the next step rather than the abandoned one — see
-    /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> on rules
-    /// as data — and nothing here forecloses it: a set whose rewrites become individually
+    /// What actually stands in the way is transcription: splitting forty <c>switch</c> arms
+    /// by hand is forty chances to change a pattern silently. That points at a source
+    /// generator over the existing bodies rather than at leaving the rewrites unnamed. See
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> item 50,
+    /// and note that nothing here forecloses it: a set whose rewrites become individually
     /// addressable keeps the same name and the same entry in the registry.
     /// </para>
     /// </remarks>

--- a/Sources/AngouriMath/Docs/Contributing/Transformations.md
+++ b/Sources/AngouriMath/Docs/Contributing/Transformations.md
@@ -165,12 +165,20 @@ Two things to get right:
 
 ## What the next step is
 
-The unit here is the rule *set*, not the single `pattern -> replacement` line, because every rewrite
-in this library is a case of one `switch` and the compiler turns that into a type test and a jump —
-splitting each case into an object would trade one dispatch per node for one delegate call per rule
-per node, on the hottest path there is. Making the individual rewrites addressable without paying
-that is the next piece of work, and nothing here forecloses it: a set whose rewrites become
-individually reachable keeps its name and its entry in the registry.
+The unit here is the rule *set*, not the single `pattern -> replacement` line — because that is what
+has been built, **not** because the finer grain costs too much. This document used to say it would
+trade one dispatch per node for one delegate call per rule per node. That was asserted, never
+measured, and it is wrong: [#825](https://github.com/asc-community/AngouriMath/issues/825) measures
+rules bucketed by the node type they match at **as fast as** the hand-written `switch` on a
+realistic-sized set and **2.3× faster** on a small one, at identical allocation. A large `switch`
+over distinct node types is compiled into that same type dispatch anyway, so an explicit registry is
+not paying for anything — it is writing down what the compiler already infers from arm order.
+
+What does stand in the way is transcription: splitting forty `switch` arms by hand is forty chances
+to change a pattern silently, and the per-rule metadata has to stay in step with the pattern. Both
+point at a source generator over the existing bodies, which is what #746 item 50 should decide.
+Nothing here forecloses it: a set whose rewrites become individually reachable keeps its name and its
+entry in the registry.
 
 After that, in dependency order: the goal/tactic layer that `Solve` belongs in, and then derivations,
 which want every step to be attributable — which is what naming the steps was for.


### PR DESCRIPTION
Follows #825, which is the measurement.

`RewriteRuleSet` and `Docs/Contributing/Transformations.md` both justified keeping the rule *set* as the unit by asserting that splitting each `switch` arm into an object would trade one dispatch per node for one delegate call per rule per node, on the hottest path in the library. **I wrote that in three places and on two issues without measuring it, and it is wrong.**

Measured on the 259-node expression `DotnetBenchmark` uses for `SimplifyHard`, minimum of seven rounds after 3000 warmup iterations, with identical output and identical allocation across all shapes:

| shape | 15 rules | 35 rules |
|---|---|---|
| `switch`, as written today | 0.0054 ms | 0.0025 ms |
| flat list of rule delegates | 0.0086 ms | — |
| bucketed by node type | **0.0022 ms** | **0.0024 ms** |

Rules bucketed by the node type they match are **2.3× faster** than the switch at fifteen rules and **indistinguishable** at thirty-five. The naive flat list is the only shape that is slower, so the objection held for that shape alone.

The reason the switch catches up is the useful part: given enough arms over enough distinct node types, Roslyn stops emitting sequential type tests and emits a real type dispatch. **The compiler is already doing the bucketing.** An explicit registry would be writing down what it infers from arm order, not paying a tax for addressability.

What actually stands in the way is transcription — forty arms split by hand are forty chances to change a pattern silently, and per-rule metadata has to stay in step with the pattern. That points at a source generator over the existing bodies, and the files now say so instead of carrying a performance claim that does not hold.

Docs and XML comments only; no behaviour change, no test change.
