### PR TITLE
Stop Expand losing a term that takes no power

### DIFF
--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Definition.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Definition.cs
@@ -290,7 +290,17 @@ namespace AngouriMath
                     coefficients[monomialKey] = coefficient;
                     Entity monomial = 1;
                     foreach (var key in exponents.Keys.OrderBy(k => k, System.StringComparer.Ordinal))
-                        monomial = (monomial * bases[key].Pow(exponents[key])).InnerSimplified;
+                    {
+                        // A factor that appeared once goes back as itself, not as base^1.
+                        // Raising to the first power is an identity only where the power is
+                        // defined at all: RR^1, ZZ^1 and true^1 are all NaN, so writing the
+                        // factor that way turns an expression that had a value into one that
+                        // does not. https://github.com/asc-community/AngouriMath/issues/851
+                        var factor = exponents[key] == Integer.Create(1)
+                            ? bases[key]
+                            : bases[key].Pow(exponents[key]);
+                        monomial = (monomial * factor).InnerSimplified;
+                    }
                     monomials[monomialKey] = monomial;
                 }
             }
@@ -306,7 +316,18 @@ namespace AngouriMath
                 var term = (coefficients[key] * monomials[key]).InnerSimplified;
                 result = result == Integer.Create(0) ? term : result + term;
             }
-            return result.InnerSimplified;
+            var collected = result.InnerSimplified;
+
+            // Collecting is an improvement, never a requirement, so a collection that
+            // introduced NaN is discarded rather than returned. The decomposition into
+            // coefficient and monomial only describes a node that multiplies and takes
+            // powers; a factor of any other kind -- a set raised above the first power,
+            // say -- reassembles into something undefined. Keeping the expanded form is
+            // always sound. https://github.com/asc-community/AngouriMath/issues/851
+            if (collected.Nodes.Any(node => node == MathS.NaN)
+                && !expanded.Nodes.Any(node => node == MathS.NaN))
+                return expanded;
+            return collected;
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Common/ExpandCollectsTermsTest.cs
+++ b/Sources/Tests/UnitTests/Common/ExpandCollectsTermsTest.cs
@@ -69,5 +69,34 @@ namespace AngouriMath.Tests.Common
         public void CancellingTermsKeepTheirDomainCondition() =>
             Assert.Equal("0 provided not x = 0".ToEntity(),
                 "(4a - 2) / (2x) + (1 - 2a) / x".ToEntity().Simplify());
+
+        // Collecting reduces each factor to a base and an exponent and then puts it back
+        // together. Writing a factor that appeared once as base^1 is an identity only where
+        // the power is defined at all -- RR^1 and true^1 are NaN -- so a term of a kind that
+        // does not take powers used to come back undefined.
+        // https://github.com/asc-community/AngouriMath/issues/851
+        [Theory]
+        [InlineData("RR + 1")]
+        [InlineData("1 + RR")]
+        [InlineData("RR + x")]
+        [InlineData("ZZ + 1")]
+        [InlineData("QQ + 1")]
+        [InlineData("CC + 1")]
+        [InlineData("BB + 1")]
+        [InlineData("true + 1")]
+        [InlineData("RR * RR + 1")]
+        public void ATermThatTakesNoPowerIsNotLost(string input)
+        {
+            Assert.NotEqual(MathS.NaN, input.ToEntity().Expand());
+            Assert.NotEqual(MathS.NaN, input.ToEntity().Simplify());
+        }
+
+        // The sets that can be shifted elementwise still are -- the guard above must not
+        // turn collecting off for them.
+        [Theory]
+        [InlineData("{ 1, 2 } + 1", "{ 2, 3 }")]
+        [InlineData("[0; 1] + 1", "[1; 2]")]
+        public void ASetThatCanBeShiftedStillIs(string input, string expected) =>
+            Assert.Equal(expected.ToEntity(), input.ToEntity().Simplify());
     }
 }


### PR DESCRIPTION
Closes #851.

## The bug

`Expand` turned `RR + 1` into `NaN` — and with it `ZZ + 1`, `CC + 1`, `QQ + 1`, `BB + 1` and `true + 1`. Because `Simplify` offers `res.Expand()` as a candidate and `NaN` rates as the simplest thing on offer, `Simplify` returned `NaN` too.

A 2.0 regression, measured against the published packages:

| | 1.4.0 | 2.0.0-preview.1 |
|---|---|---|
| `"RR + 1".Simplify()` | `RR + 1` | **`NaN`** |
| `"ZZ + 1".Simplify()` | `ZZ + 1` | **`NaN`** |

`Expand` is public, so this is not only a `Simplify` artefact — `"RR + 1".Expand()` returned `NaN` directly.

## The cause

`CollectLikeTerms` is what makes expansion finish: it reduces every factor to a base and an exponent, adds up the terms whose monomials agree, and puts them back together. The reassembly wrote a factor that appeared once as `base^1`.

**Raising to the first power is an identity only where the power is defined at all.** It is not, for these:

```
RR^1 -> NaN     ZZ^1 -> NaN     true^1 -> NaN
{1,2}^1 -> {1,2}   [0;1]^1 -> [0;1]   x^1 -> x   [[1,2],[3,4]]^1 -> [[1,2],[3,4]]
```

So the decomposition was lossless for everything that takes a power and destroyed everything that does not. That also explains why the sets that *can* be shifted were never affected: a finite set and an interval both take a power, so they round-tripped.

## The fix

A factor that appeared once goes back as itself rather than as `base^1`.

A second guard covers the same fault above the first power, where the identity does not apply and the factor cannot be written back at all (`RR * RR`): collecting is an improvement rather than a requirement, so a collection that introduced `NaN` is discarded and the expanded form kept. That one is deliberately written against the symptom rather than a list of node types, so a node added later cannot reintroduce it.

## Measured

Fixed, and the shiftable sets still shift:

```
RR + 1      Expand: RR + 1      Simplify: RR + 1
true + 1    Expand: True + 1    Simplify: True + 1
{ 1, 2 } + 1                    Simplify: { 2, 3 }
[0; 1] + 1                      Simplify: [1; 2]
```

Suite: **6061 passed, 0 failed, 14 skipped** (11 new cases).

## Verified downstream, which is where it came from

Found by running [CSharpMath](https://github.com/verybadcat/CSharpMath)'s suite against `2.0.0-preview.1` — the consumer #822 is about. It is **955 green on 1.4.0 and two red on the preview**. Rebuilt against this branch:

```
before: Total: 955, Failed: 2
after:  Total: 955, Failed: 1
```

The one that remains is `1+\sqrt{2x}` expanding to `1+\sqrt{2}\sqrt{x}` — the documented 2.0 radical change, sound and theirs to absorb, not a defect here.

## Noted, not fixed here

`(x+1)^2 * (x+1)^2` expands to `... + 2*x^2 + 4*x^2 + ...` with those two left uncollected, which is what `CollectLikeTerms` exists to prevent. **Pre-existing** — reproduced on master without this change, so it is not a regression from it and wants its own issue rather than being folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)