### PR TITLE
Hold a settings scope per flow instead of per thread

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -58,6 +58,7 @@ read first.
 | loud | the target frameworks | `net7.0;netstandard2.0` | `netstandard2.0;net8.0;net10.0` |
 | **silent** | `abs(x) = c` for a negative `c` | a set of non-solutions | the empty set |
 | loud | implicit `List<Entity>` to `Entity` | made a `FiniteSet`, and made three `params` overloads uncallable | removed |
+| **silent** | a `MathS.Settings` scope across an `await`, or inside a task | lost, or somebody else's | follows the call |
 
 ---
 
@@ -149,6 +150,61 @@ Entity set = new Entity[] { 1, 2, 3 };       // the array conversion is unchange
 The `Entity[]` conversion is kept: an array argument binds to the `params` overload in its normal
 form by an identity conversion, which beats the alternatives outright, so it never produced the
 ambiguity.
+### A settings scope belongs to the call, not to the thread
+
+`MathS.Settings` values were held in `[ThreadStatic]` fields — fourteen of them. A scope
+therefore stopped at the first `await`:
+
+```csharp
+using var _ = MathS.Settings.MaxExpansionTermCount.Set(1);
+Console.WriteLine(MathS.Settings.MaxExpansionTermCount.Value);   // 1
+await Task.Delay(20).ConfigureAwait(false);
+Console.WriteLine(MathS.Settings.MaxExpansionTermCount.Value);   // was 2000, the default
+```
+
+The continuation resumed on a pool thread that had never seen the scope, so the setting
+silently read its default. The same mechanism ran the other way too: a thread returned to
+the pool still carried whatever scope was left on it, so the *next* caller to borrow that
+thread could compute under a precision or codomain it never asked for. Neither shows up as
+an error; both change the answer.
+
+The values now live in an `AsyncLocal`, which is what the cancellation token in
+`MathS.Multithreading` already used.
+
+| | was | is |
+|---|---|---|
+| a scope across an `await` | lost | kept |
+| a scope inside `Task.Run` started under it | not inherited | **inherited** |
+| a scope opened in a task, seen by a sibling | no | no |
+| a scope opened in a task, seen after it ends | no | no |
+| a thread reused by the pool | could carry a stale scope | cannot |
+
+**What breaks.** The second row is the one to read. Work started inside a scope now runs
+under it:
+
+```csharp
+using var _ = MathS.Settings.Codomain.Set(Domain.Real);
+await Task.Run(() => expr.Solve("x"));   // now solves over R; used to solve over C
+```
+
+That is what the code says, and almost always what was meant — but if you parallelised
+inside a scope and relied on the child *not* seeing it, it does now. Move the scope inside
+the callback to keep the old behaviour.
+
+**Cost.** Measured over 20 000 000 reads and 2 000 000 scopes:
+
+| | was | is |
+|---|---|---|
+| read `PrecisionErrorZeroRange.Value` | 7.3–8.0 ns | **1.2 ns** |
+| read `DowncastingEnabled.Value` | 0.79 ns | 0.96 ns |
+| `Set()` + `Dispose()` | 388–395 ns, 32 B | **46 ns**, 112 B |
+| a `Simplify` workload | 5.6–5.8 s | 5.5–5.6 s, +1.5 % allocated |
+
+Reads got faster rather than slower: the old getter re-tested a `[ThreadStatic]` field for
+null on every access, and that is dearer than the async-local lookup that replaced it.
+Opening a scope got much cheaper because it no longer mints a `Guid` to identify itself,
+though it allocates more, since assigning an `AsyncLocal` copies the flow's value map. Reads
+outnumber scope openings by orders of magnitude in any real workload.
 
 ### `Minusf`'s two operands exchanged names
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -27,6 +27,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [Tests/UnitTests/Common/ListArgumentOverloadTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[Tests/UnitTests/Core/Multithreading/SettingsAcrossAsync.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 # A new file in a directory whose other files predate it, so the section is on the file
 # rather than the folder.
 [AngouriMath/Core/Entity/Continuous/Entity.Continuous.{Floors,Rounding}.Classes.cs]

--- a/Sources/AngouriMath/Convenience/Diagnostic/MathS.Diagnostic.cs
+++ b/Sources/AngouriMath/Convenience/Diagnostic/MathS.Diagnostic.cs
@@ -22,16 +22,14 @@ namespace AngouriMath
             /// Explicit output for ToString, that is, no signs or parentheses will be omitted. Useful
             /// for debugging and diagnostic.
             /// </summary>
-            public static Setting<bool> OutputExplicit => outputExplicit ??= false;
-            [ThreadStatic] private static Setting<bool>? outputExplicit;
+            public static Setting<bool> OutputExplicit { get; } = false;
 
             /// <summary>
             /// Set a predicate on the state of <see cref="Entity"/> so that once
             /// the predicate turns true in method <see cref="Entity.Simplify"/>,
             /// an exception <see cref="DiagnosticCatchException"/> is thrown.
             /// </summary>
-            public static Setting<Func<Entity, bool>> CatchOnSimplify => catchOnSimplify ??= (Func<Entity, bool>)(a => false);
-            [ThreadStatic] private static Setting<Func<Entity, bool>>? catchOnSimplify;
+            public static Setting<Func<Entity, bool>> CatchOnSimplify { get; } = (Func<Entity, bool>)(a => false);
 
             /// <summary>
             /// Will only occur in debug mode,

--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -5347,8 +5347,7 @@ namespace AngouriMath
             /// Exception, but we still can parse a ^ 2 + 2 * x + a * b + 2 * (g + e) ^ 3
             /// </code>
             /// </example>
-            public static Setting<bool> ExplicitParsingOnly => explicitParsingOnly ??= false;
-            [ThreadStatic] private static Setting<bool>? explicitParsingOnly;
+            public static Setting<bool> ExplicitParsingOnly { get; } = false;
             
             /// <summary>
             /// That is how we perform newton solving when no analytical solution was found
@@ -5400,8 +5399,7 @@ namespace AngouriMath
             /// AngouriMath.Entity+Number+Real
             /// </code>
             /// </example>
-            public static Setting<bool> DowncastingEnabled => downcastingEnabled ??= true;
-            [ThreadStatic] private static Setting<bool>? downcastingEnabled;
+            public static Setting<bool> DowncastingEnabled { get; } = true;
 
             /// <summary>
             /// Amount of iterations allowed for attempting to cast to a rational
@@ -5448,8 +5446,7 @@ namespace AngouriMath
             /// 5/7
             /// </code>
             /// </example>
-            public static Setting<int> FloatToRationalIterCount => floatToRationalIterCount ??= 15;
-            [ThreadStatic] private static Setting<int>? floatToRationalIterCount;
+            public static Setting<int> FloatToRationalIterCount { get; } = 15;
 
             /// <summary>
             /// If a numerator or denominator is too large, it's suspended to better keep the real number instead of casting
@@ -5503,24 +5500,20 @@ namespace AngouriMath
             /// 100/169137
             /// </code>
             /// </example>
-            public static Setting<EInteger> MaxAbsNumeratorOrDenominatorValue =>
-                maxAbsNumeratorOrDenominatorValue ??= EInteger.FromInt32(100000000);
-            [ThreadStatic] private static Setting<EInteger>? maxAbsNumeratorOrDenominatorValue;
+            public static Setting<EInteger> MaxAbsNumeratorOrDenominatorValue { get; } = EInteger.FromInt32(100000000);
 
             /// <summary>
             /// Sets threshold for comparison
             /// For example, if you don't need precision higher than 6 digits after .,
             /// you can set it to 1.0e-6 so 1.0000000 == 0.9999999
             /// </summary>
-            public static Setting<EDecimal> PrecisionErrorCommon => precisionErrorCommon ??= EDecimal.Create(1, -6);
-            [ThreadStatic] private static Setting<EDecimal>? precisionErrorCommon;
+            public static Setting<EDecimal> PrecisionErrorCommon { get; } = EDecimal.Create(1, -6);
 
 
             /// <summary>
             /// Numbers whose absolute value is less than PrecisionErrorZeroRange are considered zeros
             /// </summary>
-            public static Setting<EDecimal> PrecisionErrorZeroRange => precisionErrorZeroRange ??= EDecimal.Create(1, -16);
-            [ThreadStatic] private static Setting<EDecimal>? precisionErrorZeroRange;
+            public static Setting<EDecimal> PrecisionErrorZeroRange { get; } = EDecimal.Create(1, -16);
 
             /// <summary>
             /// The tolerance within which downcasting rounds a number onto a nearby integer.
@@ -5576,8 +5569,7 @@ namespace AngouriMath
             /// {  } // nothing was found for 5-degree polynomial without numeric solution
             /// </code>
             /// </example>
-            public static Setting<bool> AllowNewton => allowNewton ??= true;
-            [ThreadStatic] private static Setting<bool>? allowNewton;
+            public static Setting<bool> AllowNewton { get; } = true;
 
             /// <summary>
             /// Criteria for simplifier so you could control which expressions are considered easier by you.
@@ -5649,8 +5641,7 @@ namespace AngouriMath
             /// By default criteria it cannot simplify it further, however, the custom one
             /// it simplified from 2 to 1. 
             /// </example>
-            public static Setting<Func<Entity, double>> ComplexityCriteria =>
-                complexityCriteria ??= new Func<Entity, double>(expr =>
+            public static Setting<Func<Entity, double>> ComplexityCriteria { get; } = new Func<Entity, double>(expr =>
                 {
                     // Those are of the 2nd power to avoid problems with floating numbers
                     const double TinyWeight       = 0.5;
@@ -5688,7 +5679,6 @@ namespace AngouriMath
                     } + Weight; // Number of nodes
                     return DefaultCriteria(expr);
                 });
-            [ThreadStatic] private static Setting<Func<Entity, double>>? complexityCriteria;
 
             /// <summary>
             /// Settings for the Newton-Raphson's root-search method
@@ -5703,8 +5693,7 @@ namespace AngouriMath
             /// ...
             /// </code>
             /// </summary>
-            public static Setting<NewtonSetting> NewtonSolver => newtonSolver ??= new NewtonSetting();
-            [ThreadStatic] private static Setting<NewtonSetting>? newtonSolver;
+            public static Setting<NewtonSetting> NewtonSolver { get; } = new NewtonSetting();
 
             /// <summary>
             /// The maximum number of linear children of an expression in polynomial solver
@@ -5736,15 +5725,12 @@ namespace AngouriMath
             ///     </item>
             /// </list>
             /// </summary>
-            public static Setting<long> MaxExpansionTermCount => maxExpansionTermCount ??= 2_000;
-            [ThreadStatic] private static Setting<long>? maxExpansionTermCount;
+            public static Setting<long> MaxExpansionTermCount { get; } = 2_000;
 
             /// <summary>
             /// Settings for <see cref="EDecimal"/> precisions of <a href="https://github.com/peteroupc/Numbers">PeterO.Numbers</a>
             /// </summary>
-            public static Setting<EContext> DecimalPrecisionContext =>
-                decimalPrecisionContext ??= new EContext(100, ERounding.HalfUp, -100, 1000, false);
-            [ThreadStatic] private static Setting<EContext>? decimalPrecisionContext;
+            public static Setting<EContext> DecimalPrecisionContext { get; } = new EContext(100, ERounding.HalfUp, -100, 1000, false);
 
             /// <summary>
             /// Whether functions are being read as real-valued or complex-valued. It is a
@@ -5777,8 +5763,7 @@ namespace AngouriMath
             /// prints the unevaluated limit, where the default prints <c>-oo</c>.
             /// </example>
             /// </remarks>
-            public static Setting<Domain> Codomain => codomain ??= Domain.Complex;
-            [ThreadStatic] private static Setting<Domain>? codomain;
+            public static Setting<Domain> Codomain { get; } = Domain.Complex;
         }
 
         /// <summary>Returns an <see cref="Entity"/> in polynomial order if possible</summary>

--- a/Sources/AngouriMath/Convenience/SettingClass.cs
+++ b/Sources/AngouriMath/Convenience/SettingClass.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) 2019-2022 Angouri.
 // AngouriMath is licensed under MIT.
 // Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
