### PR TITLE
Write the public surface down, so changing it is a deliberate act

### DIFF
--- a/Sources/Tests/UnitTests/Common/PublicApi.txt
+++ b/Sources/Tests/UnitTests/Common/PublicApi.txt
@@ -1,0 +1,2602 @@
+AngouriMath.Convenience.Setting<T>.As(T, Func<TReturnType>) : TReturnType
+AngouriMath.Convenience.Setting<T>.As(T, System.Action) : System.Void
+AngouriMath.Convenience.Setting<T>.Default { } : T
+AngouriMath.Convenience.Setting<T>.Dispose() : System.Void
+AngouriMath.Convenience.Setting<T>.Set(T) : AutoBackRollableTemporarySettingUnit<T>
+AngouriMath.Convenience.Setting<T>.ToString() : System.String
+AngouriMath.Convenience.Setting<T>.Value { } : T
+AngouriMath.Convenience.Setting<T>.op_Implicit(AngouriMath.Convenience.Setting<T>) : T
+AngouriMath.Convenience.Setting<T>.op_Implicit(T) : AngouriMath.Convenience.Setting<T>
+AngouriMath.Core.ApproachFrom.BothSides : AngouriMath.Core.ApproachFrom
+AngouriMath.Core.ApproachFrom.Left : AngouriMath.Core.ApproachFrom
+AngouriMath.Core.ApproachFrom.Right : AngouriMath.Core.ApproachFrom
+AngouriMath.Core.ApproachFrom.value__ : System.Int32
+AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol.<Clone>$() : AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol
+AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol.ConvertBinaryNode(System.Linq.Expressions.Expression, System.Linq.Expressions.Expression, AngouriMath.Entity) : System.Linq.Expressions.Expression
+AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol.ConvertConstant(AngouriMath.Entity) : System.Linq.Expressions.Expression
+AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol.ConvertNaN(System.Type) : System.Linq.Expressions.Expression
+AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol.ConvertOtherNode(System.Collections.Generic.IEnumerable<System.Linq.Expressions.Expression>, AngouriMath.Entity) : System.Linq.Expressions.Expression
+AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol.ConvertType(System.Linq.Expressions.Expression, System.Type) : System.Linq.Expressions.Expression
+AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol.ConvertUnaryNode(System.Linq.Expressions.Expression, AngouriMath.Entity) : System.Linq.Expressions.Expression
+AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol.EqualityContract { } : System.Type
+AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol.Equals(AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol) : System.Boolean
+AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol.Equals(System.Object) : System.Boolean
+AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol.GetHashCode() : System.Int32
+AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol.ToString() : System.String
+AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol.ctor()
+AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol.ctor(AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol)
+AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol.op_Equality(AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol, AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol) : System.Boolean
+AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol.op_Inequality(AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol, AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol) : System.Boolean
+AngouriMath.Core.Domain.Any : AngouriMath.Core.Domain
+AngouriMath.Core.Domain.Boolean : AngouriMath.Core.Domain
+AngouriMath.Core.Domain.Complex : AngouriMath.Core.Domain
+AngouriMath.Core.Domain.Integer : AngouriMath.Core.Domain
+AngouriMath.Core.Domain.Rational : AngouriMath.Core.Domain
+AngouriMath.Core.Domain.Real : AngouriMath.Core.Domain
+AngouriMath.Core.Domain.value__ : System.Int32
+AngouriMath.Core.EquationSystem.Latexise() : System.String
+AngouriMath.Core.EquationSystem.Solve(AngouriMath.Entity+Variable[]) : AngouriMath.Entity+Matrix
+AngouriMath.Core.EquationSystem.ToString() : System.String
+AngouriMath.Core.EquationSystem.ctor(AngouriMath.Entity[])
+AngouriMath.Core.EquationSystem.ctor(System.Collections.Generic.IEnumerable<AngouriMath.Entity>)
+AngouriMath.Core.FastExpression.Call(System.Numerics.Complex[]) : System.Numerics.Complex
+AngouriMath.Core.FastExpression.Substitute(System.Numerics.Complex[]) : System.Numerics.Complex
+AngouriMath.Core.FastExpression.ToString() : System.String
+AngouriMath.Core.FiniteSetBuilder.Add(AngouriMath.Entity) : System.Void
+AngouriMath.Core.FiniteSetBuilder.IsEmpty { } : System.Boolean
+AngouriMath.Core.FiniteSetBuilder.Remove(AngouriMath.Entity) : System.Void
+AngouriMath.Core.FiniteSetBuilder.ToFiniteSet() : AngouriMath.Entity+Set+FiniteSet
+AngouriMath.Core.FiniteSetBuilder.ctor()
+AngouriMath.Core.FiniteSetBuilder.ctor(System.Collections.Generic.IEnumerable<AngouriMath.Entity>)
+AngouriMath.Core.IBinaryNode.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Core.IBinaryNode.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Core.IHasAbsoluteValue<TSelf,TOut>.Abs(TSelf) : TOut
+AngouriMath.Core.ILatexiseable.Latexise() : System.String
+AngouriMath.Core.IUnaryNode.NodeChild { } : AngouriMath.Entity
+AngouriMath.Core.MatrixBuilder.Add(System.Collections.Generic.IEnumerable<AngouriMath.Entity>) : System.Void
+AngouriMath.Core.MatrixBuilder.Add(System.Collections.Generic.List<AngouriMath.Entity>) : System.Void
+AngouriMath.Core.MatrixBuilder.ToMatrix() : AngouriMath.Entity+Matrix
+AngouriMath.Core.MatrixBuilder.ctor(System.Collections.Generic.List<System.Collections.Generic.List<AngouriMath.Entity>>, System.Int32)
+AngouriMath.Core.MatrixBuilder.ctor(System.Int32)
+AngouriMath.Core.ReasonOfFailureWhileParsing+InternalError.<Clone>$() : AngouriMath.Core.ReasonOfFailureWhileParsing+InternalError
+AngouriMath.Core.ReasonOfFailureWhileParsing+InternalError.Deconstruct(System.String&) : System.Void
+AngouriMath.Core.ReasonOfFailureWhileParsing+InternalError.Details { } : System.String
+AngouriMath.Core.ReasonOfFailureWhileParsing+InternalError.Equals(AngouriMath.Core.ReasonOfFailureWhileParsing+InternalError) : System.Boolean
+AngouriMath.Core.ReasonOfFailureWhileParsing+InternalError.Equals(System.Object) : System.Boolean
+AngouriMath.Core.ReasonOfFailureWhileParsing+InternalError.GetHashCode() : System.Int32
+AngouriMath.Core.ReasonOfFailureWhileParsing+InternalError.ToString() : System.String
+AngouriMath.Core.ReasonOfFailureWhileParsing+InternalError.ctor(System.String)
+AngouriMath.Core.ReasonOfFailureWhileParsing+InternalError.op_Equality(AngouriMath.Core.ReasonOfFailureWhileParsing+InternalError, AngouriMath.Core.ReasonOfFailureWhileParsing+InternalError) : System.Boolean
+AngouriMath.Core.ReasonOfFailureWhileParsing+InternalError.op_Inequality(AngouriMath.Core.ReasonOfFailureWhileParsing+InternalError, AngouriMath.Core.ReasonOfFailureWhileParsing+InternalError) : System.Boolean
+AngouriMath.Core.ReasonOfFailureWhileParsing+MissingOperator.<Clone>$() : AngouriMath.Core.ReasonOfFailureWhileParsing+MissingOperator
+AngouriMath.Core.ReasonOfFailureWhileParsing+MissingOperator.Deconstruct(System.String&) : System.Void
+AngouriMath.Core.ReasonOfFailureWhileParsing+MissingOperator.Details { } : System.String
+AngouriMath.Core.ReasonOfFailureWhileParsing+MissingOperator.Equals(AngouriMath.Core.ReasonOfFailureWhileParsing+MissingOperator) : System.Boolean
+AngouriMath.Core.ReasonOfFailureWhileParsing+MissingOperator.Equals(System.Object) : System.Boolean
+AngouriMath.Core.ReasonOfFailureWhileParsing+MissingOperator.GetHashCode() : System.Int32
+AngouriMath.Core.ReasonOfFailureWhileParsing+MissingOperator.ToString() : System.String
+AngouriMath.Core.ReasonOfFailureWhileParsing+MissingOperator.ctor(System.String)
+AngouriMath.Core.ReasonOfFailureWhileParsing+MissingOperator.op_Equality(AngouriMath.Core.ReasonOfFailureWhileParsing+MissingOperator, AngouriMath.Core.ReasonOfFailureWhileParsing+MissingOperator) : System.Boolean
+AngouriMath.Core.ReasonOfFailureWhileParsing+MissingOperator.op_Inequality(AngouriMath.Core.ReasonOfFailureWhileParsing+MissingOperator, AngouriMath.Core.ReasonOfFailureWhileParsing+MissingOperator) : System.Boolean
+AngouriMath.Core.ReasonOfFailureWhileParsing+Unknown.<Clone>$() : AngouriMath.Core.ReasonOfFailureWhileParsing+Unknown
+AngouriMath.Core.ReasonOfFailureWhileParsing+Unknown.Deconstruct(System.String&) : System.Void
+AngouriMath.Core.ReasonOfFailureWhileParsing+Unknown.Equals(AngouriMath.Core.ReasonOfFailureWhileParsing+Unknown) : System.Boolean
+AngouriMath.Core.ReasonOfFailureWhileParsing+Unknown.Equals(System.Object) : System.Boolean
+AngouriMath.Core.ReasonOfFailureWhileParsing+Unknown.GetHashCode() : System.Int32
+AngouriMath.Core.ReasonOfFailureWhileParsing+Unknown.Reason { } : System.String
+AngouriMath.Core.ReasonOfFailureWhileParsing+Unknown.ToString() : System.String
+AngouriMath.Core.ReasonOfFailureWhileParsing+Unknown.ctor(System.String)
+AngouriMath.Core.ReasonOfFailureWhileParsing+Unknown.op_Equality(AngouriMath.Core.ReasonOfFailureWhileParsing+Unknown, AngouriMath.Core.ReasonOfFailureWhileParsing+Unknown) : System.Boolean
+AngouriMath.Core.ReasonOfFailureWhileParsing+Unknown.op_Inequality(AngouriMath.Core.ReasonOfFailureWhileParsing+Unknown, AngouriMath.Core.ReasonOfFailureWhileParsing+Unknown) : System.Boolean
+AngouriMath.Core.ReasonOfFailureWhileParsing.<Clone>$() : AngouriMath.Core.ReasonOfFailureWhileParsing
+AngouriMath.Core.ReasonOfFailureWhileParsing.EqualityContract { } : System.Type
+AngouriMath.Core.ReasonOfFailureWhileParsing.Equals(AngouriMath.Core.ReasonOfFailureWhileParsing) : System.Boolean
+AngouriMath.Core.ReasonOfFailureWhileParsing.Equals(System.Object) : System.Boolean
+AngouriMath.Core.ReasonOfFailureWhileParsing.GetHashCode() : System.Int32
+AngouriMath.Core.ReasonOfFailureWhileParsing.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Core.ReasonOfFailureWhileParsing.ToString() : System.String
+AngouriMath.Core.ReasonOfFailureWhileParsing.ctor()
+AngouriMath.Core.ReasonOfFailureWhileParsing.ctor(AngouriMath.Core.ReasonOfFailureWhileParsing)
+AngouriMath.Core.ReasonOfFailureWhileParsing.op_Equality(AngouriMath.Core.ReasonOfFailureWhileParsing, AngouriMath.Core.ReasonOfFailureWhileParsing) : System.Boolean
+AngouriMath.Core.ReasonOfFailureWhileParsing.op_Inequality(AngouriMath.Core.ReasonOfFailureWhileParsing, AngouriMath.Core.ReasonOfFailureWhileParsing) : System.Boolean
+AngouriMath.Core.Transformations.RewriteRecording.Dispose() : System.Void
+AngouriMath.Core.Transformations.RewriteRecording.Start() : AngouriMath.Core.Transformations.RewriteRecording
+AngouriMath.Core.Transformations.RewriteRecording.Steps { } : System.Collections.Generic.IReadOnlyList<AngouriMath.Core.Transformations.RewriteStep>
+AngouriMath.Core.Transformations.RewriteRuleSet.ApplyOnce(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Core.Transformations.RewriteRuleSet.AsTransformation() : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.RewriteRuleSet.Description { } : System.String
+AngouriMath.Core.Transformations.RewriteRuleSet.Name { } : System.String
+AngouriMath.Core.Transformations.RewriteRuleSet.Relation { } : AngouriMath.Core.Transformations.TransformationRelation
+AngouriMath.Core.Transformations.RewriteRuleSet.Soundness { } : AngouriMath.Core.Transformations.Soundness
+AngouriMath.Core.Transformations.RewriteRuleSet.ToString() : System.String
+AngouriMath.Core.Transformations.RewriteRules.All { } : System.Collections.Generic.IReadOnlyList<AngouriMath.Core.Transformations.RewriteRuleSet>
+AngouriMath.Core.Transformations.RewriteRules.Boolean { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.CanonicalOrder { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.CanonicalOrderCountingConstants { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.CanonicalOrderExact { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.CollapseMultipleFractions { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.CollapseTrigonometricFunctions { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.Common { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.CommonDenominator { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.CommonDenominatorCountingConstants { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.CommonDenominatorExact { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.DivisionPreparing { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.ExpandFactorialDivisions { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.ExpandMultipleAngle { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.ExpandTrigonometric { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.Expansion { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.Factorization { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.FactorizeFactorialMultiplications { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.InequalityEquality { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.InvertNegativeMultipliers { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.InvertNegativePowers { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.NormalTrigonometricForm { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.NumericNeat { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.PerfectSquare { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.PhiFunction { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.PolynomialGcdCancellation { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.PolynomialLongDivision { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.Power { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.RationaliseDenominator { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.SetOperator { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.Trigonometric { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteStep.After { } : AngouriMath.Entity
+AngouriMath.Core.Transformations.RewriteStep.Before { } : AngouriMath.Entity
+AngouriMath.Core.Transformations.RewriteStep.Relation { } : AngouriMath.Core.Transformations.TransformationRelation
+AngouriMath.Core.Transformations.RewriteStep.RuleSet { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteStep.Soundness { } : AngouriMath.Core.Transformations.Soundness
+AngouriMath.Core.Transformations.RewriteStep.ToString() : System.String
+AngouriMath.Core.Transformations.Soundness.Heuristic : AngouriMath.Core.Transformations.Soundness
+AngouriMath.Core.Transformations.Soundness.Sound : AngouriMath.Core.Transformations.Soundness
+AngouriMath.Core.Transformations.Soundness.SoundUnderAssumptions : AngouriMath.Core.Transformations.Soundness
+AngouriMath.Core.Transformations.Soundness.value__ : System.Int32
+AngouriMath.Core.Transformations.Transformation.Apply(AngouriMath.Entity) : AngouriMath.Core.Transformations.TransformationResult
+AngouriMath.Core.Transformations.Transformation.ApplyCore(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Core.Transformations.Transformation.ApplyOrKeep(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Core.Transformations.Transformation.Differentiation(AngouriMath.Entity+Variable) : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.Expansion { } : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.ExpansionAtLevel(System.Int32) : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.Factorization { } : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.FactorizationAtLevel(System.Int32) : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.InnerSimplification { } : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.Integration(AngouriMath.Entity+Variable) : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.LimitAt(AngouriMath.Entity+Variable, AngouriMath.Entity, AngouriMath.Core.ApproachFrom) : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.Name { } : System.String
+AngouriMath.Core.Transformations.Transformation.Normalization { } : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.Rationalisation { } : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.Relation { } : AngouriMath.Core.Transformations.TransformationRelation
+AngouriMath.Core.Transformations.Transformation.Repeat(System.Int32) : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.Rewriting(AngouriMath.Core.Transformations.RewriteRuleSet) : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.Simplification { } : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.SimplificationAtLevel(System.Int32) : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.Soundness { } : AngouriMath.Core.Transformations.Soundness
+AngouriMath.Core.Transformations.Transformation.Substitution(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.Then(AngouriMath.Core.Transformations.Transformation) : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.ToString() : System.String
+AngouriMath.Core.Transformations.Transformation.UntilStable(System.Int32) : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.ctor()
+AngouriMath.Core.Transformations.TransformationRelation.Derivation : AngouriMath.Core.Transformations.TransformationRelation
+AngouriMath.Core.Transformations.TransformationRelation.Equivalence : AngouriMath.Core.Transformations.TransformationRelation
+AngouriMath.Core.Transformations.TransformationRelation.value__ : System.Int32
+AngouriMath.Core.Transformations.TransformationResult.Changed { } : System.Boolean
+AngouriMath.Core.Transformations.TransformationResult.Input { } : AngouriMath.Entity
+AngouriMath.Core.Transformations.TransformationResult.Output { } : AngouriMath.Entity
+AngouriMath.Core.Transformations.TransformationResult.OutputOrInput { } : AngouriMath.Entity
+AngouriMath.Core.Transformations.TransformationResult.Relation { } : AngouriMath.Core.Transformations.TransformationRelation
+AngouriMath.Core.Transformations.TransformationResult.Soundness { } : AngouriMath.Core.Transformations.Soundness
+AngouriMath.Core.Transformations.TransformationResult.Succeeded { } : System.Boolean
+AngouriMath.Core.Transformations.TransformationResult.ToString() : System.String
+AngouriMath.Core.Transformations.TransformationResult.Transformation { } : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Entity+Absf.<Clone>$() : AngouriMath.Entity+Absf
+AngouriMath.Entity+Absf.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Absf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Absf.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Absf.EqualityContract { } : System.Type
+AngouriMath.Entity+Absf.Equals(AngouriMath.Entity+Absf) : System.Boolean
+AngouriMath.Entity+Absf.Equals(AngouriMath.Entity+Function) : System.Boolean
+AngouriMath.Entity+Absf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Absf.GetHashCode() : System.Int32
+AngouriMath.Entity+Absf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Absf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Absf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Absf.Latexise() : System.String
+AngouriMath.Entity+Absf.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Absf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Absf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Absf.Stringize() : System.String
+AngouriMath.Entity+Absf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Absf.ToString() : System.String
+AngouriMath.Entity+Absf.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Absf.op_Equality(AngouriMath.Entity+Absf, AngouriMath.Entity+Absf) : System.Boolean
+AngouriMath.Entity+Absf.op_Inequality(AngouriMath.Entity+Absf, AngouriMath.Entity+Absf) : System.Boolean
+AngouriMath.Entity+Andf.<Clone>$() : AngouriMath.Entity+Andf
+AngouriMath.Entity+Andf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Andf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Andf.EqualityContract { } : System.Type
+AngouriMath.Entity+Andf.Equals(AngouriMath.Entity+Andf) : System.Boolean
+AngouriMath.Entity+Andf.Equals(AngouriMath.Entity+Statement) : System.Boolean
+AngouriMath.Entity+Andf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Andf.GetHashCode() : System.Int32
+AngouriMath.Entity+Andf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Andf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Andf.Latexise() : System.String
+AngouriMath.Entity+Andf.Left { } : AngouriMath.Entity
+AngouriMath.Entity+Andf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+Andf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+Andf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Andf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Andf.Right { } : AngouriMath.Entity
+AngouriMath.Entity+Andf.Stringize() : System.String
+AngouriMath.Entity+Andf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Andf.ToString() : System.String
+AngouriMath.Entity+Andf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Andf.op_Equality(AngouriMath.Entity+Andf, AngouriMath.Entity+Andf) : System.Boolean
+AngouriMath.Entity+Andf.op_Inequality(AngouriMath.Entity+Andf, AngouriMath.Entity+Andf) : System.Boolean
+AngouriMath.Entity+Application.<Clone>$() : AngouriMath.Entity+Application
+AngouriMath.Entity+Application.Arguments { } : HonkSharp.Functional.LList<AngouriMath.Entity>
+AngouriMath.Entity+Application.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Application.Deconstruct(AngouriMath.Entity&, HonkSharp.Functional.LList<AngouriMath.Entity>&) : System.Void
+AngouriMath.Entity+Application.EqualityContract { } : System.Type
+AngouriMath.Entity+Application.Equals(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity+Application.Equals(AngouriMath.Entity+Application) : System.Boolean
+AngouriMath.Entity+Application.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Application.Expression { } : AngouriMath.Entity
+AngouriMath.Entity+Application.GetHashCode() : System.Int32
+AngouriMath.Entity+Application.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Application.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Application.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Application.Latexise() : System.String
+AngouriMath.Entity+Application.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Application.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Application.Stringize() : System.String
+AngouriMath.Entity+Application.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Application.ToString() : System.String
+AngouriMath.Entity+Application.ctor(AngouriMath.Entity, HonkSharp.Functional.LList<AngouriMath.Entity>)
+AngouriMath.Entity+Application.op_Equality(AngouriMath.Entity+Application, AngouriMath.Entity+Application) : System.Boolean
+AngouriMath.Entity+Application.op_Inequality(AngouriMath.Entity+Application, AngouriMath.Entity+Application) : System.Boolean
+AngouriMath.Entity+Arccosecantf.<Clone>$() : AngouriMath.Entity+Arccosecantf
+AngouriMath.Entity+Arccosecantf.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Arccosecantf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Arccosecantf.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Arccosecantf.EqualityContract { } : System.Type
+AngouriMath.Entity+Arccosecantf.Equals(AngouriMath.Entity+Arccosecantf) : System.Boolean
+AngouriMath.Entity+Arccosecantf.Equals(AngouriMath.Entity+TrigonometricFunction) : System.Boolean
+AngouriMath.Entity+Arccosecantf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Arccosecantf.GetHashCode() : System.Int32
+AngouriMath.Entity+Arccosecantf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Arccosecantf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Arccosecantf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Arccosecantf.Latexise() : System.String
+AngouriMath.Entity+Arccosecantf.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Arccosecantf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Arccosecantf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Arccosecantf.Stringize() : System.String
+AngouriMath.Entity+Arccosecantf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Arccosecantf.ToString() : System.String
+AngouriMath.Entity+Arccosecantf.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Arccosecantf.op_Equality(AngouriMath.Entity+Arccosecantf, AngouriMath.Entity+Arccosecantf) : System.Boolean
+AngouriMath.Entity+Arccosecantf.op_Inequality(AngouriMath.Entity+Arccosecantf, AngouriMath.Entity+Arccosecantf) : System.Boolean
+AngouriMath.Entity+Arccosf.<Clone>$() : AngouriMath.Entity+Arccosf
+AngouriMath.Entity+Arccosf.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Arccosf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Arccosf.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Arccosf.EqualityContract { } : System.Type
+AngouriMath.Entity+Arccosf.Equals(AngouriMath.Entity+Arccosf) : System.Boolean
+AngouriMath.Entity+Arccosf.Equals(AngouriMath.Entity+TrigonometricFunction) : System.Boolean
+AngouriMath.Entity+Arccosf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Arccosf.GetHashCode() : System.Int32
+AngouriMath.Entity+Arccosf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Arccosf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Arccosf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Arccosf.Latexise() : System.String
+AngouriMath.Entity+Arccosf.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Arccosf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Arccosf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Arccosf.Stringize() : System.String
+AngouriMath.Entity+Arccosf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Arccosf.ToString() : System.String
+AngouriMath.Entity+Arccosf.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Arccosf.op_Equality(AngouriMath.Entity+Arccosf, AngouriMath.Entity+Arccosf) : System.Boolean
+AngouriMath.Entity+Arccosf.op_Inequality(AngouriMath.Entity+Arccosf, AngouriMath.Entity+Arccosf) : System.Boolean
+AngouriMath.Entity+Arccotanf.<Clone>$() : AngouriMath.Entity+Arccotanf
+AngouriMath.Entity+Arccotanf.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Arccotanf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Arccotanf.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Arccotanf.EqualityContract { } : System.Type
+AngouriMath.Entity+Arccotanf.Equals(AngouriMath.Entity+Arccotanf) : System.Boolean
+AngouriMath.Entity+Arccotanf.Equals(AngouriMath.Entity+TrigonometricFunction) : System.Boolean
+AngouriMath.Entity+Arccotanf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Arccotanf.GetHashCode() : System.Int32
+AngouriMath.Entity+Arccotanf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Arccotanf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Arccotanf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Arccotanf.Latexise() : System.String
+AngouriMath.Entity+Arccotanf.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Arccotanf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Arccotanf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Arccotanf.Stringize() : System.String
+AngouriMath.Entity+Arccotanf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Arccotanf.ToString() : System.String
+AngouriMath.Entity+Arccotanf.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Arccotanf.op_Equality(AngouriMath.Entity+Arccotanf, AngouriMath.Entity+Arccotanf) : System.Boolean
+AngouriMath.Entity+Arccotanf.op_Inequality(AngouriMath.Entity+Arccotanf, AngouriMath.Entity+Arccotanf) : System.Boolean
+AngouriMath.Entity+Arcsecantf.<Clone>$() : AngouriMath.Entity+Arcsecantf
+AngouriMath.Entity+Arcsecantf.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Arcsecantf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Arcsecantf.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Arcsecantf.EqualityContract { } : System.Type
+AngouriMath.Entity+Arcsecantf.Equals(AngouriMath.Entity+Arcsecantf) : System.Boolean
+AngouriMath.Entity+Arcsecantf.Equals(AngouriMath.Entity+TrigonometricFunction) : System.Boolean
+AngouriMath.Entity+Arcsecantf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Arcsecantf.GetHashCode() : System.Int32
+AngouriMath.Entity+Arcsecantf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Arcsecantf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Arcsecantf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Arcsecantf.Latexise() : System.String
+AngouriMath.Entity+Arcsecantf.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Arcsecantf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Arcsecantf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Arcsecantf.Stringize() : System.String
+AngouriMath.Entity+Arcsecantf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Arcsecantf.ToString() : System.String
+AngouriMath.Entity+Arcsecantf.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Arcsecantf.op_Equality(AngouriMath.Entity+Arcsecantf, AngouriMath.Entity+Arcsecantf) : System.Boolean
+AngouriMath.Entity+Arcsecantf.op_Inequality(AngouriMath.Entity+Arcsecantf, AngouriMath.Entity+Arcsecantf) : System.Boolean
+AngouriMath.Entity+Arcsinf.<Clone>$() : AngouriMath.Entity+Arcsinf
+AngouriMath.Entity+Arcsinf.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Arcsinf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Arcsinf.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Arcsinf.EqualityContract { } : System.Type
+AngouriMath.Entity+Arcsinf.Equals(AngouriMath.Entity+Arcsinf) : System.Boolean
+AngouriMath.Entity+Arcsinf.Equals(AngouriMath.Entity+TrigonometricFunction) : System.Boolean
+AngouriMath.Entity+Arcsinf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Arcsinf.GetHashCode() : System.Int32
+AngouriMath.Entity+Arcsinf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Arcsinf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Arcsinf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Arcsinf.Latexise() : System.String
+AngouriMath.Entity+Arcsinf.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Arcsinf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Arcsinf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Arcsinf.Stringize() : System.String
+AngouriMath.Entity+Arcsinf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Arcsinf.ToString() : System.String
+AngouriMath.Entity+Arcsinf.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Arcsinf.op_Equality(AngouriMath.Entity+Arcsinf, AngouriMath.Entity+Arcsinf) : System.Boolean
+AngouriMath.Entity+Arcsinf.op_Inequality(AngouriMath.Entity+Arcsinf, AngouriMath.Entity+Arcsinf) : System.Boolean
+AngouriMath.Entity+Arctanf.<Clone>$() : AngouriMath.Entity+Arctanf
+AngouriMath.Entity+Arctanf.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Arctanf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Arctanf.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Arctanf.EqualityContract { } : System.Type
+AngouriMath.Entity+Arctanf.Equals(AngouriMath.Entity+Arctanf) : System.Boolean
+AngouriMath.Entity+Arctanf.Equals(AngouriMath.Entity+TrigonometricFunction) : System.Boolean
+AngouriMath.Entity+Arctanf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Arctanf.GetHashCode() : System.Int32
+AngouriMath.Entity+Arctanf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Arctanf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Arctanf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Arctanf.Latexise() : System.String
+AngouriMath.Entity+Arctanf.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Arctanf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Arctanf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Arctanf.Stringize() : System.String
+AngouriMath.Entity+Arctanf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Arctanf.ToString() : System.String
+AngouriMath.Entity+Arctanf.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Arctanf.op_Equality(AngouriMath.Entity+Arctanf, AngouriMath.Entity+Arctanf) : System.Boolean
+AngouriMath.Entity+Arctanf.op_Inequality(AngouriMath.Entity+Arctanf, AngouriMath.Entity+Arctanf) : System.Boolean
+AngouriMath.Entity+Boolean.<Clone>$() : AngouriMath.Entity+Boolean
+AngouriMath.Entity+Boolean.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Boolean.Create(System.Boolean) : AngouriMath.Entity+Boolean
+AngouriMath.Entity+Boolean.Deconstruct(System.Boolean&) : System.Void
+AngouriMath.Entity+Boolean.EqualityContract { } : System.Type
+AngouriMath.Entity+Boolean.Equals(AngouriMath.Entity+Boolean) : System.Boolean
+AngouriMath.Entity+Boolean.Equals(AngouriMath.Entity+Statement) : System.Boolean
+AngouriMath.Entity+Boolean.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Boolean.False : AngouriMath.Entity+Boolean
+AngouriMath.Entity+Boolean.GetHashCode() : System.Int32
+AngouriMath.Entity+Boolean.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Boolean.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Boolean.Latexise() : System.String
+AngouriMath.Entity+Boolean.Parse(System.String) : AngouriMath.Entity+Boolean
+AngouriMath.Entity+Boolean.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Boolean.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Boolean.Stringize() : System.String
+AngouriMath.Entity+Boolean.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Boolean.ToString() : System.String
+AngouriMath.Entity+Boolean.True : AngouriMath.Entity+Boolean
+AngouriMath.Entity+Boolean.TryParse(System.String, AngouriMath.Entity+Boolean&) : System.Boolean
+AngouriMath.Entity+Boolean.Value { } : System.Boolean
+AngouriMath.Entity+Boolean.ctor(System.Boolean)
+AngouriMath.Entity+Boolean.op_Equality(AngouriMath.Entity+Boolean, AngouriMath.Entity+Boolean) : System.Boolean
+AngouriMath.Entity+Boolean.op_Implicit(AngouriMath.Entity+Boolean) : System.Boolean
+AngouriMath.Entity+Boolean.op_Inequality(AngouriMath.Entity+Boolean, AngouriMath.Entity+Boolean) : System.Boolean
+AngouriMath.Entity+CalculusOperator.<Clone>$() : AngouriMath.Entity+CalculusOperator
+AngouriMath.Entity+CalculusOperator.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+CalculusOperator.EqualityContract { } : System.Type
+AngouriMath.Entity+CalculusOperator.Equals(AngouriMath.Entity+CalculusOperator) : System.Boolean
+AngouriMath.Entity+CalculusOperator.Equals(AngouriMath.Entity+Function) : System.Boolean
+AngouriMath.Entity+CalculusOperator.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+CalculusOperator.Expression { } : AngouriMath.Entity
+AngouriMath.Entity+CalculusOperator.GetHashCode() : System.Int32
+AngouriMath.Entity+CalculusOperator.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+CalculusOperator.ToString() : System.String
+AngouriMath.Entity+CalculusOperator.Var { } : AngouriMath.Entity
+AngouriMath.Entity+CalculusOperator.ctor(AngouriMath.Entity+CalculusOperator)
+AngouriMath.Entity+CalculusOperator.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+CalculusOperator.op_Equality(AngouriMath.Entity+CalculusOperator, AngouriMath.Entity+CalculusOperator) : System.Boolean
+AngouriMath.Entity+CalculusOperator.op_Inequality(AngouriMath.Entity+CalculusOperator, AngouriMath.Entity+CalculusOperator) : System.Boolean
+AngouriMath.Entity+Ceilf.<Clone>$() : AngouriMath.Entity+Ceilf
+AngouriMath.Entity+Ceilf.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Ceilf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Ceilf.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Ceilf.EqualityContract { } : System.Type
+AngouriMath.Entity+Ceilf.Equals(AngouriMath.Entity+Ceilf) : System.Boolean
+AngouriMath.Entity+Ceilf.Equals(AngouriMath.Entity+Function) : System.Boolean
+AngouriMath.Entity+Ceilf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Ceilf.GetHashCode() : System.Int32
+AngouriMath.Entity+Ceilf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Ceilf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Ceilf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Ceilf.Latexise() : System.String
+AngouriMath.Entity+Ceilf.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Ceilf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Ceilf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Ceilf.Stringize() : System.String
+AngouriMath.Entity+Ceilf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Ceilf.ToString() : System.String
+AngouriMath.Entity+Ceilf.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Ceilf.op_Equality(AngouriMath.Entity+Ceilf, AngouriMath.Entity+Ceilf) : System.Boolean
+AngouriMath.Entity+Ceilf.op_Inequality(AngouriMath.Entity+Ceilf, AngouriMath.Entity+Ceilf) : System.Boolean
+AngouriMath.Entity+ComparisonSign.<Clone>$() : AngouriMath.Entity+ComparisonSign
+AngouriMath.Entity+ComparisonSign.EqualityContract { } : System.Type
+AngouriMath.Entity+ComparisonSign.Equals(AngouriMath.Entity+ComparisonSign) : System.Boolean
+AngouriMath.Entity+ComparisonSign.Equals(AngouriMath.Entity+Statement) : System.Boolean
+AngouriMath.Entity+ComparisonSign.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+ComparisonSign.GetHashCode() : System.Int32
+AngouriMath.Entity+ComparisonSign.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+ComparisonSign.ToString() : System.String
+AngouriMath.Entity+ComparisonSign.ctor()
+AngouriMath.Entity+ComparisonSign.ctor(AngouriMath.Entity+ComparisonSign)
+AngouriMath.Entity+ComparisonSign.op_Equality(AngouriMath.Entity+ComparisonSign, AngouriMath.Entity+ComparisonSign) : System.Boolean
+AngouriMath.Entity+ComparisonSign.op_Inequality(AngouriMath.Entity+ComparisonSign, AngouriMath.Entity+ComparisonSign) : System.Boolean
+AngouriMath.Entity+ContinuousNode.<Clone>$() : AngouriMath.Entity+ContinuousNode
+AngouriMath.Entity+ContinuousNode.EqualityContract { } : System.Type
+AngouriMath.Entity+ContinuousNode.Equals(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity+ContinuousNode.Equals(AngouriMath.Entity+ContinuousNode) : System.Boolean
+AngouriMath.Entity+ContinuousNode.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+ContinuousNode.GetHashCode() : System.Int32
+AngouriMath.Entity+ContinuousNode.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+ContinuousNode.ToString() : System.String
+AngouriMath.Entity+ContinuousNode.ctor()
+AngouriMath.Entity+ContinuousNode.ctor(AngouriMath.Entity+ContinuousNode)
+AngouriMath.Entity+ContinuousNode.op_Equality(AngouriMath.Entity+ContinuousNode, AngouriMath.Entity+ContinuousNode) : System.Boolean
+AngouriMath.Entity+ContinuousNode.op_Inequality(AngouriMath.Entity+ContinuousNode, AngouriMath.Entity+ContinuousNode) : System.Boolean
+AngouriMath.Entity+Cosecantf.<Clone>$() : AngouriMath.Entity+Cosecantf
+AngouriMath.Entity+Cosecantf.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Cosecantf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Cosecantf.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Cosecantf.EqualityContract { } : System.Type
+AngouriMath.Entity+Cosecantf.Equals(AngouriMath.Entity+Cosecantf) : System.Boolean
+AngouriMath.Entity+Cosecantf.Equals(AngouriMath.Entity+TrigonometricFunction) : System.Boolean
+AngouriMath.Entity+Cosecantf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Cosecantf.GetHashCode() : System.Int32
+AngouriMath.Entity+Cosecantf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Cosecantf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Cosecantf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Cosecantf.Latexise() : System.String
+AngouriMath.Entity+Cosecantf.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Cosecantf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Cosecantf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Cosecantf.Stringize() : System.String
+AngouriMath.Entity+Cosecantf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Cosecantf.ToString() : System.String
+AngouriMath.Entity+Cosecantf.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Cosecantf.op_Equality(AngouriMath.Entity+Cosecantf, AngouriMath.Entity+Cosecantf) : System.Boolean
+AngouriMath.Entity+Cosecantf.op_Inequality(AngouriMath.Entity+Cosecantf, AngouriMath.Entity+Cosecantf) : System.Boolean
+AngouriMath.Entity+Cosf.<Clone>$() : AngouriMath.Entity+Cosf
+AngouriMath.Entity+Cosf.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Cosf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Cosf.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Cosf.EqualityContract { } : System.Type
+AngouriMath.Entity+Cosf.Equals(AngouriMath.Entity+Cosf) : System.Boolean
+AngouriMath.Entity+Cosf.Equals(AngouriMath.Entity+TrigonometricFunction) : System.Boolean
+AngouriMath.Entity+Cosf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Cosf.GetHashCode() : System.Int32
+AngouriMath.Entity+Cosf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Cosf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Cosf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Cosf.Latexise() : System.String
+AngouriMath.Entity+Cosf.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Cosf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Cosf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Cosf.Stringize() : System.String
+AngouriMath.Entity+Cosf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Cosf.ToString() : System.String
+AngouriMath.Entity+Cosf.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Cosf.op_Equality(AngouriMath.Entity+Cosf, AngouriMath.Entity+Cosf) : System.Boolean
+AngouriMath.Entity+Cosf.op_Inequality(AngouriMath.Entity+Cosf, AngouriMath.Entity+Cosf) : System.Boolean
+AngouriMath.Entity+Cotanf.<Clone>$() : AngouriMath.Entity+Cotanf
+AngouriMath.Entity+Cotanf.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Cotanf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Cotanf.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Cotanf.EqualityContract { } : System.Type
+AngouriMath.Entity+Cotanf.Equals(AngouriMath.Entity+Cotanf) : System.Boolean
+AngouriMath.Entity+Cotanf.Equals(AngouriMath.Entity+TrigonometricFunction) : System.Boolean
+AngouriMath.Entity+Cotanf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Cotanf.GetHashCode() : System.Int32
+AngouriMath.Entity+Cotanf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Cotanf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Cotanf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Cotanf.Latexise() : System.String
+AngouriMath.Entity+Cotanf.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Cotanf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Cotanf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Cotanf.Stringize() : System.String
+AngouriMath.Entity+Cotanf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Cotanf.ToString() : System.String
+AngouriMath.Entity+Cotanf.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Cotanf.op_Equality(AngouriMath.Entity+Cotanf, AngouriMath.Entity+Cotanf) : System.Boolean
+AngouriMath.Entity+Cotanf.op_Inequality(AngouriMath.Entity+Cotanf, AngouriMath.Entity+Cotanf) : System.Boolean
+AngouriMath.Entity+Derivativef.<Clone>$() : AngouriMath.Entity+Derivativef
+AngouriMath.Entity+Derivativef.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Derivativef.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&, System.Int32&) : System.Void
+AngouriMath.Entity+Derivativef.EqualityContract { } : System.Type
+AngouriMath.Entity+Derivativef.Equals(AngouriMath.Entity+CalculusOperator) : System.Boolean
+AngouriMath.Entity+Derivativef.Equals(AngouriMath.Entity+Derivativef) : System.Boolean
+AngouriMath.Entity+Derivativef.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Derivativef.GetHashCode() : System.Int32
+AngouriMath.Entity+Derivativef.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Derivativef.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Derivativef.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Derivativef.Iterations { } : System.Int32
+AngouriMath.Entity+Derivativef.Latexise() : System.String
+AngouriMath.Entity+Derivativef.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Derivativef.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Derivativef.Stringize() : System.String
+AngouriMath.Entity+Derivativef.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Derivativef.ToString() : System.String
+AngouriMath.Entity+Derivativef.ctor(AngouriMath.Entity, AngouriMath.Entity, System.Int32)
+AngouriMath.Entity+Derivativef.op_Equality(AngouriMath.Entity+Derivativef, AngouriMath.Entity+Derivativef) : System.Boolean
+AngouriMath.Entity+Derivativef.op_Inequality(AngouriMath.Entity+Derivativef, AngouriMath.Entity+Derivativef) : System.Boolean
+AngouriMath.Entity+Divf.<Clone>$() : AngouriMath.Entity+Divf
+AngouriMath.Entity+Divf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Divf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Divf.Dividend { } : AngouriMath.Entity
+AngouriMath.Entity+Divf.Divisor { } : AngouriMath.Entity
+AngouriMath.Entity+Divf.EqualityContract { } : System.Type
+AngouriMath.Entity+Divf.Equals(AngouriMath.Entity+ContinuousNode) : System.Boolean
+AngouriMath.Entity+Divf.Equals(AngouriMath.Entity+Divf) : System.Boolean
+AngouriMath.Entity+Divf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Divf.GetHashCode() : System.Int32
+AngouriMath.Entity+Divf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Divf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Divf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Divf.Latexise() : System.String
+AngouriMath.Entity+Divf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+Divf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+Divf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Divf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Divf.Stringize() : System.String
+AngouriMath.Entity+Divf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Divf.ToString() : System.String
+AngouriMath.Entity+Divf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Divf.op_Equality(AngouriMath.Entity+Divf, AngouriMath.Entity+Divf) : System.Boolean
+AngouriMath.Entity+Divf.op_Inequality(AngouriMath.Entity+Divf, AngouriMath.Entity+Divf) : System.Boolean
+AngouriMath.Entity+Equalsf.<Clone>$() : AngouriMath.Entity+Equalsf
+AngouriMath.Entity+Equalsf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Equalsf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Equalsf.EqualityContract { } : System.Type
+AngouriMath.Entity+Equalsf.Equals(AngouriMath.Entity+ComparisonSign) : System.Boolean
+AngouriMath.Entity+Equalsf.Equals(AngouriMath.Entity+Equalsf) : System.Boolean
+AngouriMath.Entity+Equalsf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Equalsf.GetHashCode() : System.Int32
+AngouriMath.Entity+Equalsf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Equalsf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Equalsf.Latexise() : System.String
+AngouriMath.Entity+Equalsf.Left { } : AngouriMath.Entity
+AngouriMath.Entity+Equalsf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+Equalsf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+Equalsf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Equalsf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Equalsf.Right { } : AngouriMath.Entity
+AngouriMath.Entity+Equalsf.Stringize() : System.String
+AngouriMath.Entity+Equalsf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Equalsf.ToString() : System.String
+AngouriMath.Entity+Equalsf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Equalsf.op_Equality(AngouriMath.Entity+Equalsf, AngouriMath.Entity+Equalsf) : System.Boolean
+AngouriMath.Entity+Equalsf.op_Inequality(AngouriMath.Entity+Equalsf, AngouriMath.Entity+Equalsf) : System.Boolean
+AngouriMath.Entity+Factorialf.<Clone>$() : AngouriMath.Entity+Factorialf
+AngouriMath.Entity+Factorialf.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Factorialf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Factorialf.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Factorialf.EqualityContract { } : System.Type
+AngouriMath.Entity+Factorialf.Equals(AngouriMath.Entity+Factorialf) : System.Boolean
+AngouriMath.Entity+Factorialf.Equals(AngouriMath.Entity+Function) : System.Boolean
+AngouriMath.Entity+Factorialf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Factorialf.GetHashCode() : System.Int32
+AngouriMath.Entity+Factorialf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Factorialf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Factorialf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Factorialf.Latexise() : System.String
+AngouriMath.Entity+Factorialf.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Factorialf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Factorialf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Factorialf.Stringize() : System.String
+AngouriMath.Entity+Factorialf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Factorialf.ToString() : System.String
+AngouriMath.Entity+Factorialf.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Factorialf.op_Equality(AngouriMath.Entity+Factorialf, AngouriMath.Entity+Factorialf) : System.Boolean
+AngouriMath.Entity+Factorialf.op_Inequality(AngouriMath.Entity+Factorialf, AngouriMath.Entity+Factorialf) : System.Boolean
+AngouriMath.Entity+Floorf.<Clone>$() : AngouriMath.Entity+Floorf
+AngouriMath.Entity+Floorf.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Floorf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Floorf.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Floorf.EqualityContract { } : System.Type
+AngouriMath.Entity+Floorf.Equals(AngouriMath.Entity+Floorf) : System.Boolean
+AngouriMath.Entity+Floorf.Equals(AngouriMath.Entity+Function) : System.Boolean
+AngouriMath.Entity+Floorf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Floorf.GetHashCode() : System.Int32
+AngouriMath.Entity+Floorf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Floorf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Floorf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Floorf.Latexise() : System.String
+AngouriMath.Entity+Floorf.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Floorf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Floorf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Floorf.Stringize() : System.String
+AngouriMath.Entity+Floorf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Floorf.ToString() : System.String
+AngouriMath.Entity+Floorf.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Floorf.op_Equality(AngouriMath.Entity+Floorf, AngouriMath.Entity+Floorf) : System.Boolean
+AngouriMath.Entity+Floorf.op_Inequality(AngouriMath.Entity+Floorf, AngouriMath.Entity+Floorf) : System.Boolean
+AngouriMath.Entity+Function.<Clone>$() : AngouriMath.Entity+Function
+AngouriMath.Entity+Function.EqualityContract { } : System.Type
+AngouriMath.Entity+Function.Equals(AngouriMath.Entity+ContinuousNode) : System.Boolean
+AngouriMath.Entity+Function.Equals(AngouriMath.Entity+Function) : System.Boolean
+AngouriMath.Entity+Function.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Function.GetHashCode() : System.Int32
+AngouriMath.Entity+Function.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Function.ToString() : System.String
+AngouriMath.Entity+Function.ctor()
+AngouriMath.Entity+Function.ctor(AngouriMath.Entity+Function)
+AngouriMath.Entity+Function.op_Equality(AngouriMath.Entity+Function, AngouriMath.Entity+Function) : System.Boolean
+AngouriMath.Entity+Function.op_Inequality(AngouriMath.Entity+Function, AngouriMath.Entity+Function) : System.Boolean
+AngouriMath.Entity+Gcdf.<Clone>$() : AngouriMath.Entity+Gcdf
+AngouriMath.Entity+Gcdf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Gcdf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Gcdf.EqualityContract { } : System.Type
+AngouriMath.Entity+Gcdf.Equals(AngouriMath.Entity+Function) : System.Boolean
+AngouriMath.Entity+Gcdf.Equals(AngouriMath.Entity+Gcdf) : System.Boolean
+AngouriMath.Entity+Gcdf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Gcdf.GetHashCode() : System.Int32
+AngouriMath.Entity+Gcdf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Gcdf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Gcdf.Latexise() : System.String
+AngouriMath.Entity+Gcdf.Left { } : AngouriMath.Entity
+AngouriMath.Entity+Gcdf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+Gcdf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+Gcdf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Gcdf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Gcdf.Right { } : AngouriMath.Entity
+AngouriMath.Entity+Gcdf.Stringize() : System.String
+AngouriMath.Entity+Gcdf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Gcdf.ToString() : System.String
+AngouriMath.Entity+Gcdf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Gcdf.op_Equality(AngouriMath.Entity+Gcdf, AngouriMath.Entity+Gcdf) : System.Boolean
+AngouriMath.Entity+Gcdf.op_Inequality(AngouriMath.Entity+Gcdf, AngouriMath.Entity+Gcdf) : System.Boolean
+AngouriMath.Entity+GreaterOrEqualf.<Clone>$() : AngouriMath.Entity+GreaterOrEqualf
+AngouriMath.Entity+GreaterOrEqualf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+GreaterOrEqualf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+GreaterOrEqualf.EqualityContract { } : System.Type
+AngouriMath.Entity+GreaterOrEqualf.Equals(AngouriMath.Entity+ComparisonSign) : System.Boolean
+AngouriMath.Entity+GreaterOrEqualf.Equals(AngouriMath.Entity+GreaterOrEqualf) : System.Boolean
+AngouriMath.Entity+GreaterOrEqualf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+GreaterOrEqualf.GetHashCode() : System.Int32
+AngouriMath.Entity+GreaterOrEqualf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+GreaterOrEqualf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+GreaterOrEqualf.Latexise() : System.String
+AngouriMath.Entity+GreaterOrEqualf.Left { } : AngouriMath.Entity
+AngouriMath.Entity+GreaterOrEqualf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+GreaterOrEqualf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+GreaterOrEqualf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+GreaterOrEqualf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+GreaterOrEqualf.Right { } : AngouriMath.Entity
+AngouriMath.Entity+GreaterOrEqualf.Stringize() : System.String
+AngouriMath.Entity+GreaterOrEqualf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+GreaterOrEqualf.ToString() : System.String
+AngouriMath.Entity+GreaterOrEqualf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+GreaterOrEqualf.op_Equality(AngouriMath.Entity+GreaterOrEqualf, AngouriMath.Entity+GreaterOrEqualf) : System.Boolean
+AngouriMath.Entity+GreaterOrEqualf.op_Inequality(AngouriMath.Entity+GreaterOrEqualf, AngouriMath.Entity+GreaterOrEqualf) : System.Boolean
+AngouriMath.Entity+Greaterf.<Clone>$() : AngouriMath.Entity+Greaterf
+AngouriMath.Entity+Greaterf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Greaterf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Greaterf.EqualityContract { } : System.Type
+AngouriMath.Entity+Greaterf.Equals(AngouriMath.Entity+ComparisonSign) : System.Boolean
+AngouriMath.Entity+Greaterf.Equals(AngouriMath.Entity+Greaterf) : System.Boolean
+AngouriMath.Entity+Greaterf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Greaterf.GetHashCode() : System.Int32
+AngouriMath.Entity+Greaterf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Greaterf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Greaterf.Latexise() : System.String
+AngouriMath.Entity+Greaterf.Left { } : AngouriMath.Entity
+AngouriMath.Entity+Greaterf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+Greaterf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+Greaterf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Greaterf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Greaterf.Right { } : AngouriMath.Entity
+AngouriMath.Entity+Greaterf.Stringize() : System.String
+AngouriMath.Entity+Greaterf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Greaterf.ToString() : System.String
+AngouriMath.Entity+Greaterf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Greaterf.op_Equality(AngouriMath.Entity+Greaterf, AngouriMath.Entity+Greaterf) : System.Boolean
+AngouriMath.Entity+Greaterf.op_Inequality(AngouriMath.Entity+Greaterf, AngouriMath.Entity+Greaterf) : System.Boolean
+AngouriMath.Entity+Impliesf.<Clone>$() : AngouriMath.Entity+Impliesf
+AngouriMath.Entity+Impliesf.Assumption { } : AngouriMath.Entity
+AngouriMath.Entity+Impliesf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Impliesf.Conclusion { } : AngouriMath.Entity
+AngouriMath.Entity+Impliesf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Impliesf.EqualityContract { } : System.Type
+AngouriMath.Entity+Impliesf.Equals(AngouriMath.Entity+Impliesf) : System.Boolean
+AngouriMath.Entity+Impliesf.Equals(AngouriMath.Entity+Statement) : System.Boolean
+AngouriMath.Entity+Impliesf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Impliesf.GetHashCode() : System.Int32
+AngouriMath.Entity+Impliesf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Impliesf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Impliesf.Latexise() : System.String
+AngouriMath.Entity+Impliesf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+Impliesf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+Impliesf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Impliesf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Impliesf.Stringize() : System.String
+AngouriMath.Entity+Impliesf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Impliesf.ToString() : System.String
+AngouriMath.Entity+Impliesf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Impliesf.op_Equality(AngouriMath.Entity+Impliesf, AngouriMath.Entity+Impliesf) : System.Boolean
+AngouriMath.Entity+Impliesf.op_Inequality(AngouriMath.Entity+Impliesf, AngouriMath.Entity+Impliesf) : System.Boolean
+AngouriMath.Entity+Integralf.<Clone>$() : AngouriMath.Entity+Integralf
+AngouriMath.Entity+Integralf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Integralf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&, System.Nullable<System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity>>&) : System.Void
+AngouriMath.Entity+Integralf.EqualityContract { } : System.Type
+AngouriMath.Entity+Integralf.Equals(AngouriMath.Entity+CalculusOperator) : System.Boolean
+AngouriMath.Entity+Integralf.Equals(AngouriMath.Entity+Integralf) : System.Boolean
+AngouriMath.Entity+Integralf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Integralf.GetHashCode() : System.Int32
+AngouriMath.Entity+Integralf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Integralf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Integralf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Integralf.Latexise() : System.String
+AngouriMath.Entity+Integralf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Integralf.Range { } : System.Nullable<System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity>>
+AngouriMath.Entity+Integralf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Integralf.Stringize() : System.String
+AngouriMath.Entity+Integralf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Integralf.ToString() : System.String
+AngouriMath.Entity+Integralf.ctor(AngouriMath.Entity, AngouriMath.Entity, System.Nullable<System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity>>)
+AngouriMath.Entity+Integralf.op_Equality(AngouriMath.Entity+Integralf, AngouriMath.Entity+Integralf) : System.Boolean
+AngouriMath.Entity+Integralf.op_Inequality(AngouriMath.Entity+Integralf, AngouriMath.Entity+Integralf) : System.Boolean
+AngouriMath.Entity+Lambda.<Clone>$() : AngouriMath.Entity+Lambda
+AngouriMath.Entity+Lambda.Body { } : AngouriMath.Entity
+AngouriMath.Entity+Lambda.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Lambda.Deconstruct(AngouriMath.Entity+Variable&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Lambda.EqualityContract { } : System.Type
+AngouriMath.Entity+Lambda.Equals(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity+Lambda.Equals(AngouriMath.Entity+Lambda) : System.Boolean
+AngouriMath.Entity+Lambda.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Lambda.GetHashCode() : System.Int32
+AngouriMath.Entity+Lambda.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Lambda.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Lambda.Latexise() : System.String
+AngouriMath.Entity+Lambda.Parameter { } : AngouriMath.Entity+Variable
+AngouriMath.Entity+Lambda.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Lambda.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Lambda.Stringize() : System.String
+AngouriMath.Entity+Lambda.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Lambda.ToString() : System.String
+AngouriMath.Entity+Lambda.ctor(AngouriMath.Entity+Variable, AngouriMath.Entity)
+AngouriMath.Entity+Lambda.op_Equality(AngouriMath.Entity+Lambda, AngouriMath.Entity+Lambda) : System.Boolean
+AngouriMath.Entity+Lambda.op_Inequality(AngouriMath.Entity+Lambda, AngouriMath.Entity+Lambda) : System.Boolean
+AngouriMath.Entity+LessOrEqualf.<Clone>$() : AngouriMath.Entity+LessOrEqualf
+AngouriMath.Entity+LessOrEqualf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+LessOrEqualf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+LessOrEqualf.EqualityContract { } : System.Type
+AngouriMath.Entity+LessOrEqualf.Equals(AngouriMath.Entity+ComparisonSign) : System.Boolean
+AngouriMath.Entity+LessOrEqualf.Equals(AngouriMath.Entity+LessOrEqualf) : System.Boolean
+AngouriMath.Entity+LessOrEqualf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+LessOrEqualf.GetHashCode() : System.Int32
+AngouriMath.Entity+LessOrEqualf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+LessOrEqualf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+LessOrEqualf.Latexise() : System.String
+AngouriMath.Entity+LessOrEqualf.Left { } : AngouriMath.Entity
+AngouriMath.Entity+LessOrEqualf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+LessOrEqualf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+LessOrEqualf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+LessOrEqualf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+LessOrEqualf.Right { } : AngouriMath.Entity
+AngouriMath.Entity+LessOrEqualf.Stringize() : System.String
+AngouriMath.Entity+LessOrEqualf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+LessOrEqualf.ToString() : System.String
+AngouriMath.Entity+LessOrEqualf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+LessOrEqualf.op_Equality(AngouriMath.Entity+LessOrEqualf, AngouriMath.Entity+LessOrEqualf) : System.Boolean
+AngouriMath.Entity+LessOrEqualf.op_Inequality(AngouriMath.Entity+LessOrEqualf, AngouriMath.Entity+LessOrEqualf) : System.Boolean
+AngouriMath.Entity+Lessf.<Clone>$() : AngouriMath.Entity+Lessf
+AngouriMath.Entity+Lessf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Lessf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Lessf.EqualityContract { } : System.Type
+AngouriMath.Entity+Lessf.Equals(AngouriMath.Entity+ComparisonSign) : System.Boolean
+AngouriMath.Entity+Lessf.Equals(AngouriMath.Entity+Lessf) : System.Boolean
+AngouriMath.Entity+Lessf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Lessf.GetHashCode() : System.Int32
+AngouriMath.Entity+Lessf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Lessf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Lessf.Latexise() : System.String
+AngouriMath.Entity+Lessf.Left { } : AngouriMath.Entity
+AngouriMath.Entity+Lessf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+Lessf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+Lessf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Lessf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Lessf.Right { } : AngouriMath.Entity
+AngouriMath.Entity+Lessf.Stringize() : System.String
+AngouriMath.Entity+Lessf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Lessf.ToString() : System.String
+AngouriMath.Entity+Lessf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Lessf.op_Equality(AngouriMath.Entity+Lessf, AngouriMath.Entity+Lessf) : System.Boolean
+AngouriMath.Entity+Lessf.op_Inequality(AngouriMath.Entity+Lessf, AngouriMath.Entity+Lessf) : System.Boolean
+AngouriMath.Entity+Limitf.<Clone>$() : AngouriMath.Entity+Limitf
+AngouriMath.Entity+Limitf.ApproachFrom { } : AngouriMath.Core.ApproachFrom
+AngouriMath.Entity+Limitf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Limitf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&, AngouriMath.Entity&, AngouriMath.Core.ApproachFrom&) : System.Void
+AngouriMath.Entity+Limitf.Destination { } : AngouriMath.Entity
+AngouriMath.Entity+Limitf.EqualityContract { } : System.Type
+AngouriMath.Entity+Limitf.Equals(AngouriMath.Entity+CalculusOperator) : System.Boolean
+AngouriMath.Entity+Limitf.Equals(AngouriMath.Entity+Limitf) : System.Boolean
+AngouriMath.Entity+Limitf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Limitf.GetHashCode() : System.Int32
+AngouriMath.Entity+Limitf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Limitf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Limitf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Limitf.Latexise() : System.String
+AngouriMath.Entity+Limitf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Limitf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Limitf.Stringize() : System.String
+AngouriMath.Entity+Limitf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Limitf.ToString() : System.String
+AngouriMath.Entity+Limitf.ctor(AngouriMath.Entity, AngouriMath.Entity, AngouriMath.Entity, AngouriMath.Core.ApproachFrom)
+AngouriMath.Entity+Limitf.op_Equality(AngouriMath.Entity+Limitf, AngouriMath.Entity+Limitf) : System.Boolean
+AngouriMath.Entity+Limitf.op_Inequality(AngouriMath.Entity+Limitf, AngouriMath.Entity+Limitf) : System.Boolean
+AngouriMath.Entity+Logf.<Clone>$() : AngouriMath.Entity+Logf
+AngouriMath.Entity+Logf.Antilogarithm { } : AngouriMath.Entity
+AngouriMath.Entity+Logf.Base { } : AngouriMath.Entity
+AngouriMath.Entity+Logf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Logf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Logf.EqualityContract { } : System.Type
+AngouriMath.Entity+Logf.Equals(AngouriMath.Entity+Function) : System.Boolean
+AngouriMath.Entity+Logf.Equals(AngouriMath.Entity+Logf) : System.Boolean
+AngouriMath.Entity+Logf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Logf.GetHashCode() : System.Int32
+AngouriMath.Entity+Logf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Logf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Logf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Logf.Latexise() : System.String
+AngouriMath.Entity+Logf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+Logf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+Logf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Logf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Logf.Stringize() : System.String
+AngouriMath.Entity+Logf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Logf.ToString() : System.String
+AngouriMath.Entity+Logf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Logf.op_Equality(AngouriMath.Entity+Logf, AngouriMath.Entity+Logf) : System.Boolean
+AngouriMath.Entity+Logf.op_Inequality(AngouriMath.Entity+Logf, AngouriMath.Entity+Logf) : System.Boolean
+AngouriMath.Entity+Matrix+EntityTensorWrapperOperations.Add(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Matrix+EntityTensorWrapperOperations.AreEqual(AngouriMath.Entity, AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity+Matrix+EntityTensorWrapperOperations.Copy(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Matrix+EntityTensorWrapperOperations.CreateOne() : AngouriMath.Entity
+AngouriMath.Entity+Matrix+EntityTensorWrapperOperations.CreateZero() : AngouriMath.Entity
+AngouriMath.Entity+Matrix+EntityTensorWrapperOperations.Deserialize(System.Byte[]) : AngouriMath.Entity
+AngouriMath.Entity+Matrix+EntityTensorWrapperOperations.Divide(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Matrix+EntityTensorWrapperOperations.Forward(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Matrix+EntityTensorWrapperOperations.IsZero(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity+Matrix+EntityTensorWrapperOperations.Multiply(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Matrix+EntityTensorWrapperOperations.Negate(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Matrix+EntityTensorWrapperOperations.Serialize(AngouriMath.Entity) : System.Byte[]
+AngouriMath.Entity+Matrix+EntityTensorWrapperOperations.Subtract(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Matrix+EntityTensorWrapperOperations.ToString(AngouriMath.Entity) : System.String
+AngouriMath.Entity+Matrix.<Clone>$() : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.Adjugate { } : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.AsScalar() : AngouriMath.Entity
+AngouriMath.Entity+Matrix.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Matrix.ColumnCount { } : System.Int32
+AngouriMath.Entity+Matrix.Determinant { } : AngouriMath.Entity
+AngouriMath.Entity+Matrix.EqualityContract { } : System.Type
+AngouriMath.Entity+Matrix.Equals(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity+Matrix.Equals(AngouriMath.Entity+Matrix) : System.Boolean
+AngouriMath.Entity+Matrix.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Matrix.GetEnumerator() : System.Collections.Generic.IEnumerator<AngouriMath.Entity>
+AngouriMath.Entity+Matrix.GetHashCode() : System.Int32
+AngouriMath.Entity+Matrix.I(System.Int32) : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.I(System.Int32, System.Int32) : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Matrix.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Matrix.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Matrix.Inverse { } : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.IsRowVector { } : System.Boolean
+AngouriMath.Entity+Matrix.IsScalar { } : System.Boolean
+AngouriMath.Entity+Matrix.IsSquare { } : System.Boolean
+AngouriMath.Entity+Matrix.IsVector { } : System.Boolean
+AngouriMath.Entity+Matrix.Item { } : AngouriMath.Entity
+AngouriMath.Entity+Matrix.Item { } : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.Latexise() : System.String
+AngouriMath.Entity+Matrix.MainDiagonal { } : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.Pow(System.Int32) : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Matrix.Rank { } : System.Int32
+AngouriMath.Entity+Matrix.ReducedRowEchelonForm { } : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Matrix.RowCount { } : System.Int32
+AngouriMath.Entity+Matrix.RowEchelonForm { } : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.Stringize() : System.String
+AngouriMath.Entity+Matrix.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Matrix.T { } : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.TensorPower(System.Int32) : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.TensorProduct(AngouriMath.Entity+Matrix, AngouriMath.Entity+Matrix) : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.ToString() : System.String
+AngouriMath.Entity+Matrix.ToString(System.Boolean) : System.String
+AngouriMath.Entity+Matrix.Trace { } : AngouriMath.Entity
+AngouriMath.Entity+Matrix.With(System.Func<System.Int32,System.Int32,AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.WithColumn(System.Int32, AngouriMath.Entity+Matrix) : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.WithElement(System.Int32, AngouriMath.Entity) : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.WithElement(System.Int32, System.Int32, AngouriMath.Entity) : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.WithRow(System.Int32, AngouriMath.Entity+Matrix) : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.ctor(GenericTensor.Core.GenTensor<AngouriMath.Entity,AngouriMath.Entity+Matrix+EntityTensorWrapperOperations>)
+AngouriMath.Entity+Matrix.ctor(System.Func<System.Int32[],AngouriMath.Entity>, System.Int32[])
+AngouriMath.Entity+Matrix.op_Addition(AngouriMath.Entity+Matrix, AngouriMath.Entity+Matrix) : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.op_Equality(AngouriMath.Entity+Matrix, AngouriMath.Entity+Matrix) : System.Boolean
+AngouriMath.Entity+Matrix.op_Implicit(System.String) : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.op_Inequality(AngouriMath.Entity+Matrix, AngouriMath.Entity+Matrix) : System.Boolean
+AngouriMath.Entity+Matrix.op_Multiply(AngouriMath.Entity+Matrix, AngouriMath.Entity+Matrix) : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.op_Subtraction(AngouriMath.Entity+Matrix, AngouriMath.Entity+Matrix) : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.op_UnaryNegation(AngouriMath.Entity+Matrix) : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Matrix.op_UnaryPlus(AngouriMath.Entity+Matrix) : AngouriMath.Entity+Matrix
+AngouriMath.Entity+Maxf.<Clone>$() : AngouriMath.Entity+Maxf
+AngouriMath.Entity+Maxf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Maxf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Maxf.EqualityContract { } : System.Type
+AngouriMath.Entity+Maxf.Equals(AngouriMath.Entity+Function) : System.Boolean
+AngouriMath.Entity+Maxf.Equals(AngouriMath.Entity+Maxf) : System.Boolean
+AngouriMath.Entity+Maxf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Maxf.GetHashCode() : System.Int32
+AngouriMath.Entity+Maxf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Maxf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Maxf.Latexise() : System.String
+AngouriMath.Entity+Maxf.Left { } : AngouriMath.Entity
+AngouriMath.Entity+Maxf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+Maxf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+Maxf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Maxf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Maxf.Right { } : AngouriMath.Entity
+AngouriMath.Entity+Maxf.Stringize() : System.String
+AngouriMath.Entity+Maxf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Maxf.ToString() : System.String
+AngouriMath.Entity+Maxf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Maxf.op_Equality(AngouriMath.Entity+Maxf, AngouriMath.Entity+Maxf) : System.Boolean
+AngouriMath.Entity+Maxf.op_Inequality(AngouriMath.Entity+Maxf, AngouriMath.Entity+Maxf) : System.Boolean
+AngouriMath.Entity+Minf.<Clone>$() : AngouriMath.Entity+Minf
+AngouriMath.Entity+Minf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Minf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Minf.EqualityContract { } : System.Type
+AngouriMath.Entity+Minf.Equals(AngouriMath.Entity+Function) : System.Boolean
+AngouriMath.Entity+Minf.Equals(AngouriMath.Entity+Minf) : System.Boolean
+AngouriMath.Entity+Minf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Minf.GetHashCode() : System.Int32
+AngouriMath.Entity+Minf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Minf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Minf.Latexise() : System.String
+AngouriMath.Entity+Minf.Left { } : AngouriMath.Entity
+AngouriMath.Entity+Minf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+Minf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+Minf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Minf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Minf.Right { } : AngouriMath.Entity
+AngouriMath.Entity+Minf.Stringize() : System.String
+AngouriMath.Entity+Minf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Minf.ToString() : System.String
+AngouriMath.Entity+Minf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Minf.op_Equality(AngouriMath.Entity+Minf, AngouriMath.Entity+Minf) : System.Boolean
+AngouriMath.Entity+Minf.op_Inequality(AngouriMath.Entity+Minf, AngouriMath.Entity+Minf) : System.Boolean
+AngouriMath.Entity+Minusf.<Clone>$() : AngouriMath.Entity+Minusf
+AngouriMath.Entity+Minusf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Minusf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Minusf.EqualityContract { } : System.Type
+AngouriMath.Entity+Minusf.Equals(AngouriMath.Entity+ContinuousNode) : System.Boolean
+AngouriMath.Entity+Minusf.Equals(AngouriMath.Entity+Minusf) : System.Boolean
+AngouriMath.Entity+Minusf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Minusf.GetHashCode() : System.Int32
+AngouriMath.Entity+Minusf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Minusf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Minusf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Minusf.Latexise() : System.String
+AngouriMath.Entity+Minusf.Minuend { } : AngouriMath.Entity
+AngouriMath.Entity+Minusf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+Minusf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+Minusf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Minusf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Minusf.Stringize() : System.String
+AngouriMath.Entity+Minusf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Minusf.Subtrahend { } : AngouriMath.Entity
+AngouriMath.Entity+Minusf.ToString() : System.String
+AngouriMath.Entity+Minusf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Minusf.op_Equality(AngouriMath.Entity+Minusf, AngouriMath.Entity+Minusf) : System.Boolean
+AngouriMath.Entity+Minusf.op_Inequality(AngouriMath.Entity+Minusf, AngouriMath.Entity+Minusf) : System.Boolean
+AngouriMath.Entity+Modf.<Clone>$() : AngouriMath.Entity+Modf
+AngouriMath.Entity+Modf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Modf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Modf.Dividend { } : AngouriMath.Entity
+AngouriMath.Entity+Modf.Divisor { } : AngouriMath.Entity
+AngouriMath.Entity+Modf.EqualityContract { } : System.Type
+AngouriMath.Entity+Modf.Equals(AngouriMath.Entity+ContinuousNode) : System.Boolean
+AngouriMath.Entity+Modf.Equals(AngouriMath.Entity+Modf) : System.Boolean
+AngouriMath.Entity+Modf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Modf.GetHashCode() : System.Int32
+AngouriMath.Entity+Modf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Modf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Modf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Modf.Latexise() : System.String
+AngouriMath.Entity+Modf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+Modf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+Modf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Modf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Modf.Stringize() : System.String
+AngouriMath.Entity+Modf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Modf.ToString() : System.String
+AngouriMath.Entity+Modf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Modf.op_Equality(AngouriMath.Entity+Modf, AngouriMath.Entity+Modf) : System.Boolean
+AngouriMath.Entity+Modf.op_Inequality(AngouriMath.Entity+Modf, AngouriMath.Entity+Modf) : System.Boolean
+AngouriMath.Entity+Mulf.<Clone>$() : AngouriMath.Entity+Mulf
+AngouriMath.Entity+Mulf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Mulf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Mulf.EqualityContract { } : System.Type
+AngouriMath.Entity+Mulf.Equals(AngouriMath.Entity+ContinuousNode) : System.Boolean
+AngouriMath.Entity+Mulf.Equals(AngouriMath.Entity+Mulf) : System.Boolean
+AngouriMath.Entity+Mulf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Mulf.GetHashCode() : System.Int32
+AngouriMath.Entity+Mulf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Mulf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Mulf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Mulf.Latexise() : System.String
+AngouriMath.Entity+Mulf.Multiplicand { } : AngouriMath.Entity
+AngouriMath.Entity+Mulf.Multiplier { } : AngouriMath.Entity
+AngouriMath.Entity+Mulf.Multiply(System.Collections.Generic.IEnumerable<AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Mulf.Multiply(System.Collections.Generic.IReadOnlyList<AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Mulf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+Mulf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+Mulf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Mulf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Mulf.Stringize() : System.String
+AngouriMath.Entity+Mulf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Mulf.ToString() : System.String
+AngouriMath.Entity+Mulf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Mulf.op_Equality(AngouriMath.Entity+Mulf, AngouriMath.Entity+Mulf) : System.Boolean
+AngouriMath.Entity+Mulf.op_Inequality(AngouriMath.Entity+Mulf, AngouriMath.Entity+Mulf) : System.Boolean
+AngouriMath.Entity+Notf.<Clone>$() : AngouriMath.Entity+Notf
+AngouriMath.Entity+Notf.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Notf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Notf.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Notf.EqualityContract { } : System.Type
+AngouriMath.Entity+Notf.Equals(AngouriMath.Entity+Notf) : System.Boolean
+AngouriMath.Entity+Notf.Equals(AngouriMath.Entity+Statement) : System.Boolean
+AngouriMath.Entity+Notf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Notf.GetHashCode() : System.Int32
+AngouriMath.Entity+Notf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Notf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Notf.Latexise() : System.String
+AngouriMath.Entity+Notf.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Notf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Notf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Notf.Stringize() : System.String
+AngouriMath.Entity+Notf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Notf.ToString() : System.String
+AngouriMath.Entity+Notf.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Notf.op_Equality(AngouriMath.Entity+Notf, AngouriMath.Entity+Notf) : System.Boolean
+AngouriMath.Entity+Notf.op_Inequality(AngouriMath.Entity+Notf, AngouriMath.Entity+Notf) : System.Boolean
+AngouriMath.Entity+Number+Complex.<Clone>$() : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.Abs() : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Complex.AdditiveIdentity { } : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Number+Complex.Conjugate { } : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.Create(AngouriMath.Entity+Number+Real, AngouriMath.Entity+Number+Real) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.Create(PeterO.Numbers.EDecimal, PeterO.Numbers.EDecimal) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.CreatePolar(PeterO.Numbers.EDecimal, PeterO.Numbers.EDecimal) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.Deconstruct(AngouriMath.Entity+Number+Real&, AngouriMath.Entity+Number+Real&) : System.Void
+AngouriMath.Entity+Number+Complex.EqualityContract { } : System.Type
+AngouriMath.Entity+Number+Complex.Equals(AngouriMath.Entity+Number) : System.Boolean
+AngouriMath.Entity+Number+Complex.Equals(AngouriMath.Entity+Number+Complex) : System.Boolean
+AngouriMath.Entity+Number+Complex.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Number+Complex.GetHashCode() : System.Int32
+AngouriMath.Entity+Number+Complex.ImaginaryOne : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.ImaginaryPart { } : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Complex.IsExact { } : System.Boolean
+AngouriMath.Entity+Number+Complex.IsZero { } : System.Boolean
+AngouriMath.Entity+Number+Complex.Latexise() : System.String
+AngouriMath.Entity+Number+Complex.MinusImaginaryOne : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.MultiplicativeIdentity { } : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.NegNegInfinity : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.NegPosInfinity : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.Parse(System.String) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.Phase() : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Complex.PosNegInfinity : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.PosPosInfinity : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Number+Complex.RealPart { } : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Complex.Stringize() : System.String
+AngouriMath.Entity+Number+Complex.ThisIsFinite { } : System.Boolean
+AngouriMath.Entity+Number+Complex.ToNumerics() : System.Numerics.Complex
+AngouriMath.Entity+Number+Complex.ToString() : System.String
+AngouriMath.Entity+Number+Complex.TryParse(System.String, AngouriMath.Entity+Number+Complex&) : System.Boolean
+AngouriMath.Entity+Number+Complex.ctor(AngouriMath.Entity+Number+Complex)
+AngouriMath.Entity+Number+Complex.op_Addition(AngouriMath.Entity+Number+Complex, AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Division(AngouriMath.Entity+Number+Complex, AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Equality(AngouriMath.Entity+Number+Complex, AngouriMath.Entity+Number+Complex) : System.Boolean
+AngouriMath.Entity+Number+Complex.op_Explicit(AngouriMath.Entity+Number+Complex) : System.Numerics.Complex
+AngouriMath.Entity+Number+Complex.op_Implicit(PeterO.Numbers.EDecimal) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Implicit(PeterO.Numbers.EInteger) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Implicit(PeterO.Numbers.ERational) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Implicit(System.Byte) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Implicit(System.Decimal) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Implicit(System.Double) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Implicit(System.Int16) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Implicit(System.Int32) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Implicit(System.Int64) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Implicit(System.Numerics.Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Implicit(System.SByte) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Implicit(System.Single) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Implicit(System.UInt16) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Implicit(System.UInt32) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Implicit(System.UInt64) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Implicit(System.ValueTuple<System.Decimal,System.Decimal>) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Implicit(System.ValueTuple<System.Double,System.Double>) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Implicit(System.ValueTuple<System.Int32,System.Int32>) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Implicit(System.ValueTuple<System.Single,System.Single>) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Inequality(AngouriMath.Entity+Number+Complex, AngouriMath.Entity+Number+Complex) : System.Boolean
+AngouriMath.Entity+Number+Complex.op_Multiply(AngouriMath.Entity+Number+Complex, AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_Subtraction(AngouriMath.Entity+Number+Complex, AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_UnaryNegation(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Complex.op_UnaryPlus(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number+Integer.<Clone>$() : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.Abs() : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Integer.Abs(AngouriMath.Entity+Number+Integer) : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.AdditiveIdentity { } : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Number+Integer.CompareTo(AngouriMath.Entity+Number+Integer) : System.Int32
+AngouriMath.Entity+Number+Integer.CountDivisors() : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.Create(PeterO.Numbers.EInteger) : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.Create(System.Int32) : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.Deconstruct(System.Nullable<System.Int32>&) : System.Void
+AngouriMath.Entity+Number+Integer.EInteger { } : PeterO.Numbers.EInteger
+AngouriMath.Entity+Number+Integer.EqualityContract { } : System.Type
+AngouriMath.Entity+Number+Integer.Equals(AngouriMath.Entity+Number+Integer) : System.Boolean
+AngouriMath.Entity+Number+Integer.Equals(AngouriMath.Entity+Number+Rational) : System.Boolean
+AngouriMath.Entity+Number+Integer.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Number+Integer.Factorize() : System.Collections.Generic.IEnumerable<System.ValueTuple<AngouriMath.Entity+Number+Integer,AngouriMath.Entity+Number+Integer>>
+AngouriMath.Entity+Number+Integer.GetHashCode() : System.Int32
+AngouriMath.Entity+Number+Integer.IntegerDiv(AngouriMath.Entity+Number+Integer) : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.IsPrime { } : System.Boolean
+AngouriMath.Entity+Number+Integer.Latexise() : System.String
+AngouriMath.Entity+Number+Integer.MinusOne : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.MultiplicativeIdentity { } : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.One : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.Phi() : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Number+Integer.Stringize() : System.String
+AngouriMath.Entity+Number+Integer.ToString() : System.String
+AngouriMath.Entity+Number+Integer.Zero : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.op_Addition(AngouriMath.Entity+Number+Integer, AngouriMath.Entity+Number+Integer) : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.op_Division(AngouriMath.Entity+Number+Integer, AngouriMath.Entity+Number+Integer) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Integer.op_Equality(AngouriMath.Entity+Number+Integer, AngouriMath.Entity+Number+Integer) : System.Boolean
+AngouriMath.Entity+Number+Integer.op_GreaterThan(AngouriMath.Entity+Number+Integer, AngouriMath.Entity+Number+Integer) : System.Boolean
+AngouriMath.Entity+Number+Integer.op_GreaterThanOrEqual(AngouriMath.Entity+Number+Integer, AngouriMath.Entity+Number+Integer) : System.Boolean
+AngouriMath.Entity+Number+Integer.op_Implicit(PeterO.Numbers.EInteger) : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.op_Implicit(System.Byte) : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.op_Implicit(System.Int16) : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.op_Implicit(System.Int32) : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.op_Implicit(System.Int64) : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.op_Implicit(System.SByte) : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.op_Implicit(System.UInt16) : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.op_Implicit(System.UInt32) : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.op_Implicit(System.UInt64) : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.op_Inequality(AngouriMath.Entity+Number+Integer, AngouriMath.Entity+Number+Integer) : System.Boolean
+AngouriMath.Entity+Number+Integer.op_LessThan(AngouriMath.Entity+Number+Integer, AngouriMath.Entity+Number+Integer) : System.Boolean
+AngouriMath.Entity+Number+Integer.op_LessThanOrEqual(AngouriMath.Entity+Number+Integer, AngouriMath.Entity+Number+Integer) : System.Boolean
+AngouriMath.Entity+Number+Integer.op_Modulus(AngouriMath.Entity+Number+Integer, AngouriMath.Entity+Number+Integer) : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.op_Multiply(AngouriMath.Entity+Number+Integer, AngouriMath.Entity+Number+Integer) : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.op_Subtraction(AngouriMath.Entity+Number+Integer, AngouriMath.Entity+Number+Integer) : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.op_UnaryNegation(AngouriMath.Entity+Number+Integer) : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Integer.op_UnaryPlus(AngouriMath.Entity+Number+Integer) : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Rational.<Clone>$() : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.Abs() : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Rational.Abs(AngouriMath.Entity+Number+Rational) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.AdditiveIdentity { } : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Number+Rational.CompareTo(AngouriMath.Entity+Number+Rational) : System.Int32
+AngouriMath.Entity+Number+Rational.Create(PeterO.Numbers.EInteger, PeterO.Numbers.EInteger) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.Create(PeterO.Numbers.ERational) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.Deconstruct(AngouriMath.Entity+Number+Integer&, AngouriMath.Entity+Number+Integer&) : System.Void
+AngouriMath.Entity+Number+Rational.Deconstruct(PeterO.Numbers.ERational&) : System.Void
+AngouriMath.Entity+Number+Rational.Denominator { } : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Rational.ERational { } : PeterO.Numbers.ERational
+AngouriMath.Entity+Number+Rational.EqualityContract { } : System.Type
+AngouriMath.Entity+Number+Rational.Equals(AngouriMath.Entity+Number+Rational) : System.Boolean
+AngouriMath.Entity+Number+Rational.Equals(AngouriMath.Entity+Number+Real) : System.Boolean
+AngouriMath.Entity+Number+Rational.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Number+Rational.FindRational(PeterO.Numbers.EDecimal, System.Int32) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.GetHashCode() : System.Int32
+AngouriMath.Entity+Number+Rational.IsExact { } : System.Boolean
+AngouriMath.Entity+Number+Rational.Latexise() : System.String
+AngouriMath.Entity+Number+Rational.MultiplicativeIdentity { } : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.Numerator { } : AngouriMath.Entity+Number+Integer
+AngouriMath.Entity+Number+Rational.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Number+Rational.Stringize() : System.String
+AngouriMath.Entity+Number+Rational.ToString() : System.String
+AngouriMath.Entity+Number+Rational.ctor(AngouriMath.Entity+Number+Rational)
+AngouriMath.Entity+Number+Rational.op_Addition(AngouriMath.Entity+Number+Rational, AngouriMath.Entity+Number+Rational) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.op_Division(AngouriMath.Entity+Number+Rational, AngouriMath.Entity+Number+Rational) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Rational.op_Equality(AngouriMath.Entity+Number+Rational, AngouriMath.Entity+Number+Rational) : System.Boolean
+AngouriMath.Entity+Number+Rational.op_GreaterThan(AngouriMath.Entity+Number+Rational, AngouriMath.Entity+Number+Rational) : System.Boolean
+AngouriMath.Entity+Number+Rational.op_GreaterThanOrEqual(AngouriMath.Entity+Number+Rational, AngouriMath.Entity+Number+Rational) : System.Boolean
+AngouriMath.Entity+Number+Rational.op_Implicit(PeterO.Numbers.EInteger) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.op_Implicit(PeterO.Numbers.ERational) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.op_Implicit(System.Byte) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.op_Implicit(System.Int16) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.op_Implicit(System.Int32) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.op_Implicit(System.Int64) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.op_Implicit(System.SByte) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.op_Implicit(System.UInt16) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.op_Implicit(System.UInt32) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.op_Implicit(System.UInt64) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.op_Inequality(AngouriMath.Entity+Number+Rational, AngouriMath.Entity+Number+Rational) : System.Boolean
+AngouriMath.Entity+Number+Rational.op_LessThan(AngouriMath.Entity+Number+Rational, AngouriMath.Entity+Number+Rational) : System.Boolean
+AngouriMath.Entity+Number+Rational.op_LessThanOrEqual(AngouriMath.Entity+Number+Rational, AngouriMath.Entity+Number+Rational) : System.Boolean
+AngouriMath.Entity+Number+Rational.op_Modulus(AngouriMath.Entity+Number+Rational, AngouriMath.Entity+Number+Rational) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.op_Multiply(AngouriMath.Entity+Number+Rational, AngouriMath.Entity+Number+Rational) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.op_Subtraction(AngouriMath.Entity+Number+Rational, AngouriMath.Entity+Number+Rational) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.op_UnaryNegation(AngouriMath.Entity+Number+Rational) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Rational.op_UnaryPlus(AngouriMath.Entity+Number+Rational) : AngouriMath.Entity+Number+Rational
+AngouriMath.Entity+Number+Real.<Clone>$() : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.Abs() : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.Abs(AngouriMath.Entity+Number+Real) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.AdditiveIdentity { } : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.AsDouble() : System.Double
+AngouriMath.Entity+Number+Real.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Number+Real.CompareTo(AngouriMath.Entity+Number+Real) : System.Int32
+AngouriMath.Entity+Number+Real.CompareTo(System.Object) : System.Int32
+AngouriMath.Entity+Number+Real.Create(PeterO.Numbers.EDecimal) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.Deconstruct(PeterO.Numbers.EDecimal&) : System.Void
+AngouriMath.Entity+Number+Real.EDecimal { } : PeterO.Numbers.EDecimal
+AngouriMath.Entity+Number+Real.EqualityContract { } : System.Type
+AngouriMath.Entity+Number+Real.Equals(AngouriMath.Entity+Number+Complex) : System.Boolean
+AngouriMath.Entity+Number+Real.Equals(AngouriMath.Entity+Number+Real) : System.Boolean
+AngouriMath.Entity+Number+Real.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Number+Real.GetHashCode() : System.Int32
+AngouriMath.Entity+Number+Real.IsExact { } : System.Boolean
+AngouriMath.Entity+Number+Real.IsNegative { } : System.Boolean
+AngouriMath.Entity+Number+Real.IsPositive { } : System.Boolean
+AngouriMath.Entity+Number+Real.Latexise() : System.String
+AngouriMath.Entity+Number+Real.MultiplicativeIdentity { } : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.NaN : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.NegativeInfinity : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.PositiveInfinity : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Number+Real.RealPart { } : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.Stringize() : System.String
+AngouriMath.Entity+Number+Real.ToString() : System.String
+AngouriMath.Entity+Number+Real.ctor(AngouriMath.Entity+Number+Real)
+AngouriMath.Entity+Number+Real.op_Addition(AngouriMath.Entity+Number+Real, AngouriMath.Entity+Number+Real) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_Division(AngouriMath.Entity+Number+Real, AngouriMath.Entity+Number+Real) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_Equality(AngouriMath.Entity+Number+Real, AngouriMath.Entity+Number+Real) : System.Boolean
+AngouriMath.Entity+Number+Real.op_GreaterThan(AngouriMath.Entity+Number+Real, AngouriMath.Entity+Number+Real) : System.Boolean
+AngouriMath.Entity+Number+Real.op_GreaterThanOrEqual(AngouriMath.Entity+Number+Real, AngouriMath.Entity+Number+Real) : System.Boolean
+AngouriMath.Entity+Number+Real.op_Implicit(PeterO.Numbers.EDecimal) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_Implicit(PeterO.Numbers.EInteger) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_Implicit(PeterO.Numbers.ERational) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_Implicit(System.Byte) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_Implicit(System.Decimal) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_Implicit(System.Double) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_Implicit(System.Int16) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_Implicit(System.Int32) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_Implicit(System.Int64) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_Implicit(System.SByte) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_Implicit(System.Single) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_Implicit(System.UInt16) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_Implicit(System.UInt32) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_Implicit(System.UInt64) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_Inequality(AngouriMath.Entity+Number+Real, AngouriMath.Entity+Number+Real) : System.Boolean
+AngouriMath.Entity+Number+Real.op_LessThan(AngouriMath.Entity+Number+Real, AngouriMath.Entity+Number+Real) : System.Boolean
+AngouriMath.Entity+Number+Real.op_LessThanOrEqual(AngouriMath.Entity+Number+Real, AngouriMath.Entity+Number+Real) : System.Boolean
+AngouriMath.Entity+Number+Real.op_Modulus(AngouriMath.Entity+Number+Real, AngouriMath.Entity+Number+Real) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_Multiply(AngouriMath.Entity+Number+Real, AngouriMath.Entity+Number+Real) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_Subtraction(AngouriMath.Entity+Number+Real, AngouriMath.Entity+Number+Real) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_UnaryNegation(AngouriMath.Entity+Number+Real) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number+Real.op_UnaryPlus(AngouriMath.Entity+Number+Real) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number.<Clone>$() : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.Abs(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Real
+AngouriMath.Entity+Number.Arccos(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.Arccosecant(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.Arccotan(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.Arcsecant(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.Arcsin(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.Arctan(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.Cos(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.Cosecant(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.Cotan(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.EqualityContract { } : System.Type
+AngouriMath.Entity+Number.Equals(AngouriMath.Entity+ContinuousNode) : System.Boolean
+AngouriMath.Entity+Number.Equals(AngouriMath.Entity+Number) : System.Boolean
+AngouriMath.Entity+Number.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Number.Exp(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.Factorial(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.Gamma(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.GetAllRoots(AngouriMath.Entity+Number+Complex, PeterO.Numbers.EInteger) : System.Collections.Generic.HashSet<AngouriMath.Entity+Number+Complex>
+AngouriMath.Entity+Number.GetAllRootsOf1(PeterO.Numbers.EInteger) : System.Collections.Generic.IEnumerable<AngouriMath.Entity>
+AngouriMath.Entity+Number.GetHashCode() : System.Int32
+AngouriMath.Entity+Number.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Number.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Number.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Number.IsExact { } : System.Boolean
+AngouriMath.Entity+Number.IsZero(AngouriMath.Entity+Number+Complex) : System.Boolean
+AngouriMath.Entity+Number.IsZero(AngouriMath.Entity+Number+Real) : System.Boolean
+AngouriMath.Entity+Number.IsZero(PeterO.Numbers.EDecimal) : System.Boolean
+AngouriMath.Entity+Number.Ln(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.Log(AngouriMath.Entity+Number+Complex, AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.Pow(AngouriMath.Entity+Number+Complex, AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Number.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Number.Secant(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.Signum(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.Sin(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.Sqrt(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.SuperSwitch(AngouriMath.Entity+Number, AngouriMath.Entity+Number, Func<AngouriMath.Entity+Number+Integer,AngouriMath.Entity+Number+Integer,T>, Func<AngouriMath.Entity+Number+Rational,AngouriMath.Entity+Number+Rational,T>, Func<AngouriMath.Entity+Number+Real,AngouriMath.Entity+Number+Real,T>, Func<AngouriMath.Entity+Number+Complex,AngouriMath.Entity+Number+Complex,T>) : T
+AngouriMath.Entity+Number.SuperSwitch(T, T, System.Func<AngouriMath.Entity+Number+Integer,AngouriMath.Entity+Number+Integer,AngouriMath.Entity+Number+Integer>, System.Func<AngouriMath.Entity+Number+Rational,AngouriMath.Entity+Number+Rational,AngouriMath.Entity+Number+Rational>, System.Func<AngouriMath.Entity+Number+Real,AngouriMath.Entity+Number+Real,AngouriMath.Entity+Number+Real>, System.Func<AngouriMath.Entity+Number+Complex,AngouriMath.Entity+Number+Complex,AngouriMath.Entity+Number+Complex>) : T
+AngouriMath.Entity+Number.Tan(AngouriMath.Entity+Number+Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity+Number.ToString() : System.String
+AngouriMath.Entity+Number.ctor()
+AngouriMath.Entity+Number.ctor(AngouriMath.Entity+Number)
+AngouriMath.Entity+Number.op_Addition(AngouriMath.Entity+Number, AngouriMath.Entity+Number) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_Division(AngouriMath.Entity+Number, AngouriMath.Entity+Number) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_Equality(AngouriMath.Entity+Number, AngouriMath.Entity+Number) : System.Boolean
+AngouriMath.Entity+Number.op_Explicit(AngouriMath.Entity+Number) : System.Decimal
+AngouriMath.Entity+Number.op_Explicit(AngouriMath.Entity+Number) : System.Double
+AngouriMath.Entity+Number.op_Explicit(AngouriMath.Entity+Number) : System.Int32
+AngouriMath.Entity+Number.op_Explicit(AngouriMath.Entity+Number) : System.Int64
+AngouriMath.Entity+Number.op_Explicit(AngouriMath.Entity+Number) : System.Numerics.BigInteger
+AngouriMath.Entity+Number.op_Explicit(AngouriMath.Entity+Number) : System.Numerics.Complex
+AngouriMath.Entity+Number.op_Explicit(AngouriMath.Entity+Number) : System.Single
+AngouriMath.Entity+Number.op_Implicit(PeterO.Numbers.EDecimal) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_Implicit(PeterO.Numbers.EInteger) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_Implicit(PeterO.Numbers.ERational) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_Implicit(System.Byte) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_Implicit(System.Decimal) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_Implicit(System.Double) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_Implicit(System.Int16) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_Implicit(System.Int32) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_Implicit(System.Int64) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_Implicit(System.Numerics.BigInteger) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_Implicit(System.Numerics.Complex) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_Implicit(System.SByte) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_Implicit(System.Single) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_Implicit(System.UInt16) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_Implicit(System.UInt32) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_Implicit(System.UInt64) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_Inequality(AngouriMath.Entity+Number, AngouriMath.Entity+Number) : System.Boolean
+AngouriMath.Entity+Number.op_Multiply(AngouriMath.Entity+Number, AngouriMath.Entity+Number) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_Subtraction(AngouriMath.Entity+Number, AngouriMath.Entity+Number) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_UnaryNegation(AngouriMath.Entity+Number) : AngouriMath.Entity+Number
+AngouriMath.Entity+Number.op_UnaryPlus(AngouriMath.Entity+Number) : AngouriMath.Entity+Number
+AngouriMath.Entity+Orf.<Clone>$() : AngouriMath.Entity+Orf
+AngouriMath.Entity+Orf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Orf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Orf.EqualityContract { } : System.Type
+AngouriMath.Entity+Orf.Equals(AngouriMath.Entity+Orf) : System.Boolean
+AngouriMath.Entity+Orf.Equals(AngouriMath.Entity+Statement) : System.Boolean
+AngouriMath.Entity+Orf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Orf.GetHashCode() : System.Int32
+AngouriMath.Entity+Orf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Orf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Orf.Latexise() : System.String
+AngouriMath.Entity+Orf.Left { } : AngouriMath.Entity
+AngouriMath.Entity+Orf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+Orf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+Orf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Orf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Orf.Right { } : AngouriMath.Entity
+AngouriMath.Entity+Orf.Stringize() : System.String
+AngouriMath.Entity+Orf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Orf.ToString() : System.String
+AngouriMath.Entity+Orf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Orf.op_Equality(AngouriMath.Entity+Orf, AngouriMath.Entity+Orf) : System.Boolean
+AngouriMath.Entity+Orf.op_Inequality(AngouriMath.Entity+Orf, AngouriMath.Entity+Orf) : System.Boolean
+AngouriMath.Entity+Phif.<Clone>$() : AngouriMath.Entity+Phif
+AngouriMath.Entity+Phif.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Phif.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Phif.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Phif.EqualityContract { } : System.Type
+AngouriMath.Entity+Phif.Equals(AngouriMath.Entity+Function) : System.Boolean
+AngouriMath.Entity+Phif.Equals(AngouriMath.Entity+Phif) : System.Boolean
+AngouriMath.Entity+Phif.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Phif.GetHashCode() : System.Int32
+AngouriMath.Entity+Phif.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Phif.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Phif.Latexise() : System.String
+AngouriMath.Entity+Phif.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Phif.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Phif.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Phif.Stringize() : System.String
+AngouriMath.Entity+Phif.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Phif.ToString() : System.String
+AngouriMath.Entity+Phif.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Phif.op_Equality(AngouriMath.Entity+Phif, AngouriMath.Entity+Phif) : System.Boolean
+AngouriMath.Entity+Phif.op_Inequality(AngouriMath.Entity+Phif, AngouriMath.Entity+Phif) : System.Boolean
+AngouriMath.Entity+Piecewise.<Clone>$() : AngouriMath.Entity+Piecewise
+AngouriMath.Entity+Piecewise.Apply(System.Func<AngouriMath.Entity+Providedf,AngouriMath.Entity+Providedf>) : AngouriMath.Entity+Piecewise
+AngouriMath.Entity+Piecewise.ApplyToValues(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity+Piecewise
+AngouriMath.Entity+Piecewise.Cases { } : System.Collections.Generic.IEnumerable<AngouriMath.Entity+Providedf>
+AngouriMath.Entity+Piecewise.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Piecewise.EqualityContract { } : System.Type
+AngouriMath.Entity+Piecewise.Equals(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity+Piecewise.Equals(AngouriMath.Entity+Piecewise) : System.Boolean
+AngouriMath.Entity+Piecewise.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Piecewise.GetHashCode() : System.Int32
+AngouriMath.Entity+Piecewise.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Piecewise.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Piecewise.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Piecewise.Latexise() : System.String
+AngouriMath.Entity+Piecewise.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Piecewise.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Piecewise.Stringize() : System.String
+AngouriMath.Entity+Piecewise.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Piecewise.ToString() : System.String
+AngouriMath.Entity+Piecewise.ctor(System.Collections.Generic.IEnumerable<AngouriMath.Entity+Providedf>)
+AngouriMath.Entity+Piecewise.op_Equality(AngouriMath.Entity+Piecewise, AngouriMath.Entity+Piecewise) : System.Boolean
+AngouriMath.Entity+Piecewise.op_Inequality(AngouriMath.Entity+Piecewise, AngouriMath.Entity+Piecewise) : System.Boolean
+AngouriMath.Entity+Powf.<Clone>$() : AngouriMath.Entity+Powf
+AngouriMath.Entity+Powf.Base { } : AngouriMath.Entity
+AngouriMath.Entity+Powf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Powf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Powf.EqualityContract { } : System.Type
+AngouriMath.Entity+Powf.Equals(AngouriMath.Entity+Function) : System.Boolean
+AngouriMath.Entity+Powf.Equals(AngouriMath.Entity+Powf) : System.Boolean
+AngouriMath.Entity+Powf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Powf.Exponent { } : AngouriMath.Entity
+AngouriMath.Entity+Powf.GetHashCode() : System.Int32
+AngouriMath.Entity+Powf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Powf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Powf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Powf.Latexise() : System.String
+AngouriMath.Entity+Powf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+Powf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+Powf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Powf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Powf.Stringize() : System.String
+AngouriMath.Entity+Powf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Powf.ToString() : System.String
+AngouriMath.Entity+Powf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Powf.op_Equality(AngouriMath.Entity+Powf, AngouriMath.Entity+Powf) : System.Boolean
+AngouriMath.Entity+Powf.op_Inequality(AngouriMath.Entity+Powf, AngouriMath.Entity+Powf) : System.Boolean
+AngouriMath.Entity+Providedf.<Clone>$() : AngouriMath.Entity+Providedf
+AngouriMath.Entity+Providedf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Providedf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Providedf.EqualityContract { } : System.Type
+AngouriMath.Entity+Providedf.Equals(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity+Providedf.Equals(AngouriMath.Entity+Providedf) : System.Boolean
+AngouriMath.Entity+Providedf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Providedf.Expression { } : AngouriMath.Entity
+AngouriMath.Entity+Providedf.GetHashCode() : System.Int32
+AngouriMath.Entity+Providedf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Providedf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Providedf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Providedf.Latexise() : System.String
+AngouriMath.Entity+Providedf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+Providedf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+Providedf.Predicate { } : AngouriMath.Entity
+AngouriMath.Entity+Providedf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Providedf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Providedf.Stringize() : System.String
+AngouriMath.Entity+Providedf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Providedf.ToString() : System.String
+AngouriMath.Entity+Providedf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Providedf.op_Equality(AngouriMath.Entity+Providedf, AngouriMath.Entity+Providedf) : System.Boolean
+AngouriMath.Entity+Providedf.op_Inequality(AngouriMath.Entity+Providedf, AngouriMath.Entity+Providedf) : System.Boolean
+AngouriMath.Entity+Roundf.<Clone>$() : AngouriMath.Entity+Roundf
+AngouriMath.Entity+Roundf.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Roundf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Roundf.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Roundf.EqualityContract { } : System.Type
+AngouriMath.Entity+Roundf.Equals(AngouriMath.Entity+Function) : System.Boolean
+AngouriMath.Entity+Roundf.Equals(AngouriMath.Entity+Roundf) : System.Boolean
+AngouriMath.Entity+Roundf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Roundf.GetHashCode() : System.Int32
+AngouriMath.Entity+Roundf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Roundf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Roundf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Roundf.Latexise() : System.String
+AngouriMath.Entity+Roundf.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Roundf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Roundf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Roundf.Stringize() : System.String
+AngouriMath.Entity+Roundf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Roundf.ToString() : System.String
+AngouriMath.Entity+Roundf.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Roundf.op_Equality(AngouriMath.Entity+Roundf, AngouriMath.Entity+Roundf) : System.Boolean
+AngouriMath.Entity+Roundf.op_Inequality(AngouriMath.Entity+Roundf, AngouriMath.Entity+Roundf) : System.Boolean
+AngouriMath.Entity+Secantf.<Clone>$() : AngouriMath.Entity+Secantf
+AngouriMath.Entity+Secantf.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Secantf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Secantf.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Secantf.EqualityContract { } : System.Type
+AngouriMath.Entity+Secantf.Equals(AngouriMath.Entity+Secantf) : System.Boolean
+AngouriMath.Entity+Secantf.Equals(AngouriMath.Entity+TrigonometricFunction) : System.Boolean
+AngouriMath.Entity+Secantf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Secantf.GetHashCode() : System.Int32
+AngouriMath.Entity+Secantf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Secantf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Secantf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Secantf.Latexise() : System.String
+AngouriMath.Entity+Secantf.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Secantf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Secantf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Secantf.Stringize() : System.String
+AngouriMath.Entity+Secantf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Secantf.ToString() : System.String
+AngouriMath.Entity+Secantf.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Secantf.op_Equality(AngouriMath.Entity+Secantf, AngouriMath.Entity+Secantf) : System.Boolean
+AngouriMath.Entity+Secantf.op_Inequality(AngouriMath.Entity+Secantf, AngouriMath.Entity+Secantf) : System.Boolean
+AngouriMath.Entity+Set+ConditionalSet.<Clone>$() : AngouriMath.Entity+Set+ConditionalSet
+AngouriMath.Entity+Set+ConditionalSet.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Set+ConditionalSet.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Set+ConditionalSet.EqualityContract { } : System.Type
+AngouriMath.Entity+Set+ConditionalSet.Equals(AngouriMath.Entity+Set) : System.Boolean
+AngouriMath.Entity+Set+ConditionalSet.Equals(AngouriMath.Entity+Set+ConditionalSet) : System.Boolean
+AngouriMath.Entity+Set+ConditionalSet.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Set+ConditionalSet.Filter(AngouriMath.Entity, AngouriMath.Entity+Variable) : AngouriMath.Entity+Set
+AngouriMath.Entity+Set+ConditionalSet.GetHashCode() : System.Int32
+AngouriMath.Entity+Set+ConditionalSet.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Set+ConditionalSet.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Set+ConditionalSet.IsSetEmpty { } : System.Boolean
+AngouriMath.Entity+Set+ConditionalSet.IsSetFinite { } : System.Boolean
+AngouriMath.Entity+Set+ConditionalSet.Latexise() : System.String
+AngouriMath.Entity+Set+ConditionalSet.Predicate { } : AngouriMath.Entity
+AngouriMath.Entity+Set+ConditionalSet.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Set+ConditionalSet.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Set+ConditionalSet.Stringize() : System.String
+AngouriMath.Entity+Set+ConditionalSet.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Set+ConditionalSet.ToString() : System.String
+AngouriMath.Entity+Set+ConditionalSet.TryContains(AngouriMath.Entity, System.Boolean&) : System.Boolean
+AngouriMath.Entity+Set+ConditionalSet.Var { } : AngouriMath.Entity
+AngouriMath.Entity+Set+ConditionalSet.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Set+ConditionalSet.op_Equality(AngouriMath.Entity+Set+ConditionalSet, AngouriMath.Entity+Set+ConditionalSet) : System.Boolean
+AngouriMath.Entity+Set+ConditionalSet.op_Inequality(AngouriMath.Entity+Set+ConditionalSet, AngouriMath.Entity+Set+ConditionalSet) : System.Boolean
+AngouriMath.Entity+Set+FiniteSet.<Clone>$() : AngouriMath.Entity+Set+FiniteSet
+AngouriMath.Entity+Set+FiniteSet.Apply(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity+Set+FiniteSet
+AngouriMath.Entity+Set+FiniteSet.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Set+FiniteSet.Count { } : System.Int32
+AngouriMath.Entity+Set+FiniteSet.Deconstruct(System.Collections.Generic.IEnumerable<AngouriMath.Entity>&) : System.Void
+AngouriMath.Entity+Set+FiniteSet.Elements { } : System.Collections.Generic.IEnumerable<AngouriMath.Entity>
+AngouriMath.Entity+Set+FiniteSet.EqualityContract { } : System.Type
+AngouriMath.Entity+Set+FiniteSet.Equals(AngouriMath.Entity+Set) : System.Boolean
+AngouriMath.Entity+Set+FiniteSet.Equals(AngouriMath.Entity+Set+FiniteSet) : System.Boolean
+AngouriMath.Entity+Set+FiniteSet.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Set+FiniteSet.Filter(AngouriMath.Entity, AngouriMath.Entity+Variable) : AngouriMath.Entity+Set
+AngouriMath.Entity+Set+FiniteSet.GetEnumerator() : System.Collections.Generic.IEnumerator<AngouriMath.Entity>
+AngouriMath.Entity+Set+FiniteSet.GetHashCode() : System.Int32
+AngouriMath.Entity+Set+FiniteSet.GetPowerSet() : AngouriMath.Entity+Set+FiniteSet
+AngouriMath.Entity+Set+FiniteSet.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Set+FiniteSet.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Set+FiniteSet.IsSetEmpty { } : System.Boolean
+AngouriMath.Entity+Set+FiniteSet.IsSetFinite { } : System.Boolean
+AngouriMath.Entity+Set+FiniteSet.Latexise() : System.String
+AngouriMath.Entity+Set+FiniteSet.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Set+FiniteSet.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Set+FiniteSet.Stringize() : System.String
+AngouriMath.Entity+Set+FiniteSet.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Set+FiniteSet.ToString() : System.String
+AngouriMath.Entity+Set+FiniteSet.TryContains(AngouriMath.Entity, System.Boolean&) : System.Boolean
+AngouriMath.Entity+Set+FiniteSet.TryIsSubsetOf(AngouriMath.Entity+Set+FiniteSet, System.Boolean&) : System.Boolean
+AngouriMath.Entity+Set+FiniteSet.ctor(AngouriMath.Entity[])
+AngouriMath.Entity+Set+FiniteSet.ctor(System.Collections.Generic.IEnumerable<AngouriMath.Entity>)
+AngouriMath.Entity+Set+FiniteSet.op_Equality(AngouriMath.Entity+Set+FiniteSet, AngouriMath.Entity+Set+FiniteSet) : System.Boolean
+AngouriMath.Entity+Set+FiniteSet.op_Implicit(System.String) : AngouriMath.Entity+Set+FiniteSet
+AngouriMath.Entity+Set+FiniteSet.op_Inequality(AngouriMath.Entity+Set+FiniteSet, AngouriMath.Entity+Set+FiniteSet) : System.Boolean
+AngouriMath.Entity+Set+Inf.<Clone>$() : AngouriMath.Entity+Set+Inf
+AngouriMath.Entity+Set+Inf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Set+Inf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Set+Inf.Element { } : AngouriMath.Entity
+AngouriMath.Entity+Set+Inf.EqualityContract { } : System.Type
+AngouriMath.Entity+Set+Inf.Equals(AngouriMath.Entity+Set+Inf) : System.Boolean
+AngouriMath.Entity+Set+Inf.Equals(AngouriMath.Entity+Statement) : System.Boolean
+AngouriMath.Entity+Set+Inf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Set+Inf.GetHashCode() : System.Int32
+AngouriMath.Entity+Set+Inf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Set+Inf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Set+Inf.Latexise() : System.String
+AngouriMath.Entity+Set+Inf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+Set+Inf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+Set+Inf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Set+Inf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Set+Inf.Stringize() : System.String
+AngouriMath.Entity+Set+Inf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Set+Inf.SupSet { } : AngouriMath.Entity
+AngouriMath.Entity+Set+Inf.ToString() : System.String
+AngouriMath.Entity+Set+Inf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Set+Inf.op_Equality(AngouriMath.Entity+Set+Inf, AngouriMath.Entity+Set+Inf) : System.Boolean
+AngouriMath.Entity+Set+Inf.op_Inequality(AngouriMath.Entity+Set+Inf, AngouriMath.Entity+Set+Inf) : System.Boolean
+AngouriMath.Entity+Set+Intersectionf.<Clone>$() : AngouriMath.Entity+Set+Intersectionf
+AngouriMath.Entity+Set+Intersectionf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Set+Intersectionf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Set+Intersectionf.EqualityContract { } : System.Type
+AngouriMath.Entity+Set+Intersectionf.Equals(AngouriMath.Entity+Set) : System.Boolean
+AngouriMath.Entity+Set+Intersectionf.Equals(AngouriMath.Entity+Set+Intersectionf) : System.Boolean
+AngouriMath.Entity+Set+Intersectionf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Set+Intersectionf.Filter(AngouriMath.Entity, AngouriMath.Entity+Variable) : AngouriMath.Entity+Set
+AngouriMath.Entity+Set+Intersectionf.GetHashCode() : System.Int32
+AngouriMath.Entity+Set+Intersectionf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Set+Intersectionf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Set+Intersectionf.IsSetEmpty { } : System.Boolean
+AngouriMath.Entity+Set+Intersectionf.IsSetFinite { } : System.Boolean
+AngouriMath.Entity+Set+Intersectionf.Latexise() : System.String
+AngouriMath.Entity+Set+Intersectionf.Left { } : AngouriMath.Entity
+AngouriMath.Entity+Set+Intersectionf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Set+Intersectionf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Set+Intersectionf.Right { } : AngouriMath.Entity
+AngouriMath.Entity+Set+Intersectionf.Stringize() : System.String
+AngouriMath.Entity+Set+Intersectionf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Set+Intersectionf.ToString() : System.String
+AngouriMath.Entity+Set+Intersectionf.TryContains(AngouriMath.Entity, System.Boolean&) : System.Boolean
+AngouriMath.Entity+Set+Intersectionf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Set+Intersectionf.op_Equality(AngouriMath.Entity+Set+Intersectionf, AngouriMath.Entity+Set+Intersectionf) : System.Boolean
+AngouriMath.Entity+Set+Intersectionf.op_Inequality(AngouriMath.Entity+Set+Intersectionf, AngouriMath.Entity+Set+Intersectionf) : System.Boolean
+AngouriMath.Entity+Set+Interval.<Clone>$() : AngouriMath.Entity+Set+Interval
+AngouriMath.Entity+Set+Interval.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Set+Interval.Deconstruct(AngouriMath.Entity&, System.Boolean&, AngouriMath.Entity&, System.Boolean&) : System.Void
+AngouriMath.Entity+Set+Interval.EqualityContract { } : System.Type
+AngouriMath.Entity+Set+Interval.Equals(AngouriMath.Entity+Set) : System.Boolean
+AngouriMath.Entity+Set+Interval.Equals(AngouriMath.Entity+Set+Interval) : System.Boolean
+AngouriMath.Entity+Set+Interval.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Set+Interval.Filter(AngouriMath.Entity, AngouriMath.Entity+Variable) : AngouriMath.Entity+Set
+AngouriMath.Entity+Set+Interval.GetHashCode() : System.Int32
+AngouriMath.Entity+Set+Interval.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Set+Interval.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Set+Interval.IsNumeric { } : System.Boolean
+AngouriMath.Entity+Set+Interval.IsSetEmpty { } : System.Boolean
+AngouriMath.Entity+Set+Interval.IsSetFinite { } : System.Boolean
+AngouriMath.Entity+Set+Interval.Latexise() : System.String
+AngouriMath.Entity+Set+Interval.Left { } : AngouriMath.Entity
+AngouriMath.Entity+Set+Interval.LeftClosed { } : System.Boolean
+AngouriMath.Entity+Set+Interval.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Set+Interval.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Set+Interval.Right { } : AngouriMath.Entity
+AngouriMath.Entity+Set+Interval.RightClosed { } : System.Boolean
+AngouriMath.Entity+Set+Interval.Stringize() : System.String
+AngouriMath.Entity+Set+Interval.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Set+Interval.ToString() : System.String
+AngouriMath.Entity+Set+Interval.TryContains(AngouriMath.Entity, System.Boolean&) : System.Boolean
+AngouriMath.Entity+Set+Interval.ctor(AngouriMath.Entity, System.Boolean, AngouriMath.Entity, System.Boolean)
+AngouriMath.Entity+Set+Interval.op_Equality(AngouriMath.Entity+Set+Interval, AngouriMath.Entity+Set+Interval) : System.Boolean
+AngouriMath.Entity+Set+Interval.op_Inequality(AngouriMath.Entity+Set+Interval, AngouriMath.Entity+Set+Interval) : System.Boolean
+AngouriMath.Entity+Set+SetMinusf.<Clone>$() : AngouriMath.Entity+Set+SetMinusf
+AngouriMath.Entity+Set+SetMinusf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Set+SetMinusf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Set+SetMinusf.EqualityContract { } : System.Type
+AngouriMath.Entity+Set+SetMinusf.Equals(AngouriMath.Entity+Set) : System.Boolean
+AngouriMath.Entity+Set+SetMinusf.Equals(AngouriMath.Entity+Set+SetMinusf) : System.Boolean
+AngouriMath.Entity+Set+SetMinusf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Set+SetMinusf.Filter(AngouriMath.Entity, AngouriMath.Entity+Variable) : AngouriMath.Entity+Set
+AngouriMath.Entity+Set+SetMinusf.GetHashCode() : System.Int32
+AngouriMath.Entity+Set+SetMinusf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Set+SetMinusf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Set+SetMinusf.IsSetEmpty { } : System.Boolean
+AngouriMath.Entity+Set+SetMinusf.IsSetFinite { } : System.Boolean
+AngouriMath.Entity+Set+SetMinusf.Latexise() : System.String
+AngouriMath.Entity+Set+SetMinusf.Left { } : AngouriMath.Entity
+AngouriMath.Entity+Set+SetMinusf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Set+SetMinusf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Set+SetMinusf.Right { } : AngouriMath.Entity
+AngouriMath.Entity+Set+SetMinusf.Stringize() : System.String
+AngouriMath.Entity+Set+SetMinusf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Set+SetMinusf.ToString() : System.String
+AngouriMath.Entity+Set+SetMinusf.TryContains(AngouriMath.Entity, System.Boolean&) : System.Boolean
+AngouriMath.Entity+Set+SetMinusf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Set+SetMinusf.op_Equality(AngouriMath.Entity+Set+SetMinusf, AngouriMath.Entity+Set+SetMinusf) : System.Boolean
+AngouriMath.Entity+Set+SetMinusf.op_Inequality(AngouriMath.Entity+Set+SetMinusf, AngouriMath.Entity+Set+SetMinusf) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Booleans.<Clone>$() : AngouriMath.Entity+Set+SpecialSet+Booleans
+AngouriMath.Entity+Set+SpecialSet+Booleans.EqualityContract { } : System.Type
+AngouriMath.Entity+Set+SpecialSet+Booleans.Equals(AngouriMath.Entity+Set+SpecialSet) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Booleans.Equals(AngouriMath.Entity+Set+SpecialSet+Booleans) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Booleans.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Booleans.GetHashCode() : System.Int32
+AngouriMath.Entity+Set+SpecialSet+Booleans.MayContain(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Booleans.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Booleans.Stringize() : System.String
+AngouriMath.Entity+Set+SpecialSet+Booleans.ToString() : System.String
+AngouriMath.Entity+Set+SpecialSet+Booleans.ctor()
+AngouriMath.Entity+Set+SpecialSet+Booleans.op_Equality(AngouriMath.Entity+Set+SpecialSet+Booleans, AngouriMath.Entity+Set+SpecialSet+Booleans) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Booleans.op_Inequality(AngouriMath.Entity+Set+SpecialSet+Booleans, AngouriMath.Entity+Set+SpecialSet+Booleans) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Complexes.<Clone>$() : AngouriMath.Entity+Set+SpecialSet+Complexes
+AngouriMath.Entity+Set+SpecialSet+Complexes.EqualityContract { } : System.Type
+AngouriMath.Entity+Set+SpecialSet+Complexes.Equals(AngouriMath.Entity+Set+SpecialSet) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Complexes.Equals(AngouriMath.Entity+Set+SpecialSet+Complexes) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Complexes.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Complexes.GetHashCode() : System.Int32
+AngouriMath.Entity+Set+SpecialSet+Complexes.MayContain(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Complexes.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Complexes.Stringize() : System.String
+AngouriMath.Entity+Set+SpecialSet+Complexes.ToString() : System.String
+AngouriMath.Entity+Set+SpecialSet+Complexes.ctor()
+AngouriMath.Entity+Set+SpecialSet+Complexes.op_Equality(AngouriMath.Entity+Set+SpecialSet+Complexes, AngouriMath.Entity+Set+SpecialSet+Complexes) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Complexes.op_Inequality(AngouriMath.Entity+Set+SpecialSet+Complexes, AngouriMath.Entity+Set+SpecialSet+Complexes) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Integers.<Clone>$() : AngouriMath.Entity+Set+SpecialSet+Integers
+AngouriMath.Entity+Set+SpecialSet+Integers.EqualityContract { } : System.Type
+AngouriMath.Entity+Set+SpecialSet+Integers.Equals(AngouriMath.Entity+Set+SpecialSet) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Integers.Equals(AngouriMath.Entity+Set+SpecialSet+Integers) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Integers.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Integers.GetHashCode() : System.Int32
+AngouriMath.Entity+Set+SpecialSet+Integers.MayContain(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Integers.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Integers.Stringize() : System.String
+AngouriMath.Entity+Set+SpecialSet+Integers.ToString() : System.String
+AngouriMath.Entity+Set+SpecialSet+Integers.ctor()
+AngouriMath.Entity+Set+SpecialSet+Integers.op_Equality(AngouriMath.Entity+Set+SpecialSet+Integers, AngouriMath.Entity+Set+SpecialSet+Integers) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Integers.op_Inequality(AngouriMath.Entity+Set+SpecialSet+Integers, AngouriMath.Entity+Set+SpecialSet+Integers) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Rationals.<Clone>$() : AngouriMath.Entity+Set+SpecialSet+Rationals
+AngouriMath.Entity+Set+SpecialSet+Rationals.EqualityContract { } : System.Type
+AngouriMath.Entity+Set+SpecialSet+Rationals.Equals(AngouriMath.Entity+Set+SpecialSet) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Rationals.Equals(AngouriMath.Entity+Set+SpecialSet+Rationals) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Rationals.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Rationals.GetHashCode() : System.Int32
+AngouriMath.Entity+Set+SpecialSet+Rationals.MayContain(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Rationals.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Rationals.Stringize() : System.String
+AngouriMath.Entity+Set+SpecialSet+Rationals.ToString() : System.String
+AngouriMath.Entity+Set+SpecialSet+Rationals.ctor()
+AngouriMath.Entity+Set+SpecialSet+Rationals.op_Equality(AngouriMath.Entity+Set+SpecialSet+Rationals, AngouriMath.Entity+Set+SpecialSet+Rationals) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Rationals.op_Inequality(AngouriMath.Entity+Set+SpecialSet+Rationals, AngouriMath.Entity+Set+SpecialSet+Rationals) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Reals.<Clone>$() : AngouriMath.Entity+Set+SpecialSet+Reals
+AngouriMath.Entity+Set+SpecialSet+Reals.EqualityContract { } : System.Type
+AngouriMath.Entity+Set+SpecialSet+Reals.Equals(AngouriMath.Entity+Set+SpecialSet) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Reals.Equals(AngouriMath.Entity+Set+SpecialSet+Reals) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Reals.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Reals.GetHashCode() : System.Int32
+AngouriMath.Entity+Set+SpecialSet+Reals.MayContain(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Reals.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Reals.Stringize() : System.String
+AngouriMath.Entity+Set+SpecialSet+Reals.ToString() : System.String
+AngouriMath.Entity+Set+SpecialSet+Reals.ctor()
+AngouriMath.Entity+Set+SpecialSet+Reals.op_Equality(AngouriMath.Entity+Set+SpecialSet+Reals, AngouriMath.Entity+Set+SpecialSet+Reals) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet+Reals.op_Inequality(AngouriMath.Entity+Set+SpecialSet+Reals, AngouriMath.Entity+Set+SpecialSet+Reals) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet.<Clone>$() : AngouriMath.Entity+Set+SpecialSet
+AngouriMath.Entity+Set+SpecialSet.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Set+SpecialSet.Create(AngouriMath.Core.Domain) : AngouriMath.Entity+Set+SpecialSet
+AngouriMath.Entity+Set+SpecialSet.Create(System.String) : AngouriMath.Entity+Set+SpecialSet
+AngouriMath.Entity+Set+SpecialSet.EqualityContract { } : System.Type
+AngouriMath.Entity+Set+SpecialSet.Equals(AngouriMath.Entity+Set) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet.Equals(AngouriMath.Entity+Set+SpecialSet) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet.Filter(AngouriMath.Entity, AngouriMath.Entity+Variable) : AngouriMath.Entity+Set
+AngouriMath.Entity+Set+SpecialSet.GetHashCode() : System.Int32
+AngouriMath.Entity+Set+SpecialSet.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Set+SpecialSet.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Set+SpecialSet.IsSetEmpty { } : System.Boolean
+AngouriMath.Entity+Set+SpecialSet.IsSetFinite { } : System.Boolean
+AngouriMath.Entity+Set+SpecialSet.Latexise() : System.String
+AngouriMath.Entity+Set+SpecialSet.MayContain(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Set+SpecialSet.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Set+SpecialSet.ToString() : System.String
+AngouriMath.Entity+Set+SpecialSet.TryContains(AngouriMath.Entity, System.Boolean&) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet.ctor()
+AngouriMath.Entity+Set+SpecialSet.ctor(AngouriMath.Entity+Set+SpecialSet)
+AngouriMath.Entity+Set+SpecialSet.op_Equality(AngouriMath.Entity+Set+SpecialSet, AngouriMath.Entity+Set+SpecialSet) : System.Boolean
+AngouriMath.Entity+Set+SpecialSet.op_Inequality(AngouriMath.Entity+Set+SpecialSet, AngouriMath.Entity+Set+SpecialSet) : System.Boolean
+AngouriMath.Entity+Set+Unionf.<Clone>$() : AngouriMath.Entity+Set+Unionf
+AngouriMath.Entity+Set+Unionf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Set+Unionf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Set+Unionf.EqualityContract { } : System.Type
+AngouriMath.Entity+Set+Unionf.Equals(AngouriMath.Entity+Set) : System.Boolean
+AngouriMath.Entity+Set+Unionf.Equals(AngouriMath.Entity+Set+Unionf) : System.Boolean
+AngouriMath.Entity+Set+Unionf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Set+Unionf.Filter(AngouriMath.Entity, AngouriMath.Entity+Variable) : AngouriMath.Entity+Set
+AngouriMath.Entity+Set+Unionf.GetHashCode() : System.Int32
+AngouriMath.Entity+Set+Unionf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Set+Unionf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Set+Unionf.IsSetEmpty { } : System.Boolean
+AngouriMath.Entity+Set+Unionf.IsSetFinite { } : System.Boolean
+AngouriMath.Entity+Set+Unionf.Latexise() : System.String
+AngouriMath.Entity+Set+Unionf.Left { } : AngouriMath.Entity
+AngouriMath.Entity+Set+Unionf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Set+Unionf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Set+Unionf.Right { } : AngouriMath.Entity
+AngouriMath.Entity+Set+Unionf.Stringize() : System.String
+AngouriMath.Entity+Set+Unionf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Set+Unionf.ToString() : System.String
+AngouriMath.Entity+Set+Unionf.TryContains(AngouriMath.Entity, System.Boolean&) : System.Boolean
+AngouriMath.Entity+Set+Unionf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Set+Unionf.op_Equality(AngouriMath.Entity+Set+Unionf, AngouriMath.Entity+Set+Unionf) : System.Boolean
+AngouriMath.Entity+Set+Unionf.op_Inequality(AngouriMath.Entity+Set+Unionf, AngouriMath.Entity+Set+Unionf) : System.Boolean
+AngouriMath.Entity+Set.<Clone>$() : AngouriMath.Entity+Set
+AngouriMath.Entity+Set.Contains(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity+Set.Empty : AngouriMath.Entity+Set+FiniteSet
+AngouriMath.Entity+Set.EqualityContract { } : System.Type
+AngouriMath.Entity+Set.Equals(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity+Set.Equals(AngouriMath.Entity+Set) : System.Boolean
+AngouriMath.Entity+Set.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Set.Filter(AngouriMath.Entity, AngouriMath.Entity+Variable) : AngouriMath.Entity+Set
+AngouriMath.Entity+Set.GetHashCode() : System.Int32
+AngouriMath.Entity+Set.IsSetEmpty { } : System.Boolean
+AngouriMath.Entity+Set.IsSetFinite { } : System.Boolean
+AngouriMath.Entity+Set.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Set.ToString() : System.String
+AngouriMath.Entity+Set.TryContains(AngouriMath.Entity, System.Boolean&) : System.Boolean
+AngouriMath.Entity+Set.ctor()
+AngouriMath.Entity+Set.ctor(AngouriMath.Entity+Set)
+AngouriMath.Entity+Set.op_Equality(AngouriMath.Entity+Set, AngouriMath.Entity+Set) : System.Boolean
+AngouriMath.Entity+Set.op_Implicit(System.String) : AngouriMath.Entity+Set
+AngouriMath.Entity+Set.op_Inequality(AngouriMath.Entity+Set, AngouriMath.Entity+Set) : System.Boolean
+AngouriMath.Entity+Signumf.<Clone>$() : AngouriMath.Entity+Signumf
+AngouriMath.Entity+Signumf.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Signumf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Signumf.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Signumf.EqualityContract { } : System.Type
+AngouriMath.Entity+Signumf.Equals(AngouriMath.Entity+Function) : System.Boolean
+AngouriMath.Entity+Signumf.Equals(AngouriMath.Entity+Signumf) : System.Boolean
+AngouriMath.Entity+Signumf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Signumf.GetHashCode() : System.Int32
+AngouriMath.Entity+Signumf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Signumf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Signumf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Signumf.Latexise() : System.String
+AngouriMath.Entity+Signumf.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Signumf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Signumf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Signumf.Stringize() : System.String
+AngouriMath.Entity+Signumf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Signumf.ToString() : System.String
+AngouriMath.Entity+Signumf.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Signumf.op_Equality(AngouriMath.Entity+Signumf, AngouriMath.Entity+Signumf) : System.Boolean
+AngouriMath.Entity+Signumf.op_Inequality(AngouriMath.Entity+Signumf, AngouriMath.Entity+Signumf) : System.Boolean
+AngouriMath.Entity+Sinf.<Clone>$() : AngouriMath.Entity+Sinf
+AngouriMath.Entity+Sinf.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Sinf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Sinf.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Sinf.EqualityContract { } : System.Type
+AngouriMath.Entity+Sinf.Equals(AngouriMath.Entity+Sinf) : System.Boolean
+AngouriMath.Entity+Sinf.Equals(AngouriMath.Entity+TrigonometricFunction) : System.Boolean
+AngouriMath.Entity+Sinf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Sinf.GetHashCode() : System.Int32
+AngouriMath.Entity+Sinf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Sinf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Sinf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Sinf.Latexise() : System.String
+AngouriMath.Entity+Sinf.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Sinf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Sinf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Sinf.Stringize() : System.String
+AngouriMath.Entity+Sinf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Sinf.ToString() : System.String
+AngouriMath.Entity+Sinf.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Sinf.op_Equality(AngouriMath.Entity+Sinf, AngouriMath.Entity+Sinf) : System.Boolean
+AngouriMath.Entity+Sinf.op_Inequality(AngouriMath.Entity+Sinf, AngouriMath.Entity+Sinf) : System.Boolean
+AngouriMath.Entity+Statement.<Clone>$() : AngouriMath.Entity+Statement
+AngouriMath.Entity+Statement.EqualityContract { } : System.Type
+AngouriMath.Entity+Statement.Equals(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity+Statement.Equals(AngouriMath.Entity+Statement) : System.Boolean
+AngouriMath.Entity+Statement.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Statement.GetHashCode() : System.Int32
+AngouriMath.Entity+Statement.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Statement.ToString() : System.String
+AngouriMath.Entity+Statement.ctor()
+AngouriMath.Entity+Statement.ctor(AngouriMath.Entity+Statement)
+AngouriMath.Entity+Statement.op_Equality(AngouriMath.Entity+Statement, AngouriMath.Entity+Statement) : System.Boolean
+AngouriMath.Entity+Statement.op_Inequality(AngouriMath.Entity+Statement, AngouriMath.Entity+Statement) : System.Boolean
+AngouriMath.Entity+Sumf.<Clone>$() : AngouriMath.Entity+Sumf
+AngouriMath.Entity+Sumf.Addend { } : AngouriMath.Entity
+AngouriMath.Entity+Sumf.Augend { } : AngouriMath.Entity
+AngouriMath.Entity+Sumf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Sumf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Sumf.EqualityContract { } : System.Type
+AngouriMath.Entity+Sumf.Equals(AngouriMath.Entity+ContinuousNode) : System.Boolean
+AngouriMath.Entity+Sumf.Equals(AngouriMath.Entity+Sumf) : System.Boolean
+AngouriMath.Entity+Sumf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Sumf.GetHashCode() : System.Int32
+AngouriMath.Entity+Sumf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Sumf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Sumf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Sumf.Latexise() : System.String
+AngouriMath.Entity+Sumf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+Sumf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+Sumf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Sumf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Sumf.Stringize() : System.String
+AngouriMath.Entity+Sumf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Sumf.Sum(System.Collections.Generic.IEnumerable<AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Sumf.Sum(System.Collections.Generic.IReadOnlyList<AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Sumf.ToString() : System.String
+AngouriMath.Entity+Sumf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Sumf.op_Equality(AngouriMath.Entity+Sumf, AngouriMath.Entity+Sumf) : System.Boolean
+AngouriMath.Entity+Sumf.op_Inequality(AngouriMath.Entity+Sumf, AngouriMath.Entity+Sumf) : System.Boolean
+AngouriMath.Entity+Tanf.<Clone>$() : AngouriMath.Entity+Tanf
+AngouriMath.Entity+Tanf.Argument { } : AngouriMath.Entity
+AngouriMath.Entity+Tanf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Tanf.Deconstruct(AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Tanf.EqualityContract { } : System.Type
+AngouriMath.Entity+Tanf.Equals(AngouriMath.Entity+Tanf) : System.Boolean
+AngouriMath.Entity+Tanf.Equals(AngouriMath.Entity+TrigonometricFunction) : System.Boolean
+AngouriMath.Entity+Tanf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Tanf.GetHashCode() : System.Int32
+AngouriMath.Entity+Tanf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Tanf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Tanf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Tanf.Latexise() : System.String
+AngouriMath.Entity+Tanf.NodeChild { } : AngouriMath.Entity
+AngouriMath.Entity+Tanf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Tanf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Tanf.Stringize() : System.String
+AngouriMath.Entity+Tanf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Tanf.ToString() : System.String
+AngouriMath.Entity+Tanf.ctor(AngouriMath.Entity)
+AngouriMath.Entity+Tanf.op_Equality(AngouriMath.Entity+Tanf, AngouriMath.Entity+Tanf) : System.Boolean
+AngouriMath.Entity+Tanf.op_Inequality(AngouriMath.Entity+Tanf, AngouriMath.Entity+Tanf) : System.Boolean
+AngouriMath.Entity+TrigonometricFunction.<Clone>$() : AngouriMath.Entity+TrigonometricFunction
+AngouriMath.Entity+TrigonometricFunction.EqualityContract { } : System.Type
+AngouriMath.Entity+TrigonometricFunction.Equals(AngouriMath.Entity+Function) : System.Boolean
+AngouriMath.Entity+TrigonometricFunction.Equals(AngouriMath.Entity+TrigonometricFunction) : System.Boolean
+AngouriMath.Entity+TrigonometricFunction.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+TrigonometricFunction.GetHashCode() : System.Int32
+AngouriMath.Entity+TrigonometricFunction.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+TrigonometricFunction.ToString() : System.String
+AngouriMath.Entity+TrigonometricFunction.ctor()
+AngouriMath.Entity+TrigonometricFunction.ctor(AngouriMath.Entity+TrigonometricFunction)
+AngouriMath.Entity+TrigonometricFunction.op_Equality(AngouriMath.Entity+TrigonometricFunction, AngouriMath.Entity+TrigonometricFunction) : System.Boolean
+AngouriMath.Entity+TrigonometricFunction.op_Inequality(AngouriMath.Entity+TrigonometricFunction, AngouriMath.Entity+TrigonometricFunction) : System.Boolean
+AngouriMath.Entity+Variable.<Clone>$() : AngouriMath.Entity+Variable
+AngouriMath.Entity+Variable.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Variable.Deconstruct(System.String&) : System.Void
+AngouriMath.Entity+Variable.EqualityContract { } : System.Type
+AngouriMath.Entity+Variable.Equals(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity+Variable.Equals(AngouriMath.Entity+Variable) : System.Boolean
+AngouriMath.Entity+Variable.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Variable.GetHashCode() : System.Int32
+AngouriMath.Entity+Variable.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Variable.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity+Variable.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Variable.Latexise() : System.String
+AngouriMath.Entity+Variable.Name { } : System.String
+AngouriMath.Entity+Variable.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Variable.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Variable.Stringize() : System.String
+AngouriMath.Entity+Variable.ToString() : System.String
+AngouriMath.Entity+Variable.op_Equality(AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : System.Boolean
+AngouriMath.Entity+Variable.op_Implicit(System.String) : AngouriMath.Entity+Variable
+AngouriMath.Entity+Variable.op_Inequality(AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : System.Boolean
+AngouriMath.Entity+Xorf.<Clone>$() : AngouriMath.Entity+Xorf
+AngouriMath.Entity+Xorf.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity+Xorf.Deconstruct(AngouriMath.Entity&, AngouriMath.Entity&) : System.Void
+AngouriMath.Entity+Xorf.EqualityContract { } : System.Type
+AngouriMath.Entity+Xorf.Equals(AngouriMath.Entity+Statement) : System.Boolean
+AngouriMath.Entity+Xorf.Equals(AngouriMath.Entity+Xorf) : System.Boolean
+AngouriMath.Entity+Xorf.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Xorf.GetHashCode() : System.Int32
+AngouriMath.Entity+Xorf.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity+Xorf.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Xorf.Latexise() : System.String
+AngouriMath.Entity+Xorf.Left { } : AngouriMath.Entity
+AngouriMath.Entity+Xorf.NodeFirstChild { } : AngouriMath.Entity
+AngouriMath.Entity+Xorf.NodeSecondChild { } : AngouriMath.Entity
+AngouriMath.Entity+Xorf.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Xorf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity+Xorf.Right { } : AngouriMath.Entity
+AngouriMath.Entity+Xorf.Stringize() : System.String
+AngouriMath.Entity+Xorf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity+Xorf.ToString() : System.String
+AngouriMath.Entity+Xorf.ctor(AngouriMath.Entity, AngouriMath.Entity)
+AngouriMath.Entity+Xorf.op_Equality(AngouriMath.Entity+Xorf, AngouriMath.Entity+Xorf) : System.Boolean
+AngouriMath.Entity+Xorf.op_Inequality(AngouriMath.Entity+Xorf, AngouriMath.Entity+Xorf) : System.Boolean
+AngouriMath.Entity.<Clone>$() : AngouriMath.Entity
+AngouriMath.Entity.Abs() : AngouriMath.Entity
+AngouriMath.Entity.AdditiveIdentity { } : AngouriMath.Entity
+AngouriMath.Entity.Alternate(System.Int32) : System.Collections.Generic.IEnumerable<AngouriMath.Entity>
+AngouriMath.Entity.Apply(AngouriMath.Entity[]) : AngouriMath.Entity
+AngouriMath.Entity.Apply(HonkSharp.Functional.LList<AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity.Arccos() : AngouriMath.Entity
+AngouriMath.Entity.Arccosec() : AngouriMath.Entity
+AngouriMath.Entity.Arccotan() : AngouriMath.Entity
+AngouriMath.Entity.Arcsec() : AngouriMath.Entity
+AngouriMath.Entity.Arcsin() : AngouriMath.Entity
+AngouriMath.Entity.Arctan() : AngouriMath.Entity
+AngouriMath.Entity.Ceil() : AngouriMath.Entity
+AngouriMath.Entity.Codomain { } : AngouriMath.Core.Domain
+AngouriMath.Entity.Compile(AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol, System.Type, System.Collections.Generic.IEnumerable<System.ValueTuple<System.Type,AngouriMath.Entity+Variable>>) : TDelegate
+AngouriMath.Entity.Compile(AngouriMath.Entity+Variable) : Func<TIn1,TOut>
+AngouriMath.Entity.Compile(AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : Func<TIn1,TIn2,TOut>
+AngouriMath.Entity.Compile(AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : Func<TIn1,TIn2,TIn3,TOut>
+AngouriMath.Entity.Compile(AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : Func<TIn1,TIn2,TIn3,TIn4,TOut>
+AngouriMath.Entity.Compile(AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : Func<TIn1,TIn2,TIn3,TIn4,TIn5,TOut>
+AngouriMath.Entity.Compile(AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : Func<TIn1,TIn2,TIn3,TIn4,TIn5,TIn6,TOut>
+AngouriMath.Entity.Compile(AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : Func<TIn1,TIn2,TIn3,TIn4,TIn5,TIn6,TIn7,TOut>
+AngouriMath.Entity.Compile(AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : Func<TIn1,TIn2,TIn3,TIn4,TIn5,TIn6,TIn7,TIn8,TOut>
+AngouriMath.Entity.Compile(AngouriMath.Entity+Variable[]) : AngouriMath.Core.FastExpression
+AngouriMath.Entity.Compile(System.String[]) : AngouriMath.Core.FastExpression
+AngouriMath.Entity.Complexity { } : System.Int32
+AngouriMath.Entity.ContainsNode(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity.Cos() : AngouriMath.Entity
+AngouriMath.Entity.Cosec() : AngouriMath.Entity
+AngouriMath.Entity.Cotan() : AngouriMath.Entity
+AngouriMath.Entity.DefiniteIntegral(AngouriMath.Entity+Variable, AngouriMath.Entity+Number+Complex, AngouriMath.Entity+Number+Complex, System.Int32) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity.DefiniteIntegral(AngouriMath.Entity+Variable, PeterO.Numbers.EDecimal, PeterO.Numbers.EDecimal, System.Int32) : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity.Differentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity.Differentiate(AngouriMath.Entity+Variable, System.Int32) : AngouriMath.Entity
+AngouriMath.Entity.DirectChildren { } : System.Collections.Generic.IReadOnlyList<AngouriMath.Entity>
+AngouriMath.Entity.DomainCondition { } : AngouriMath.Entity
+AngouriMath.Entity.EqualTo(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.EqualityContract { } : System.Type
+AngouriMath.Entity.Equalizes(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.Equals(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity.Equals(System.Object) : System.Boolean
+AngouriMath.Entity.EqualsImprecisely(AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity.EqualsImprecisely(AngouriMath.Entity, AngouriMath.Entity+Number+Real) : System.Boolean
+AngouriMath.Entity.EvalBoolean() : AngouriMath.Entity+Boolean
+AngouriMath.Entity.EvalNumerical() : AngouriMath.Entity+Number+Complex
+AngouriMath.Entity.Evaled { } : AngouriMath.Entity
+AngouriMath.Entity.EvaluableBoolean { } : System.Boolean
+AngouriMath.Entity.EvaluableNumerical { } : System.Boolean
+AngouriMath.Entity.Expand(System.Int32) : AngouriMath.Entity
+AngouriMath.Entity.Factorial() : AngouriMath.Entity
+AngouriMath.Entity.Factorize(System.Int32) : AngouriMath.Entity
+AngouriMath.Entity.Floor() : AngouriMath.Entity
+AngouriMath.Entity.FreeVariables { } : System.Collections.Generic.IReadOnlyCollection<AngouriMath.Entity+Variable>
+AngouriMath.Entity.Gcd(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.GetHashCode() : System.Int32
+AngouriMath.Entity.Implies(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.In(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.InitDirectChildren() : AngouriMath.Entity[]
+AngouriMath.Entity.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity.InnerSimplified { } : AngouriMath.Entity
+AngouriMath.Entity.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity.Integrate(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity.Integrate(AngouriMath.Entity+Variable, AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.Intersect(AngouriMath.Entity) : AngouriMath.Entity+Set
+AngouriMath.Entity.IsConstant { } : System.Boolean
+AngouriMath.Entity.IsConstantLeaf { } : System.Boolean
+AngouriMath.Entity.IsFinite { } : System.Boolean
+AngouriMath.Entity.IsNaN { } : System.Boolean
+AngouriMath.Entity.IsSymbolic { } : System.Boolean
+AngouriMath.Entity.LambdaOver(AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Entity.Latexise() : System.String
+AngouriMath.Entity.Latexise(System.Boolean) : System.String
+AngouriMath.Entity.Limit(AngouriMath.Entity+Variable, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.Limit(AngouriMath.Entity+Variable, AngouriMath.Entity, AngouriMath.Core.ApproachFrom) : AngouriMath.Entity
+AngouriMath.Entity.Log(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.Max(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.Min(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.Mod(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.MultiplicativeIdentity { } : AngouriMath.Entity
+AngouriMath.Entity.Nodes { } : System.Collections.Generic.IEnumerable<AngouriMath.Entity>
+AngouriMath.Entity.Parse(System.String, System.IFormatProvider) : AngouriMath.Entity
+AngouriMath.Entity.PhiFunction() : AngouriMath.Entity
+AngouriMath.Entity.Pow(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity.Provided(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity.Round() : AngouriMath.Entity
+AngouriMath.Entity.Sec() : AngouriMath.Entity
+AngouriMath.Entity.SetSubtract(AngouriMath.Entity) : AngouriMath.Entity+Set
+AngouriMath.Entity.Signum() : AngouriMath.Entity
+AngouriMath.Entity.SimplifiedRate { } : System.Double
+AngouriMath.Entity.Simplify(System.Int32) : AngouriMath.Entity
+AngouriMath.Entity.Sin() : AngouriMath.Entity
+AngouriMath.Entity.Solve(AngouriMath.Entity+Variable) : AngouriMath.Entity+Set
+AngouriMath.Entity.SolveBoolean(AngouriMath.Entity+Variable) : AngouriMath.Entity+Set
+AngouriMath.Entity.SolveEquation(AngouriMath.Entity+Variable) : AngouriMath.Entity+Set
+AngouriMath.Entity.SolveNt(AngouriMath.Entity+Variable) : System.Collections.Generic.HashSet<AngouriMath.Entity+Number+Complex>
+AngouriMath.Entity.Stringize() : System.String
+AngouriMath.Entity.Stringize(System.Boolean) : System.String
+AngouriMath.Entity.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.Substitute(IReadOnlyDictionary<TFrom,TTo>) : AngouriMath.Entity
+AngouriMath.Entity.Substitute(System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity,AngouriMath.Entity,AngouriMath.Entity>, System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity,AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity.Substitute(System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity,AngouriMath.Entity>, System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity.Substitute(System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity>, System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity.Tan() : AngouriMath.Entity
+AngouriMath.Entity.ThisIsFinite { } : System.Boolean
+AngouriMath.Entity.ToString() : System.String
+AngouriMath.Entity.ToSymPy(System.Boolean) : System.String
+AngouriMath.Entity.TryParse(System.String, System.IFormatProvider, AngouriMath.Entity&) : System.Boolean
+AngouriMath.Entity.Unite(AngouriMath.Entity) : AngouriMath.Entity+Set
+AngouriMath.Entity.Vars { } : System.Collections.Generic.IReadOnlyList<AngouriMath.Entity+Variable>
+AngouriMath.Entity.VarsAndConsts { } : System.Collections.Generic.IReadOnlyCollection<AngouriMath.Entity+Variable>
+AngouriMath.Entity.WithCodomain(AngouriMath.Core.Domain) : AngouriMath.Entity
+AngouriMath.Entity.Xor(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.ctor()
+AngouriMath.Entity.ctor(AngouriMath.Entity)
+AngouriMath.Entity.op_Addition(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.op_BitwiseAnd(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.op_BitwiseOr(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.op_Division(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.op_Equality(AngouriMath.Entity, AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity.op_ExclusiveOr(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.op_GreaterThan(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.op_GreaterThanOrEqual(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(AngouriMath.Core.Domain) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(AngouriMath.Entity[]) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(PeterO.Numbers.EDecimal) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(PeterO.Numbers.EInteger) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(PeterO.Numbers.ERational) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(System.Byte) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(System.Collections.Generic.List<AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(System.Decimal) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(System.Double) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(System.Int16) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(System.Int32) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(System.Int64) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(System.Numerics.BigInteger) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(System.Numerics.Complex) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(System.SByte) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(System.Single) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(System.String) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(System.UInt16) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(System.UInt32) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(System.UInt64) : AngouriMath.Entity
+AngouriMath.Entity.op_Implicit(System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Entity.op_Inequality(AngouriMath.Entity, AngouriMath.Entity) : System.Boolean
+AngouriMath.Entity.op_LessThan(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.op_LessThanOrEqual(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.op_LogicalNot(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.op_Modulus(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.op_Multiply(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.op_Subtraction(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.op_UnaryNegation(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Entity.op_UnaryPlus(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Extensions.AngouriMathExtensions.Compile(System.String, AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol, System.Type, System.Collections.Generic.IEnumerable<System.ValueTuple<System.Type,AngouriMath.Entity+Variable>>) : TDelegate
+AngouriMath.Extensions.AngouriMathExtensions.Compile(System.String, AngouriMath.Entity+Variable) : Func<TIn1,TOut>
+AngouriMath.Extensions.AngouriMathExtensions.Compile(System.String, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : Func<TIn1,TIn2,TOut>
+AngouriMath.Extensions.AngouriMathExtensions.Compile(System.String, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : Func<TIn1,TIn2,TIn3,TOut>
+AngouriMath.Extensions.AngouriMathExtensions.Compile(System.String, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : Func<TIn1,TIn2,TIn3,TIn4,TOut>
+AngouriMath.Extensions.AngouriMathExtensions.Compile(System.String, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : Func<TIn1,TIn2,TIn3,TIn4,TIn5,TOut>
+AngouriMath.Extensions.AngouriMathExtensions.Compile(System.String, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : Func<TIn1,TIn2,TIn3,TIn4,TIn5,TIn6,TOut>
+AngouriMath.Extensions.AngouriMathExtensions.Compile(System.String, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : Func<TIn1,TIn2,TIn3,TIn4,TIn5,TIn6,TIn7,TOut>
+AngouriMath.Extensions.AngouriMathExtensions.Compile(System.String, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : Func<TIn1,TIn2,TIn3,TIn4,TIn5,TIn6,TIn7,TIn8,TOut>
+AngouriMath.Extensions.AngouriMathExtensions.Compile(System.String, AngouriMath.Entity+Variable[]) : AngouriMath.Core.FastExpression
+AngouriMath.Extensions.AngouriMathExtensions.ConcatToTheBottom(AngouriMath.Entity+Matrix, AngouriMath.Entity+Matrix) : AngouriMath.Entity+Matrix
+AngouriMath.Extensions.AngouriMathExtensions.ConcatToTheRight(AngouriMath.Entity+Matrix, AngouriMath.Entity+Matrix) : AngouriMath.Entity+Matrix
+AngouriMath.Extensions.AngouriMathExtensions.Differentiate(System.String, AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Extensions.AngouriMathExtensions.EvalBoolean(System.String) : AngouriMath.Entity+Boolean
+AngouriMath.Extensions.AngouriMathExtensions.EvalNumerical(System.String) : AngouriMath.Entity+Number+Complex
+AngouriMath.Extensions.AngouriMathExtensions.Expand(System.String) : AngouriMath.Entity
+AngouriMath.Extensions.AngouriMathExtensions.Factorize(System.String) : AngouriMath.Entity
+AngouriMath.Extensions.AngouriMathExtensions.Integrate(System.String, AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.Extensions.AngouriMathExtensions.Integrate(System.String, AngouriMath.Entity+Variable, AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Extensions.AngouriMathExtensions.Intersect(System.Collections.Generic.IEnumerable<AngouriMath.Entity+Set>) : AngouriMath.Entity+Set
+AngouriMath.Extensions.AngouriMathExtensions.Latexise(System.String) : System.String
+AngouriMath.Extensions.AngouriMathExtensions.Limit(System.String, AngouriMath.Entity+Variable, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Extensions.AngouriMathExtensions.Limit(System.String, AngouriMath.Entity+Variable, AngouriMath.Entity, AngouriMath.Core.ApproachFrom) : AngouriMath.Entity
+AngouriMath.Extensions.AngouriMathExtensions.MultiplyAll(System.Collections.Generic.IEnumerable<AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Extensions.AngouriMathExtensions.Simplify(System.String) : AngouriMath.Entity
+AngouriMath.Extensions.AngouriMathExtensions.Simplify(System.String, System.Int32) : AngouriMath.Entity
+AngouriMath.Extensions.AngouriMathExtensions.Solve(System.String, AngouriMath.Entity+Variable) : AngouriMath.Entity+Set
+AngouriMath.Extensions.AngouriMathExtensions.SolveEquation(System.String, AngouriMath.Entity+Variable) : AngouriMath.Entity+Set
+AngouriMath.Extensions.AngouriMathExtensions.SolveSystem(System.ValueTuple<System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.ValueTuple<System.String,System.String>>, System.String, System.String, System.String, System.String, System.String, System.String, System.String, System.String, System.String) : AngouriMath.Entity+Matrix
+AngouriMath.Extensions.AngouriMathExtensions.SolveSystem(System.ValueTuple<System.String,System.String,System.String,System.String,System.String,System.String,System.String,System.ValueTuple<System.String>>, System.String, System.String, System.String, System.String, System.String, System.String, System.String, System.String) : AngouriMath.Entity+Matrix
+AngouriMath.Extensions.AngouriMathExtensions.SolveSystem(System.ValueTuple<System.String,System.String,System.String,System.String,System.String,System.String,System.String>, System.String, System.String, System.String, System.String, System.String, System.String, System.String) : AngouriMath.Entity+Matrix
+AngouriMath.Extensions.AngouriMathExtensions.SolveSystem(System.ValueTuple<System.String,System.String,System.String,System.String,System.String,System.String>, System.String, System.String, System.String, System.String, System.String, System.String) : AngouriMath.Entity+Matrix
+AngouriMath.Extensions.AngouriMathExtensions.SolveSystem(System.ValueTuple<System.String,System.String,System.String,System.String,System.String>, System.String, System.String, System.String, System.String, System.String) : AngouriMath.Entity+Matrix
+AngouriMath.Extensions.AngouriMathExtensions.SolveSystem(System.ValueTuple<System.String,System.String,System.String,System.String>, System.String, System.String, System.String, System.String) : AngouriMath.Entity+Matrix
+AngouriMath.Extensions.AngouriMathExtensions.SolveSystem(System.ValueTuple<System.String,System.String,System.String>, System.String, System.String, System.String) : AngouriMath.Entity+Matrix
+AngouriMath.Extensions.AngouriMathExtensions.SolveSystem(System.ValueTuple<System.String,System.String>, System.String, System.String) : AngouriMath.Entity+Matrix
+AngouriMath.Extensions.AngouriMathExtensions.Substitute(System.String, AngouriMath.Entity+Variable, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Extensions.AngouriMathExtensions.Substitute(System.String, System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity,AngouriMath.Entity,AngouriMath.Entity>, System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity,AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Extensions.AngouriMathExtensions.Substitute(System.String, System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity,AngouriMath.Entity>, System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Extensions.AngouriMathExtensions.Substitute(System.String, System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity>, System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Extensions.AngouriMathExtensions.SumAll(System.Collections.Generic.IEnumerable<AngouriMath.Entity>) : AngouriMath.Entity
+AngouriMath.Extensions.AngouriMathExtensions.ToBoolean(System.Boolean) : AngouriMath.Entity+Boolean
+AngouriMath.Extensions.AngouriMathExtensions.ToEntity(System.String) : AngouriMath.Entity
+AngouriMath.Extensions.AngouriMathExtensions.ToEntity(System.ValueTuple<AngouriMath.Entity,System.Boolean,AngouriMath.Entity,System.Boolean>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Double,System.Boolean,System.Double,System.Boolean>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Double,System.Boolean,System.Int32,System.Boolean>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Double,System.Boolean,System.Single,System.Boolean>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Double,System.Boolean,System.String,System.Boolean>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Double,System.Double>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Double,System.Int32>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Double,System.Single>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Double,System.String>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Int32,System.Boolean,System.Double,System.Boolean>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Int32,System.Boolean,System.Int32,System.Boolean>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Int32,System.Boolean,System.Single,System.Boolean>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Int32,System.Boolean,System.String,System.Boolean>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Int32,System.Double>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Int32,System.Int32>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Int32,System.Single>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Int32,System.String>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Single,System.Boolean,System.Double,System.Boolean>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Single,System.Boolean,System.Int32,System.Boolean>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Single,System.Boolean,System.Single,System.Boolean>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Single,System.Boolean,System.String,System.Boolean>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Single,System.Double>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Single,System.Int32>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Single,System.Single>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.Single,System.String>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.String,System.Boolean,System.Double,System.Boolean>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.String,System.Boolean,System.Int32,System.Boolean>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.String,System.Boolean,System.Single,System.Boolean>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.String,System.Boolean,System.String,System.Boolean>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.String,System.Double>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.String,System.Int32>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.String,System.Single>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToInterval(System.ValueTuple<System.String,System.String>) : AngouriMath.Entity+Set+Interval
+AngouriMath.Extensions.AngouriMathExtensions.ToNumber(PeterO.Numbers.EDecimal) : AngouriMath.Entity+Number+Real
+AngouriMath.Extensions.AngouriMathExtensions.ToNumber(PeterO.Numbers.EInteger) : AngouriMath.Entity+Number+Integer
+AngouriMath.Extensions.AngouriMathExtensions.ToNumber(System.Decimal) : AngouriMath.Entity+Number+Real
+AngouriMath.Extensions.AngouriMathExtensions.ToNumber(System.Double) : AngouriMath.Entity+Number+Real
+AngouriMath.Extensions.AngouriMathExtensions.ToNumber(System.Int32) : AngouriMath.Entity+Number+Integer
+AngouriMath.Extensions.AngouriMathExtensions.ToNumber(System.Int64) : AngouriMath.Entity+Number+Integer
+AngouriMath.Extensions.AngouriMathExtensions.ToNumber(System.Numerics.Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.Extensions.AngouriMathExtensions.ToNumber(System.Single) : AngouriMath.Entity+Number+Real
+AngouriMath.Extensions.AngouriMathExtensions.ToPiecewise(System.Collections.Generic.IEnumerable<AngouriMath.Entity+Providedf>) : AngouriMath.Entity+Piecewise
+AngouriMath.Extensions.AngouriMathExtensions.ToProvided(System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity+Providedf
+AngouriMath.Extensions.AngouriMathExtensions.ToSet(System.Collections.Generic.IEnumerable<AngouriMath.Entity>) : AngouriMath.Entity+Set+FiniteSet
+AngouriMath.Extensions.AngouriMathExtensions.ToVector(System.Collections.Generic.IEnumerable<AngouriMath.Entity>) : AngouriMath.Entity+Matrix
+AngouriMath.Extensions.AngouriMathExtensions.Unite(System.Collections.Generic.IEnumerable<AngouriMath.Entity+Set>) : AngouriMath.Entity+Set
+AngouriMath.MathS+Boolean.BuildTruthTable(AngouriMath.Entity, AngouriMath.Entity+Variable[]) : AngouriMath.Entity+Matrix
+AngouriMath.MathS+Boolean.Create(System.Boolean) : AngouriMath.Entity+Boolean
+AngouriMath.MathS+Boolean.False : AngouriMath.Entity+Boolean
+AngouriMath.MathS+Boolean.True : AngouriMath.Entity+Boolean
+AngouriMath.MathS+Compute.Phi(AngouriMath.Entity+Number+Integer) : AngouriMath.Entity+Number+Integer
+AngouriMath.MathS+Compute.SymbolicFormOfCosine(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+Compute.SymbolicFormOfSine(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+DecimalConst.e { } : PeterO.Numbers.EDecimal
+AngouriMath.MathS+DecimalConst.pi { } : PeterO.Numbers.EDecimal
+AngouriMath.MathS+Diagnostic.CatchOnSimplify { } : AngouriMath.Convenience.Setting<System.Func<AngouriMath.Entity,System.Boolean>>
+AngouriMath.MathS+Diagnostic.OutputExplicit { } : AngouriMath.Convenience.Setting<System.Boolean>
+AngouriMath.MathS+ExperimentalFeatures.DecomposeRational(AngouriMath.Entity+Number+Integer, AngouriMath.Entity+Number+Integer) : System.Collections.Generic.IEnumerable<System.ValueTuple<AngouriMath.Entity+Number+Integer,AngouriMath.Entity+Number+Integer,AngouriMath.Entity+Number+Integer>>
+AngouriMath.MathS+ExperimentalFeatures.DecomposeRational(AngouriMath.Entity+Number+Rational) : System.Collections.Generic.IEnumerable<System.ValueTuple<AngouriMath.Entity+Number+Integer,AngouriMath.Entity+Number+Integer,AngouriMath.Entity+Number+Integer>>
+AngouriMath.MathS+ExperimentalFeatures.ExpandCosineArgumentMultiplied(AngouriMath.Entity, AngouriMath.Entity, System.Int32) : AngouriMath.Entity
+AngouriMath.MathS+ExperimentalFeatures.ExpandCosineOfSum(System.Collections.Generic.IReadOnlyList<System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity>>) : AngouriMath.Entity
+AngouriMath.MathS+ExperimentalFeatures.ExpandSineArgumentMultiplied(AngouriMath.Entity, AngouriMath.Entity, System.Int32) : AngouriMath.Entity
+AngouriMath.MathS+ExperimentalFeatures.ExpandSineOfSum(System.Collections.Generic.IReadOnlyList<System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity>>) : AngouriMath.Entity
+AngouriMath.MathS+ExperimentalFeatures.GetCosineOfHalvedAngle(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+ExperimentalFeatures.GetSineOfHalvedAngle(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+ExperimentalFeatures.SolveDiophantineEquation(AngouriMath.Entity+Number+Integer, AngouriMath.Entity+Number+Integer, AngouriMath.Entity+Number+Integer) : System.Nullable<System.ValueTuple<AngouriMath.Entity+Number+Integer,AngouriMath.Entity+Number+Integer>>
+AngouriMath.MathS+ExperimentalFeatures.SymbolicFormOfCosine(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+ExperimentalFeatures.SymbolicFormOfSine(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+Hyperbolic.Arcosech(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+Hyperbolic.Arcosh(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+Hyperbolic.Arcotanh(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+Hyperbolic.Arsech(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+Hyperbolic.Arsinh(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+Hyperbolic.Artanh(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+Hyperbolic.Cosech(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+Hyperbolic.Cosh(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+Hyperbolic.Cotanh(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+Hyperbolic.Sech(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+Hyperbolic.Sinh(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+Hyperbolic.Tanh(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+Matrices+Direction.Horizontal : AngouriMath.MathS+Matrices+Direction
+AngouriMath.MathS+Matrices+Direction.Vertical : AngouriMath.MathS+Matrices+Direction
+AngouriMath.MathS+Matrices+Direction.value__ : System.Int32
+AngouriMath.MathS+Matrices.Concat(AngouriMath.MathS+Matrices+Direction, AngouriMath.Entity+Matrix[]) : AngouriMath.Entity+Matrix
+AngouriMath.MathS+Matrices.Matrix(System.Int32, System.Int32, AngouriMath.Entity[]) : AngouriMath.Entity+Matrix
+AngouriMath.MathS+Matrices.PointwiseMultiplication(AngouriMath.Entity+Matrix, AngouriMath.Entity+Matrix) : AngouriMath.Entity+Matrix
+AngouriMath.MathS+Multithreading.SetLocalCancellationToken(System.Threading.CancellationToken) : System.Void
+AngouriMath.MathS+NumberTheory.CountDivisors(AngouriMath.Entity+Number+Integer) : AngouriMath.Entity+Number+Integer
+AngouriMath.MathS+NumberTheory.Factorize(AngouriMath.Entity+Number+Integer) : System.Collections.Generic.IEnumerable<System.ValueTuple<AngouriMath.Entity+Number+Integer,AngouriMath.Entity+Number+Integer>>
+AngouriMath.MathS+NumberTheory.GreatestCommonDivisor(AngouriMath.Entity+Number+Integer, AngouriMath.Entity+Number+Integer) : AngouriMath.Entity+Number+Integer
+AngouriMath.MathS+NumberTheory.Phi(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+Numbers.Create(PeterO.Numbers.EDecimal) : AngouriMath.Entity+Number+Real
+AngouriMath.MathS+Numbers.Create(PeterO.Numbers.EDecimal, PeterO.Numbers.EDecimal) : AngouriMath.Entity+Number+Complex
+AngouriMath.MathS+Numbers.Create(PeterO.Numbers.EInteger) : AngouriMath.Entity+Number+Integer
+AngouriMath.MathS+Numbers.Create(PeterO.Numbers.ERational) : AngouriMath.Entity+Number+Rational
+AngouriMath.MathS+Numbers.Create(System.Double) : AngouriMath.Entity+Number+Real
+AngouriMath.MathS+Numbers.Create(System.Int32) : AngouriMath.Entity+Number+Integer
+AngouriMath.MathS+Numbers.Create(System.Int64) : AngouriMath.Entity+Number+Integer
+AngouriMath.MathS+Numbers.Create(System.Numerics.Complex) : AngouriMath.Entity+Number+Complex
+AngouriMath.MathS+Numbers.CreateRational(PeterO.Numbers.EInteger, PeterO.Numbers.EInteger) : AngouriMath.Entity+Number+Rational
+AngouriMath.MathS+Quantum.EqualUpToGlobalPhase(AngouriMath.Entity, AngouriMath.Entity) : System.Nullable<System.Boolean>
+AngouriMath.MathS+Quantum.Factorise(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+Quantum.IsNormalised(AngouriMath.Entity) : System.Nullable<System.Boolean>
+AngouriMath.MathS+Quantum.Ket(System.Int32[]) : AngouriMath.Entity
+AngouriMath.MathS+Quantum.TensorExpand(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+Series.Maclaurin(AngouriMath.Entity, System.Int32, AngouriMath.Entity+Variable[]) : AngouriMath.Entity
+AngouriMath.MathS+Series.Taylor(AngouriMath.Entity, System.Int32, System.ValueTuple<AngouriMath.Entity+Variable,AngouriMath.Entity+Variable,AngouriMath.Entity>[]) : AngouriMath.Entity
+AngouriMath.MathS+Series.Taylor(AngouriMath.Entity, System.Int32, System.ValueTuple<AngouriMath.Entity+Variable,AngouriMath.Entity>[]) : AngouriMath.Entity
+AngouriMath.MathS+Series.TaylorTerms(AngouriMath.Entity, System.ValueTuple<AngouriMath.Entity+Variable,AngouriMath.Entity+Variable,AngouriMath.Entity>[]) : System.Collections.Generic.IEnumerable<AngouriMath.Entity>
+AngouriMath.MathS+Sets.C { } : AngouriMath.Entity+Set
+AngouriMath.MathS+Sets.ElementInSet(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+Sets.Empty { } : AngouriMath.Entity+Set
+AngouriMath.MathS+Sets.Finite(AngouriMath.Entity[]) : AngouriMath.Entity+Set+FiniteSet
+AngouriMath.MathS+Sets.Finite(System.Collections.Generic.List<AngouriMath.Entity>) : AngouriMath.Entity+Set+FiniteSet
+AngouriMath.MathS+Sets.Interval(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity+Set+Interval
+AngouriMath.MathS+Sets.Interval(AngouriMath.Entity, System.Boolean, AngouriMath.Entity, System.Boolean) : AngouriMath.Entity+Set+Interval
+AngouriMath.MathS+Sets.Q { } : AngouriMath.Entity+Set
+AngouriMath.MathS+Sets.R { } : AngouriMath.Entity+Set
+AngouriMath.MathS+Sets.Z { } : AngouriMath.Entity+Set
+AngouriMath.MathS+Settings+NewtonSetting.<Clone>$() : AngouriMath.MathS+Settings+NewtonSetting
+AngouriMath.MathS+Settings+NewtonSetting.Equals(AngouriMath.MathS+Settings+NewtonSetting) : System.Boolean
+AngouriMath.MathS+Settings+NewtonSetting.Equals(System.Object) : System.Boolean
+AngouriMath.MathS+Settings+NewtonSetting.From { } : System.ValueTuple<PeterO.Numbers.EDecimal,PeterO.Numbers.EDecimal>
+AngouriMath.MathS+Settings+NewtonSetting.GetHashCode() : System.Int32
+AngouriMath.MathS+Settings+NewtonSetting.Precision { } : System.Int32
+AngouriMath.MathS+Settings+NewtonSetting.StepCount { } : System.ValueTuple<System.Int32,System.Int32>
+AngouriMath.MathS+Settings+NewtonSetting.To { } : System.ValueTuple<PeterO.Numbers.EDecimal,PeterO.Numbers.EDecimal>
+AngouriMath.MathS+Settings+NewtonSetting.ToString() : System.String
+AngouriMath.MathS+Settings+NewtonSetting.ctor()
+AngouriMath.MathS+Settings+NewtonSetting.op_Equality(AngouriMath.MathS+Settings+NewtonSetting, AngouriMath.MathS+Settings+NewtonSetting) : System.Boolean
+AngouriMath.MathS+Settings+NewtonSetting.op_Inequality(AngouriMath.MathS+Settings+NewtonSetting, AngouriMath.MathS+Settings+NewtonSetting) : System.Boolean
+AngouriMath.MathS+Settings.AllowNewton { } : AngouriMath.Convenience.Setting<System.Boolean>
+AngouriMath.MathS+Settings.Codomain { } : AngouriMath.Convenience.Setting<AngouriMath.Core.Domain>
+AngouriMath.MathS+Settings.ComplexityCriteria { } : AngouriMath.Convenience.Setting<System.Func<AngouriMath.Entity,System.Double>>
+AngouriMath.MathS+Settings.DecimalPrecisionContext { } : AngouriMath.Convenience.Setting<PeterO.Numbers.EContext>
+AngouriMath.MathS+Settings.DowncastingEnabled { } : AngouriMath.Convenience.Setting<System.Boolean>
+AngouriMath.MathS+Settings.ExplicitParsingOnly { } : AngouriMath.Convenience.Setting<System.Boolean>
+AngouriMath.MathS+Settings.FloatToRationalIterCount { } : AngouriMath.Convenience.Setting<System.Int32>
+AngouriMath.MathS+Settings.MaxAbsNumeratorOrDenominatorValue { } : AngouriMath.Convenience.Setting<PeterO.Numbers.EInteger>
+AngouriMath.MathS+Settings.MaxExpansionTermCount { } : AngouriMath.Convenience.Setting<System.Int64>
+AngouriMath.MathS+Settings.NewtonSolver { } : AngouriMath.Convenience.Setting<AngouriMath.MathS+Settings+NewtonSetting>
+AngouriMath.MathS+Settings.PrecisionErrorCommon { } : AngouriMath.Convenience.Setting<PeterO.Numbers.EDecimal>
+AngouriMath.MathS+Settings.PrecisionErrorZeroRange { } : AngouriMath.Convenience.Setting<PeterO.Numbers.EDecimal>
+AngouriMath.MathS+UnsafeAndInternal.AreEqualNumerically(AngouriMath.Entity, AngouriMath.Entity) : System.Boolean
+AngouriMath.MathS+UnsafeAndInternal.AreEqualNumerically(AngouriMath.Entity, AngouriMath.Entity, AngouriMath.Entity[]) : System.Boolean
+AngouriMath.MathS+UnsafeAndInternal.CheckPoints { } : AngouriMath.Convenience.Setting<AngouriMath.Entity[]>
+AngouriMath.MathS+UnsafeAndInternal.ClearFromStringCache() : System.Void
+AngouriMath.MathS+UnsafeAndInternal.DivideByEntityStrict(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+UnsafeAndInternal.RepresentRational(AngouriMath.Entity+Number+Rational, System.Collections.Generic.IEnumerable<AngouriMath.Entity+Number+Rational>) : System.Collections.Generic.IEnumerable<System.ValueTuple<AngouriMath.Entity+Number+Integer,AngouriMath.Entity+Number+Rational>>
+AngouriMath.MathS+Utils.SmartExpandOver(AngouriMath.Entity, AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.MathS+Utils.TryGetPolyLinear(AngouriMath.Entity, AngouriMath.Entity+Variable, AngouriMath.Entity&, AngouriMath.Entity&) : System.Boolean
+AngouriMath.MathS+Utils.TryGetPolyQuadratic(AngouriMath.Entity, AngouriMath.Entity+Variable, AngouriMath.Entity&, AngouriMath.Entity&, AngouriMath.Entity&) : System.Boolean
+AngouriMath.MathS+Utils.TryGetPolynomial(AngouriMath.Entity, AngouriMath.Entity+Variable, System.Collections.Generic.Dictionary<PeterO.Numbers.EInteger,AngouriMath.Entity>&) : System.Boolean
+AngouriMath.MathS.Abs(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Apply(AngouriMath.Entity, AngouriMath.Entity[]) : AngouriMath.Entity
+AngouriMath.MathS.Arccos(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Arccosec(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Arccotan(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Arcsec(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Arcsin(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Arctan(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Cbrt(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Ceil(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Conjunction(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Cos(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Cosec(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Cotan(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Derivative(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Derivative(AngouriMath.Entity, AngouriMath.Entity, System.Int32) : AngouriMath.Entity
+AngouriMath.MathS.Det(AngouriMath.Entity+Matrix) : AngouriMath.Entity
+AngouriMath.MathS.Disjunction(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Equality(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Equations(AngouriMath.Entity[]) : AngouriMath.Core.EquationSystem
+AngouriMath.MathS.Equations(System.Collections.Generic.IEnumerable<AngouriMath.Entity>) : AngouriMath.Core.EquationSystem
+AngouriMath.MathS.ExclusiveDisjunction(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Factorial(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Floor(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.FromBaseN(System.String, System.Int32) : AngouriMath.Entity+Number+Real
+AngouriMath.MathS.FromString(System.String) : AngouriMath.Entity
+AngouriMath.MathS.FromString(System.String, System.Boolean) : AngouriMath.Entity
+AngouriMath.MathS.Gamma(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Gcd(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.GreaterOrEqualThan(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.GreaterThan(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.I_1 : AngouriMath.Entity+Matrix
+AngouriMath.MathS.I_2 : AngouriMath.Entity+Matrix
+AngouriMath.MathS.I_3 : AngouriMath.Entity+Matrix
+AngouriMath.MathS.I_4 : AngouriMath.Entity+Matrix
+AngouriMath.MathS.IdentityMatrix(System.Int32) : AngouriMath.Entity+Matrix
+AngouriMath.MathS.IdentityMatrix(System.Int32, System.Int32) : AngouriMath.Entity+Matrix
+AngouriMath.MathS.Implication(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Integral(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Integral(AngouriMath.Entity, AngouriMath.Entity, AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Intersection(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity+Set
+AngouriMath.MathS.Interval(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity+Set+Interval
+AngouriMath.MathS.Interval(AngouriMath.Entity, System.Boolean, AngouriMath.Entity, System.Boolean) : AngouriMath.Entity+Set+Interval
+AngouriMath.MathS.Lambda(AngouriMath.Entity+Variable, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Latex(AngouriMath.Core.ILatexiseable) : System.String
+AngouriMath.MathS.LessOrEqualThan(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.LessThan(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Limit(AngouriMath.Entity, AngouriMath.Entity, AngouriMath.Entity, AngouriMath.Core.ApproachFrom) : AngouriMath.Entity
+AngouriMath.MathS.Ln(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Log(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Log(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Matrix(AngouriMath.Entity[,]) : AngouriMath.Entity+Matrix
+AngouriMath.MathS.Matrix(System.Int32, System.Int32, System.Func<System.Int32,System.Int32,AngouriMath.Entity>) : AngouriMath.Entity+Matrix
+AngouriMath.MathS.MatrixFromIEnum2x2(System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<AngouriMath.Entity>>) : AngouriMath.Entity+Matrix
+AngouriMath.MathS.MatrixFromRows(System.Collections.Generic.IEnumerable<AngouriMath.Entity+Matrix>) : AngouriMath.Entity+Matrix
+AngouriMath.MathS.Max(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Min(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Mod(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.NaN : AngouriMath.Entity
+AngouriMath.MathS.Negation(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.O_1 : AngouriMath.Entity+Matrix
+AngouriMath.MathS.O_2 : AngouriMath.Entity+Matrix
+AngouriMath.MathS.O_3 : AngouriMath.Entity+Matrix
+AngouriMath.MathS.O_4 : AngouriMath.Entity+Matrix
+AngouriMath.MathS.Parse(System.String) : HonkSharp.Functional.Either<AngouriMath.Entity,HonkSharp.Functional.Failure<HonkSharp.Functional.Either<AngouriMath.Core.ReasonOfFailureWhileParsing+Unknown,AngouriMath.Core.ReasonOfFailureWhileParsing+MissingOperator,AngouriMath.Core.ReasonOfFailureWhileParsing+InternalError>>>
+AngouriMath.MathS.Piecewise(System.Collections.Generic.IEnumerable<AngouriMath.Entity+Providedf>, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Piecewise(System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity>[]) : AngouriMath.Entity
+AngouriMath.MathS.Pow(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Provided(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Round(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Scalar(AngouriMath.Entity) : AngouriMath.Entity+Matrix
+AngouriMath.MathS.Sec(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.SetSubtraction(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity+Set
+AngouriMath.MathS.Signum(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Sin(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.SolveBooleanTable(AngouriMath.Entity, AngouriMath.Entity+Variable[]) : AngouriMath.Entity+Matrix
+AngouriMath.MathS.SolveEquation(AngouriMath.Entity, AngouriMath.Entity+Variable) : AngouriMath.Entity+Set
+AngouriMath.MathS.Sqr(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Sqrt(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.Tan(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS.ToBaseN(AngouriMath.Entity+Number+Real, System.Int32) : System.String
+AngouriMath.MathS.ToSympyCode(AngouriMath.Entity) : System.String
+AngouriMath.MathS.TryPolynomial(AngouriMath.Entity, AngouriMath.Entity+Variable, AngouriMath.Entity&) : System.Boolean
+AngouriMath.MathS.Union(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity+Set
+AngouriMath.MathS.Var(System.String) : AngouriMath.Entity+Variable
+AngouriMath.MathS.Var(System.String, System.String) : System.ValueTuple<AngouriMath.Entity+Variable,AngouriMath.Entity+Variable>
+AngouriMath.MathS.Var(System.String, System.String, System.String) : System.ValueTuple<AngouriMath.Entity+Variable,AngouriMath.Entity+Variable,AngouriMath.Entity+Variable>
+AngouriMath.MathS.Var(System.String, System.String, System.String, System.String) : System.ValueTuple<AngouriMath.Entity+Variable,AngouriMath.Entity+Variable,AngouriMath.Entity+Variable,AngouriMath.Entity+Variable>
+AngouriMath.MathS.Var(System.String, System.String, System.String, System.String, System.String) : System.ValueTuple<AngouriMath.Entity+Variable,AngouriMath.Entity+Variable,AngouriMath.Entity+Variable,AngouriMath.Entity+Variable,AngouriMath.Entity+Variable>
+AngouriMath.MathS.Vector(AngouriMath.Entity[]) : AngouriMath.Entity+Matrix
+AngouriMath.MathS.ZeroMatrix(System.Int32) : AngouriMath.Entity+Matrix
+AngouriMath.MathS.ZeroMatrix(System.Int32, System.Int32) : AngouriMath.Entity+Matrix
+AngouriMath.MathS.ZeroVector(System.Int32) : AngouriMath.Entity+Matrix
+AngouriMath.MathS.e : AngouriMath.Entity+Variable
+AngouriMath.MathS.i : AngouriMath.Entity+Number+Complex
+AngouriMath.MathS.oo : AngouriMath.Entity+Number+Real
+AngouriMath.MathS.pi : AngouriMath.Entity+Variable
+class AngouriMath.Convenience.Setting<T>
+class AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol
+class AngouriMath.Core.EquationSystem
+class AngouriMath.Core.Exceptions.AngouriBugException
+class AngouriMath.Core.Exceptions.AngouriMathBaseException
+class AngouriMath.Core.Exceptions.BadMatrixShapeException
+class AngouriMath.Core.Exceptions.CannotEvalException
+class AngouriMath.Core.Exceptions.CannotParseInstanceException
+class AngouriMath.Core.Exceptions.ElementInSetAmbiguousException
+class AngouriMath.Core.Exceptions.FunctionArgumentCountException
+class AngouriMath.Core.Exceptions.FutureReleaseException
+class AngouriMath.Core.Exceptions.InvalidArgumentParseException
+class AngouriMath.Core.Exceptions.InvalidMatrixOperationException
+class AngouriMath.Core.Exceptions.InvalidNumberException
+class AngouriMath.Core.Exceptions.InvalidNumericSystemException
+class AngouriMath.Core.Exceptions.InvalidProtocolProvided
+class AngouriMath.Core.Exceptions.LimitOperationNotSupportedException
+class AngouriMath.Core.Exceptions.MathSException
+class AngouriMath.Core.Exceptions.MissingOperatorParseException
+class AngouriMath.Core.Exceptions.NotSufficientlySupportedException
+class AngouriMath.Core.Exceptions.NumberCastException
+class AngouriMath.Core.Exceptions.ParseException
+class AngouriMath.Core.Exceptions.SolveRequiresStatementException
+class AngouriMath.Core.Exceptions.TreeException
+class AngouriMath.Core.Exceptions.UncompilableNodeException
+class AngouriMath.Core.Exceptions.UnhandledParseException
+class AngouriMath.Core.Exceptions.UnrecognizedDomainException
+class AngouriMath.Core.Exceptions.UnrecognizedFunctionParseException
+class AngouriMath.Core.Exceptions.WrongNumberOfArgumentsException
+class AngouriMath.Core.FastExpression
+class AngouriMath.Core.FiniteSetBuilder
+class AngouriMath.Core.MatrixBuilder
+class AngouriMath.Core.ReasonOfFailureWhileParsing
+class AngouriMath.Core.ReasonOfFailureWhileParsing+InternalError
+class AngouriMath.Core.ReasonOfFailureWhileParsing+MissingOperator
+class AngouriMath.Core.ReasonOfFailureWhileParsing+Unknown
+class AngouriMath.Core.Transformations.RewriteRecording
+class AngouriMath.Core.Transformations.RewriteRuleSet
+class AngouriMath.Core.Transformations.RewriteRules
+class AngouriMath.Core.Transformations.Transformation
+class AngouriMath.Entity
+class AngouriMath.Entity+Absf
+class AngouriMath.Entity+Andf
+class AngouriMath.Entity+Application
+class AngouriMath.Entity+Arccosecantf
+class AngouriMath.Entity+Arccosf
+class AngouriMath.Entity+Arccotanf
+class AngouriMath.Entity+Arcsecantf
+class AngouriMath.Entity+Arcsinf
+class AngouriMath.Entity+Arctanf
+class AngouriMath.Entity+Boolean
+class AngouriMath.Entity+CalculusOperator
+class AngouriMath.Entity+Ceilf
+class AngouriMath.Entity+ComparisonSign
+class AngouriMath.Entity+ContinuousNode
+class AngouriMath.Entity+Cosecantf
+class AngouriMath.Entity+Cosf
+class AngouriMath.Entity+Cotanf
+class AngouriMath.Entity+Derivativef
+class AngouriMath.Entity+Divf
+class AngouriMath.Entity+Equalsf
+class AngouriMath.Entity+Factorialf
+class AngouriMath.Entity+Floorf
+class AngouriMath.Entity+Function
+class AngouriMath.Entity+Gcdf
+class AngouriMath.Entity+GreaterOrEqualf
+class AngouriMath.Entity+Greaterf
+class AngouriMath.Entity+Impliesf
+class AngouriMath.Entity+Integralf
+class AngouriMath.Entity+Lambda
+class AngouriMath.Entity+LessOrEqualf
+class AngouriMath.Entity+Lessf
+class AngouriMath.Entity+Limitf
+class AngouriMath.Entity+Logf
+class AngouriMath.Entity+Matrix
+class AngouriMath.Entity+Maxf
+class AngouriMath.Entity+Minf
+class AngouriMath.Entity+Minusf
+class AngouriMath.Entity+Modf
+class AngouriMath.Entity+Mulf
+class AngouriMath.Entity+Notf
+class AngouriMath.Entity+Number
+class AngouriMath.Entity+Number+Complex
+class AngouriMath.Entity+Number+Integer
+class AngouriMath.Entity+Number+Rational
+class AngouriMath.Entity+Number+Real
+class AngouriMath.Entity+Orf
+class AngouriMath.Entity+Phif
+class AngouriMath.Entity+Piecewise
+class AngouriMath.Entity+Powf
+class AngouriMath.Entity+Providedf
+class AngouriMath.Entity+Roundf
+class AngouriMath.Entity+Secantf
+class AngouriMath.Entity+Set
+class AngouriMath.Entity+Set+ConditionalSet
+class AngouriMath.Entity+Set+FiniteSet
+class AngouriMath.Entity+Set+Inf
+class AngouriMath.Entity+Set+Intersectionf
+class AngouriMath.Entity+Set+Interval
+class AngouriMath.Entity+Set+SetMinusf
+class AngouriMath.Entity+Set+SpecialSet
+class AngouriMath.Entity+Set+SpecialSet+Booleans
+class AngouriMath.Entity+Set+SpecialSet+Complexes
+class AngouriMath.Entity+Set+SpecialSet+Integers
+class AngouriMath.Entity+Set+SpecialSet+Rationals
+class AngouriMath.Entity+Set+SpecialSet+Reals
+class AngouriMath.Entity+Set+Unionf
+class AngouriMath.Entity+Signumf
+class AngouriMath.Entity+Sinf
+class AngouriMath.Entity+Statement
+class AngouriMath.Entity+Sumf
+class AngouriMath.Entity+Tanf
+class AngouriMath.Entity+TrigonometricFunction
+class AngouriMath.Entity+Variable
+class AngouriMath.Entity+Xorf
+class AngouriMath.Extensions.AngouriMathExtensions
+class AngouriMath.MathS
+class AngouriMath.MathS+Boolean
+class AngouriMath.MathS+Compute
+class AngouriMath.MathS+DecimalConst
+class AngouriMath.MathS+Diagnostic
+class AngouriMath.MathS+Diagnostic+DiagnosticCatchException
+class AngouriMath.MathS+ExperimentalFeatures
+class AngouriMath.MathS+Hyperbolic
+class AngouriMath.MathS+Matrices
+class AngouriMath.MathS+Multithreading
+class AngouriMath.MathS+NumberTheory
+class AngouriMath.MathS+Numbers
+class AngouriMath.MathS+Quantum
+class AngouriMath.MathS+Series
+class AngouriMath.MathS+Sets
+class AngouriMath.MathS+Settings
+class AngouriMath.MathS+Settings+NewtonSetting
+class AngouriMath.MathS+UnsafeAndInternal
+class AngouriMath.MathS+Utils
+enum AngouriMath.Core.ApproachFrom
+enum AngouriMath.Core.Domain
+enum AngouriMath.Core.Transformations.Soundness
+enum AngouriMath.Core.Transformations.TransformationRelation
+enum AngouriMath.MathS+Matrices+Direction
+interface AngouriMath.Core.IBinaryNode
+interface AngouriMath.Core.IClosedArithmetics<T>
+interface AngouriMath.Core.IHasAbsoluteValue<TSelf,TOut>
+interface AngouriMath.Core.IHasNeutralValues<T>
+interface AngouriMath.Core.ILatexiseable
+interface AngouriMath.Core.IScalarClosedArithmetics<T>
+interface AngouriMath.Core.IUnaryNode
+struct AngouriMath.Convenience.Setting<T>
+struct AngouriMath.Core.Transformations.RewriteStep
+struct AngouriMath.Core.Transformations.TransformationResult
+struct AngouriMath.Entity+Matrix+EntityTensorWrapperOperations

--- a/Sources/Tests/UnitTests/Common/PublicApiSurfaceTest.cs
+++ b/Sources/Tests/UnitTests/Common/PublicApiSurfaceTest.cs
@@ -1,0 +1,194 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using AngouriMath;
+using Xunit;
+
+namespace AngouriMath.Tests.Common
+{
+    /// <summary>
+    /// The public surface, written down, so that changing it is a deliberate act.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Removing or renaming a public member breaks every consumer at compile time, and adding
+    /// one is a promise that has to be kept for the rest of the major version. Neither shows
+    /// up in a test run: the suite calls the API it knows about, so a member that vanishes
+    /// takes its own tests with it and the summary line stays green.
+    /// </para>
+    /// <para>
+    /// This is what the RS0016/RS0017 analyzer used to do before its settings were retired in
+    /// <a href="https://github.com/asc-community/AngouriMath/pull/835">#835</a> — the settings
+    /// were dead, but the guarantee was worth keeping, and this restores it without the
+    /// analyzer package. The measured surface is compared against
+    /// <c>PublicApi.txt</c> beside this file; a difference fails with both lists spelled out.
+    /// </para>
+    /// <para>
+    /// To accept an intended change, run the suite once with <c>AM_UPDATE_PUBLIC_API=1</c> and
+    /// commit the result. The diff is then part of review, which is the whole point — the file
+    /// is not a chore to keep in sync, it is the record of what was promised and when.
+    /// </para>
+    /// <para>
+    /// One assembly, one target framework. The surface genuinely differs per framework — the
+    /// generic-math members exist on <c>net7.0</c> and later only — so this pins the framework
+    /// the tests run on and says nothing about <c>netstandard2.0</c>.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Common")]
+    public sealed class PublicApiSurfaceTest
+    {
+        // The build preserves the folder the Content item sits in, so it lands under Common/.
+        private static readonly string BaselinePath =
+            Path.Combine(AppContext.BaseDirectory, "Common", "PublicApi.txt");
+
+        [Fact]
+        public void ThePublicSurfaceIsTheOneOnRecord()
+        {
+            var measured = Surface();
+
+            if (Environment.GetEnvironmentVariable("AM_UPDATE_PUBLIC_API") is "1")
+            {
+                // Written next to the sources rather than to the output directory, which is
+                // where the copy the test reads lives and would be overwritten by the build.
+                var source = Path.Combine(SourceDirectory(), "PublicApi.txt");
+                File.WriteAllLines(source, measured);
+                return;
+            }
+
+            Assert.True(File.Exists(BaselinePath),
+                $"No public API baseline at {BaselinePath}. "
+                + "Run the suite with AM_UPDATE_PUBLIC_API=1 to write one, then commit it.");
+
+            var recorded = new SortedSet<string>(File.ReadAllLines(BaselinePath)
+                                                     .Where(l => l.Length > 0), StringComparer.Ordinal);
+
+            var removed = recorded.Except(measured, StringComparer.Ordinal).ToList();
+            var added = measured.Except(recorded, StringComparer.Ordinal).ToList();
+            if (removed.Count is 0 && added.Count is 0)
+                return;
+
+            var message = new StringBuilder();
+            message.AppendLine("The public surface no longer matches PublicApi.txt.");
+            message.AppendLine("If the change is intended, re-run with AM_UPDATE_PUBLIC_API=1 and commit the file.");
+            Describe(message, "REMOVED — breaks every consumer at compile time", removed);
+            Describe(message, "ADDED — a promise for the rest of the major version", added);
+            Assert.True(false, message.ToString());
+        }
+
+        private static void Describe(StringBuilder into, string heading, List<string> members)
+        {
+            if (members.Count is 0) return;
+            into.AppendLine().AppendLine($"{heading} ({members.Count}):");
+            foreach (var member in members.Take(40))
+                into.AppendLine("  " + member);
+            if (members.Count > 40)
+                into.AppendLine($"  ... and {members.Count - 40} more");
+        }
+
+        /// <summary>Walks up from the test binary to this file's directory.</summary>
+        private static string SourceDirectory()
+        {
+            var path = AppContext.BaseDirectory;
+            while (path is not null && Path.GetFileName(path) is not "UnitTests")
+                path = Path.GetDirectoryName(path);
+            if (path is null)
+                throw new InvalidOperationException("Could not find the UnitTests directory from "
+                                                    + AppContext.BaseDirectory);
+            return Path.Combine(path, "Common");
+        }
+
+        /// <summary>
+        /// Every publicly reachable member, one per line. Protected members count: a consumer
+        /// can derive, so they are as much a promise as a public one.
+        /// </summary>
+        private static SortedSet<string> Surface()
+        {
+            var lines = new SortedSet<string>(StringComparer.Ordinal);
+            foreach (var type in typeof(Entity).Assembly.GetTypes()
+                         .Where(Visible)
+                         .OrderBy(t => t.FullName, StringComparer.Ordinal))
+            {
+                var kind = type.IsEnum ? "enum" : type.IsInterface ? "interface"
+                         : type.IsValueType ? "struct" : "class";
+                lines.Add($"{kind} {Nice(type)}");
+
+                const BindingFlags Flags = BindingFlags.Public | BindingFlags.NonPublic
+                                         | BindingFlags.Instance | BindingFlags.Static
+                                         | BindingFlags.DeclaredOnly;
+                foreach (var member in type.GetMembers(Flags))
+                    if (Signature(type, member) is { } signature)
+                        lines.Add(signature);
+            }
+            return lines;
+        }
+
+        private static string? Signature(Type type, MemberInfo member)
+        {
+            switch (member)
+            {
+                case MethodInfo m when Reachable(m):
+                    // Accessors are reported through the property or event that owns them.
+                    if (m.IsSpecialName && (m.Name.StartsWith("get_", StringComparison.Ordinal)
+                                         || m.Name.StartsWith("set_", StringComparison.Ordinal)
+                                         || m.Name.StartsWith("add_", StringComparison.Ordinal)
+                                         || m.Name.StartsWith("remove_", StringComparison.Ordinal)))
+                        return null;
+                    return $"{Nice(type)}.{m.Name}({Parameters(m.GetParameters())}) : {Nice(m.ReturnType)}";
+                case ConstructorInfo c when Reachable(c):
+                    return $"{Nice(type)}.ctor({Parameters(c.GetParameters())})";
+                case PropertyInfo p when (p.GetMethod ?? p.SetMethod) is { } a && Reachable(a):
+                    return $"{Nice(type)}.{p.Name} {{ }} : {Nice(p.PropertyType)}";
+                case FieldInfo f when f.IsPublic || f.IsFamily || f.IsFamilyOrAssembly:
+                    return $"{Nice(type)}.{f.Name} : {Nice(f.FieldType)}";
+                case EventInfo e:
+                    return $"{Nice(type)}.{e.Name} (event)";
+                default:
+                    return null;
+            }
+        }
+
+        private static bool Reachable(MethodBase m) => m.IsPublic || m.IsFamily || m.IsFamilyOrAssembly;
+
+        private static string Parameters(ParameterInfo[] parameters)
+            => string.Join(", ", parameters.Select(p => Nice(p.ParameterType)));
+
+        private static bool Visible(Type type)
+        {
+            while (type.IsNested)
+            {
+                if (!type.IsNestedPublic && !type.IsNestedFamily && !type.IsNestedFamORAssem)
+                    return false;
+                type = type.DeclaringType!;
+            }
+            return type.IsPublic;
+        }
+
+        /// <summary>
+        /// A stable name. By-ref, array and pointer types carry an assembly-qualified
+        /// <see cref="Type.FullName"/> that embeds the assembly version, so comparing those raw
+        /// would report every such signature as changed on each version bump.
+        /// </summary>
+        private static string Nice(Type type)
+        {
+            if (type.IsGenericParameter) return type.Name;
+            if (type.IsByRef) return Nice(type.GetElementType()!) + "&";
+            if (type.IsPointer) return Nice(type.GetElementType()!) + "*";
+            if (type.IsArray)
+                return Nice(type.GetElementType()!) + "[" + new string(',', type.GetArrayRank() - 1) + "]";
+            if (type.IsGenericType)
+                return (type.FullName ?? type.Name).Split('`')[0]
+                     + "<" + string.Join(",", type.GetGenericArguments().Select(Nice)) + ">";
+            return type.FullName ?? type.Name;
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/UnitTests.csproj
+++ b/Sources/Tests/UnitTests/UnitTests.csproj
@@ -40,6 +40,9 @@
 
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+
+    <!-- Read at run time by PublicApiSurfaceTest; see its remarks. -->
+    <Content Include="Common\PublicApi.txt" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Removing a public member breaks every consumer at compile time; adding one is a promise that has to be kept for the rest of the major version. **Neither shows up in a test run** — the suite only calls the API it knows about, so a member that vanishes takes its own tests with it and the summary line stays green.

RS0016/RS0017 used to cover this. #835 retired the settings — they were dead, and that was right — but the guarantee went with them, and 2.0 is the release where its absence costs the most.

## What this adds

`PublicApiSurfaceTest` measures the surface by reflection and compares it against `Sources/Tests/UnitTests/Common/PublicApi.txt` — **2602 members**. A difference fails with both lists spelled out, headed by which direction it went.

To accept an intended change:

```
AM_UPDATE_PUBLIC_API=1 dotnet test Sources/Tests/UnitTests
```

and commit the file. The diff is then part of review, which is the point — it is not a chore to keep in sync, it is the record of what was promised and when.

Runs in **13 ms**.

## Choices worth naming

- **Protected members count.** A consumer can derive, so they are as much a promise as a public one.
- **One assembly, one framework.** The surface genuinely differs per target — the generic-math members are `net7.0`+ only — so this pins the framework the tests run on and claims nothing about `netstandard2.0`.
- **By-ref/array/pointer names are normalised.** Their `Type.FullName` embeds the assembly version, so comparing raw would report every such signature as changed on each version bump.

## Verified non-vacuous

A guard that cannot fail is worse than none, so I added a public member on purpose:

```
The public surface no longer matches PublicApi.txt.
ADDED — a promise for the rest of the major version (1):
  AngouriMath.MathS.CanaryDoNotShip(AngouriMath.Entity) : AngouriMath.Entity
```

## What the audit that prompted this found

I diffed 2.0 against the **published 1.4.0 package** (`netstandard2.0`, both surfaces dumped by reflection): **2325 → 2579** members, **34 removals**.

**All 34 are already named in `BREAKING-CHANGES.md`** — no gap. Twelve did not match by name because the document names them collectively, and correctly: "`CompilationProtocol`'s six converter delegates" is exactly six, and the class that owns the other six is listed.

This PR records the surface as it stands; it asserts nothing about whether that surface is *right*. Two things there are worth a separate decision, not folded in here:

- 2.0 currently adds **288 public members**, of which ~86 are the `Core.Transformations` layer.
- New public types in 2.0: the 8 transformation types, 7 nodes (`Ceilf`, `Floorf`, `Gcdf`, `Maxf`, `Minf`, `Modf`, `Roundf`), `MathS.Quantum`, and `UnrecognizedFunctionParseException`.

Tests: **6050 passing, 0 failed, 14 skipped**.
