### PR TITLE
Drop a CS0618 pragma that had nothing left to suppress

### DIFF
--- a/Sources/Tests/UnitTests/Core/Multithreading/SettingsAndThreads.cs
+++ b/Sources/Tests/UnitTests/Core/Multithreading/SettingsAndThreads.cs
@@ -16,8 +16,10 @@ namespace AngouriMath.Tests.Core.Multithreading
     [Trait("Area", "Core")]
     public sealed class SettingsAndThreads
     {
-        #region Obsolete settings
-#pragma warning disable CS0618 // The obsolete method should still work!
+        // A setting can be scoped two ways: As(value, action) runs the action under it, and
+        // Set(value) returns a disposable that restores it. Both are supported; each region
+        // covers one of them.
+        #region Callback form -- As(value, action)
         [Fact]
         public void OSettingValue1()
         {
@@ -86,10 +88,9 @@ namespace AngouriMath.Tests.Core.Multithreading
                 }
             );
         }
-#pragma warning restore CS0618 // The obsolote method should still work!
         #endregion
 
-        #region Normal settings
+        #region Disposable form -- Set(value)
         [Fact]
         public void SettingValue1()
         {


### PR DESCRIPTION
Hygiene found while checking what 2.0 still needs.

`Sources/Tests/UnitTests/Core/Multithreading/SettingsAndThreads.cs` had a region labelled `Obsolete settings` wrapped in `#pragma warning disable CS0618`. Neither is true any more:

- `SettingClass.As(T value, Action action)` (`SettingClass.cs:57`) is a live, documented, non-obsolete member. It was never removed.
- There are now **zero** `[Obsolete]` members anywhere in `Sources` — #832 removed all 28.

So the pragma suppressed nothing, while remaining able to hide the next member that becomes obsolete inside those forty lines. This repository has already been bitten once by a CS0618 pragma masking real usage (#832 found two), which is the argument for not leaving dead ones lying about.

**The build is the proof, not the reasoning.** `TreatWarningsAsErrors` is on, so with the pragma removed a genuinely obsolete call in that region would now fail the build. It compiles clean, and `grep -c CS0618` over `Sources` is 0.

## The label was the more misleading half

The two regions do not divide into "obsolete" and "current". They cover the two ways a setting can be scoped, both supported:

```csharp
MathS.Settings.MaxExpansionTermCount.As(27, () => { /* ... */ });   // callback form
using var _ = MathS.Settings.MaxExpansionTermCount.Set(27);          // disposable form
```

A reader would reasonably have concluded from `#region Obsolete settings` that `As` was deprecated and avoided it. The regions now name the two forms.

```
Passed! - Failed: 0, Passed: 10, Skipped: 0, Total: 10 - SettingsAndThreads
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)