@@ -6,6 +6,7 @@
 //
 
 using System;
+using System.Threading;
 
 namespace AngouriMath.Convenience
 {
@@ -15,13 +16,49 @@ namespace AngouriMath.Convenience
     /// <typeparam name="T">
     /// Those configurations can be of different types
     /// </typeparam>
+    /// <remarks>
+    /// <para>
+    /// A setting is one object for the whole process, and what it holds is per *flow*, not
+    /// per thread: the stack of values lives in an <see cref="AsyncLocal{T}"/>. A scope
+    /// opened before an <see langword="await"/> is therefore still in force after it, and a
+    /// scope opened inside a task is invisible to that task's siblings and to whatever
+    /// started it. Backing the field with <c>[ThreadStatic]</c> gave neither: a continuation
+    /// resumed on a pool thread saw the defaults, and a thread returned to the pool carried
+    /// whatever scope was left on it into the next caller.
+    /// </para>
+    /// <para>
+    /// The frames are immutable, which is what makes the reference safe to share. An
+    /// <see cref="AsyncLocal{T}"/> copies on assignment to <see cref="AsyncLocal{T}.Value"/>
+    /// and on nothing else, so if a frame could be mutated in place, two flows holding the
+    /// same chain would write over each other. Pushing and popping therefore build a new
+    /// chain and assign it, rather than editing one.
+    /// </para>
+    /// </remarks>
     public sealed class Setting<T> where T : notnull
     {
-        internal Setting(T defaultValue)
+        /// <summary>
+        /// One pushed value, and the chain below it. Never mutated once built.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Id"/> is what a scope is released by, rather than the frame's own
+        /// reference. Releasing a scope that is not on top rebuilds everything above it, and
+        /// a rebuilt frame is a different object — so identifying a scope by its frame would
+        /// leave the ones above it impossible to release afterwards. The id is a counter and
+        /// not a <see cref="Guid"/>: generating a guid per scope cost more than everything
+        /// else <see cref="Set"/> does put together.
+        /// </remarks>
+        private sealed class Frame
         {
-            Set(defaultValue);
-            Default = defaultValue; 
+            internal readonly long Id;
+            internal readonly T Value;
+            internal readonly Frame? Next;
+            internal Frame(long id, T value, Frame? next) => (Id, Value, Next) = (id, value, next);
         }
+
+        private readonly AsyncLocal<Frame?> frames = new();
+        private long lastId;
+
+        internal Setting(T defaultValue) => Default = defaultValue;
 
         /// <summary>
         /// Sets the new value for the setting
@@ -40,9 +77,42 @@ namespace AngouriMath.Convenience
         /// </returns>
         public AutoBackRollableTemporarySettingUnit Set(T value)
         {
-            var guid = Guid.NewGuid();
-            values.Push(guid, value);
-            return new AutoBackRollableTemporarySettingUnit(this, guid);
+            var id = Interlocked.Increment(ref lastId);
+            frames.Value = new Frame(id, value, frames.Value);
+            return new AutoBackRollableTemporarySettingUnit(this, id);
+        }
+
+        /// <summary>
+        /// Takes the scope numbered <paramref name="id"/> back out of this flow's chain,
+        /// wherever in it it sits. Disposal is normally in the reverse order of
+        /// <see cref="Set"/>, which is the cheap case of popping the head; out-of-order
+        /// disposal rebuilds what was above it. An id that is not in this flow's chain —
+        /// because the scope was opened in another one, or is already released — is not an
+        /// error and undoes nothing.
+        /// </summary>
+        private void Remove(long id)
+        {
+            var top = frames.Value;
+            if (top is null)
+                return;
+            if (top.Id == id)
+            {
+                frames.Value = top.Next;
+                return;
+            }
+            var above = new System.Collections.Generic.List<Frame>();
+            var current = top;
+            while (current is not null && current.Id != id)
+            {
+                above.Add(current);
+                current = current.Next;
+            }
+            if (current is null)
+                return;
+            var rebuilt = current.Next;
+            for (var i = above.Count - 1; i >= 0; i--)
+                rebuilt = new Frame(above[i].Id, above[i].Value, rebuilt);
+            frames.Value = rebuilt;
         }
 
         /// <summary>
@@ -92,12 +162,10 @@ namespace AngouriMath.Convenience
         /// </summary>
         public override string? ToString() => Value.ToString();
 
-        private readonly KeyStack<Guid, T> values = new();
-
         /// <summary>
         /// The current value of the setting
         /// </summary>
-        public T Value => values.Peek();
+        public T Value => frames.Value is { } frame ? frame.Value : Default;
 
         /// <summary>
         /// The default value of the setting
@@ -110,7 +178,7 @@ namespace AngouriMath.Convenience
         /// Lets a default be treated as "nobody expressed an opinion" rather than as a
         /// deliberate choice.
         /// </summary>
-        internal bool IsOverriden => values.Count > 1;
+        internal bool IsOverriden => frames.Value is not null;
 
         /// <summary>
         /// This tiny struct is needed to be under `using` operator, so that your settings
@@ -124,49 +192,18 @@ namespace AngouriMath.Convenience
         {
             private readonly Setting<T> setting;
             private bool disposed;
-            private readonly Guid guid;
-            internal AutoBackRollableTemporarySettingUnit(Setting<T> settingToRollBack, Guid guid)
-                => (this.setting, disposed, this.guid) = (settingToRollBack, false, guid);
+            private readonly long id;
+            internal AutoBackRollableTemporarySettingUnit(Setting<T> settingToRollBack, long id)
+                => (setting, disposed, this.id) = (settingToRollBack, false, id);
 
             /// <inheritdoc/>
             public void Dispose()
             {
                 if (disposed)
                     return;
-                setting.values.Remove(guid);
+                setting.Remove(id);
                 disposed = true;
             }
         }
-    }
-
-
-    internal sealed class KeyStack<TKey, TValue>
-    {
-        private readonly List<(TKey key, TValue value)> list = new();
-
-        internal int Count => list.Count;
-
-        internal TValue Peek() => list[^1].value;
-
-        internal bool Remove(TKey key)
-        {
-            int index = -1;
-            for (int i = list.Count - 1; i >= 0; i--)
-                if (key is not null && key.Equals(list[i].key))
-                {
-                    index = i;
-                    break;
-                }
-            if (index == -1)
-                return false;
-            list.RemoveAt(index);
-            return true;
-        }
-
-        internal void Push(TKey key, TValue value)
-            => list.Add((key, value));
-
-        internal void Pop()
-            => list.RemoveAt(list.Count - 1);
     }
 }

