### PR TITLE
Build the samples against the source, not a package from two majors ago

### DIFF
--- a/Sources/Samples/FSharpSample/FSharpSample.fsproj
+++ b/Sources/Samples/FSharpSample/FSharpSample.fsproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngouriMath.FSharp" Version="1.3.0" />
+    <ProjectReference Include="..\..\Wrappers\AngouriMath.FSharp\AngouriMath.FSharp.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/Sources/Samples/FSharpSample/Program.fs
+++ b/Sources/Samples/FSharpSample/Program.fs
@@ -43,4 +43,4 @@ printfn "%O" (``lim x->0`` "sin(a x) / x")
 printfn "%O" (limit "x" 0 "sin(a x) / x")
 
 // LaTeX
-printfn "%O" (latex "x / e + alpha + sqrt(x) + integral(y + 3, y, 1)")
+printfn "%O" (latex "x / e + alpha + sqrt(x) + integral(y + 3, y)")

--- a/Sources/Samples/SampleNet5/Program.cs
+++ b/Sources/Samples/SampleNet5/Program.cs
@@ -38,24 +38,24 @@ WriteLine();
 // Solve a complicated statement
 WriteLine("(x - 2)(x - 3) = 0 and (x - 1)(x - 2) = 0".Solve("x").InnerSimplified.Stringize());
 WriteLine("sin(a x)2 + c sin(2 a x) = c".Solve("x"));
-WriteLine("(x - 6)(x + 9) >= 0".Solve("x").Latexise());
+WriteLine("(x - 6)(x + 9) >= 0".Solve("x").Latexize());
 WriteLine();
 
 // Work with sets
-WriteLine("{ 1, 2 }".Latexise());
-WriteLine("[3; +oo)".Latexise());
-WriteLine("RR".Latexise());
-WriteLine("{ x : x8 + a x < 0 }".Latexise());
-WriteLine(@"A \/ B".Latexise());
-WriteLine(@"A /\ B".Latexise());
-WriteLine(@"A \ B".Latexise());
+WriteLine("{ 1, 2 }".Latexize());
+WriteLine("[3; +oo)".Latexize());
+WriteLine("RR".Latexize());
+WriteLine("{ x : x8 + a x < 0 }".Latexize());
+WriteLine(@"A \/ B".Latexize());
+WriteLine(@"A /\ B".Latexize());
+WriteLine(@"A \ B".Latexize());
 WriteLine(@"{ 1, 2, 3 } \/ { 3, 5 }".Simplify());
 WriteLine(@"[a; b) \/ { b }".Simplify());
 WriteLine();
 
 // Differentiate, integrate, find limits
 WriteLine("x2 + a x".Differentiate("x").InnerSimplified);
-WriteLine("x2 + a x".Integrate("x").InnerSimplified.Latexise());
+WriteLine("x2 + a x".Integrate("x").InnerSimplified.Latexize());
 WriteLine("(a x2 + b x) / (e x - h x2 - 3)".Limit("x", "+oo").InnerSimplified);
 WriteLine();
 
@@ -66,4 +66,4 @@ WriteLine(MathS.Boolean.BuildTruthTable("a and b implies c", "a", "b", "c"));
 WriteLine();
 
 // LaTeX
-WriteLine("x ^ y + sqrt(x) + integral(sqrt(x) / a, x, 1) + derivative(sqrt(x) / a, x, 1) + limit(sqrt(x) / a, x, +oo)".Latexise());
+WriteLine("x ^ y + sqrt(x) + integral(sqrt(x) / a, x) + derivative(sqrt(x) / a, x, 1) + limit(sqrt(x) / a, x, +oo)".Latexize());

--- a/Sources/Samples/SampleNet5/SampleNet5.csproj
+++ b/Sources/Samples/SampleNet5/SampleNet5.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngouriMath" Version="1.3.0" />
+    <ProjectReference Include="..\..\AngouriMath\AngouriMath.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Answers the question of whether the samples need pinning at all. Measured: they do not, and the pin was actively hiding a bug.

## The change

`SampleNet5` referenced `AngouriMath 1.3.0` and `FSharpSample` referenced `AngouriMath.FSharp 1.3.0`, while every other project in the solution uses a `ProjectReference`. Both now do too.

The usual argument for a `PackageReference` in a sample is that it demonstrates what a consumer actually gets. This pin did not do that — it demonstrated neither the current source nor the current release, only January's 1.3.0. What it did do was keep the samples out of every tree-wide change: the `Latexise` rename in #842 swept the whole repository and skipped them silently, which is how I found them.

`SampleNet5` needed the rename applied. `FSharpSample` needed nothing.

## What running them turned up

Building was not enough. Both samples **compiled clean and then crashed**, in the same place:

```
FunctionArgumentCountException: integral should have exactly 4 arguments
or 2 arguments but 3 arguments are provided
```

Both called `integral(f, x, 1)`. Measured across three published versions rather than inferred:

| version | `integral(f, x, 1)` | `derivative(f, x, 1)` |
|---|---|---|
| 1.3.0 | **accepted** → `integral(f, x)` | accepted |
| 1.4.0 | **throws** | accepted |
| 2.0.0-preview.1 | **throws** | accepted |

So this is **not a 2.0 change — it shipped in 1.4.0**. Both samples have been broken against the current release since January, and the 1.3.0 pin is exactly why nobody could see it.

They now use the two-argument form, which is what 1.3.0 turned the three-argument one into anyway (`integral(f, x, 1)` printed as `integral(f, x)`), so the samples are unchanged in meaning.

Filed separately as #847, since whether `integral` should regain the three-argument form — or whether `derivative` keeping it is the inconsistency — is a decision rather than a cleanup.

## Measured

```
[0] Samples/SampleNet5/SampleNet5.csproj   :: 0 err, 0 warn
[0] Samples/FSharpSample/FSharpSample.fsproj :: 0 err, 0 warn
```

Both run to completion against 2.0. `SampleNet5`'s last line:

```
{x}^{y}+\sqrt{x}+\int \frac{\sqrt{x}}{a}\,\mathrm{d}x+\frac{\mathrm{d}}{\mathrm{d}x}\frac{\sqrt{x}}{a}+\lim_{x\to \infty } \frac{\sqrt{x}}{a}
```

## Worth considering separately

Nothing builds or runs these in CI. That is what let a sample stay broken for seven months. A job that runs both would have caught it the week it happened, and would catch the next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
