### PR TITLE
Drop the implicit List<Entity> conversion that makes three params overloads uncallable

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -127,10 +127,10 @@ fine — only a concrete `List<Entity>` broke, which is why it survived to a 2.0
 This was not three separate defects. One conversion made *every* `params Entity[]` overload in
 the library uncallable with a list, including any added later.
 
-**This one moves between previews.** The conversion is present in `2.0.0-preview.1`, which is
-published, and gone from `2.0.0-preview.2`. It is so far the only entry here that changes
-between two previews rather than between releases: a reader coming from 1.3.0 or 1.4.0 can
-ignore the distinction, one already on preview.1 cannot.
+**This one moves between previews.** The conversion is in `2.0.0-preview.1` and
+`2.0.0-preview.2`, both published, and is removed in the release that follows them. It is so
+far the only entry here that changes between two previews rather than between releases: a
+reader coming from 1.3.0 or 1.4.0 can ignore the distinction, one already on a preview cannot.
 
 **What breaks.** Assigning a list where an `Entity` is expected:
 

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -57,6 +57,7 @@ read first.
 | loud | `MathS.Quantum.IsNormalised` | the British spelling | `MathS.Quantum.IsNormalized` |
 | loud | the target frameworks | `net7.0;netstandard2.0` | `netstandard2.0;net8.0;net10.0` |
 | **silent** | `abs(x) = c` for a negative `c` | a set of non-solutions | the empty set |
+| loud | implicit `List<Entity>` to `Entity` | made a `FiniteSet`, and made three `params` overloads uncallable | removed |
 
 ---
 