--- a/Sources/Tests/UnitTests/Core/Multithreading/SettingsAcrossAsync.cs
+++ b/Sources/Tests/UnitTests/Core/Multithreading/SettingsAcrossAsync.cs
@@ -1,0 +1,145 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Threading;
+using System.Threading.Tasks;
+using AngouriMath;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Multithreading
+{
+    /// <summary>
+    /// A setting scope belongs to the flow that opened it, not to the thread that happened
+    /// to be running it. These are the four properties that distinguishes: it survives an
+    /// await, it is not visible to a sibling, it does not escape upwards, and it unwinds in
+    /// whatever order the scopes are disposed.
+    /// </summary>
+    [Trait("Area", "Core")]
+    public sealed class SettingsAcrossAsync
+    {
+        static long Current => MathS.Settings.MaxExpansionTermCount.Value;
+        static long Default => MathS.Settings.MaxExpansionTermCount.Default;
+
+        /// <summary>
+        /// The regression. Backed by <c>[ThreadStatic]</c> the continuation resumed on a pool
+        /// thread that had never seen the scope, and the setting silently read its default.
+        /// </summary>
+        [Fact]
+        public async Task ScopeSurvivesAnAwait()
+        {
+            Assert.NotEqual(27L, Default);
+            using var _ = MathS.Settings.MaxExpansionTermCount.Set(27);
+            Assert.Equal(27, Current);
+            await Task.Yield();
+            Assert.Equal(27, Current);
+            await Task.Delay(20).ConfigureAwait(false);
+            Assert.Equal(27, Current);
+        }
+
+        /// <summary>
+        /// What the per-thread field did give, and what a naive <c>AsyncLocal&lt;Setting&lt;T&gt;&gt;</c>
+        /// would have taken away: two flows sharing one setting object would have pushed onto
+        /// one stack. The barrier makes both scopes open before either reads.
+        /// </summary>
+        [Fact]
+        public async Task SiblingFlowsDoNotSeeEachOther()
+        {
+            using var barrier = new Barrier(2);
+            async Task<long> Branch(long value)
+            {
+                await Task.Yield();
+                using var _ = MathS.Settings.MaxExpansionTermCount.Set(value);
+                barrier.SignalAndWait();
+                await Task.Delay(20).ConfigureAwait(false);
+                return Current;
+            }
+            var both = await Task.WhenAll(Branch(101), Branch(202));
+            Assert.Equal(new[] { 101L, 202L }, both);
+        }
+
+        /// <summary>
+        /// The direction of the change that can surprise someone: work started under a scope
+        /// runs under it. With the per-thread field the pool thread had never seen the scope
+        /// and the child read the default instead.
+        /// </summary>
+        [Fact]
+        public async Task WorkStartedUnderAScopeInheritsIt()
+        {
+            using var _ = MathS.Settings.MaxExpansionTermCount.Set(77);
+            Assert.Equal(77, await Task.Run(() => Current));
+            Assert.Equal(77, await Task.Run(async () => { await Task.Yield(); return Current; }));
+        }
+
+        /// <summary>A scope opened inside a task is gone once that task is.</summary>
+        [Fact]
+        public async Task ScopeDoesNotEscapeUpwards()
+        {
+            await Task.Run(async () =>
+            {
+                using var _ = MathS.Settings.MaxExpansionTermCount.Set(55);
+                await Task.Yield();
+                Assert.Equal(55, Current);
+            });
+            Assert.Equal(Default, Current);
+        }
+
+        [Fact]
+        public void NestedScopesUnwindInOrder()
+        {
+            using (var _ = MathS.Settings.MaxExpansionTermCount.Set(1))
+            {
+                Assert.Equal(1, Current);
+                using (var __ = MathS.Settings.MaxExpansionTermCount.Set(2))
+                    Assert.Equal(2, Current);
+                Assert.Equal(1, Current);
+            }
+            Assert.Equal(Default, Current);
+        }
+
+        /// <summary>
+        /// Disposal is normally the reverse of opening, so popping the head covers it. This
+        /// is the other path: releasing the outer scope first has to rebuild the chain above
+        /// it and leave the inner one standing.
+        /// </summary>
+        [Fact]
+        public void OutOfOrderDisposalKeepsTheOtherScope()
+        {
+            var outer = MathS.Settings.MaxExpansionTermCount.Set(7);
+            var inner = MathS.Settings.MaxExpansionTermCount.Set(9);
+            Assert.Equal(9, Current);
+
+            outer.Dispose();
+            Assert.Equal(9, Current);
+
+            inner.Dispose();
+            Assert.Equal(Default, Current);
+        }
+
+        [Fact]
+        public void DisposingTwiceIsHarmless()
+        {
+            var scope = MathS.Settings.MaxExpansionTermCount.Set(31);
+            using (var other = MathS.Settings.MaxExpansionTermCount.Set(32))
+            {
+                scope.Dispose();
+                scope.Dispose();
+                Assert.Equal(32, Current);
+            }
+            Assert.Equal(Default, Current);
+        }
+
+        /// <summary>A setting nobody has touched reports its default and says so.</summary>
+        [Fact]
+        public void UntouchedSettingReadsItsDefault()
+        {
+            Assert.Equal(Default, Current);
+            using (var _ = MathS.Settings.MaxExpansionTermCount.Set(Default + 1))
+                Assert.Equal(Default + 1, Current);
+            Assert.Equal(Default, Current);
+        }
+    }
+}


