### PR TITLE
Name the version under development 2.0.0-preview.2

### DIFF
--- a/Sources/Package.Build.props
+++ b/Sources/Package.Build.props
@@ -17,7 +17,7 @@
     release tag, so what ships is named by the tag; this is what a local build and the
     assembly metadata carry.
     -->
-    <Version>2.0.0-preview.1</Version>
+    <Version>2.0.0-preview.2</Version>
 
     <!--
     Pinned to the major for the whole of 2.x, and deliberately not tracking Version.


### PR DESCRIPTION
Ahead of cutting `v2.0.0-preview.2`.

The NuGet workflow takes what it publishes from the release tag, so `<Version>` is what a local build and the **assembly metadata** carry. Left at `preview.1` it would stamp `preview.1` into an assembly shipped as `preview.2` — which is exactly the confusion that cost me a wrong conclusion earlier today, when a stale Release build made a fixed package look unfixed.

`AssemblyVersion` stays pinned at `2.0.0.0` for the whole of 2.x, as the comment beside it says.

Verified by packing all four at the new version and testing the artifact rather than the build:

```
AngouriMath.2.0.0-preview.2.nupkg              AngouriMath.FSharp -> AngouriMath        2.0.0-preview.2
AngouriMath.FSharp.2.0.0-preview.2.nupkg       AngouriMath.Interactive -> .FSharp       2.0.0-preview.2
AngouriMath.Interactive.2.0.0-preview.2.nupkg
AngouriMath.Terminal.2.0.0-preview.2.nupkg     "RR + 1".Simplify() -> RR + 1   (the #851 fix is in)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)