### PR TITLE
Pin the language version instead of building on preview

### DIFF
--- a/Sources/AngouriMath/AngouriMath.csproj
+++ b/Sources/AngouriMath/AngouriMath.csproj
@@ -9,7 +9,7 @@
   
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>14.0</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTags>$(PackageTags), csharp</PackageTags>
     <Description>Enables to work with formulas built in the code or from a string. Computing, derivating, latex rendering, compilation, solving equations and systems of equations analytycally, simplification, and much more. Read more on https://am.angouri.org.</Description>

--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
+    <LangVersion>14.0</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.fsproj'">
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 </Project>

--- a/Sources/Samples/Samples/Playground.csproj
+++ b/Sources/Samples/Samples/Playground.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
`Sources/Directory.Build.props` set `<LangVersion>preview</LangVersion>` for every project, and `AngouriMath.csproj` and `Playground.csproj` repeated it. `preview` means "whatever the installed SDK currently considers unreleased", so the language semantics of this repository could change between SDK patch releases with nothing in the tree to say so. For a library shipping strong-named binaries that is a dependency on a moving target.

## What changed

- C# projects pin to `14.0`.
- F# takes `latest`. This is not cosmetic: `FSC` rejects a numeric LangVersion outright.

  ```
  FSC : error FS0246: Unrecognized value '14.0' for --langversion
  ```

  `Sources/Directory.Build.props` applies to `.fsproj` as well, so a flat pin breaks both F# wrappers. The property is now scoped by `$(MSBuildProjectExtension)`, and `latest` is the stable equivalent of the `preview` those projects had.

## Nothing is given up

`14.0` supplies everything `preview` did that this repository uses. Checked specifically for extension members, since #821 is considering them: a C# 14 `extension(T)` block compiles under `<LangVersion>14.0</LangVersion>` on SDK 10.0.302.

## Measured

Every project that builds on Linux, built individually rather than through the solution:

| project | result |
|---|---|
| `AngouriMath` | 0 errors, 0 warnings |
| `Analyzers` | 0 errors |
| `UnitTests` | 0 errors |
| `AngouriMath.FSharp` | 0 errors |
| `AngouriMath.Interactive` | 0 errors |
| `AngouriMath.CPP.Exporting` | 0 errors |
| `Playground` | 0 errors |

```
Passed! - Failed: 0, Passed: 6049, Skipped: 14, Total: 6063 - UnitTests.dll (net10.0)
```

## Two pre-existing failures this does not touch

Both were reproduced on `master` without this change, so neither is a regression:

- `Analyzers.CodeFixes` and `Analyzers.Debug` fail with `NETSDK1060`, out of a backslash-separated `ProjectReference` that does not split on Linux.
- `AngouriMathPlot` and `GraphicExample` fail with `NETSDK1100` (Windows targeting on Linux), which is why the solution build cannot be used as the gate here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)