### PR DESCRIPTION
`MathS.Settings` kept its fourteen values in `[ThreadStatic]` fields, so a scope stopped at the first `await`:

```csharp
using var _ = MathS.Settings.MaxExpansionTermCount.Set(1);
Console.WriteLine(MathS.Settings.MaxExpansionTermCount.Value);   // 1
await Task.Delay(20).ConfigureAwait(false);
Console.WriteLine(MathS.Settings.MaxExpansionTermCount.Value);   // 2000 — the default, silently
```

The continuation resumes on a pool thread that has never seen the scope. The same mechanism runs the other way, too: a thread going back to the pool still carries whatever scope was left on it, so the *next* caller to borrow that thread can compute under a precision or codomain it never asked for. Neither surfaces as an error; both change the answer.

The values now live in an `AsyncLocal` — which is what the cancellation token in `MathS.Multithreading` already used, so this brings settings in line with a decision the codebase had already made.

## Why not just `AsyncLocal<Setting<T>>` on the field

Because that is wrong. An `AsyncLocal` flows the *reference*, and `Setting<T>` was mutable, so two concurrent tasks would have pushed onto one shared stack and corrupted each other — losing the one property the per-thread field did give.

What has to be per-flow is the value stack itself. So the stack moved inside `Setting<T>` as an immutable chain behind an `AsyncLocal`, and the static fields became ordinary singletons. They also had to stop being lazily created: `field ??= default` on a non-thread-static field races, and a scope opened on the loser of that race would silently vanish.

