### PR TITLE
Build and run the samples in CI, and fix the one that was already broken

### DIFF
--- a/.github/workflows/EverythingBuild.yml
+++ b/.github/workflows/EverythingBuild.yml
@@ -37,3 +37,26 @@ jobs:
 
     - name: Build Utils
       run: dotnet build Sources/Utils/Utils/Utils.csproj
+
+    # The samples are the code most like what a user writes, and nothing built them
+    # until now. Two of them called integral(f, x, 1), which stopped parsing in 1.4.0,
+    # and stayed broken for seven months because no job compiled or ran them.
+    - name: Build samples
+      run: |
+        dotnet build Sources/Samples/SampleNet5/SampleNet5.csproj
+        dotnet build Sources/Samples/FSharpSample/FSharpSample.fsproj
+        dotnet build Sources/Samples/FSharpPlayground/FSharpPlayground.fsproj
+        dotnet build Sources/Samples/Samples/Playground.csproj
+        dotnet build Sources/Samples/InteractivePlayground/InteractivePlayground.fsproj
+        dotnet build Sources/Samples/AngouriMathPlot/AngouriMathPlot.csproj
+        dotnet build Sources/Samples/GraphicExample/GraphicExample.csproj
+
+    # Building is not enough: both samples that broke compiled cleanly and threw at
+    # runtime. Only the console ones can run here -- AngouriMathPlot and GraphicExample
+    # are windowed, and InteractivePlayground opens a browser through Plotly.
+    - name: Run console samples
+      run: |
+        dotnet run --project Sources/Samples/SampleNet5/SampleNet5.csproj --no-build
+        dotnet run --project Sources/Samples/FSharpSample/FSharpSample.fsproj --no-build
+        dotnet run --project Sources/Samples/FSharpPlayground/FSharpPlayground.fsproj --no-build
+        dotnet run --project Sources/Samples/Samples/Playground.csproj --no-build

--- a/Sources/Samples/FSharpPlayground/Program.fs
+++ b/Sources/Samples/FSharpPlayground/Program.fs
@@ -12,4 +12,4 @@ printfn "%O" (integral "x" "x2 + e")
 
 printfn "%O" (``lim x->0`` "sin(a x) / x")
 
-printfn "%O" (latex "x / e + alpha + sqrt(x) + integral(y + 3, y, 1)")
+printfn "%O" (latex "x / e + alpha + sqrt(x) + integral(y + 3, y)")


### PR DESCRIPTION
Closes the gap that #846 exposed: nothing in CI built anything under `Sources/Samples`.

## Why building them is not optional

That gap is why `SampleNet5` and `FSharpSample` stayed broken against the current release for **seven months** while looking healthy. They were pinned to `AngouriMath 1.3.0`, so they compiled against a version that still accepted `integral(f, x, 1)`. Unpinning them in #846 was only half the fix — a sample that nothing builds will break again.

## Why running them is not optional either

Both of those samples **compiled cleanly and threw at runtime**. A build-only job would have passed on both. The console samples are therefore run as well; each takes about two seconds.

## Writing this found a third one

`FSharpPlayground` already used a `ProjectReference`, so nothing was concealing it — **it is broken on master today**:

```
FunctionArgumentCountException: integral should have exactly 4 arguments
or 2 arguments but 3 arguments are provided
   at <StartupCode$FSharpPlayground>.$Program.main@() in .../FSharpPlayground/Program.fs:line 15
```

Same call, `integral(y + 3, y, 1)`. Nothing was hiding this one at all; it simply was never run. Fixed here to the two-argument form, and it now completes.

That is the argument for the job in one example: the pin explained two of the three, and the third was broken in plain sight.

## What runs and what only builds

| sample | built | run | why |
|---|---|---|---|
| `SampleNet5` | ✅ | ✅ | |
| `FSharpSample` | ✅ | ✅ | |
| `FSharpPlayground` | ✅ | ✅ | |
| `Playground` | ✅ | ✅ | |
| `InteractivePlayground` | ✅ | ❌ | Plotly opens a browser |
| `AngouriMathPlot` | ✅ | ❌ | windowed application |
| `GraphicExample` | ✅ | ❌ | windowed application |

The steps go in `EverythingBuild.yml`, which already runs on `windows-latest` — so the two windowed samples compile there, which they cannot do on Linux (`NETSDK1100`).

## Measured locally

All four console samples build and exit 0:

```
SampleNet5        exit=0   2s   34 lines
FSharpSample      exit=0   1s   18 lines
FSharpPlayground  exit=0   2s   36 lines   (after the fix; exit=134 before)
Playground        exit=0   1s    7 lines
```

YAML parses and the job resolves to nine steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)