### PR TITLE
Let a numeric factor reach the coefficient when collecting like terms

### DIFF
--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Definition.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Definition.cs
@@ -239,6 +239,22 @@ namespace AngouriMath
         /// product of powers, and terms whose products agree are added together --
         /// enough to collect like terms and nothing more.
         /// </remarks>
+        /// <summary>
+        /// Whether every node of the expression is one that monomial collection describes:
+        /// numbers, variables, and the operations that build a polynomial out of them.
+        /// </summary>
+        /// <remarks>
+        /// Opening a product to reach its numeric factor is what lets like terms meet, and
+        /// it is also what stops a product cancelling as a whole -- lifting the 1/2 out of
+        /// <c>(1/2 * sin(2t))^2 * csc(t)^2</c> costs the cancellation to <c>cos(t)^2</c>.
+        /// Collection is a statement about polynomials, so it opens polynomials and leaves
+        /// anything carrying a function intact for the rules that do know it.
+        /// https://github.com/asc-community/AngouriMath/issues/855
+        /// </remarks>
+        private static bool IsPolynomialShaped(Entity expression)
+            => expression.Nodes.All(node =>
+                node is Number or Variable or Mulf or Powf or Sumf or Minusf or Divf);
+
         private static Entity CollectLikeTerms(Entity expanded)
         {
             if (expanded is not Sumf and not Minusf)
@@ -261,14 +277,37 @@ namespace AngouriMath
                 var exponents = new Dictionary<string, Entity>();
                 var bases = new Dictionary<string, Entity>();
 
-                foreach (var factor in Mulf.LinearChildren(term))
+                var pending = new Stack<Entity>(Mulf.LinearChildren(term));
+                while (pending.Count > 0)
                 {
                     // PowerRules folds (x^2)^2 into x^4, without which the two would be
                     // counted as different monomials.
-                    var reduced = factor.Rewrite(RewriteRules.Power).InnerSimplified;
+                    var reduced = pending.Pop().Rewrite(RewriteRules.Power).InnerSimplified;
                     if (reduced is Number)
                     {
                         coefficient = (coefficient * reduced).InnerSimplified;
+                        continue;
+                    }
+                    // Reducing a factor can turn it into a product -- (2 * x)^2 becomes
+                    // 4 * x^2 -- and taken whole that is a monomial of its own, keyed on
+                    // "4 * x ^ 2" and unable to meet the plain x^2 terms it belongs with.
+                    // Split it again so the 4 reaches the coefficient. Each child is
+                    // smaller than the product it came from, so this terminates.
+                    // https://github.com/asc-community/AngouriMath/issues/855
+                    if (reduced is Mulf && IsPolynomialShaped(reduced))
+                    {
+                        foreach (var inner in Mulf.LinearChildren(reduced))
+                            pending.Push(inner);
+                        continue;
+                    }
+                    // The same one shape out: (2 * x * y)^2 is a power of a product that
+                    // the rules above do not distribute. Only for an integer exponent,
+                    // where (a * b)^n = a^n * b^n holds for every a and b; for any other
+                    // exponent it is a statement about branches.
+                    if (reduced is Powf(Mulf product, Integer wholePower) && IsPolynomialShaped(product))
+                    {
+                        foreach (var inner in Mulf.LinearChildren(product))
+                            pending.Push(inner.Pow(wholePower));
                         continue;
                     }
                     var (@base, exponent) = reduced is Powf(var b, var e) ? (b, e) : (reduced, (Entity)1);
@@ -327,6 +366,7 @@ namespace AngouriMath
             if (collected.Nodes.Any(node => node == MathS.NaN)
                 && !expanded.Nodes.Any(node => node == MathS.NaN))
                 return expanded;
+
             return collected;
         }
 

--- a/Sources/Tests/UnitTests/Common/ExpandCollectsTermsTest.cs
+++ b/Sources/Tests/UnitTests/Common/ExpandCollectsTermsTest.cs
@@ -91,6 +91,40 @@ namespace AngouriMath.Tests.Common
             Assert.NotEqual(MathS.NaN, input.ToEntity().Simplify());
         }
 