Scopes are identified by a counter rather than by their frame object. Releasing a scope that is not on top rebuilds the frames above it, and a rebuilt frame is a different object — so keying on the frame left every scope above it impossible to release afterwards. The out-of-order test caught exactly that. Dropping the `Guid` it replaces is most of why `Set()` got cheaper.

## Behaviour

| | was | is |
|---|---|---|
| a scope across an `await` | lost | kept |
| a scope inside `Task.Run` started under it | not inherited | **inherited** |
| a scope opened in a task, seen by a sibling | no | no |
| a scope opened in a task, seen after it ends | no | no |
| a thread reused by the pool | could carry a stale scope | cannot |

The second row is the one that can surprise. Work started inside a scope now runs under it — what the code says, and almost always what was meant, but a caller who parallelised inside a scope and relied on the child *not* seeing it will notice. Every row above is a test in `SettingsAcrossAsync`.

## Cost

Measured over 20 000 000 reads and 2 000 000 scopes, two runs each:

| | was | is |
|---|---|---|
| read `PrecisionErrorZeroRange.Value` | 7.3–8.0 ns | **1.2 ns** |
| read `DowncastingEnabled.Value` | 0.79 ns | 0.96 ns |
| `Set()` + `Dispose()` | 388–395 ns, 32 B | **46 ns**, 112 B |
| a `Simplify` workload | 5.6–5.8 s | 5.5–5.6 s, +1.5 % allocated |

Reads got *faster*, not slower: the old getter re-tested a `[ThreadStatic]` field for null on every access, and that costs more than the async-local lookup replacing it. Opening a scope allocates ~3.5× more, because assigning an `AsyncLocal` copies the flow's value map — but reads outnumber scope openings by orders of magnitude, and the end-to-end workload is within noise.

## Deliberately not changed

The recursion-depth counters and per-thread scratch caches elsewhere (`lHopitalDepth`, `Gruntz.depth`, `FastExpression.scratch`, the constant caches) keep `[ThreadStatic]`. A recursion depth must *not* follow a call into a sibling task. `RewriteRecording` has the same per-thread ambient shape and is left alone here — its documentation already says "on this thread" — but it is worth a look separately.

## Verification

- 6069 C# tests pass, 0 failed
- 130 F# wrapper tests pass
- public surface unchanged (`PublicApiSurfaceTest` green, `PublicApi.txt` untouched)

Breaking, so it wants the 2.0 window; recorded in `BREAKING-CHANGES.md` with the migration and the measured before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
