### PR TITLE
Let the boolean table solver be cancelled

### DIFF
--- a/Sources/AngouriMath/Functions/Boolean/TableSolver.cs
+++ b/Sources/AngouriMath/Functions/Boolean/TableSolver.cs
@@ -6,6 +6,7 @@
 //
 
 using AngouriMath.Core.Exceptions;
+using AngouriMath.Core.Multithreading;
 using System;
 using static AngouriMath.Entity;
 
@@ -91,6 +92,7 @@ namespace AngouriMath.Functions.Boolean
         static void Search(Entity expr, Variable[] variables, Dictionary<Variable, int> index,
                            int[] assignment, int depth, MatrixBuilder tb)
         {
+            MultithreadingFunctional.ExitIfCancelled();
             switch (Evaluate(expr, index, assignment))
             {
                 case Verdict.False:
@@ -121,12 +123,20 @@ namespace AngouriMath.Functions.Boolean
         /// Writes out every way of filling in the variables from <paramref name="depth"/> on,
         /// in counting order. Called where the expression is already true whatever they are.
         /// </summary>
+        /// <remarks>
+        /// This is where the cost of the method's shape lands. The search is cheap, but every
+        /// model has to be written down, and a formula that most assignments satisfy has a
+        /// great many: a tautology over 22 variables is four million rows and 2.4 GB. So this
+        /// is the loop that most needs to be interruptible — the caller cannot know in advance
+        /// that the answer will not fit.
+        /// </remarks>
         static void EmitEveryCompletion(int[] assignment, int depth, MatrixBuilder tb)
         {
             var free = assignment.Length - depth;
             var total = 1L << free;
             for (long combination = 0; combination < total; combination++)
             {
+                MultithreadingFunctional.ExitIfCancelled();
                 var row = new Entity[assignment.Length];
                 for (var i = 0; i < depth; i++)
                     row[i] = assignment[i] == 1;
@@ -241,6 +251,9 @@ namespace AngouriMath.Functions.Boolean
             var variablesStorage = new Dictionary<Variable, Entity>();
             do
             {
+                // A truth table is all 2^n rows by definition, so there is no pruning to be
+                // had here and the only mercy available is being able to stop.
+                MultithreadingFunctional.ExitIfCancelled();
                 for (int i = 0; i < count; i++)
                     variablesStorage[variables[i]] = states[i];
                 tb.Add(states.Select(s => (Entity)s).Append(expr.Substitute(variablesStorage).EvalBoolean()));

--- a/Sources/Tests/UnitTests/Discrete/BooleanSolver.cs
+++ b/Sources/Tests/UnitTests/Discrete/BooleanSolver.cs
@@ -6,8 +6,10 @@
 //
 
 using AngouriMath;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Xunit;
 
 namespace AngouriMath.Tests.Discrete
@@ -149,6 +151,81 @@ namespace AngouriMath.Tests.Discrete
                 for (var j = 0; j < 4; j++)
                     actual = (actual << 1) | ((bool)solutions[row, j].EvalBoolean() ? 1 : 0);
                 Assert.Equal(expected[row], actual);
+            }
+        }
+
+        /// <summary>
+        /// A tautology over n variables has 2^n models and every one has to be written down,
+        /// so the answer can be far larger than the caller could know in advance — 22
+        /// variables is four million rows and some gigabytes. Pruning cannot help, since
+        /// there is nothing to prune, which leaves stopping as the only recourse. It was not
+        /// available: the token that aborts <see cref="Entity.Solve"/> was not consulted here
+        /// at all.
+        /// </summary>
+        static Entity Tautology(int count)
+        {
+            Entity all = (Entity)"p_0" | !(Entity)"p_0";
+            for (var i = 1; i < count; i++)
+                all &= (Entity)$"p_{i}" | !(Entity)$"p_{i}";
+            return all;
+        }
+
+        [Fact]
+        public void AnAlreadyCancelledTokenStopsTheSolverAtOnce()
+        {
+            using var source = new CancellationTokenSource();
+            source.Cancel();
+            MathS.Multithreading.SetLocalCancellationToken(source.Token);
+            try
+            {
+                Assert.Throws<OperationCanceledException>(
+                    () => MathS.SolveBooleanTable(Tautology(24), Vars(24)));
+            }
+            finally
+            {
+                MathS.Multithreading.SetLocalCancellationToken(default);
+            }
+        }
+
+        [Fact]
+        public void CancellingPartwayThroughStopsTheSolver()
+        {
+            using var source = new CancellationTokenSource();
+            using var started = new ManualResetEventSlim();
+
+            var worker = new Thread(() =>
+            {
+                MathS.Multithreading.SetLocalCancellationToken(source.Token);
+                started.Set();
+                try { MathS.SolveBooleanTable(Tautology(24), Vars(24)); }
+                catch (OperationCanceledException) { cancelled = true; }
+            });
+            worker.Start();
+            started.Wait();
+            Thread.Sleep(200);
+            source.Cancel();
+
+            Assert.True(worker.Join(TimeSpan.FromSeconds(20)), "the solver ignored the cancellation");
+            Assert.True(cancelled, "the solver stopped without reporting cancellation");
+        }
+
+        private volatile bool cancelled;
+
+        /// <summary>The truth table is all 2^n rows by definition, and must stop too.</summary>
+        [Fact]
+        public void AnAlreadyCancelledTokenStopsTheTruthTableAtOnce()
+        {
+            using var source = new CancellationTokenSource();
+            source.Cancel();
+            MathS.Multithreading.SetLocalCancellationToken(source.Token);
+            try
+            {
+                Assert.Throws<OperationCanceledException>(
+                    () => MathS.Boolean.BuildTruthTable(Tautology(24), Vars(24)));
+            }
+            finally
+            {
+                MathS.Multithreading.SetLocalCancellationToken(default);
             }
         }
 


### PR DESCRIPTION
Towards #858, and it removes most of the reason that issue needed a decision.

`SolveBooleanTable` and `BuildTruthTable` never consulted the cancellation token, so the escape hatch that works everywhere else in the library did not exist here. **Measured before changing anything: a token cancelled after three seconds was still being ignored twenty seconds later.**

That matters because of where the cost of these methods now sits. #864 made the *search* cheap, which leaves writing every model down as the wall — and how tall it is depends on the answer, not the question:

| tautology | rows | time | memory |
|---|---|---|---|
| 18 variables | 262 144 | 575 ms | 124 MB |
| 20 variables | 1 048 576 | 1.7 s | 544 MB |
| 22 variables | 4 194 304 | 8.0 s | **2.4 GB** |

A caller cannot know in advance which of those they asked for, and a formula every assignment satisfies offers nothing to prune. Being able to stop is the whole of the remedy available without changing the signature — which is why this is worth doing regardless of how #858 is settled.

## What changed

`MultithreadingFunctional.ExitIfCancelled()` — the same helper `PolynomialGcd`, `Simplificator`, `Minimiser` and `ExponentialSolver` already use — at three places:

- the branch nodes of the pruning search;
- the loop that writes out completions, which is where the gigabytes land;
- the truth-table loop, which is all 2ⁿ rows by definition and so has nothing but stopping to offer.

**It costs nothing measurable.** 22 variables went from 7979 ms to 7943 ms — inside the noise — because the check is one async-local read set against a per-row allocation.

## On #858's remaining question

Worth recording what this leaves. The genuinely useful additions — asking whether a formula is satisfiable, asking for one model, capping the count — are all **additive**, so they do not need the 2.0 window and can be designed at leisure in 2.1. The only thing that would need the window is changing `SolveBooleanTable`'s existing return type, and there is a decent argument against: a method named for returning the table of solutions returning exactly that is coherent, and the bounded and lazy needs are better served by new members than by mutating this one.

So #858 is no longer a deadline, which is the useful part.

## Verification

- cancellation returns at the moment it is asked, rather than not at all
- 6087 C# tests pass, 0 failed — three new
- 130 F# wrapper tests pass

No behavioural change for anyone who does not set a token, and no signature change, so nothing for `BREAKING-CHANGES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
