### PR TITLE
Write down integral's two forms, and 1.4.0's unrecorded break

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -1528,6 +1528,34 @@ Not behavioural changes, listed so that a reader working through this file has t
 
 ---
 
+## 1.4.0 — one change that was never written down
+
+This file begins at 2.0.0, so a break introduced *by* 1.4.0 has had no home in it. One is worth
+recording, because 1.4.0 is what a `dotnet add package` installs today and the change is silent
+until a string is parsed.
+
+### `integral` takes bounds, not an iteration count
+
+| | 1.3.0 | 1.4.0 onwards |
+|---|---|---|
+| `integral(f, x, 1)` | accepted, read as `integral(f, x)` | `FunctionArgumentCountException` |
+| `integral(f, x, a, b)` | — | the definite integral from `a` to `b` |
+
+The third argument used to be a repetition count and is now the lower bound of a range, so three
+arguments name neither form and are refused. `derivative(f, x, n)` is unaffected and still takes an
+order, which is why the two functions read differently.
+
+This was deliberate — PR [#657](https://github.com/asc-community/AngouriMath/pull/657), "change
+integral node to support range instead of iterations" — and it is covered by a test. It simply went
+out without a note. Both samples in this repository called `integral(f, x, 1)` and had been failing
+against 1.4.0 since January without anyone seeing it, because they were pinned to 1.3.0; PR
+[#846](https://github.com/asc-community/AngouriMath/pull/846) is what surfaced it.
+
+**What to do.** `integral(f, x, 1)` becomes `integral(f, x)` — identical in meaning, since 1.3.0
+turned the former into the latter anyway. For a repeated antiderivative, nest the calls.
+
+---
+
 ## If one of these hurts
 
 Open an issue at https://github.com/asc-community/AngouriMath/issues saying what you were relying

--- a/Sources/AngouriMath/Docs/Usage/Syntax.md
+++ b/Sources/AngouriMath/Docs/Usage/Syntax.md
@@ -108,8 +108,14 @@ any number of arguments and fold. `min` and `max` compare only where the argumen
 are otherwise left as written. `gcd` computes over integers and rationals — `gcd(1/2, 1/3)` is
 `1/6` — and leaves the polynomial case alone.
 
-**Calculus** — `derivative(expr, var, order)`, `integral(expr, var)`, `limit(expr, var, dest)`,
-`limitleft(...)`, `limitright(...)`.
+**Calculus** — `derivative(expr, var, order)`, `integral(expr, var)`,
+`integral(expr, var, from, to)`, `limit(expr, var, dest)`, `limitleft(...)`, `limitright(...)`.
+
+`derivative` takes an order and `integral` does not: `derivative(f, x, 2)` is the second
+derivative, while `integral`'s third and fourth arguments are the bounds of a definite integral,
+not a count. `integral(f, x, 2)` is therefore a parse error rather than the second antiderivative
+— three arguments name neither form. This is deliberate; the iteration count was replaced by the
+range in [#657](https://github.com/asc-community/AngouriMath/pull/657).
 
 **Structural** — `piecewise(a provided p, b provided q)`, `lambda(param, body)`,
 `apply(f, arg, ...)`, `domain(expr, set)`.


### PR DESCRIPTION
The documentation half of #847 — which is all that survives of it, after I corrected the rest of that issue.

## What was actually missing

`Syntax.md:111` listed `integral(expr, var)` and stopped. The definite form `integral(expr, var, from, to)` is supported and covered by tests in three files (`FromStringTest.cs:160`, `ToSymPyTEst.cs:40`, `IntegrationTest.cs:210`), but a caller reading the syntax reference was told only the two-argument form existed, with no way to discover the other — which is precisely the form that *replaced* the three-argument one.

It now lists both, and says why the two calculus functions read differently:

> `derivative` takes an order and `integral` does not: `derivative(f, x, 2)` is the second derivative, while `integral`'s third and fourth arguments are the bounds of a definite integral, not a count.

That asymmetry is real and looks like an inconsistency until you know it is a range rather than a count. Saying so is cheaper than the alternatives I originally proposed in #847, both of which I have since withdrawn.

## The 1.4.0 note

`BREAKING-CHANGES.md` begins at "2.0.0 — since 1.4.0", so a break introduced *by* 1.4.0 has never had a home in it. This one is worth recording because **1.4.0 is what `dotnet add package` installs today** and the change is silent until a string is parsed:

| | 1.3.0 | 1.4.0 onwards |
|---|---|---|
| `integral(f, x, 1)` | accepted, read as `integral(f, x)` | `FunctionArgumentCountException` |
| `integral(f, x, a, b)` | — | the definite integral |

It gets a short section at the end of the file, with the fix (`integral(f, x, 1)` → `integral(f, x)`, identical in meaning).

## How this was found, and what I got wrong

Both samples in this repository called `integral(f, x, 1)` and had been failing against 1.4.0 since January without anyone seeing it, because they were pinned to `AngouriMath 1.3.0`. #846 unpinned them, which is what surfaced it.

I then filed #847 claiming the change was accidental and untested, and proposed restoring the three-argument form. Both claims were false — `git log -S` finds it as a deliberate design change in #657, and `FromStringTest.cs:282` has asserted the new arity all along. That correction is on the issue; only the documentation gap survives, and this is it.

Documentation-only. No code changes, no behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)