### PR TITLE
Rename Latexise to Latexize, so the library has one spelling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,16 +92,16 @@ printed with `if` came back as a product with `if` read as an undeclared variabl
 usual notation is not in the grammar, print the function call the parser does have.
 `StringizeRoundTripTest` is where that is enforced; add to it when you add a node.
 
-**`Latexise` has a round trip too, and it is enforced in someone else's repository.**
+**`Latexize` has a round trip too, and it is enforced in someone else's repository.**
 [CSharpMath.Evaluation](https://github.com/verybadcat/CSharpMath/blob/master/CSharpMath.Evaluation/Evaluation.cs)
 reads LaTeX back into an `Entity`, and says so in its own source: *"CSharpMath must handle all LaTeX
-coming from AngouriMath or a bug is present!"* So a change to what `Latexise` emits — a new node, a
+coming from AngouriMath or a bug is present!"* So a change to what `Latexize` emits — a new node, a
 different command, a changed bracketing — can break a downstream project, and no test here will say
 so.
 
 That is weaker than `Stringize`'s contract, not stronger. `StringizeRoundTripTest` fails in this
 repository the moment the printed form stops parsing; the LaTeX contract fails as a bug report from
-someone else, months later. When you change `Latexise` output, check it against CSharpMath and open
+someone else, months later. When you change `Latexize` output, check it against CSharpMath and open
 a PR there as well ([#822](https://github.com/asc-community/AngouriMath/issues/822)).
 
 The syntax the parser accepts is written down in
@@ -217,7 +217,7 @@ the *basis* is, and it is made differently on purpose:
 
 | | basis | why |
 |---|---|---|
-| quantum | `Entity`-backed | the state is then an ordinary expression, so `Simplify`, `Substitute`, `Latexise` and the rest work on it without anything being taught about quantum |
+| quantum | `Entity`-backed | the state is then an ordinary expression, so `Simplify`, `Substitute`, `Latexize` and the rest work on it without anything being taught about quantum |
 | polynomials, series | a generic `TBasis` struct | exponent vectors never enter the expression tree, and the internal layers stay allocation-free and type-safe |
 
 One generic spine, instantiated twice. That is less tidy than picking a single answer, and the

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -52,6 +52,7 @@ read first.
 | loud | `floor(x)`, `ceil(x)`, `ceiling(x)` | `UnrecognizedFunctionParseException` | the functions |
 | loud | `round(x)`, `min(a, b)`, `max(a, b)`, `gcd(a, b)` | `UnrecognizedFunctionParseException` | the functions |
 | loud | 28 members deprecated since 1.x | obsolete but present | removed |
+| loud | `Latexise`, `ILatexiseable`, `entity_latexise` | the British spelling | `Latexize`, `ILatexizeable`, `entity_latexize` |
 | loud | the target frameworks | `net7.0;netstandard2.0` | `netstandard2.0;net8.0;net10.0` |
 | **silent** | `abs(x) = c` for a negative `c` | a set of non-solutions | the empty set |
 
@@ -117,6 +118,42 @@ right answer. Code written against the old names was wrong in the same way.
 
 [#632](https://github.com/asc-community/AngouriMath/issues/632), PR
 [#664](https://github.com/asc-community/AngouriMath/pull/664).
+
+### `Latexise` is now `Latexize`
+
+The library serialises a node to text two ways, and spelled them in two languages:
+
+| | was | is |
+|---|---|---|
+| the method | `Latexise()` | `Latexize()` |
+| the interface | `ILatexiseable` | `ILatexizeable` |
+| the string extension | `"x + 1".Latexise()` | `"x + 1".Latexize()` |
+| the C# helper | `MathS.Latex(ILatexiseable)` | `MathS.Latex(ILatexizeable)` |
+| the native entry point | `entity_latexise` | `entity_latexize` |
+| the C++ method | `Entity::Latexise()` | `Entity::Latexize()` |
+| the F# function | `latexise` | `latexize` |
+
+Everything else in the public surface is `-ize` — `Stringize`, `Factorize`, `Serialize`,
+`Deserialize` — so `Latexise` and its interface were the only members a caller had to remember the
+other spelling for. `Stringize` and `Latexise` do the same kind of thing and sit next to each other
+in every file that has either, which is what made the split spelling costly rather than merely
+untidy.
+
+**What breaks.** Every call, every override, and every implementation of the interface. There is no
+forwarding member: this release is the one that removed 28 members that accumulated as forwarders,
+so adding a permanent one here would undo that on the same day. The compiler reports each site, and
+the fix is mechanical.
+
+`MathS.Quantum.Factorise` keeps its spelling for now. Renaming it to `Factorize` would give the
+library two public `Factorize` methods doing unrelated things — expression factoring on `Entity`,
+tensor factorisation on a quantum state — which is a worse outcome than the inconsistency. It wants
+a distinguishing name rather than a spelling change, and that is not decided here.
+
+**Downstream.** [`CSharpMath.Evaluation`](https://github.com/verybadcat/CSharpMath) reads LaTeX
+produced here back into an `Entity` and calls this method. It is unaffected until it moves to 2.0,
+at which point it needs the new name.
+
+[#840](https://github.com/asc-community/AngouriMath/issues/840).
 
 ---
 
@@ -312,7 +349,10 @@ This one is worth reading twice if you parse printed output, because the misread
 ordinary number: every root of a trigonometric equation prints through this path, and
 `cos(x)^2 + sin(x) = 0` returns roots that are exact as entities and were not as text.
 
-`Latexise` is under no such obligation, since nothing parses LaTeX, and is unaffected.
+`Latexize` is unaffected by this change. Its output is under a weaker obligation, not none:
+nothing in this repository parses LaTeX back, but [`CSharpMath.Evaluation`](https://github.com/verybadcat/CSharpMath)
+does, so a change to what it emits can break a downstream project with no test here to say so
+([#822](https://github.com/asc-community/AngouriMath/issues/822)).
 
 The syntax the parser accepts is now written down in
 [`Sources/AngouriMath/Docs/Usage/Syntax.md`](Sources/AngouriMath/Docs/Usage/Syntax.md).

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Console.WriteLine("x^2 + x + a".SolveEquation("x"));
 Under developing now and forever (always available)
 ```cs
 Entity expr = "(sin(x)^2 - sin(x) + a)(b - x)((-3) * x + 2 + 3 * x ^ 2 + (x + (-3)) * x ^ 3)";
-Console.WriteLine(expr.SolveEquation("x").Latexise());
+Console.WriteLine(expr.SolveEquation("x").Latexize());
 ```
 <img src="https://render.githubusercontent.com/render/math?math=\left\{-\left(-\arcsin\left(\frac{1-\sqrt{1-4\times a}}{2}\right)-2\times \pi\times n_{1}\right),-\left(-\pi--\arcsin\left(\frac{1-\sqrt{1-4\times a}}{2}\right)-2\times \pi\times n_{1}\right),-\left(-\arcsin\left(\frac{1%2B\sqrt{1-4\times a}}{2}\right)-2\times \pi\times n_{1}\right),-\left(-\pi--\arcsin\left(\frac{1%2B\sqrt{1-4\times a}}{2}\right)-2\times \pi\times n_{1}\right),\frac{-b}{-1},-i,i,1,2\right\}">
 
@@ -297,7 +297,7 @@ var system = MathS.Equations(
     "cos(x2 + 1)^2 + 3y",
     "y * (-1) + 4cos(x2 + 1)"
 );
-Console.WriteLine(system.Latexise());
+Console.WriteLine(system.Latexize());
 var solutions = system.Solve("x", "y");
 Console.WriteLine(solutions);
 ```
@@ -334,10 +334,10 @@ WriteLine("x^2 + a x".Integrate("x").InnerSimplified);
 
 There are four types of sets:
 ```cs
-WriteLine("{ 1, 2 }".Latexise());
-WriteLine("[3; +oo)".Latexise());
-WriteLine("RR".Latexise());
-WriteLine("{ x : x^8 + a x < 0 }".Latexise());
+WriteLine("{ 1, 2 }".Latexize());
+WriteLine("[3; +oo)".Latexize());
+WriteLine("RR".Latexize());
+WriteLine("{ x : x^8 + a x < 0 }".Latexize());
 ```
 
 <img src="https://render.githubusercontent.com/render/math?math=\left\{ 1, 2 \right\}">
@@ -347,9 +347,9 @@ WriteLine("{ x : x^8 + a x < 0 }".Latexise());
 
 And there operators:
 ```cs
-WriteLine(@"A \/ B".Latexise());
-WriteLine(@"A /\ B".Latexise());
-WriteLine(@"A \ B".Latexise());
+WriteLine(@"A \/ B".Latexize());
+WriteLine(@"A /\ B".Latexize());
+WriteLine(@"A \ B".Latexize());
 ```
 
 <img src="https://render.githubusercontent.com/render/math?math=A\cup B">
@@ -363,7 +363,7 @@ WriteLine(@"A \ B".Latexise());
 You can build LaTeX with AngouriMath:
 ```cs
 var expr = "x ^ y + sqrt(x) + integral(sqrt(x) / a, x, 1) + derive(sqrt(x) / a, x, 1) + limit(sqrt(x) / a, x, +oo)";
-Console.WriteLine(expr.Latexise());
+Console.WriteLine(expr.Latexize());
 >>> {x}^{y}+\sqrt{x}+\int \left[\frac{\sqrt{x}}{a}\right] dx+\frac{d\left[\frac{\sqrt{x}}{a}\right]}{dx}+\lim_{x\to \infty } \left[\frac{\sqrt{x}}{a}\right]
 ```
 <img src="https://render.githubusercontent.com/render/math?math={x}^{y}%2B\sqrt{x}%2B\int\left[\frac{\sqrt{x}}{a}\right]dx%2B\frac{d\left[\frac{\sqrt{x}}{a}\right]}{dx}%2B\lim_{x\to\infty}\left[\frac{\sqrt{x}}{a}\right]">

--- a/Sources/AngouriMath/Convenience/AngouriMathExtensions.cs
+++ b/Sources/AngouriMath/Convenience/AngouriMathExtensions.cs
@@ -279,7 +279,7 @@ namespace AngouriMath.Extensions
         /// Builds a LaTeX code from an expression
         /// </summary>
         /// <returns>A <see cref="string"/> which can be rendered into pretty output</returns>
-        public static string Latexise(this string str) => str.ToEntity().Latexise();
+        public static string Latexize(this string str) => str.ToEntity().Latexize();
 
         /// <summary>
         /// Compiles an expression into a special compiled code that runs via

--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -3162,7 +3162,7 @@ namespace AngouriMath
         /// var inCyrillic = Var("Абаваола");
         /// </code>
         /// Underscore "_" allows indexing. Greek letter names (e. g.
-        /// "alpha") will be latexised as Greek letter (but other than that,
+        /// "alpha") will be latexized as Greek letter (but other than that,
         /// will appear as "alpha" in other places).
         /// </example>
         public static Variable Var(string name) => name;
@@ -3184,7 +3184,7 @@ namespace AngouriMath
         /// var inCyrillic = Var("Абаваола");
         /// </code>
         /// Underscore "_" allows indexing. Greek letter names (e. g.
-        /// "alpha") will be latexised as Greek letter (but other than that,
+        /// "alpha") will be latexized as Greek letter (but other than that,
         /// will appear as "alpha" in other places).
         /// </example>
         public static (Variable, Variable) Var(string name1, string name2) => (Var(name1), Var(name2));
@@ -3206,7 +3206,7 @@ namespace AngouriMath
         /// var inCyrillic = Var("Абаваола");
         /// </code>
         /// Underscore "_" allows indexing. Greek letter names (e. g.
-        /// "alpha") will be latexised as Greek letter (but other than that,
+        /// "alpha") will be latexized as Greek letter (but other than that,
         /// will appear as "alpha" in other places).
         /// </example>
         public static (Variable, Variable, Variable) Var(string name1, string name2, string name3)
@@ -3231,7 +3231,7 @@ namespace AngouriMath
         /// var inCyrillic = Var("Абаваола");
         /// </code>
         /// Underscore "_" allows indexing. Greek letter names (e. g.
-        /// "alpha") will be latexised as Greek letter (but other than that,
+        /// "alpha") will be latexized as Greek letter (but other than that,
         /// will appear as "alpha" in other places).
         /// </example>
         public static (Variable, Variable, Variable, Variable) Var(string name1, string name2, string name3, string name4)
@@ -3256,7 +3256,7 @@ namespace AngouriMath
         /// var inCyrillic = Var("Абаваола");
         /// </code>
         /// Underscore "_" allows indexing. Greek letter names (e. g.
-        /// "alpha") will be latexised as Greek letter (but other than that,
+        /// "alpha") will be latexized as Greek letter (but other than that,
         /// will appear as "alpha" in other places).
         /// </example>
         public static (Variable, Variable, Variable, Variable, Variable) Var(string name1, string name2, string name3, string name4, string name5)
@@ -3984,7 +3984,7 @@ namespace AngouriMath
         /// <returns>
         /// The <a href="https://en.wikipedia.org/wiki/LaTeX">LaTeX</a> representation of the argument
         /// </returns>
-        /// <param name="latexiseable">
+        /// <param name="latexizeable">
         /// Any element (<see cref="Entity"/>, <see cref="Set"/>, etc.) that can be represented in LaTeX
         /// </param>
         /// <example>
@@ -4008,7 +4008,7 @@ namespace AngouriMath
         /// \frac{a}{{b}^{\lim_{x\to \infty } \left[\sin\left(x\right)-\frac{{e}^{y}+{e}^{-y}}{2}\right]}}
         /// </code>
         /// </example>
-        public static string Latex(ILatexiseable latexiseable) => latexiseable.Latexise();
+        public static string Latex(ILatexizeable latexizeable) => latexizeable.Latexize();
 
         /// <summary>
         /// <para>All operations for <see cref="Number"/> and its derived classes are available from here.</para>

--- a/Sources/AngouriMath/Core/Entity/Entity.Definition.cs
+++ b/Sources/AngouriMath/Core/Entity/Entity.Definition.cs
@@ -70,10 +70,10 @@ namespace AngouriMath.Core
     /// 
     /// Entity expr = "sqrt(a) + integral(sin(x), x)";
     /// Console.WriteLine(expr);
-    /// Console.WriteLine(expr.Latexise());
+    /// Console.WriteLine(expr.Latexize());
     /// Entity expr2 = "a / b ^ limit(sin(x) - cosh(y), x, +oo)";
     /// Console.WriteLine(expr2);
-    /// Console.WriteLine(expr2.Latexise());
+    /// Console.WriteLine(expr2.Latexize());
     /// </code>
     /// Prints
     /// <code>
@@ -83,13 +83,13 @@ namespace AngouriMath.Core
     /// \frac{a}{{b}^{\lim_{x\to \infty } \left[\sin\left(x\right)-\frac{{e}^{y}+{e}^{-y}}{2}\right]}}
     /// </code>
     /// </example>
-    public interface ILatexiseable
+    public interface ILatexizeable
     { 
         /// <summary>
         /// Converts the object to the LaTeX format
         /// That is, a string that can be later displayed and rendered as LaTeX
         /// </summary>
-        public string Latexise(); 
+        public string Latexize(); 
     }
 }
 
@@ -101,7 +101,7 @@ namespace AngouriMath
     /// Every node, expression, or number is an <see cref="Entity"/>.
     /// However, you cannot create an instance of this class, look for the nested classes instead.
     /// </summary>
-    public abstract partial record Entity : ILatexiseable
+    public abstract partial record Entity : ILatexizeable
     {
         /// <summary>
         /// Returns the array of the direct children. Will be

--- a/Sources/AngouriMath/Core/EquationSystem.cs
+++ b/Sources/AngouriMath/Core/EquationSystem.cs
@@ -17,13 +17,13 @@ namespace AngouriMath.Core
     /// It is a system of arbitrary equations, not only those linear. However,
     /// it is not a system of <see cref="Statement"/>s.
     /// </summary>
-    public sealed class EquationSystem : ILatexiseable
+    public sealed class EquationSystem : ILatexizeable
     {
         private readonly IEnumerable<Entity> equations;
 
         /// <summary>
         /// The equations you pass should not have an <see cref="MathS.Equality"/> node.
-        /// After having created a system of equations, you may solve or latexise it.
+        /// After having created a system of equations, you may solve or latexize it.
         /// </summary>
         /// <param name="equations">
         /// Any <see cref="IEnumerable{T}"/> parameter, such as <see cref="List{T}"/> or <see cref="System.Array"/>.
@@ -40,7 +40,7 @@ namespace AngouriMath.Core
 
         /// <summary>
         /// The equations you pass should not have an <see cref="MathS.Equality"/> node.
-        /// After having created a system of equations, you may solve or latexise it.
+        /// After having created a system of equations, you may solve or latexize it.
         /// </summary>
         /// <param name="equations">
         /// An <see cref="System.Array"/>
@@ -73,19 +73,19 @@ namespace AngouriMath.Core
         public Matrix? Solve(params Variable[] vars) => EquationSolver.SolveSystem(equations, vars);
 
         /// <returns>
-        /// Latexised version of the system. It adds
+        /// Latexized version of the system. It adds
         /// zero equality to all the provided expressions
         /// </returns>
-        public string Latexise()
+        public string Latexize()
         {
             using var enumerator = equations.GetEnumerator();
             if (!enumerator.MoveNext())
                 return string.Empty;
-            var firstEquation = enumerator.Current.Latexise() + " = 0";
+            var firstEquation = enumerator.Current.Latexize() + " = 0";
             if (!enumerator.MoveNext())
                 return firstEquation;
             var sb = new StringBuilder(@"\begin{cases}").Append(firstEquation);
-            do sb.Append(@"\\").Append(enumerator.Current.Latexise()).Append(" = 0");
+            do sb.Append(@"\\").Append(enumerator.Current.Latexize()).Append(" = 0");
             while (enumerator.MoveNext());
             sb.Append(@"\end{cases}");
             return sb.ToString();

--- a/Sources/AngouriMath/Docs/Contributing/AddingNode.cs
+++ b/Sources/AngouriMath/Docs/Contributing/AddingNode.cs
@@ -30,7 +30,7 @@
 /// 3. A few essential methods
 ///     a. InnerEval and InnerSimplify (<see cref="AngouriMath.Entity.Sinf.InnerEval"/> for numerical and <see cref="AngouriMath.Entity.Andf.InnerEval"/> for boolean)
 ///     b. Stringize (<see cref="AngouriMath.Entity.Sinf.Stringize"/>) (and tests to CircleTest.cs)
-///     c. Latexise (<see cref="AngouriMath.Entity.Sinf.Latexise"/>) (and tests to LatexTest.cs)
+///     c. Latexize (<see cref="AngouriMath.Entity.Sinf.Latexize"/>) (and tests to LatexTest.cs)
 ///     d. Limit computation (<see cref="AngouriMath.Entity.Sinf.ComputeLimitDivideEtImpera"/>) (and tests to LimitTest.cs)
 ///     e. Hash for sorting (<see cref="AngouriMath.Entity.Sinf.SortHashName"/>)
 ///     f. Default domain <see cref="AngouriMath.Entity.Sinf.Codomain"/>

--- a/Sources/AngouriMath/Docs/Usage/Syntax.md
+++ b/Sources/AngouriMath/Docs/Usage/Syntax.md
@@ -16,7 +16,7 @@ form would silently come back as something else.
 **LaTeX output has a round trip too, and it is checked in someone else's repository.**
 [CSharpMath.Evaluation](https://github.com/verybadcat/CSharpMath/blob/master/CSharpMath.Evaluation/Evaluation.cs)
 reads LaTeX back into an `Entity` and says so in its own source — *"CSharpMath must handle all
-LaTeX coming from AngouriMath or a bug is present!"* — so `Latexise` is free to use `\frac`,
+LaTeX coming from AngouriMath or a bug is present!"* — so `Latexize` is free to use `\frac`,
 `\bmod` and the rest, but changing what it emits can break a downstream project and no test here
 will say so ([#822](https://github.com/asc-community/AngouriMath/issues/822)).
 

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
@@ -15,7 +15,7 @@ using static AngouriMath.Entity.Set;
 
 namespace AngouriMath
 {
-    partial record Entity : ILatexiseable
+    partial record Entity : ILatexizeable
     {
         /// <summary>
         /// Attempt to find analytical roots of a custom equation.

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/InvertNode.Classes.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/InvertNode.Classes.cs
@@ -10,7 +10,7 @@ using AngouriMath.Functions.Algebra;
 
 namespace AngouriMath
 {
-    partial record Entity : ILatexiseable
+    partial record Entity : ILatexizeable
     {
         partial record Number
         {

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/InvertNode.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/InvertNode.Definition.cs
@@ -7,7 +7,7 @@
 
 namespace AngouriMath
 {
-    partial record Entity : ILatexiseable
+    partial record Entity : ILatexizeable
     {
         /// <summary><para>This <see cref="Entity"/> MUST contain exactly ONE occurance of <paramref name="x"/>,
         /// otherwise this function won't work correctly.</para>

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/NumericalSolving/NewtonSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/NumericalSolving/NewtonSolver.cs
@@ -291,7 +291,7 @@ namespace AngouriMath.Functions.Algebra.NumericalSolving
 
 namespace AngouriMath
 {
-    partial record Entity : ILatexiseable
+    partial record Entity : ILatexizeable
     {
         /// <summary>
         /// Searches for numerical solutions via Newton's method

--- a/Sources/AngouriMath/Functions/Output/Latex.Definition.cs
+++ b/Sources/AngouriMath/Functions/Output/Latex.Definition.cs
@@ -8,7 +8,7 @@
 namespace AngouriMath
 {
     using Core;
-    partial record Entity : ILatexiseable
+    partial record Entity : ILatexizeable
     {
         /// <summary>
         /// Returns the expression in LaTeX
@@ -16,7 +16,7 @@ namespace AngouriMath
         /// <example>
         /// <code>
         /// Entity expr = "a / b + sqrt(c)";
-        /// Console.WriteLine(expr.Latexise());
+        /// Console.WriteLine(expr.Latexize());
         /// </code>
         /// Output:
         /// <code>
@@ -31,10 +31,10 @@ namespace AngouriMath
         /// 
         /// Entity expr = "sqrt(a) + integral(sin(x), x)";
         /// Console.WriteLine(expr);
-        /// Console.WriteLine(expr.Latexise());
+        /// Console.WriteLine(expr.Latexize());
         /// Entity expr2 = "a / b ^ limit(sin(x) - cosh(y), x, +oo)";
         /// Console.WriteLine(expr2);
-        /// Console.WriteLine(expr2.Latexise());
+        /// Console.WriteLine(expr2.Latexize());
         /// </code>
         /// Prints
         /// <code>
@@ -44,7 +44,7 @@ namespace AngouriMath
         /// \frac{a}{{b}^{\lim_{x\to \infty } \left[\sin\left(x\right)-\frac{{e}^{y}+{e}^{-y}}{2}\right]}}
         /// </code>
         /// </example>
-        public abstract string Latexise();
+        public abstract string Latexize();
         /// <summary>
         /// Calculus operators, unlike other functions, have a <see cref="LatexPriority"/> between addition/subtraction
         /// and multiplication/division which is different from <see cref="Priority"/>.
@@ -53,7 +53,7 @@ namespace AngouriMath
 
         /// <summary>Returns the expression in LaTeX (for example, a / b -> \frac{a}{b})</summary>
         /// <param name="parenthesesRequired">Whether to wrap it with parentheses</param>
-        protected internal string Latexise(bool parenthesesRequired) =>
-            parenthesesRequired ? @$"\left({Latexise()}\right)" : Latexise();
+        protected internal string Latexize(bool parenthesesRequired) =>
+            parenthesesRequired ? @$"\left({Latexize()}\right)" : Latexize();
     }
 }

--- a/Sources/AngouriMath/Functions/Output/Latex/Latex.Arithmetics.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/Latex/Latex.Arithmetics.Classes.cs
@@ -14,24 +14,24 @@ namespace AngouriMath
         public partial record Sumf
         {
             /// <inheritdoc/>
-            public override string Latexise() =>
-                Augend.Latexise(Augend.LatexPriority < LatexPriority)
-                + (Addend.Latexise(Addend.LatexPriority < LatexPriority) is var addend && addend.StartsWith("-")
+            public override string Latexize() =>
+                Augend.Latexize(Augend.LatexPriority < LatexPriority)
+                + (Addend.Latexize(Addend.LatexPriority < LatexPriority) is var addend && addend.StartsWith("-")
                     ? addend : "+" + addend);
         }
 
         public partial record Minusf
         {
             /// <inheritdoc/>
-            public override string Latexise() =>
-                Minuend.Latexise(Minuend.LatexPriority < LatexPriority)
-                + "-" + Subtrahend.Latexise(Subtrahend.LatexPriority <= LatexPriority);
+            public override string Latexize() =>
+                Minuend.Latexize(Minuend.LatexPriority < LatexPriority)
+                + "-" + Subtrahend.Latexize(Subtrahend.LatexPriority <= LatexPriority);
         }
 
         public partial record Mulf
         {
             /// <inheritdoc/>
-            public override string Latexise()
+            public override string Latexize()
             {
                 var longArray = GatherProducts(this).ToArray();
                 return longArray.AggregateIndexed("",
@@ -44,15 +44,15 @@ namespace AngouriMath
                                 {
                                     // -1, -2, 2i, i, -i, -2i etc. in the front and not (1+i) etc.
                                     Number { LatexPriority: Priority.Sum } and not Complex { RealPart.IsZero: false, ImaginaryPart.IsZero: false } =>
-                                        currIn.Latexise(false),
-                                    _ => currIn.Latexise(currIn.LatexPriority < LatexPriority)
+                                        currIn.Latexize(false),
+                                    _ => currIn.Latexize(currIn.LatexPriority < LatexPriority)
                                 };
                             case 1:
                                 if (longArray[index - 1] is Integer(-1))
-                                    return $"-{currIn.Latexise(currIn.LatexPriority < LatexPriority)}"; // display "-1 * x * y" as "-x \cdot y", only for the first -1
+                                    return $"-{currIn.Latexize(currIn.LatexPriority < LatexPriority)}"; // display "-1 * x * y" as "-x \cdot y", only for the first -1
                                 break;
                         }
-                        var currOut = currIn.Latexise(currIn.LatexPriority < LatexPriority);
+                        var currOut = currIn.Latexize(currIn.LatexPriority < LatexPriority);
 
                         return (longArray[index - 1], currIn) switch // whether we use juxtaposition and omit \cdot
                         {
@@ -90,39 +90,39 @@ namespace AngouriMath
         public partial record Divf
         {
             /// <inheritdoc/>
-            public override string Latexise() =>
-                @"\frac{" + Dividend.Latexise() + "}{" + Divisor.Latexise() + "}";
+            public override string Latexize() =>
+                @"\frac{" + Dividend.Latexize() + "}{" + Divisor.Latexize() + "}";
         }
 
         public partial record Modf
         {
             /// <inheritdoc/>
-            public override string Latexise() =>
-                Dividend.Latexise(Dividend.Priority < Priority) + @" \bmod " + Divisor.Latexise(Divisor.Priority <= Priority);
+            public override string Latexize() =>
+                Dividend.Latexize(Dividend.Priority < Priority) + @" \bmod " + Divisor.Latexize(Divisor.Priority <= Priority);
         }
 
         public partial record Logf
         {
             /// <inheritdoc/>
-            public override string Latexise() =>
+            public override string Latexize() =>
                 Base == 10
-                ? @"\log\left(" + Antilogarithm.Latexise() + @"\right)"
+                ? @"\log\left(" + Antilogarithm.Latexize() + @"\right)"
                 : Base == MathS.e
-                ? @"\ln\left(" + Antilogarithm.Latexise() + @"\right)"
-                : @"\log_{" + Base.Latexise() + @"}\left(" + Antilogarithm.Latexise() + @"\right)";
+                ? @"\ln\left(" + Antilogarithm.Latexize() + @"\right)"
+                : @"\log_{" + Base.Latexize() + @"}\left(" + Antilogarithm.Latexize() + @"\right)";
         }
 
         public partial record Powf
         {
             /// <inheritdoc/>
-            public override string Latexise()
+            public override string Latexize()
             {
                 if (Exponent is Rational { ERational: { Numerator: var numerator, Denominator: var denominator } }
                     and not Integer)
                 {
                     var str =
                         @"\sqrt" + (denominator.Equals(2) ? "" : "[" + denominator + "]")
-                        + "{" + Base.Latexise() + "}";
+                        + "{" + Base.Latexize() + "}";
                     var abs = numerator.Abs();
                     if (!abs.Equals(EInteger.One))
                         str += "^{" + abs + "}";
@@ -132,7 +132,7 @@ namespace AngouriMath
                 }
                 else
                 {
-                    return "{" + Base.Latexise(Base.LatexPriority <= LatexPriority) + "}^{" + Exponent.Latexise() + "}";
+                    return "{" + Base.Latexize(Base.LatexPriority <= LatexPriority) + "}^{" + Exponent.Latexize() + "}";
                 }
             }
         }
@@ -140,72 +140,72 @@ namespace AngouriMath
         public partial record Factorialf
         {
             /// <inheritdoc/>
-            public override string Latexise() =>
-                Argument.Latexise(Argument.LatexPriority <= LatexPriority) + "!";
+            public override string Latexize() =>
+                Argument.Latexize(Argument.LatexPriority <= LatexPriority) + "!";
         }
 
         partial record Signumf
         {
             /// <inheritdoc/>
-            public override string Latexise()
-                => $@"\operatorname{{sgn}}\left({Argument.Latexise()}\right)";
+            public override string Latexize()
+                => $@"\operatorname{{sgn}}\left({Argument.Latexize()}\right)";
         }
 
         partial record Absf
         {
             /// <inheritdoc/>
-            public override string Latexise()
-                => $@"\left|{Argument.Latexise()}\right|";
+            public override string Latexize()
+                => $@"\left|{Argument.Latexize()}\right|";
         }
 
         partial record Floorf
         {
             /// <inheritdoc/>
-            public override string Latexise()
-                => $@"\left\lfloor{{{Argument.Latexise()}}}\right\rfloor";
+            public override string Latexize()
+                => $@"\left\lfloor{{{Argument.Latexize()}}}\right\rfloor";
         }
 
         partial record Ceilf
         {
             /// <inheritdoc/>
-            public override string Latexise()
-                => $@"\left\lceil{{{Argument.Latexise()}}}\right\rceil";
+            public override string Latexize()
+                => $@"\left\lceil{{{Argument.Latexize()}}}\right\rceil";
         }
 
         partial record Roundf
         {
             // The nearest-integer brackets: a floor on the left, a ceiling on the right.
             /// <inheritdoc/>
-            public override string Latexise()
-                => $@"\left\lfloor{{{Argument.Latexise()}}}\right\rceil";
+            public override string Latexize()
+                => $@"\left\lfloor{{{Argument.Latexize()}}}\right\rceil";
         }
 
         partial record Minf
         {
             /// <inheritdoc/>
-            public override string Latexise()
-                => $@"\min\left({Left.Latexise()}, {Right.Latexise()}\right)";
+            public override string Latexize()
+                => $@"\min\left({Left.Latexize()}, {Right.Latexize()}\right)";
         }
 
         partial record Maxf
         {
             /// <inheritdoc/>
-            public override string Latexise()
-                => $@"\max\left({Left.Latexise()}, {Right.Latexise()}\right)";
+            public override string Latexize()
+                => $@"\max\left({Left.Latexize()}, {Right.Latexize()}\right)";
         }
 
         partial record Gcdf
         {
             /// <inheritdoc/>
-            public override string Latexise()
-                => $@"\gcd\left({Left.Latexise()}, {Right.Latexise()}\right)";
+            public override string Latexize()
+                => $@"\gcd\left({Left.Latexize()}, {Right.Latexize()}\right)";
         }
 
         partial record Phif
         {
             /// <inheritdoc/>
             // NOTE: \operatorname is used here to distinguish the phi function from variables, consistent with sgn and other functions.
-            public override string Latexise() => $@"\operatorname{{\varphi}}\left({Argument.Latexise()}\right)";
+            public override string Latexize() => $@"\operatorname{{\varphi}}\left({Argument.Latexize()}\right)";
         }
     }
 }

--- a/Sources/AngouriMath/Functions/Output/Latex/Latex.Calculus.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/Latex/Latex.Calculus.Classes.cs
@@ -19,39 +19,39 @@ namespace AngouriMath
         public partial record Derivativef
         {
             /// <inheritdoc/>
-            public override string Latexise()
+            public override string Latexize()
             {
                 if (Iterations < 0)
                 {
                     var sb = new StringBuilder();
                     for (int i = 0; i < -Iterations; i++)
                         sb.Append(@"\int");
-                    sb.Append(' ').Append(Expression.Latexise(Expression.LatexPriority < Priority.LatexCalculusOperation));
+                    sb.Append(' ').Append(Expression.Latexize(Expression.LatexPriority < Priority.LatexCalculusOperation));
 
                     for (int i = 0; i < -Iterations; i++)
                     {
                         sb.Append(@"\,");
                         sb.Append(@"\mathrm{d}");
-                        sb.Append(Var.Latexise(Var is not Variable { IsLatexUprightFormatted: false }));
+                        sb.Append(Var.Latexize(Var is not Variable { IsLatexUprightFormatted: false }));
                     }
                     return sb.ToString();
                 }
                 var powerIfNeeded = Iterations == 1 ? "" : "^{" + Iterations + "}";
                 // NOTE: \mathrm{d} is used for upright 'd' following ISO 80000-2 standard.
                 // The differential operator should be upright (roman) to distinguish it from variables, similar to sin, cos, log, etc.
-                return $$"""\frac{\mathrm{d}{{powerIfNeeded}}}{\mathrm{d}{{Var.Latexise(Var is not Variable { IsLatexUprightFormatted: false })
-                    }}{{powerIfNeeded}}}{{Expression.Latexise(Expression.LatexPriority < Priority.LatexCalculusOperation)}}""";
+                return $$"""\frac{\mathrm{d}{{powerIfNeeded}}}{\mathrm{d}{{Var.Latexize(Var is not Variable { IsLatexUprightFormatted: false })
+                    }}{{powerIfNeeded}}}{{Expression.Latexize(Expression.LatexPriority < Priority.LatexCalculusOperation)}}""";
             }
         }
 
         public partial record Integralf
         {
             /// <inheritdoc/>
-            public override string Latexise()
+            public override string Latexize()
             {
                 var sb = new StringBuilder(@"\int");
-                if (Range is var (from, to)) sb.Append('_').Append('{').Append(from.Latexise()).Append('}').Append('^').Append('{').Append(to.Latexise()).Append('}');
-                sb.Append(' ').Append(Expression.Latexise(Expression.LatexPriority < Priority.LatexCalculusOperation));
+                if (Range is var (from, to)) sb.Append('_').Append('{').Append(from.Latexize()).Append('}').Append('^').Append('{').Append(to.Latexize()).Append('}');
+                sb.Append(' ').Append(Expression.Latexize(Expression.LatexPriority < Priority.LatexCalculusOperation));
 
                 // NOTE: \mathrm{d} is used for upright 'd' following ISO 80000-2 standard.
                 // The differential operator should be upright (roman) to distinguish it from variables.
@@ -61,7 +61,7 @@ namespace AngouriMath
                 // Thin spaces (\,) are added between differentials following standard practice.
                 sb.Append(@"\,"); // Leading space before first differential and between differentials
                 sb.Append(@"\mathrm{d}");
-                sb.Append(Var.Latexise(Var is not Variable { IsLatexUprightFormatted: false }));
+                sb.Append(Var.Latexize(Var is not Variable { IsLatexUprightFormatted: false }));
                 return sb.ToString();
             }
         }
@@ -69,27 +69,27 @@ namespace AngouriMath
         public partial record Limitf
         {
             /// <inheritdoc/>
-            public override string Latexise()
+            public override string Latexize()
             {
                 var sb = new StringBuilder();
-                sb.Append(@"\lim_{").Append(Var.Latexise())
+                sb.Append(@"\lim_{").Append(Var.Latexize())
                     .Append(@"\to ");
 
                 switch (ApproachFrom)
                 {
                     case ApproachFrom.Left:
-                        sb.Append(Destination.Latexise(Destination.LatexPriority <= Priority.Pow)).Append("^-");
+                        sb.Append(Destination.Latexize(Destination.LatexPriority <= Priority.Pow)).Append("^-");
                         break;
                     case ApproachFrom.Right:
-                        sb.Append(Destination.Latexise(Destination.LatexPriority <= Priority.Pow)).Append("^+");
+                        sb.Append(Destination.Latexize(Destination.LatexPriority <= Priority.Pow)).Append("^+");
                         break;
                     case ApproachFrom.BothSides:
-                        sb.Append(Destination.Latexise());
+                        sb.Append(Destination.Latexize());
                         break;
                 }
 
                 sb.Append("} ");
-                sb.Append(Expression.Latexise(Expression.LatexPriority < Priority.LatexCalculusOperation));
+                sb.Append(Expression.Latexize(Expression.LatexPriority < Priority.LatexCalculusOperation));
                 return sb.ToString();
             }
         }

--- a/Sources/AngouriMath/Functions/Output/Latex/Latex.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/Latex/Latex.Classes.cs
@@ -37,22 +37,22 @@ namespace AngouriMath
                 // Single-letter variables remain italic as per standard mathematical typography.
                 varName.Length > 1 && !LatexisableConstants.Contains(varName);
             /// <summary>
-            /// Returns latexised const if it is possible to latexise it,
+            /// Returns latexized const if it is possible to latexize it,
             /// or its original name otherwise
             /// </summary>
-            public override string Latexise()
+            public override string Latexize()
             {
-                static string LatexisePart(string symbol)
+                static string LatexizePart(string symbol)
                 {
                     var inner = LatexisableConstants.Contains(symbol) ? $@"\{symbol}" : symbol;
                     return IsNameLatexUprightFormatted(symbol) ? $@"\mathrm{{{inner}}}" : inner;
                 }
                 // For variables with subscripts (e.g., "pi_2", "x_e", "e_pi")
-                // Both the main part and subscript are processed through LatexisePart,
+                // Both the main part and subscript are processed through LatexizePart,
                 // which handles upright formatting for "pi" and "e" consistently
                 return SplitIndex() is var (prefix, index)
-                    ? $"{LatexisePart(prefix)}_{{{LatexisePart(index)}}}"
-                    : LatexisePart(Name);
+                    ? $"{LatexizePart(prefix)}_{{{LatexizePart(index)}}}"
+                    : LatexizePart(Name);
             }
         }
     }

--- a/Sources/AngouriMath/Functions/Output/Latex/Latex.Discrete.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/Latex/Latex.Discrete.Classes.cs
@@ -13,22 +13,22 @@ namespace AngouriMath
         partial record Boolean
         {
             /// <inheritdoc/>
-            public override string Latexise() => (bool)this ? @"\top " : @"\bot ";
+            public override string Latexize() => (bool)this ? @"\top " : @"\bot ";
         }
 
         partial record Notf
         {
             /// <inheritdoc/>
-            public override string Latexise()
+            public override string Latexize()
                 => Argument is Equalsf(var left, var right)
-                   ? $@"{left.Latexise(left.LatexPriority <= Priority.Equal)} \neq {right.Latexise(right.LatexPriority <= Priority.Equal)}"
-                   : $@"\neg{{{Argument.Latexise(Argument.LatexPriority < LatexPriority)}}}";
+                   ? $@"{left.Latexize(left.LatexPriority <= Priority.Equal)} \neq {right.Latexize(right.LatexPriority <= Priority.Equal)}"
+                   : $@"\neg{{{Argument.Latexize(Argument.LatexPriority < LatexPriority)}}}";
         }
 
         partial record Andf
         {
             /// <inheritdoc/>
-            public override string Latexise()
+            public override string Latexize()
             {
                 var result = new System.Text.StringBuilder();
                 Entity? left = null;
@@ -42,7 +42,7 @@ namespace AngouriMath
                             var renew = left != child.DirectChildren[0];
                             if (!first && renew) result.Append(@" \land ");
                             first = false;
-                            if (first || renew) result.Append(child.DirectChildren[0].Latexise(child.DirectChildren[0].LatexPriority <= child.LatexPriority));
+                            if (first || renew) result.Append(child.DirectChildren[0].Latexize(child.DirectChildren[0].LatexPriority <= child.LatexPriority));
                             renew = false;
                             result.Append(child switch {
                                 Equalsf => " = ",
@@ -50,24 +50,24 @@ namespace AngouriMath
                                 GreaterOrEqualf => @" \geq ",
                                 Lessf => " < ",
                                 LessOrEqualf => @" \leq ",
-                                _ => throw new Core.Exceptions.AngouriBugException("Unexpected comparison sign in Andf.Latexise")
-                            }).Append(child.DirectChildren[1].Latexise(child.DirectChildren[1].LatexPriority <= child.LatexPriority));
+                                _ => throw new Core.Exceptions.AngouriBugException("Unexpected comparison sign in Andf.Latexize")
+                            }).Append(child.DirectChildren[1].Latexize(child.DirectChildren[1].LatexPriority <= child.LatexPriority));
                             left = child.DirectChildren[1];
                             break;
                         case Notf (Equalsf eq):
                             renew = left != eq.Left;
                             if (!first && renew) result.Append(@" \land ");
                             first = false;
-                            if (first || renew) result.Append(eq.Left.Latexise(eq.Left.LatexPriority <= eq.LatexPriority));
+                            if (first || renew) result.Append(eq.Left.Latexize(eq.Left.LatexPriority <= eq.LatexPriority));
                             renew = false;
-                            result.Append(@" \neq ").Append(eq.Right.Latexise(eq.Right.LatexPriority <= eq.LatexPriority));
+                            result.Append(@" \neq ").Append(eq.Right.Latexize(eq.Right.LatexPriority <= eq.LatexPriority));
                             left = eq.Right;
                             break;
                         default:
                             if (!first) result.Append(" \\land ");
                             left = null;
                             first = false;
-                            result.Append(child.Latexise(child.LatexPriority < LatexPriority));
+                            result.Append(child.Latexize(child.LatexPriority < LatexPriority));
                             break;
                     }
                 }
@@ -78,16 +78,16 @@ namespace AngouriMath
         partial record Orf
         {
             /// <inheritdoc/>
-            public override string Latexise()
-                => $@"{Left.Latexise(Left.LatexPriority < LatexPriority)} \lor {Right.Latexise(Right.LatexPriority < LatexPriority)}";
+            public override string Latexize()
+                => $@"{Left.Latexize(Left.LatexPriority < LatexPriority)} \lor {Right.Latexize(Right.LatexPriority < LatexPriority)}";
         }
 
         partial record Xorf
         {
             /// <inheritdoc/>
             // NOTE: \veebar (⊻) can disambiguate better than \oplus (⊕) which can mean the direct sum in algebra.
-            public override string Latexise()
-                => $@"{Left.Latexise(Left.LatexPriority < LatexPriority)} \veebar {Right.Latexise(Right.LatexPriority < LatexPriority)}";
+            public override string Latexize()
+                => $@"{Left.Latexize(Left.LatexPriority < LatexPriority)} \veebar {Right.Latexize(Right.LatexPriority < LatexPriority)}";
         }
 
         partial record Impliesf
@@ -98,22 +98,22 @@ namespace AngouriMath
             // \implies (⇒) is a metalanguage symbol indicating a logical consequence or entailment. It's used to express that one statement logically follows from another.
             // ISO 80000-2 puts ⇒ first for implies, but → is also accepted and is more common in logic contexts.
             // ⇒ can be used in steps for proofs if we were to add it later.
-            public override string Latexise()
-                => $@"{Assumption.Latexise(Assumption.LatexPriority <= LatexPriority)} \to {Conclusion.Latexise(Conclusion.LatexPriority < LatexPriority)}";
+            public override string Latexize()
+                => $@"{Assumption.Latexize(Assumption.LatexPriority <= LatexPriority)} \to {Conclusion.Latexize(Conclusion.LatexPriority < LatexPriority)}";
         }
 
         partial record Equalsf
         {
             /// <inheritdoc/>
-            public override string Latexise()
-                => $@"{Left.Latexise(Left.LatexPriority <= LatexPriority)} = {Right.Latexise(Right.LatexPriority <= LatexPriority)}";
+            public override string Latexize()
+                => $@"{Left.Latexize(Left.LatexPriority <= LatexPriority)} = {Right.Latexize(Right.LatexPriority <= LatexPriority)}";
         }
 
         partial record Greaterf
         {
             /// <inheritdoc/>
-            public override string Latexise()
-                => $@"{Left.Latexise(Left.LatexPriority <= LatexPriority)} > {Right.Latexise(Right.LatexPriority <= LatexPriority)}";
+            public override string Latexize()
+                => $@"{Left.Latexize(Left.LatexPriority <= LatexPriority)} > {Right.Latexize(Right.LatexPriority <= LatexPriority)}";
         }
 
         partial record GreaterOrEqualf
@@ -121,15 +121,15 @@ namespace AngouriMath
             /// <inheritdoc/>
             // NOTE: While \geqslant (⩾) is more used in e.g. Russian texts, \geq (≥) is more universally used in English texts.
             // Since the output language of LaTeX is English (referencing Piecewise and Providedf), \geq is more appropriate.
-            public override string Latexise()
-                => $@"{Left.Latexise(Left.LatexPriority <= LatexPriority)} \geq {Right.Latexise(Right.LatexPriority <= LatexPriority)}";
+            public override string Latexize()
+                => $@"{Left.Latexize(Left.LatexPriority <= LatexPriority)} \geq {Right.Latexize(Right.LatexPriority <= LatexPriority)}";
         }
 
         partial record Lessf
         {
             /// <inheritdoc/>
-            public override string Latexise()
-                => $@"{Left.Latexise(Left.LatexPriority <= LatexPriority)} < {Right.Latexise(Right.LatexPriority <= LatexPriority)}";
+            public override string Latexize()
+                => $@"{Left.Latexize(Left.LatexPriority <= LatexPriority)} < {Right.Latexize(Right.LatexPriority <= LatexPriority)}";
         }
 
         partial record LessOrEqualf
@@ -137,8 +137,8 @@ namespace AngouriMath
             /// <inheritdoc/>
             // NOTE: While \leqslant (⩽) is more used in e.g. Russian texts, \leq (≤) is more universally used in English texts.
             // Since the output language of LaTeX is English (referencing Piecewise and Providedf), \leq is more appropriate.
-            public override string Latexise()
-                => $@"{Left.Latexise(Left.LatexPriority <= LatexPriority)} \leq {Right.Latexise(Right.LatexPriority <= LatexPriority)}";
+            public override string Latexize()
+                => $@"{Left.Latexize(Left.LatexPriority <= LatexPriority)} \leq {Right.Latexize(Right.LatexPriority <= LatexPriority)}";
         }
     }
 }

--- a/Sources/AngouriMath/Functions/Output/Latex/Latex.Number.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/Latex/Latex.Number.Classes.cs
@@ -16,7 +16,7 @@ namespace AngouriMath
             partial record Complex
             {
                 /// <inheritdoc/>
-                public override string Latexise()
+                public override string Latexize()
                 {
                     static string RenderNum(Real number)
                     {
@@ -25,22 +25,22 @@ namespace AngouriMath
                         else if (number == Integer.One)
                             return "";
                         else
-                            return number.Latexise();
+                            return number.Latexize();
                     }
                     if (ImaginaryPart is Integer(0))
-                        return RealPart.Latexise();
+                        return RealPart.Latexize();
                     else if (RealPart is Integer(0))
                         return RenderNum(ImaginaryPart) + @"\mathrm{i}"; // Display i upright per ISO 80000-2.
                     var (im, sign) = ImaginaryPart > 0 ? (ImaginaryPart, "+") : (-ImaginaryPart, "-");
-                    return RealPart.Latexise() + " " + sign + " " +
-                        (im == 1 ? "" : im.Latexise(ImaginaryPart is Rational and not Integer)) + @"\mathrm{i}";
+                    return RealPart.Latexize() + " " + sign + " " +
+                        (im == 1 ? "" : im.Latexize(ImaginaryPart is Rational and not Integer)) + @"\mathrm{i}";
                 }
             }
 
             partial record Real
             {
                 /// <inheritdoc/>
-                public override string Latexise() => this switch
+                public override string Latexize() => this switch
                 {
                     { IsFinite: true } => EDecimal.ToString(),
                     { IsNaN: true } => @"\mathrm{undefined}",
@@ -52,14 +52,14 @@ namespace AngouriMath
             partial record Rational
             {
                 /// <inheritdoc/>
-                public override string Latexise() => $@"\frac{{{ERational.Numerator}}}{{{ERational.Denominator}}}";
+                public override string Latexize() => $@"\frac{{{ERational.Numerator}}}{{{ERational.Denominator}}}";
 
             }
 
             partial record Integer
             {
                 /// <inheritdoc/>
-                public override string Latexise() => EInteger.ToString();
+                public override string Latexize() => EInteger.ToString();
             }
         }
     }

--- a/Sources/AngouriMath/Functions/Output/Latex/Latex.Omni.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/Latex/Latex.Omni.Classes.cs
@@ -16,8 +16,8 @@ namespace AngouriMath
             partial record FiniteSet
             {
                 /// <inheritdoc/>
-                public override string Latexise()
-                    => IsSetEmpty ? @"\emptyset" : $@"\left\{{ {string.Join(", ", Elements.Select(c => c.Latexise()))} \right\}}";
+                public override string Latexize()
+                    => IsSetEmpty ? @"\emptyset" : $@"\left\{{ {string.Join(", ", Elements.Select(c => c.Latexize()))} \right\}}";
             }
 
             partial record Interval
@@ -25,73 +25,73 @@ namespace AngouriMath
                 /// <inheritdoc/>
                 // NOTE: Comma is used as the separator following standard mathematical notation (ISO 80000-2).
                 // Some regional variants use semicolon, but comma is more universally recognized.
-                public override string Latexise()
+                public override string Latexize()
                 {
                     var left = LeftClosed ? "[" : "(";
                     var right = RightClosed ? "]" : ")";
-                    return @"\left" + left + Left.Latexise() + ", " + Right.Latexise() + @"\right" + right;
+                    return @"\left" + left + Left.Latexize() + ", " + Right.Latexize() + @"\right" + right;
                 }
             }
 
             partial record ConditionalSet
             {
                 /// <inheritdoc/>
-                public override string Latexise()
-                    => $@"\left\{{ {Var.Latexise()} : {Predicate.Latexise()} \right\}}";
+                public override string Latexize()
+                    => $@"\left\{{ {Var.Latexize()} : {Predicate.Latexize()} \right\}}";
             }
 
             partial record SpecialSet
             {
                 /// <inheritdoc/>
-                public override string Latexise()
+                public override string Latexize()
                     => $@"\mathbb{{{Stringize()[0]}}}";
             }
 
             partial record Unionf
             {
                 /// <inheritdoc/>
-                public override string Latexise()
-                    => $@"{Left.Latexise(Left.LatexPriority < LatexPriority)} \cup {Right.Latexise(Right.LatexPriority < LatexPriority)}";
+                public override string Latexize()
+                    => $@"{Left.Latexize(Left.LatexPriority < LatexPriority)} \cup {Right.Latexize(Right.LatexPriority < LatexPriority)}";
             }
 
             partial record Intersectionf
             {
                 /// <inheritdoc/>
-                public override string Latexise()
-                    => $@"{Left.Latexise(Left.LatexPriority < LatexPriority)} \cap {Right.Latexise(Right.LatexPriority < LatexPriority)}";
+                public override string Latexize()
+                    => $@"{Left.Latexize(Left.LatexPriority < LatexPriority)} \cap {Right.Latexize(Right.LatexPriority < LatexPriority)}";
             }
 
             partial record SetMinusf
             {
                 /// <inheritdoc/>
-                public override string Latexise()
-                    => $@"{Left.Latexise(Left.LatexPriority < LatexPriority)} \setminus {Right.Latexise(Right.LatexPriority < LatexPriority)}";
+                public override string Latexize()
+                    => $@"{Left.Latexize(Left.LatexPriority < LatexPriority)} \setminus {Right.Latexize(Right.LatexPriority < LatexPriority)}";
             }
 
             partial record Inf
             {
                 /// <inheritdoc/>
-                public override string Latexise()
-                    => $@"{Element.Latexise(Element.LatexPriority < LatexPriority)} \in {SupSet.Latexise(SupSet.LatexPriority < LatexPriority)}";
+                public override string Latexize()
+                    => $@"{Element.Latexize(Element.LatexPriority < LatexPriority)} \in {SupSet.Latexize(SupSet.LatexPriority < LatexPriority)}";
             }
         }
 
         partial record Providedf
         {
             /// <inheritdoc/>
-            public override string Latexise() => $@"{Expression.Latexise(Expression.LatexPriority < LatexPriority)} \quad \text{{for}} \quad {Predicate.Latexise(Predicate.LatexPriority < LatexPriority)}";
+            public override string Latexize() => $@"{Expression.Latexize(Expression.LatexPriority < LatexPriority)} \quad \text{{for}} \quad {Predicate.Latexize(Predicate.LatexPriority < LatexPriority)}";
         }
 
         partial record Piecewise
         {
             /// <inheritdoc/>
-            public override string Latexise() => @"\begin{cases}" +
+            public override string Latexize() => @"\begin{cases}" +
                 string.Join(@"\\",
                 Cases.Select(c =>
                 {
                     if (c.Predicate == Boolean.True)
-                        return $@"{c.Expression.Latexise(c.Expression.LatexPriority < Priority.Provided)} & \text{{otherwise}}";
-                    return $@"{c.Expression.Latexise(c.Expression.LatexPriority < Priority.Provided)} & \text{{for }} {c.Predicate.Latexise(c.Predicate.LatexPriority <= Priority.Provided)}"; // "for" used in https://mathworld.wolfram.com/Derivative.html
+                        return $@"{c.Expression.Latexize(c.Expression.LatexPriority < Priority.Provided)} & \text{{otherwise}}";
+                    return $@"{c.Expression.Latexize(c.Expression.LatexPriority < Priority.Provided)} & \text{{for }} {c.Predicate.Latexize(c.Predicate.LatexPriority <= Priority.Provided)}"; // "for" used in https://mathworld.wolfram.com/Derivative.html
                 }
                 ))
                 +
@@ -101,13 +101,13 @@ namespace AngouriMath
         partial record Matrix
         {
             /// <inheritdoc/>
-            public override string Latexise()
+            public override string Latexize()
             {
                 if (IsVector)
                 {
                     var sb = new StringBuilder();
                     sb.Append(@"\begin{bmatrix}");
-                    sb.Append(string.Join(@" \\ ", InnerMatrix.Iterate().Select(k => k.Value.Latexise())));
+                    sb.Append(string.Join(@" \\ ", InnerMatrix.Iterate().Select(k => k.Value.Latexize())));
                     sb.Append(@"\end{bmatrix}");
                     return sb.ToString();
                 }
@@ -120,7 +120,7 @@ namespace AngouriMath
                         var items = new List<string>();
 
                         for (int y = 0; y < ColumnCount; y++)
-                            items.Add(this[x, y].Latexise());
+                            items.Add(this[x, y].Latexize());
 
                         var line = string.Join(" & ", items);
                         lines.Add(line);
@@ -137,12 +137,12 @@ namespace AngouriMath
             /// <inheritdoc/>
             // NOTE: Application represents curried function application. Multiple arguments
             // are rendered as separate applications: f(x)(y) rather than f(x, y)
-            public override string Latexise()
+            public override string Latexize()
             {
-                var result = new StringBuilder(Expression.Latexise(Expression.LatexPriority < LatexPriority));
+                var result = new StringBuilder(Expression.Latexize(Expression.LatexPriority < LatexPriority));
                 foreach (var arg in Arguments)
                 {
-                    result.Append(@"\left(").Append(arg.Latexise()).Append(@"\right)");
+                    result.Append(@"\left(").Append(arg.Latexize()).Append(@"\right)");
                 }
                 return result.ToString();
             }
@@ -153,8 +153,8 @@ namespace AngouriMath
             /// <inheritdoc/>
             // NOTE: \mapsto (↦) links the function variable with its output while
             // \rightarrow (→) links the function domain with its codomain. See https://math.stackexchange.com/a/651240, https://math.stackexchange.com/a/936591
-            public override string Latexise()
-                => Parameter.Latexise() + @" \mapsto " + Body.Latexise(Body.LatexPriority < LatexPriority);
+            public override string Latexize()
+                => Parameter.Latexize() + @" \mapsto " + Body.Latexize(Body.LatexPriority < LatexPriority);
         }
     }
 }

--- a/Sources/AngouriMath/Functions/Output/Latex/Latex.Trigonometry.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/Latex/Latex.Trigonometry.Classes.cs
@@ -12,85 +12,85 @@ namespace AngouriMath
         public partial record Sinf
         {
             /// <inheritdoc/>
-            public override string Latexise() =>
-                @"\sin\left(" + Argument.Latexise() + @"\right)";
+            public override string Latexize() =>
+                @"\sin\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Cosf
         {
             /// <inheritdoc/>
-            public override string Latexise() =>
-                @"\cos\left(" + Argument.Latexise() + @"\right)";
+            public override string Latexize() =>
+                @"\cos\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Secantf
         {
             /// <inheritdoc/>
-            public override string Latexise() =>
-                @"\sec\left(" + Argument.Latexise() + @"\right)";
+            public override string Latexize() =>
+                @"\sec\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Cosecantf
         {
             /// <inheritdoc/>
-            public override string Latexise() =>
-                @"\csc\left(" + Argument.Latexise() + @"\right)";
+            public override string Latexize() =>
+                @"\csc\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Arcsecantf
         {
             /// <inheritdoc/>
-            public override string Latexise() =>
-                @"\operatorname{arcsec}\left(" + Argument.Latexise() + @"\right)";
+            public override string Latexize() =>
+                @"\operatorname{arcsec}\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Arccosecantf
         {
             /// <inheritdoc/>
-            public override string Latexise() =>
-                @"\operatorname{arccsc}\left(" + Argument.Latexise() + @"\right)";
+            public override string Latexize() =>
+                @"\operatorname{arccsc}\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Tanf
         {
             /// <inheritdoc/>
-            public override string Latexise() =>
-                @"\tan\left(" + Argument.Latexise() + @"\right)";
+            public override string Latexize() =>
+                @"\tan\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Cotanf
         {
             /// <inheritdoc/>
-            public override string Latexise() =>
-                @"\cot\left(" + Argument.Latexise() + @"\right)";
+            public override string Latexize() =>
+                @"\cot\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Arcsinf
         {
             /// <inheritdoc/>
-            public override string Latexise() =>
-                @"\arcsin\left(" + Argument.Latexise() + @"\right)";
+            public override string Latexize() =>
+                @"\arcsin\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Arccosf
         {
             /// <inheritdoc/>
-            public override string Latexise() =>
-                @"\arccos\left(" + Argument.Latexise() + @"\right)";
+            public override string Latexize() =>
+                @"\arccos\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Arctanf
         {
             /// <inheritdoc/>
-            public override string Latexise() =>
-                @"\arctan\left(" + Argument.Latexise() + @"\right)";
+            public override string Latexize() =>
+                @"\arctan\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Arccotanf
         {
             /// <inheritdoc/>
-            public override string Latexise() =>
-                @"\operatorname{arccot}\left(" + Argument.Latexise() + @"\right)";
+            public override string Latexize() =>
+                @"\operatorname{arccot}\left(" + Argument.Latexize() + @"\right)";
         }
     }
 }

--- a/Sources/AngouriMath/extension.dib
+++ b/Sources/AngouriMath/extension.dib
@@ -28,7 +28,7 @@ Formatter.Register<PeterO.Numbers.EDecimal>(o => o.ToString(), "text/plain");
 Formatter.SetPreferredMimeTypesFor(typeof(PeterO.Numbers.EInteger), "text/plain");
 Formatter.Register<PeterO.Numbers.EInteger>(o => o.ToString(), "text/plain");
 
-RegisterLatex<AngouriMath.Core.ILatexiseable>(o => o.Latexise());
+RegisterLatex<AngouriMath.Core.ILatexizeable>(o => o.Latexize());
 
 RegisterLatex<PeterO.Numbers.ERational>(o => $@"\frac{{{o.Numerator}}}{{{o.Denominator}}}");
 

--- a/Sources/Terminal/AngouriMath.Terminal.Lib/FSharpInteractive.fs
+++ b/Sources/Terminal/AngouriMath.Terminal.Lib/FSharpInteractive.fs
@@ -22,8 +22,8 @@ JsonFSharpConverter () |> options.Converters.Add
 
 let private objectEncode (o : obj) =
     match o with
-    | :? ILatexiseable as latexiseable -> 
-        let toSerialize = LatexSuccess (latexiseable.Latexise (), string o)
+    | :? ILatexizeable as latexizeable -> 
+        let toSerialize = LatexSuccess (latexizeable.Latexize (), string o)
         EncodingLatexPrefix + JsonSerializer.Serialize(toSerialize, options)
     | _ ->
         let toSerialize = PlainTextSuccess (string o)

--- a/Sources/Tests/CPPWrapperUnitTests/tests/RunTests.cpp
+++ b/Sources/Tests/CPPWrapperUnitTests/tests/RunTests.cpp
@@ -30,13 +30,13 @@ TEST(RunTests, ParsingTest3) {
 TEST(RunTests, Latex1) {
     auto src = "x + 1";
     AngouriMath::Entity entity = src;
-    EXPECT_EQ("x+1", entity.Latexise());
+    EXPECT_EQ("x+1", entity.Latexize());
 }
 
 TEST(RunTests, Latex2) {
     auto src = "sqrt(x)";
     AngouriMath::Entity entity = src;
-    EXPECT_EQ("\\sqrt{x}", entity.Latexise());
+    EXPECT_EQ("\\sqrt{x}", entity.Latexize());
 }
 
 TEST(RunTests, DiffTest1) {

--- a/Sources/Tests/InteractiveWrapperUnitTests/HtmlOutput.fs
+++ b/Sources/Tests/InteractiveWrapperUnitTests/HtmlOutput.fs
@@ -13,7 +13,7 @@ open AngouriMath
 open AngouriMath.FSharp.Functions
 
 [<Fact>]
-let ``Latex with magic ILatexiseable html`` () =
+let ``Latex with magic ILatexizeable html`` () =
     AngouriMath.InteractiveExtension.KernelExtension.applyMagic()
     let entity = parsed "x / 2"
     let html = entity.ToDisplayString("text/html")
@@ -46,7 +46,7 @@ let ``Latex with magic ERational multi-char for html`` () =
 
 
 [<Fact>]
-let ``Latex with magic ILatexiseable latex`` () =
+let ``Latex with magic ILatexizeable latex`` () =
     AngouriMath.InteractiveExtension.KernelExtension.applyMagic()
     let entity = parsed "x / 2"
     let latex = entity.ToDisplayString("text/latex")

--- a/Sources/Tests/UnitTests/Common/EveryNodeSurvivesEveryPipelineTest.cs
+++ b/Sources/Tests/UnitTests/Common/EveryNodeSurvivesEveryPipelineTest.cs
@@ -74,7 +74,7 @@ namespace AngouriMath.Tests.Common
         private static readonly (string Name, Action<Entity> Run)[] Pipelines =
         {
             ("Stringize",     e => e.Stringize()),
-            ("Latexise",      e => e.Latexise()),
+            ("Latexize",      e => e.Latexize()),
             ("ToString",      e => e.ToString()),
             ("InnerSimplified", e => { _ = e.InnerSimplified; }),
             ("Evaled",        e => { _ = e.Evaled; }),

--- a/Sources/Tests/UnitTests/Common/NonStrictTest.cs
+++ b/Sources/Tests/UnitTests/Common/NonStrictTest.cs
@@ -18,7 +18,7 @@ namespace AngouriMath.Tests.Common
         public void TensorLatex()
         {
             var tens = MathS.Matrices.Matrix(2, 2, 1342, 2123, 1423, 1122);
-            Assert.True(tens.Latexise().Length > 16);
+            Assert.True(tens.Latexize().Length > 16);
         }
 
         [Fact]
@@ -28,7 +28,7 @@ namespace AngouriMath.Tests.Common
                 "x + 3",
                 "y + x + 5"
             );
-            Assert.True(eq.Latexise().Length > 10);
+            Assert.True(eq.Latexize().Length > 10);
         }
 
         [Fact]

--- a/Sources/Tests/UnitTests/Common/PublicApi.txt
+++ b/Sources/Tests/UnitTests/Common/PublicApi.txt
@@ -35,7 +35,7 @@ AngouriMath.Core.Domain.Integer : AngouriMath.Core.Domain
 AngouriMath.Core.Domain.Rational : AngouriMath.Core.Domain
 AngouriMath.Core.Domain.Real : AngouriMath.Core.Domain
 AngouriMath.Core.Domain.value__ : System.Int32
-AngouriMath.Core.EquationSystem.Latexise() : System.String
+AngouriMath.Core.EquationSystem.Latexize() : System.String
 AngouriMath.Core.EquationSystem.Solve(AngouriMath.Entity+Variable[]) : AngouriMath.Entity+Matrix
 AngouriMath.Core.EquationSystem.ToString() : System.String
 AngouriMath.Core.EquationSystem.ctor(AngouriMath.Entity[])
@@ -52,7 +52,7 @@ AngouriMath.Core.FiniteSetBuilder.ctor(System.Collections.Generic.IEnumerable<An
 AngouriMath.Core.IBinaryNode.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Core.IBinaryNode.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Core.IHasAbsoluteValue<TSelf,TOut>.Abs(TSelf) : TOut
-AngouriMath.Core.ILatexiseable.Latexise() : System.String
+AngouriMath.Core.ILatexizeable.Latexize() : System.String
 AngouriMath.Core.IUnaryNode.NodeChild { } : AngouriMath.Entity
 AngouriMath.Core.MatrixBuilder.Add(System.Collections.Generic.IEnumerable<AngouriMath.Entity>) : System.Void
 AngouriMath.Core.MatrixBuilder.Add(System.Collections.Generic.List<AngouriMath.Entity>) : System.Void
@@ -200,7 +200,7 @@ AngouriMath.Entity+Absf.GetHashCode() : System.Int32
 AngouriMath.Entity+Absf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Absf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Absf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Absf.Latexise() : System.String
+AngouriMath.Entity+Absf.Latexize() : System.String
 AngouriMath.Entity+Absf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Absf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Absf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -220,7 +220,7 @@ AngouriMath.Entity+Andf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Andf.GetHashCode() : System.Int32
 AngouriMath.Entity+Andf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Andf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Andf.Latexise() : System.String
+AngouriMath.Entity+Andf.Latexize() : System.String
 AngouriMath.Entity+Andf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Andf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Andf.NodeSecondChild { } : AngouriMath.Entity
@@ -246,7 +246,7 @@ AngouriMath.Entity+Application.GetHashCode() : System.Int32
 AngouriMath.Entity+Application.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Application.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Application.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Application.Latexise() : System.String
+AngouriMath.Entity+Application.Latexize() : System.String
 AngouriMath.Entity+Application.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Application.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Application.Stringize() : System.String
@@ -267,7 +267,7 @@ AngouriMath.Entity+Arccosecantf.GetHashCode() : System.Int32
 AngouriMath.Entity+Arccosecantf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Arccosecantf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Arccosecantf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Arccosecantf.Latexise() : System.String
+AngouriMath.Entity+Arccosecantf.Latexize() : System.String
 AngouriMath.Entity+Arccosecantf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Arccosecantf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Arccosecantf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -289,7 +289,7 @@ AngouriMath.Entity+Arccosf.GetHashCode() : System.Int32
 AngouriMath.Entity+Arccosf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Arccosf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Arccosf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Arccosf.Latexise() : System.String
+AngouriMath.Entity+Arccosf.Latexize() : System.String
 AngouriMath.Entity+Arccosf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Arccosf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Arccosf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -311,7 +311,7 @@ AngouriMath.Entity+Arccotanf.GetHashCode() : System.Int32
 AngouriMath.Entity+Arccotanf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Arccotanf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Arccotanf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Arccotanf.Latexise() : System.String
+AngouriMath.Entity+Arccotanf.Latexize() : System.String
 AngouriMath.Entity+Arccotanf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Arccotanf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Arccotanf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -333,7 +333,7 @@ AngouriMath.Entity+Arcsecantf.GetHashCode() : System.Int32
 AngouriMath.Entity+Arcsecantf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Arcsecantf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Arcsecantf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Arcsecantf.Latexise() : System.String
+AngouriMath.Entity+Arcsecantf.Latexize() : System.String
 AngouriMath.Entity+Arcsecantf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Arcsecantf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Arcsecantf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -355,7 +355,7 @@ AngouriMath.Entity+Arcsinf.GetHashCode() : System.Int32
 AngouriMath.Entity+Arcsinf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Arcsinf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Arcsinf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Arcsinf.Latexise() : System.String
+AngouriMath.Entity+Arcsinf.Latexize() : System.String
 AngouriMath.Entity+Arcsinf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Arcsinf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Arcsinf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -377,7 +377,7 @@ AngouriMath.Entity+Arctanf.GetHashCode() : System.Int32
 AngouriMath.Entity+Arctanf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Arctanf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Arctanf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Arctanf.Latexise() : System.String
+AngouriMath.Entity+Arctanf.Latexize() : System.String
 AngouriMath.Entity+Arctanf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Arctanf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Arctanf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -399,7 +399,7 @@ AngouriMath.Entity+Boolean.False : AngouriMath.Entity+Boolean
 AngouriMath.Entity+Boolean.GetHashCode() : System.Int32
 AngouriMath.Entity+Boolean.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Boolean.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Boolean.Latexise() : System.String
+AngouriMath.Entity+Boolean.Latexize() : System.String
 AngouriMath.Entity+Boolean.Parse(System.String) : AngouriMath.Entity+Boolean
 AngouriMath.Entity+Boolean.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Boolean.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -440,7 +440,7 @@ AngouriMath.Entity+Ceilf.GetHashCode() : System.Int32
 AngouriMath.Entity+Ceilf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Ceilf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Ceilf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Ceilf.Latexise() : System.String
+AngouriMath.Entity+Ceilf.Latexize() : System.String
 AngouriMath.Entity+Ceilf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Ceilf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Ceilf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -486,7 +486,7 @@ AngouriMath.Entity+Cosecantf.GetHashCode() : System.Int32
 AngouriMath.Entity+Cosecantf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Cosecantf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Cosecantf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Cosecantf.Latexise() : System.String
+AngouriMath.Entity+Cosecantf.Latexize() : System.String
 AngouriMath.Entity+Cosecantf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Cosecantf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Cosecantf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -508,7 +508,7 @@ AngouriMath.Entity+Cosf.GetHashCode() : System.Int32
 AngouriMath.Entity+Cosf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Cosf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Cosf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Cosf.Latexise() : System.String
+AngouriMath.Entity+Cosf.Latexize() : System.String
 AngouriMath.Entity+Cosf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Cosf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Cosf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -530,7 +530,7 @@ AngouriMath.Entity+Cotanf.GetHashCode() : System.Int32
 AngouriMath.Entity+Cotanf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Cotanf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Cotanf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Cotanf.Latexise() : System.String
+AngouriMath.Entity+Cotanf.Latexize() : System.String
 AngouriMath.Entity+Cotanf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Cotanf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Cotanf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -552,7 +552,7 @@ AngouriMath.Entity+Derivativef.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Derivativef.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Derivativef.InnerSimplify(System.Boolean) : AngouriMath.Entity
 AngouriMath.Entity+Derivativef.Iterations { } : System.Int32
-AngouriMath.Entity+Derivativef.Latexise() : System.String
+AngouriMath.Entity+Derivativef.Latexize() : System.String
 AngouriMath.Entity+Derivativef.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Derivativef.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Derivativef.Stringize() : System.String
@@ -574,7 +574,7 @@ AngouriMath.Entity+Divf.GetHashCode() : System.Int32
 AngouriMath.Entity+Divf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Divf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Divf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Divf.Latexise() : System.String
+AngouriMath.Entity+Divf.Latexize() : System.String
 AngouriMath.Entity+Divf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Divf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Divf.PrintMembers(System.Text.StringBuilder) : System.Boolean
@@ -595,7 +595,7 @@ AngouriMath.Entity+Equalsf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Equalsf.GetHashCode() : System.Int32
 AngouriMath.Entity+Equalsf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Equalsf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Equalsf.Latexise() : System.String
+AngouriMath.Entity+Equalsf.Latexize() : System.String
 AngouriMath.Entity+Equalsf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Equalsf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Equalsf.NodeSecondChild { } : AngouriMath.Entity
@@ -620,7 +620,7 @@ AngouriMath.Entity+Factorialf.GetHashCode() : System.Int32
 AngouriMath.Entity+Factorialf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Factorialf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Factorialf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Factorialf.Latexise() : System.String
+AngouriMath.Entity+Factorialf.Latexize() : System.String
 AngouriMath.Entity+Factorialf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Factorialf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Factorialf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -642,7 +642,7 @@ AngouriMath.Entity+Floorf.GetHashCode() : System.Int32
 AngouriMath.Entity+Floorf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Floorf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Floorf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Floorf.Latexise() : System.String
+AngouriMath.Entity+Floorf.Latexize() : System.String
 AngouriMath.Entity+Floorf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Floorf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Floorf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -674,7 +674,7 @@ AngouriMath.Entity+Gcdf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Gcdf.GetHashCode() : System.Int32
 AngouriMath.Entity+Gcdf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Gcdf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Gcdf.Latexise() : System.String
+AngouriMath.Entity+Gcdf.Latexize() : System.String
 AngouriMath.Entity+Gcdf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Gcdf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Gcdf.NodeSecondChild { } : AngouriMath.Entity
@@ -697,7 +697,7 @@ AngouriMath.Entity+GreaterOrEqualf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+GreaterOrEqualf.GetHashCode() : System.Int32
 AngouriMath.Entity+GreaterOrEqualf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+GreaterOrEqualf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+GreaterOrEqualf.Latexise() : System.String
+AngouriMath.Entity+GreaterOrEqualf.Latexize() : System.String
 AngouriMath.Entity+GreaterOrEqualf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+GreaterOrEqualf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+GreaterOrEqualf.NodeSecondChild { } : AngouriMath.Entity
@@ -720,7 +720,7 @@ AngouriMath.Entity+Greaterf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Greaterf.GetHashCode() : System.Int32
 AngouriMath.Entity+Greaterf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Greaterf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Greaterf.Latexise() : System.String
+AngouriMath.Entity+Greaterf.Latexize() : System.String
 AngouriMath.Entity+Greaterf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Greaterf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Greaterf.NodeSecondChild { } : AngouriMath.Entity
@@ -745,7 +745,7 @@ AngouriMath.Entity+Impliesf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Impliesf.GetHashCode() : System.Int32
 AngouriMath.Entity+Impliesf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Impliesf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Impliesf.Latexise() : System.String
+AngouriMath.Entity+Impliesf.Latexize() : System.String
 AngouriMath.Entity+Impliesf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Impliesf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Impliesf.PrintMembers(System.Text.StringBuilder) : System.Boolean
@@ -767,7 +767,7 @@ AngouriMath.Entity+Integralf.GetHashCode() : System.Int32
 AngouriMath.Entity+Integralf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Integralf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Integralf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Integralf.Latexise() : System.String
+AngouriMath.Entity+Integralf.Latexize() : System.String
 AngouriMath.Entity+Integralf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Integralf.Range { } : System.Nullable<System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity>>
 AngouriMath.Entity+Integralf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -788,7 +788,7 @@ AngouriMath.Entity+Lambda.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Lambda.GetHashCode() : System.Int32
 AngouriMath.Entity+Lambda.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Lambda.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Lambda.Latexise() : System.String
+AngouriMath.Entity+Lambda.Latexize() : System.String
 AngouriMath.Entity+Lambda.Parameter { } : AngouriMath.Entity+Variable
 AngouriMath.Entity+Lambda.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Lambda.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -808,7 +808,7 @@ AngouriMath.Entity+LessOrEqualf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+LessOrEqualf.GetHashCode() : System.Int32
 AngouriMath.Entity+LessOrEqualf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+LessOrEqualf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+LessOrEqualf.Latexise() : System.String
+AngouriMath.Entity+LessOrEqualf.Latexize() : System.String
 AngouriMath.Entity+LessOrEqualf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+LessOrEqualf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+LessOrEqualf.NodeSecondChild { } : AngouriMath.Entity
@@ -831,7 +831,7 @@ AngouriMath.Entity+Lessf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Lessf.GetHashCode() : System.Int32
 AngouriMath.Entity+Lessf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Lessf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Lessf.Latexise() : System.String
+AngouriMath.Entity+Lessf.Latexize() : System.String
 AngouriMath.Entity+Lessf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Lessf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Lessf.NodeSecondChild { } : AngouriMath.Entity
@@ -857,7 +857,7 @@ AngouriMath.Entity+Limitf.GetHashCode() : System.Int32
 AngouriMath.Entity+Limitf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Limitf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Limitf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Limitf.Latexise() : System.String
+AngouriMath.Entity+Limitf.Latexize() : System.String
 AngouriMath.Entity+Limitf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Limitf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Limitf.Stringize() : System.String
@@ -879,7 +879,7 @@ AngouriMath.Entity+Logf.GetHashCode() : System.Int32
 AngouriMath.Entity+Logf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Logf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Logf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Logf.Latexise() : System.String
+AngouriMath.Entity+Logf.Latexize() : System.String
 AngouriMath.Entity+Logf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Logf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Logf.PrintMembers(System.Text.StringBuilder) : System.Boolean
@@ -928,7 +928,7 @@ AngouriMath.Entity+Matrix.IsSquare { } : System.Boolean
 AngouriMath.Entity+Matrix.IsVector { } : System.Boolean
 AngouriMath.Entity+Matrix.Item { } : AngouriMath.Entity
 AngouriMath.Entity+Matrix.Item { } : AngouriMath.Entity+Matrix
-AngouriMath.Entity+Matrix.Latexise() : System.String
+AngouriMath.Entity+Matrix.Latexize() : System.String
 AngouriMath.Entity+Matrix.MainDiagonal { } : AngouriMath.Entity+Matrix
 AngouriMath.Entity+Matrix.Pow(System.Int32) : AngouriMath.Entity+Matrix
 AngouriMath.Entity+Matrix.PrintMembers(System.Text.StringBuilder) : System.Boolean
@@ -970,7 +970,7 @@ AngouriMath.Entity+Maxf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Maxf.GetHashCode() : System.Int32
 AngouriMath.Entity+Maxf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Maxf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Maxf.Latexise() : System.String
+AngouriMath.Entity+Maxf.Latexize() : System.String
 AngouriMath.Entity+Maxf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Maxf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Maxf.NodeSecondChild { } : AngouriMath.Entity
@@ -993,7 +993,7 @@ AngouriMath.Entity+Minf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Minf.GetHashCode() : System.Int32
 AngouriMath.Entity+Minf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Minf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Minf.Latexise() : System.String
+AngouriMath.Entity+Minf.Latexize() : System.String
 AngouriMath.Entity+Minf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Minf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Minf.NodeSecondChild { } : AngouriMath.Entity
@@ -1017,7 +1017,7 @@ AngouriMath.Entity+Minusf.GetHashCode() : System.Int32
 AngouriMath.Entity+Minusf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Minusf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Minusf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Minusf.Latexise() : System.String
+AngouriMath.Entity+Minusf.Latexize() : System.String
 AngouriMath.Entity+Minusf.Minuend { } : AngouriMath.Entity
 AngouriMath.Entity+Minusf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Minusf.NodeSecondChild { } : AngouriMath.Entity
@@ -1043,7 +1043,7 @@ AngouriMath.Entity+Modf.GetHashCode() : System.Int32
 AngouriMath.Entity+Modf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Modf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Modf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Modf.Latexise() : System.String
+AngouriMath.Entity+Modf.Latexize() : System.String
 AngouriMath.Entity+Modf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Modf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Modf.PrintMembers(System.Text.StringBuilder) : System.Boolean
@@ -1065,7 +1065,7 @@ AngouriMath.Entity+Mulf.GetHashCode() : System.Int32
 AngouriMath.Entity+Mulf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Mulf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Mulf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Mulf.Latexise() : System.String
+AngouriMath.Entity+Mulf.Latexize() : System.String
 AngouriMath.Entity+Mulf.Multiplicand { } : AngouriMath.Entity
 AngouriMath.Entity+Mulf.Multiplier { } : AngouriMath.Entity
 AngouriMath.Entity+Mulf.Multiply(System.Collections.Generic.IEnumerable<AngouriMath.Entity>) : AngouriMath.Entity
@@ -1091,7 +1091,7 @@ AngouriMath.Entity+Notf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Notf.GetHashCode() : System.Int32
 AngouriMath.Entity+Notf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Notf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Notf.Latexise() : System.String
+AngouriMath.Entity+Notf.Latexize() : System.String
 AngouriMath.Entity+Notf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Notf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Notf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -1119,7 +1119,7 @@ AngouriMath.Entity+Number+Complex.ImaginaryOne : AngouriMath.Entity+Number+Compl
 AngouriMath.Entity+Number+Complex.ImaginaryPart { } : AngouriMath.Entity+Number+Real
 AngouriMath.Entity+Number+Complex.IsExact { } : System.Boolean
 AngouriMath.Entity+Number+Complex.IsZero { } : System.Boolean
-AngouriMath.Entity+Number+Complex.Latexise() : System.String
+AngouriMath.Entity+Number+Complex.Latexize() : System.String
 AngouriMath.Entity+Number+Complex.MinusImaginaryOne : AngouriMath.Entity+Number+Complex
 AngouriMath.Entity+Number+Complex.MultiplicativeIdentity { } : AngouriMath.Entity+Number+Complex
 AngouriMath.Entity+Number+Complex.NegNegInfinity : AngouriMath.Entity+Number+Complex
@@ -1183,7 +1183,7 @@ AngouriMath.Entity+Number+Integer.Factorize() : System.Collections.Generic.IEnum
 AngouriMath.Entity+Number+Integer.GetHashCode() : System.Int32
 AngouriMath.Entity+Number+Integer.IntegerDiv(AngouriMath.Entity+Number+Integer) : AngouriMath.Entity+Number+Integer
 AngouriMath.Entity+Number+Integer.IsPrime { } : System.Boolean
-AngouriMath.Entity+Number+Integer.Latexise() : System.String
+AngouriMath.Entity+Number+Integer.Latexize() : System.String
 AngouriMath.Entity+Number+Integer.MinusOne : AngouriMath.Entity+Number+Integer
 AngouriMath.Entity+Number+Integer.MultiplicativeIdentity { } : AngouriMath.Entity+Number+Integer
 AngouriMath.Entity+Number+Integer.One : AngouriMath.Entity+Number+Integer
@@ -1233,7 +1233,7 @@ AngouriMath.Entity+Number+Rational.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Number+Rational.FindRational(PeterO.Numbers.EDecimal, System.Int32) : AngouriMath.Entity+Number+Rational
 AngouriMath.Entity+Number+Rational.GetHashCode() : System.Int32
 AngouriMath.Entity+Number+Rational.IsExact { } : System.Boolean
-AngouriMath.Entity+Number+Rational.Latexise() : System.String
+AngouriMath.Entity+Number+Rational.Latexize() : System.String
 AngouriMath.Entity+Number+Rational.MultiplicativeIdentity { } : AngouriMath.Entity+Number+Rational
 AngouriMath.Entity+Number+Rational.Numerator { } : AngouriMath.Entity+Number+Integer
 AngouriMath.Entity+Number+Rational.PrintMembers(System.Text.StringBuilder) : System.Boolean
@@ -1282,7 +1282,7 @@ AngouriMath.Entity+Number+Real.GetHashCode() : System.Int32
 AngouriMath.Entity+Number+Real.IsExact { } : System.Boolean
 AngouriMath.Entity+Number+Real.IsNegative { } : System.Boolean
 AngouriMath.Entity+Number+Real.IsPositive { } : System.Boolean
-AngouriMath.Entity+Number+Real.Latexise() : System.String
+AngouriMath.Entity+Number+Real.Latexize() : System.String
 AngouriMath.Entity+Number+Real.MultiplicativeIdentity { } : AngouriMath.Entity+Number+Real
 AngouriMath.Entity+Number+Real.NaN : AngouriMath.Entity+Number+Real
 AngouriMath.Entity+Number+Real.NegativeInfinity : AngouriMath.Entity+Number+Real
@@ -1403,7 +1403,7 @@ AngouriMath.Entity+Orf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Orf.GetHashCode() : System.Int32
 AngouriMath.Entity+Orf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Orf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Orf.Latexise() : System.String
+AngouriMath.Entity+Orf.Latexize() : System.String
 AngouriMath.Entity+Orf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Orf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Orf.NodeSecondChild { } : AngouriMath.Entity
@@ -1427,7 +1427,7 @@ AngouriMath.Entity+Phif.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Phif.GetHashCode() : System.Int32
 AngouriMath.Entity+Phif.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Phif.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Phif.Latexise() : System.String
+AngouriMath.Entity+Phif.Latexize() : System.String
 AngouriMath.Entity+Phif.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Phif.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Phif.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -1450,7 +1450,7 @@ AngouriMath.Entity+Piecewise.GetHashCode() : System.Int32
 AngouriMath.Entity+Piecewise.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Piecewise.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Piecewise.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Piecewise.Latexise() : System.String
+AngouriMath.Entity+Piecewise.Latexize() : System.String
 AngouriMath.Entity+Piecewise.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Piecewise.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Piecewise.Stringize() : System.String
@@ -1472,7 +1472,7 @@ AngouriMath.Entity+Powf.GetHashCode() : System.Int32
 AngouriMath.Entity+Powf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Powf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Powf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Powf.Latexise() : System.String
+AngouriMath.Entity+Powf.Latexize() : System.String
 AngouriMath.Entity+Powf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Powf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Powf.PrintMembers(System.Text.StringBuilder) : System.Boolean
@@ -1495,7 +1495,7 @@ AngouriMath.Entity+Providedf.GetHashCode() : System.Int32
 AngouriMath.Entity+Providedf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Providedf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Providedf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Providedf.Latexise() : System.String
+AngouriMath.Entity+Providedf.Latexize() : System.String
 AngouriMath.Entity+Providedf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Providedf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Providedf.Predicate { } : AngouriMath.Entity
@@ -1519,7 +1519,7 @@ AngouriMath.Entity+Roundf.GetHashCode() : System.Int32
 AngouriMath.Entity+Roundf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Roundf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Roundf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Roundf.Latexise() : System.String
+AngouriMath.Entity+Roundf.Latexize() : System.String
 AngouriMath.Entity+Roundf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Roundf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Roundf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -1541,7 +1541,7 @@ AngouriMath.Entity+Secantf.GetHashCode() : System.Int32
 AngouriMath.Entity+Secantf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Secantf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Secantf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Secantf.Latexise() : System.String
+AngouriMath.Entity+Secantf.Latexize() : System.String
 AngouriMath.Entity+Secantf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Secantf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Secantf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -1564,7 +1564,7 @@ AngouriMath.Entity+Set+ConditionalSet.InitDirectChildren() : AngouriMath.Entity[
 AngouriMath.Entity+Set+ConditionalSet.InnerSimplify(System.Boolean) : AngouriMath.Entity
 AngouriMath.Entity+Set+ConditionalSet.IsSetEmpty { } : System.Boolean
 AngouriMath.Entity+Set+ConditionalSet.IsSetFinite { } : System.Boolean
-AngouriMath.Entity+Set+ConditionalSet.Latexise() : System.String
+AngouriMath.Entity+Set+ConditionalSet.Latexize() : System.String
 AngouriMath.Entity+Set+ConditionalSet.Predicate { } : AngouriMath.Entity
 AngouriMath.Entity+Set+ConditionalSet.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Set+ConditionalSet.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -1594,7 +1594,7 @@ AngouriMath.Entity+Set+FiniteSet.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Set+FiniteSet.InnerSimplify(System.Boolean) : AngouriMath.Entity
 AngouriMath.Entity+Set+FiniteSet.IsSetEmpty { } : System.Boolean
 AngouriMath.Entity+Set+FiniteSet.IsSetFinite { } : System.Boolean
-AngouriMath.Entity+Set+FiniteSet.Latexise() : System.String
+AngouriMath.Entity+Set+FiniteSet.Latexize() : System.String
 AngouriMath.Entity+Set+FiniteSet.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Set+FiniteSet.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Set+FiniteSet.Stringize() : System.String
@@ -1618,7 +1618,7 @@ AngouriMath.Entity+Set+Inf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Set+Inf.GetHashCode() : System.Int32
 AngouriMath.Entity+Set+Inf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Set+Inf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Set+Inf.Latexise() : System.String
+AngouriMath.Entity+Set+Inf.Latexize() : System.String
 AngouriMath.Entity+Set+Inf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Set+Inf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Set+Inf.PrintMembers(System.Text.StringBuilder) : System.Boolean
@@ -1643,7 +1643,7 @@ AngouriMath.Entity+Set+Intersectionf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Set+Intersectionf.InnerSimplify(System.Boolean) : AngouriMath.Entity
 AngouriMath.Entity+Set+Intersectionf.IsSetEmpty { } : System.Boolean
 AngouriMath.Entity+Set+Intersectionf.IsSetFinite { } : System.Boolean
-AngouriMath.Entity+Set+Intersectionf.Latexise() : System.String
+AngouriMath.Entity+Set+Intersectionf.Latexize() : System.String
 AngouriMath.Entity+Set+Intersectionf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Set+Intersectionf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Set+Intersectionf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -1669,7 +1669,7 @@ AngouriMath.Entity+Set+Interval.InnerSimplify(System.Boolean) : AngouriMath.Enti
 AngouriMath.Entity+Set+Interval.IsNumeric { } : System.Boolean
 AngouriMath.Entity+Set+Interval.IsSetEmpty { } : System.Boolean
 AngouriMath.Entity+Set+Interval.IsSetFinite { } : System.Boolean
-AngouriMath.Entity+Set+Interval.Latexise() : System.String
+AngouriMath.Entity+Set+Interval.Latexize() : System.String
 AngouriMath.Entity+Set+Interval.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Set+Interval.LeftClosed { } : System.Boolean
 AngouriMath.Entity+Set+Interval.PrintMembers(System.Text.StringBuilder) : System.Boolean
@@ -1696,7 +1696,7 @@ AngouriMath.Entity+Set+SetMinusf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Set+SetMinusf.InnerSimplify(System.Boolean) : AngouriMath.Entity
 AngouriMath.Entity+Set+SetMinusf.IsSetEmpty { } : System.Boolean
 AngouriMath.Entity+Set+SetMinusf.IsSetFinite { } : System.Boolean
-AngouriMath.Entity+Set+SetMinusf.Latexise() : System.String
+AngouriMath.Entity+Set+SetMinusf.Latexize() : System.String
 AngouriMath.Entity+Set+SetMinusf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Set+SetMinusf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Set+SetMinusf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -1787,7 +1787,7 @@ AngouriMath.Entity+Set+SpecialSet.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Set+SpecialSet.InnerSimplify(System.Boolean) : AngouriMath.Entity
 AngouriMath.Entity+Set+SpecialSet.IsSetEmpty { } : System.Boolean
 AngouriMath.Entity+Set+SpecialSet.IsSetFinite { } : System.Boolean
-AngouriMath.Entity+Set+SpecialSet.Latexise() : System.String
+AngouriMath.Entity+Set+SpecialSet.Latexize() : System.String
 AngouriMath.Entity+Set+SpecialSet.MayContain(AngouriMath.Entity) : System.Boolean
 AngouriMath.Entity+Set+SpecialSet.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Set+SpecialSet.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -1811,7 +1811,7 @@ AngouriMath.Entity+Set+Unionf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Set+Unionf.InnerSimplify(System.Boolean) : AngouriMath.Entity
 AngouriMath.Entity+Set+Unionf.IsSetEmpty { } : System.Boolean
 AngouriMath.Entity+Set+Unionf.IsSetFinite { } : System.Boolean
-AngouriMath.Entity+Set+Unionf.Latexise() : System.String
+AngouriMath.Entity+Set+Unionf.Latexize() : System.String
 AngouriMath.Entity+Set+Unionf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Set+Unionf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Set+Unionf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -1854,7 +1854,7 @@ AngouriMath.Entity+Signumf.GetHashCode() : System.Int32
 AngouriMath.Entity+Signumf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Signumf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Signumf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Signumf.Latexise() : System.String
+AngouriMath.Entity+Signumf.Latexize() : System.String
 AngouriMath.Entity+Signumf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Signumf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Signumf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -1876,7 +1876,7 @@ AngouriMath.Entity+Sinf.GetHashCode() : System.Int32
 AngouriMath.Entity+Sinf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Sinf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Sinf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Sinf.Latexise() : System.String
+AngouriMath.Entity+Sinf.Latexize() : System.String
 AngouriMath.Entity+Sinf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Sinf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Sinf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -1911,7 +1911,7 @@ AngouriMath.Entity+Sumf.GetHashCode() : System.Int32
 AngouriMath.Entity+Sumf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Sumf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Sumf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Sumf.Latexise() : System.String
+AngouriMath.Entity+Sumf.Latexize() : System.String
 AngouriMath.Entity+Sumf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Sumf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Sumf.PrintMembers(System.Text.StringBuilder) : System.Boolean
@@ -1936,7 +1936,7 @@ AngouriMath.Entity+Tanf.GetHashCode() : System.Int32
 AngouriMath.Entity+Tanf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Tanf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Tanf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Tanf.Latexise() : System.String
+AngouriMath.Entity+Tanf.Latexize() : System.String
 AngouriMath.Entity+Tanf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Tanf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Tanf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -1969,7 +1969,7 @@ AngouriMath.Entity+Variable.GetHashCode() : System.Int32
 AngouriMath.Entity+Variable.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Variable.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Variable.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Variable.Latexise() : System.String
+AngouriMath.Entity+Variable.Latexize() : System.String
 AngouriMath.Entity+Variable.Name { } : System.String
 AngouriMath.Entity+Variable.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Variable.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -1988,7 +1988,7 @@ AngouriMath.Entity+Xorf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Xorf.GetHashCode() : System.Int32
 AngouriMath.Entity+Xorf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Xorf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Xorf.Latexise() : System.String
+AngouriMath.Entity+Xorf.Latexize() : System.String
 AngouriMath.Entity+Xorf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Xorf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Xorf.NodeSecondChild { } : AngouriMath.Entity
@@ -2071,8 +2071,8 @@ AngouriMath.Entity.IsFinite { } : System.Boolean
 AngouriMath.Entity.IsNaN { } : System.Boolean
 AngouriMath.Entity.IsSymbolic { } : System.Boolean
 AngouriMath.Entity.LambdaOver(AngouriMath.Entity+Variable) : AngouriMath.Entity
-AngouriMath.Entity.Latexise() : System.String
-AngouriMath.Entity.Latexise(System.Boolean) : System.String
+AngouriMath.Entity.Latexize() : System.String
+AngouriMath.Entity.Latexize(System.Boolean) : System.String
 AngouriMath.Entity.Limit(AngouriMath.Entity+Variable, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity.Limit(AngouriMath.Entity+Variable, AngouriMath.Entity, AngouriMath.Core.ApproachFrom) : AngouriMath.Entity
 AngouriMath.Entity.Log(AngouriMath.Entity) : AngouriMath.Entity
@@ -2176,7 +2176,7 @@ AngouriMath.Extensions.AngouriMathExtensions.Factorize(System.String) : AngouriM
 AngouriMath.Extensions.AngouriMathExtensions.Integrate(System.String, AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Extensions.AngouriMathExtensions.Integrate(System.String, AngouriMath.Entity+Variable, AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Extensions.AngouriMathExtensions.Intersect(System.Collections.Generic.IEnumerable<AngouriMath.Entity+Set>) : AngouriMath.Entity+Set
-AngouriMath.Extensions.AngouriMathExtensions.Latexise(System.String) : System.String
+AngouriMath.Extensions.AngouriMathExtensions.Latexize(System.String) : System.String
 AngouriMath.Extensions.AngouriMathExtensions.Limit(System.String, AngouriMath.Entity+Variable, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Extensions.AngouriMathExtensions.Limit(System.String, AngouriMath.Entity+Variable, AngouriMath.Entity, AngouriMath.Core.ApproachFrom) : AngouriMath.Entity
 AngouriMath.Extensions.AngouriMathExtensions.MultiplyAll(System.Collections.Generic.IEnumerable<AngouriMath.Entity>) : AngouriMath.Entity
@@ -2396,7 +2396,7 @@ AngouriMath.MathS.Intersection(AngouriMath.Entity, AngouriMath.Entity) : Angouri
 AngouriMath.MathS.Interval(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity+Set+Interval
 AngouriMath.MathS.Interval(AngouriMath.Entity, System.Boolean, AngouriMath.Entity, System.Boolean) : AngouriMath.Entity+Set+Interval
 AngouriMath.MathS.Lambda(AngouriMath.Entity+Variable, AngouriMath.Entity) : AngouriMath.Entity
-AngouriMath.MathS.Latex(AngouriMath.Core.ILatexiseable) : System.String
+AngouriMath.MathS.Latex(AngouriMath.Core.ILatexizeable) : System.String
 AngouriMath.MathS.LessOrEqualThan(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.MathS.LessThan(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.MathS.Limit(AngouriMath.Entity, AngouriMath.Entity, AngouriMath.Entity, AngouriMath.Core.ApproachFrom) : AngouriMath.Entity
@@ -2593,7 +2593,7 @@ interface AngouriMath.Core.IBinaryNode
 interface AngouriMath.Core.IClosedArithmetics<T>
 interface AngouriMath.Core.IHasAbsoluteValue<TSelf,TOut>
 interface AngouriMath.Core.IHasNeutralValues<T>
-interface AngouriMath.Core.ILatexiseable
+interface AngouriMath.Core.ILatexizeable
 interface AngouriMath.Core.IScalarClosedArithmetics<T>
 interface AngouriMath.Core.IUnaryNode
 struct AngouriMath.Convenience.Setting<T>

--- a/Sources/Tests/UnitTests/Convenience/FloorCeilTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/FloorCeilTest.cs
@@ -86,7 +86,7 @@ namespace AngouriMath.Tests.Convenience
         [InlineData("floor(x)", @"\left\lfloor{x}\right\rfloor")]
         [InlineData("ceil(x)", @"\left\lceil{x}\right\rceil")]
         public void TheLatexIsTheUsualBrackets(string input, string expected)
-            => Assert.Equal(expected, input.ToEntity().Latexise());
+            => Assert.Equal(expected, input.ToEntity().Latexize());
 
         // Stringize prints the short spelling, and SymPy's `ceiling` is accepted on the way
         // in so that an expression copied from there parses.

--- a/Sources/Tests/UnitTests/Convenience/LatexTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/LatexTest.cs
@@ -23,8 +23,8 @@ namespace AngouriMath.Tests.Convenience
         private static readonly Entity m2i = -2 * MathS.i;
         private static readonly Entity numPi = MathS.DecimalConst.pi;
         private static readonly Entity mNumPi = -MathS.DecimalConst.pi;
-        void Test(string expected, ILatexiseable actual) =>
-            Assert.Equal(expected, actual.Latexise());
+        void Test(string expected, ILatexizeable actual) =>
+            Assert.Equal(expected, actual.Latexize());
         void TestSimplify(string expected, Entity actual) =>
             Test(expected, actual.Simplify());
         [Fact] public void Num0() => TestSimplify("0", 0);
@@ -246,7 +246,7 @@ namespace AngouriMath.Tests.Convenience
             Test(@"\int\int\int \left({x}^{23}-x_{\mathrm{16}}\right)\,\mathrm{d}\left({x_{f}}^{2}\right)\,\mathrm{d}\left({x_{f}}^{2}\right)\,\mathrm{d}\left({x_{f}}^{2}\right)", MathS.Derivative("x^23-x_16", "x_f^2", -3));
         [Fact] public void DerivativeAt0() => Test(@"\frac{\mathrm{d}^{0}}{\mathrm{d}x^{0}}\left(x+1\right)+1", MathS.Derivative("x+1", "x", 0) + 1);
         [Theory, CombinatorialData] public void DerivativeAsIntegral([CombinatorialValues("x", "x_f", "ab", "ab_cd", "e", "alpha", "alpha_beta", "alpha_e")] string v) =>
-            Test(MathS.Integral(Integer.One + v, v).Latexise(), MathS.Derivative(Integer.One + v, v, -1));
+            Test(MathS.Integral(Integer.One + v, v).Latexize(), MathS.Derivative(Integer.One + v, v, -1));
         [Fact] public void Limit1() =>
             Test(@"\lim_{x\to 0^-} \left(x+y\right)", (Entity)"limitleft(x + y, x, 0)");
         [Fact] public void Limit2() =>

--- a/Sources/Tests/UnitTests/Convenience/ModulusTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/ModulusTest.cs
@@ -88,8 +88,8 @@ namespace AngouriMath.Tests.Convenience
             Assert.Equal("x mod 3", "x mod 3".ToEntity().Stringize());
 
         [Fact]
-        public void ItLatexisesAsBmod() =>
-            Assert.Equal(@"x \bmod 3", "x mod 3".ToEntity().Latexise());
+        public void ItLatexizesAsBmod() =>
+            Assert.Equal(@"x \bmod 3", "x mod 3".ToEntity().Latexize());
 
         [Theory]
         [InlineData("x mod x", "0")]

--- a/Sources/Tests/UnitTests/Convenience/RoundMinMaxGcdTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/RoundMinMaxGcdTest.cs
@@ -119,7 +119,7 @@ namespace AngouriMath.Tests.Convenience
         [InlineData("max(x, y)", @"\max\left(x, y\right)")]
         [InlineData("gcd(x, y)", @"\gcd\left(x, y\right)")]
         public void TheLatexIsTheUsualNotation(string input, string expected)
-            => Assert.Equal(expected, input.ToEntity().Latexise());
+            => Assert.Equal(expected, input.ToEntity().Latexize());
 
         /// <summary>
         /// Round is flat between the <i>half</i>-integers and jumps at each of them, which is

--- a/Sources/Wrappers/AngouriMath.CPP.Exporting/Exports.Entity.Methods.cs
+++ b/Sources/Wrappers/AngouriMath.CPP.Exporting/Exports.Entity.Methods.cs
@@ -22,10 +22,10 @@ namespace AngouriMath.CPP.Exporting
                 exprPtr => Marshal.StringToHGlobalAnsi(exprPtr.AsEntity.ToString())
             );
 
-        [UnmanagedCallersOnly(EntryPoint = "entity_latexise")]
+        [UnmanagedCallersOnly(EntryPoint = "entity_latexize")]
         public static NErrorCode EntityToLatex(ObjRef exprPtr, IntPtr* res)
             => ExceptionEncode(res, exprPtr,
-                exprPtr => Marshal.StringToHGlobalAnsi(exprPtr.AsEntity.Latexise())
+                exprPtr => Marshal.StringToHGlobalAnsi(exprPtr.AsEntity.Latexize())
             );
 
         #endregion

--- a/Sources/Wrappers/AngouriMath.CPP.Importing/AngouriMath.cpp
+++ b/Sources/Wrappers/AngouriMath.CPP.Importing/AngouriMath.cpp
@@ -84,10 +84,10 @@ namespace AngouriMath
         return innerEntityInstance.get()->CachedString();
     }
 
-    std::string Entity::Latexise() const
+    std::string Entity::Latexize() const
     {
         char* buff = nullptr;
-        HandleErrorCode(entity_latexise(innerEntityInstance.get()->GetReference(), &buff));
+        HandleErrorCode(entity_latexize(innerEntityInstance.get()->GetReference(), &buff));
         auto res = buff != nullptr ? std::string(buff) : std::string();
         free_string(buff);
         return res;

--- a/Sources/Wrappers/AngouriMath.CPP.Importing/AngouriMath.h
+++ b/Sources/Wrappers/AngouriMath.CPP.Importing/AngouriMath.h
@@ -64,7 +64,7 @@ namespace AngouriMath
 
         // Methods
         std::string ToString() const;
-        std::string Latexise() const;
+        std::string Latexize() const;
         Entity Differentiate(const Entity& var) const;
         Entity Integrate(const Entity& var) const;
         Entity Solve(const Entity& var) const;

--- a/Sources/Wrappers/AngouriMath.CPP.Importing/Imports.h
+++ b/Sources/Wrappers/AngouriMath.CPP.Importing/Imports.h
@@ -17,7 +17,7 @@ extern "C"
     DLL_CODE NativeErrorCode free_string(String);
 
     DLL_CODE NativeErrorCode entity_to_string(EntityRef, StringOut);
-    DLL_CODE NativeErrorCode entity_latexise(EntityRef, StringOut);
+    DLL_CODE NativeErrorCode entity_latexize(EntityRef, StringOut);
     DLL_CODE NativeErrorCode maths_from_string(String, EntityOut);
 
     DLL_CODE NativeErrorCode entity_differentiate(EntityRef, EntityRef, EntityOut);

--- a/Sources/Wrappers/AngouriMath.FSharp/Functions.fs
+++ b/Sources/Wrappers/AngouriMath.FSharp/Functions.fs
@@ -25,7 +25,7 @@ let asBool expr =
 
 /// Gets the LaTeX form of an expression
 let latex x =
-    (parsed x).Latexise()
+    (parsed x).Latexize()
 
 /// Substitutes the given variable with the given value in the given expression
 let substituted x value expr = (parsed expr).Substitute(parsed x, parsed value).InnerSimplified

--- a/Sources/Wrappers/AngouriMath.Interactive/KernelExtension.fs
+++ b/Sources/Wrappers/AngouriMath.Interactive/KernelExtension.fs
@@ -12,9 +12,9 @@ open AngouriMath.FSharp.Functions
 
 type KernelExtension() = 
     static member public applyMagic () =
-        let registerLatexRendering (latexiser : 'a -> string) =
+        let registerLatexRendering (latexizer : 'a -> string) =
             // register text/latex
-            (fun o -> $"$${latexiser o}$$")
+            (fun o -> $"$${latexizer o}$$")
             |> (fun f -> new Func<'a, string>(f))
             |> (fun f -> Formatter.Register<'a>(f, "text/latex"))
 
@@ -22,7 +22,7 @@ type KernelExtension() =
             (fun o -> $@"
 <script src='https://polyfill.io/v3/polyfill.min.js?features=es6'></script>
 <script id='MathJax-script' async src='https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js'></script>
-\[{latexiser o}\]")
+\[{latexizer o}\]")
             |> (fun f -> new Func<'a, string>(f))
             |> (fun f -> Formatter.Register<'a>(f, "text/html"))
 
@@ -36,7 +36,7 @@ type KernelExtension() =
         Formatter.SetPreferredMimeTypesFor(typeof<EInteger>, "text/plain")
         Formatter.Register<EInteger>(new Func<EInteger, string>(fun o -> o.ToString()), "text/plain")
 
-        registerLatexRendering (fun (o : ILatexiseable) -> latex o)
+        registerLatexRendering (fun (o : ILatexizeable) -> latex o)
 
         registerLatexRendering (fun (o : ERational) -> $@"\frac{{{o.Numerator}}}{{{o.Denominator}}}")
 


### PR DESCRIPTION
Closes #840, taking option 1 from that issue.

## Why

`Stringize` and `Latexise` do the same kind of thing, are declared next to each other, and are overridden per node in the same files. One is American, one is British. Measured on `9ae9a845`:

| | `override string …` | identifier occurrences |
|---|---|---|
| `Stringize` | 65 | 276 |
| `Latexise` | 61 | 189 |

Everything else public is `-ize` — `Stringize`, `Entity.Factorize`, `Integer.Factorize`, `Serialize`, `Deserialize`. `Latexise` and `ILatexiseable` were the only members a caller had to remember the other spelling for.

## What changed

Every surface the name reaches, not only the C# method:

| | was | is |
|---|---|---|
| method | `Latexise()` | `Latexize()` |
| interface | `ILatexiseable` | `ILatexizeable` |
| string extension | `"x + 1".Latexise()` | `"x + 1".Latexize()` |
| helper | `MathS.Latex(ILatexiseable)` | `MathS.Latex(ILatexizeable)` |
| native entry point | `entity_latexise` | `entity_latexize` |
| C++ wrapper | `Entity::Latexise()` | `Entity::Latexize()` |
| F# | `latexise` | `latexize` |

**No forwarding member.** #832 has just finished deleting 28 members that accumulated as forwarders; adding a permanent one here would undo that on the same day.

`MathS.Quantum.Factorise` deliberately keeps its spelling — renaming it to `Factorize` would give the library two unrelated public `Factorize` methods (expression factoring on `Entity`, tensor factorisation on a quantum state), which is worse than the inconsistency. It wants a distinguishing name, which is not decided here.

## One file deliberately not renamed

`Sources/Samples/SampleNet5/Program.cs` keeps `Latexise`. It compiles against `PackageReference AngouriMath 1.3.0`, not against this source, so the old name is the correct one there until the sample is repointed at 2.0. Renaming it broke the build, which is how this was found.

## Also fixed

`BREAKING-CHANGES.md` claimed *"nothing parses LaTeX"*. CSharpMath does — that is what #822 established and what `AGENTS.md` already says. Corrected rather than left standing in the release notes.

## Measured

Every project that builds on Linux, built individually:

| project | result |
|---|---|
| `AngouriMath` | 0 errors |
| `UnitTests` | 0 errors |
| `AngouriMath.FSharp` | 0 errors |
| `AngouriMath.Interactive` | 0 errors |
| `AngouriMath.CPP.Exporting` | 0 errors |
| `AngouriMath.Terminal.Lib` | 0 errors |
| `SampleNet5` | 0 errors |

```
Passed! - Failed: 0, Passed: 6049, Skipped: 14, Total: 6063 - UnitTests.dll (net10.0)
```

## Downstream, and the order it has to happen in

`CSharpMath.Evaluation` is affected in four files — and more deeply than a call-site count suggests: its `MathItem` record **implements `ILatexiseable`** and overrides `Latexise()`.

It cannot be fixed first, or in parallel. It consumes `<PackageReference Include="AngouriMath" Version="1.4.0" />`, so a rename there does not compile until 2.0 is on NuGet. The order is forced:

1. this PR,
2. publish 2.0 to NuGet,
3. one PR to CSharpMath that bumps the package reference to 2.0 **and** renames — atomically, since neither half compiles without the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