+        // Collecting keys a term on its monomial, so a numeric factor has to reach the
+        // coefficient rather than stay inside the key. A factor that reduces to a product
+        // -- (2 * x)^2 becomes 4 * x^2 -- or that is a power of one -- (2 * x * y)^2 --
+        // was taken whole, keyed on "4 * x ^ 2", and could not meet the plain x^2 terms it
+        // belonged with. https://github.com/asc-community/AngouriMath/issues/855
+        [Theory]
+        [InlineData("(x+1)^2 * (x+1)^2", "1 + 4 * x + 6 * x ^ 2 + 4 * x ^ 3 + x ^ 4")]
+        [InlineData("(x+1)^4", "1 + 4 * x + 6 * x ^ 2 + 4 * x ^ 3 + x ^ 4")]
+        [InlineData("(2x+1)^2 * (2x+1)^2", "1 + 8 * x + 24 * x ^ 2 + 32 * x ^ 3 + 16 * x ^ 4")]
+        [InlineData("(3x)^2 + x^2", "10 * x ^ 2")]
+        public void ANumericFactorReachesTheCoefficient(string input, string expected) =>
+            Assert.Equal(expected.ToEntity(), input.ToEntity().Expand());
+
+        // Compared as printed rather than as trees: the two agree in value and in every
+        // coefficient and differ only in how the products associate.
+        [Fact]
+        public void APowerOfAProductIsSplitOverItsFactors() =>
+            Assert.Equal("y ^ 4 + 4 * x * y ^ 3 + 6 * x ^ 2 * y ^ 2 + 4 * x ^ 3 * y + x ^ 4",
+                "(x+y)^2 * (x+y)^2".ToEntity().Expand().Stringize());
+
+        // A term carrying a function is left whole, because opening it costs a cancellation
+        // the trigonometric rules would otherwise make: (1/2 * sin(2t))^2 * csc(t)^2
+        // collapses to cos(t)^2 while it is intact and does not once the 1/2 is lifted out.
+        [Fact]
+        public void ATermCarryingAFunctionIsLeftWhole()
+        {
+            // The domain condition is stripped the way DoubleAngleOverSineTest does: the
+            // cosecant makes this undefined where sin(x) is 0, which is a true statement
+            // about the expression and not what this test is about.
+            var simplified = "(sin(2 * x) * cosec(x)) ^ 2 / 4 - cos(2 * x) - sin(x) ^ 2".ToEntity().Simplify();
+            while (simplified is Entity.Providedf(var inner, _)) simplified = inner;
+            Assert.Equal(Entity.Number.Integer.Create(0), simplified);
+        }
+
         // The sets that can be shifted elementwise still are -- the guard above must not
         // turn collecting off for them.
         [Theory]


### PR DESCRIPTION
Closes #855.

## The defect

`CollectLikeTerms` failed on the expression its **own documentation cites** as the reason it exists:

```
(x+1)^2 * (x+1)^2   ->   1 + 4x + 2x^2 + 4x^2 + 4x^3 + x^4
```

The two `x^2` terms sit side by side instead of being added. Correct, but one term longer than it should be — and `(x+1)^4`, `(x+1)*(x+1)*(x+1)*(x+1)` and `(x+1)^2*(x+2)^2` all collect properly, which is what made it look arbitrary.

## The cause, from instrumenting the monomial keys

```
[collect] term=1              key=''              coeff=1
[collect] term=2 * x          key='x^1'           coeff=2
[collect] term=x ^ 2          key='x^2'           coeff=1
[collect] term=(2 * x) ^ 2    key='4 * x ^ 2^1'   coeff=1     <-- here
```

`(2 * x)^2` reduces to `4 * x^2`, which is a **product, not a power**, so it fell to the exponent-of-one branch and the `4` was baked into the *monomial key* instead of being extracted into the coefficient. Keyed on `4 * x ^ 2`, it could never meet the plain `x^2` terms.

## The fix

A factor that reduces to a product is split again, and an integer power of a product is distributed over its factors — so the number reaches the coefficient in both shapes. `(a*b)^n = a^n * b^n` is used only for integer `n`, where it holds for every `a` and `b`.

**Only for polynomial-shaped factors**, and that restriction is the whole design, not a caveat.

## What the restriction is for

Opening a product is what lets like terms meet. It is also what stops a product cancelling as a whole:

```
(1/2 * sin(2t))^2 * csc(t)^2     collapses to cos(t)^2 while intact
                                 does not, once the 1/2 is lifted out
```

`DoubleAngleOverSineTest.TheReportersSecondExpressionIsAlsoZero` exists to catch exactly that, and it caught it. Collection is a statement about polynomials, so it now opens polynomials and leaves anything carrying a function to the rules that know it.

## Two other shapes tried and rejected — against the test, not against reasoning

1. **Split only products carrying a number.** Does not help: `1/2` *is* a number, so the trigonometric term is opened anyway.
2. **Build both forms and keep the shorter by `SimplifiedRate`.** Does not work either, and the reason is already written down in this repository — the comment on `TheReportersSecondExpressionIsAlsoZero` says the opened form "was offered to the complexity metric in the one shape where its payoff had not happened yet". A local comparison cannot see a payoff that only materialises after later passes. I tried it at the `Simplificator` level too, offering the uncollected expansion as a candidate; still no.

Recording these because each looks obviously right until it is run.

## Measured

| | before | after |
|---|---|---|
| `(x+1)^2 * (x+1)^2` | `1 + 4x + 2x² + 4x² + 4x³ + x⁴` | `1 + 4x + 6x² + 4x³ + x⁴` |
| `(x+y)^2 * (x+y)^2` | `… + 2x²y² + (2xy)² + …` | `… + 6x²y² + …` |
| `(2x+1)^2 * (2x+1)^2` | uncollected | `1 + 8x + 24x² + 32x³ + 16x⁴` |
| `(3x)^2 + x^2` | uncollected | `10x²` |
| `(x*y+1)^2 * (x*y+1)^2` | uncollected | `1 + 4xy + 6x²y² + 4x³y³ + x⁴y⁴` |

All binomial coefficients `1, 4, 6, 4, 1` as they should be.

```
Passed! - Failed: 0, Passed: 6067, Skipped: 14, Total: 6081
```

Six new cases, including one that asserts the trigonometric term is **not** opened — so the restriction has a test of its own rather than only the pre-existing one it was derived from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)