@@ -98,6 +99,51 @@ the built assemblies: present in `net8.0` and `net10.0`, absent from `netstandar
 ---
 
 ## Types and members
+
+### The implicit conversion from `List<Entity>` is removed
+
+`Entity` had two implicit conversions from a collection, both building a `FiniteSet`:
+
+```csharp
+public static implicit operator Entity(Entity[] elements);
+public static implicit operator Entity(List<Entity> elements);   // removed
+```
+
+The second one made three public members impossible to call with a `List<Entity>`:
+
+```csharp
+var equations = new List<Entity> { "x - 1", "y - 2" };
+new EquationSystem(equations);        // error CS0121: the call is ambiguous
+new FiniteSet(equations);             // error CS0121
+MathS.Equations(equations);           // error CS0121
+```
+
+Each of those has both an `IEnumerable<Entity>` overload and a `params Entity[]` overload. With
+the conversion in place a `List<Entity>` also converts to a single `Entity`, so the `params`
+overload becomes applicable in its expanded form, neither candidate is better than the other,
+and the call does not compile. The array, `IEnumerable<Entity>`, and variadic forms were always
+fine — only a concrete `List<Entity>` broke, which is why it survived to a 2.0 preview.
+
+This was not three separate defects. One conversion made *every* `params Entity[]` overload in
+the library uncallable with a list, including any added later.
+
+**What breaks.** Assigning a list where an `Entity` is expected:
+
+```csharp
+Entity set = new List<Entity> { 1, 2, 3 };   // no longer compiles
+```
+
+Write one of these instead:
+
+```csharp
+Entity set = new FiniteSet(new List<Entity> { 1, 2, 3 });
+Entity set = new List<Entity> { 1, 2, 3 }.ToSet();
+Entity set = new Entity[] { 1, 2, 3 };       // the array conversion is unchanged
+```
+
+The `Entity[]` conversion is kept: an array argument binds to the `params` overload in its normal
+form by an identity conversion, which beats the alternatives outright, so it never produced the
+ambiguity.
 
 ### `Minusf`'s two operands exchanged names
 

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -127,6 +127,11 @@ fine — only a concrete `List<Entity>` broke, which is why it survived to a 2.0
 This was not three separate defects. One conversion made *every* `params Entity[]` overload in
 the library uncallable with a list, including any added later.
 
+**This one moves between previews.** The conversion is present in `2.0.0-preview.1`, which is
+published, and gone from `2.0.0-preview.2`. It is so far the only entry here that changes
+between two previews rather than between releases: a reader coming from 1.3.0 or 1.4.0 can
+ignore the distinction, one already on preview.1 cannot.
+
 **What breaks.** Assigning a list where an `Entity` is expected:
 
 ```csharp

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -24,6 +24,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [Tests/UnitTests/Core/Transformations/*.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[Tests/UnitTests/Common/ListArgumentOverloadTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 # A new file in a directory whose other files predate it, so the section is on the file
 # rather than the folder.
 [AngouriMath/Core/Entity/Continuous/Entity.Continuous.{Floors,Rounding}.Classes.cs]

--- a/Sources/AngouriMath/Core/Entity/Omni/Entity.Set.cs
+++ b/Sources/AngouriMath/Core/Entity/Omni/Entity.Set.cs
@@ -83,7 +83,6 @@ namespace AngouriMath
         public static implicit operator Entity(Domain domain) => Set.SpecialSet.Create(domain);
         public static implicit operator Entity((Entity left, Entity right) interval) => new Interval(interval.left, true, interval.right, true);
         public static implicit operator Entity(Entity[] elements) => new FiniteSet(elements);
-        public static implicit operator Entity(List<Entity> elements) => new FiniteSet((IEnumerable<Entity>)elements);
 #pragma warning restore CS1591
 
     }

--- a/Sources/Tests/UnitTests/Common/ListArgumentOverloadTest.cs
+++ b/Sources/Tests/UnitTests/Common/ListArgumentOverloadTest.cs
@@ -1,0 +1,72 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Collections.Generic;
+using AngouriMath;
+using AngouriMath.Core;
+using Xunit;
+
+namespace AngouriMath.Tests.Common
+{
+    /// <summary>
+    /// Every member here takes both an <see cref="IEnumerable{T}"/> and a <c>params Entity[]</c>.
+    /// While <c>Entity</c> also had an implicit conversion from <c>List&lt;Entity&gt;</c>, a list
+    /// argument matched the params overload in its expanded form as well, neither candidate was
+    /// better than the other, and none of these calls compiled -- CS0121. The conversion is gone;
+    /// this file failing to compile is what says it has not come back.
+    /// </summary>
+    [Trait("Area", "Common")]
+    public sealed class ListArgumentOverloadTest
+    {
+        static List<Entity> Equations => new() { "x - 1", "y - 2" };
+
+        [Fact]
+        public void EquationSystemTakesAList()
+        {
+            var solutions = new EquationSystem(Equations).Solve("x", "y");
+            Assert.NotNull(solutions);
+            Assert.Equal(1, solutions.RowCount);
+            Assert.Equal(2, solutions.ColumnCount);
+        }
+
+        [Fact]
+        public void MathSEquationsTakesAList()
+        {
+            var solutions = MathS.Equations(Equations).Solve("x", "y");
+            Assert.NotNull(solutions);
+            Assert.Equal(1, solutions.RowCount);
+        }
+
+        [Fact]
+        public void FiniteSetTakesAList()
+        {
+            var set = new Entity.Set.FiniteSet(new List<Entity> { 1, 2, 3 });
+            Assert.Equal(3, set.Count);
+        }
+
+        /// <summary>The array and variadic forms were never ambiguous, and must stay that way.</summary>
+        [Fact]
+        public void ArrayAndVariadicFormsStillBind()
+        {
+            Entity[] equations = { "x - 1", "y - 2" };
+            Assert.NotNull(new EquationSystem(equations).Solve("x", "y"));
+            Assert.NotNull(new EquationSystem("x - 1", "y - 2").Solve("x", "y"));
+            Assert.Equal(3, new Entity.Set.FiniteSet(1, 2, 3).Count);
+        }
+
+        /// <summary>
+        /// The conversion from an array is deliberately kept, so an array in an
+        /// <c>Entity</c> position is still a set.
+        /// </summary>
+        [Fact]
+        public void ArrayStillConvertsToASet()
+        {
+            Entity set = new Entity[] { 1, 2, 3 };
+            Assert.Equal(new Entity.Set.FiniteSet(1, 2, 3), set);
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Common/PublicApi.txt
+++ b/Sources/Tests/UnitTests/Common/PublicApi.txt
@@ -2132,7 +2132,6 @@ AngouriMath.Entity.op_Implicit(PeterO.Numbers.EInteger) : AngouriMath.Entity
 AngouriMath.Entity.op_Implicit(PeterO.Numbers.ERational) : AngouriMath.Entity
 AngouriMath.Entity.op_Implicit(System.Boolean) : AngouriMath.Entity
 AngouriMath.Entity.op_Implicit(System.Byte) : AngouriMath.Entity
-AngouriMath.Entity.op_Implicit(System.Collections.Generic.List<AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity.op_Implicit(System.Decimal) : AngouriMath.Entity
 AngouriMath.Entity.op_Implicit(System.Double) : AngouriMath.Entity
 AngouriMath.Entity.op_Implicit(System.Int16) : AngouriMath.Entity


### PR DESCRIPTION
`Entity` has implicit conversions to itself from both `Entity[]` and `List<Entity>`, each building a `FiniteSet`. The `List<Entity>` one has a side effect: a list also converts to a *single* `Entity`, so for any member that has both an `IEnumerable<Entity>` overload and a `params Entity[]` overload, the params form becomes applicable in its expanded form. Neither candidate is better than the other, and the call does not compile.

```csharp
var equations = new List<Entity> { "x - 1", "y - 2" };

new EquationSystem(equations);   // error CS0121: the call is ambiguous
new FiniteSet(equations);        // error CS0121
MathS.Equations(equations);      // error CS0121
```

This is not three separate defects. It is one conversion making *every* `params Entity[]` overload in the library uncallable with a list — including any added later.

## How the three were found

Rather than fix the one I tripped over, I swept all 2602 members in `PublicApi.txt` for the `IEnumerable<T>` / `T[]` single-parameter overload pattern. Exactly three matched, and each was then confirmed by compiling the call in isolation:

| call shape | before | after |
|---|---|---|
| `new EquationSystem(list)` | CS0121 | OK |
| `new FiniteSet(list)` | CS0121 | OK |
| `MathS.Equations(list)` | CS0121 | OK |
| the same three with `Entity[]` | OK | OK |
| the same three with `IEnumerable<Entity>` | OK | OK |
| the same three variadic | OK | OK |

Only a concrete `List<Entity>` ever broke — an array, an `IEnumerable<Entity>`-typed expression, and the variadic form all compiled fine. That is why it survived to a 2.0 preview.

## What changes

The `List<Entity>` conversion is removed. The `Entity[]` conversion is kept: an array binds to the `params` overload in its normal form by an identity conversion, which wins outright, so it never produced the ambiguity.

```csharp
Entity set = new List<Entity> { 1, 2, 3 };            // no longer compiles
Entity set = new List<Entity> { 1, 2, 3 }.ToSet();    // use this
Entity set = new Entity[] { 1, 2, 3 };                // unchanged
```

Breaking, so it wants the 2.0 window — recorded in `BREAKING-CHANGES.md`, and `PublicApi.txt` updated.

## Regression guard

`ListArgumentOverloadTest` calls all three members with a `List<Entity>`. The guard is that the test project **compiles** — restore the conversion and the build breaks, which a runtime assertion could not catch. `Sources/.editorconfig` gets a per-file header section for the new file, since `Tests/UnitTests/Common` still carries the 2022 template and IDE0073 is an error.

## Verification

- 6055 C# tests pass, 0 failed, 14 skipped
- 130 F# wrapper tests pass
- library, F# wrapper and `Utils` build clean
- all ten call shapes in the matrix above compile

The two `NETSDK1100` failures in a full solution build are the WinForms/WPF sample projects, which cannot build on Linux; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
