### PR TITLE
Take a repeated rational root out of a denominator all at once

### DIFF
--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialFactoring.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialFactoring.cs
@@ -204,20 +204,58 @@ namespace AngouriMath.Functions
             {
                 if (!Evaluate(d, root).IsZero)
                     continue;
-                var q = DivideByLinear(d, root);
+
+                // Divide the root out as many times as it goes. Stopping at one and giving up
+                // on the rest left 1/(x^4 + x^2) with no antiderivative: its only rational
+                // root is zero, twice, so a single division leaves x^3 + x, which is zero
+                // there again. A root of multiplicity m contributes a term over the m-th
+                // power, and one degree still comes off the denominator, so this ends for the
+                // same reason the single case did.
+                var q = d;
+                var multiplicity = 0;
+                do
+                {
+                    q = DivideByLinear(q, root);
+                    multiplicity++;
+                }
+                while (q.Length > 1 && Evaluate(q, root).IsZero);
+
                 var atRoot = Evaluate(q, root);
                 if (atRoot.IsZero)
-                    continue;                       // repeated root, see above
+                    continue;                       // the denominator is a power of this factor alone
+
                 var a = Evaluate(n, root).Divide(atRoot);
                 var left = Subtract(n, Scale(q, a));
                 if (!Evaluate(left, root).IsZero)
                     continue;                       // cannot happen; checked rather than assumed
-                simplePart = Rational.Create(a) / LinearFactor(root, x);
+
+                var factor = LinearFactor(root, x);
+                simplePart = Rational.Create(a) / (multiplicity == 1 ? factor : factor.Pow(multiplicity));
+
+                // What is left is over (x - r)^(m-1) times q, having cancelled one (x - r)
+                // against the numerator, which vanishes at the root by construction.
+                var restCoefficients = q;
+                for (var i = 1; i < multiplicity; i++)
+                    restCoefficients = MultiplyByLinear(restCoefficients, root);
                 restNumerator = BuildPolynomial(DivideByLinear(left, root), x);
-                restDenominator = BuildPolynomial(q, x);
+                restDenominator = BuildPolynomial(restCoefficients, x);
                 return true;
             }
             return false;
+        }
+
+        /// <summary>Multiplies by <c>x - root</c>, the inverse of <see cref="DivideByLinear"/>.</summary>
+        private static ERational[] MultiplyByLinear(ERational[] coefficients, ERational root)
+        {
+            var product = new ERational[coefficients.Length + 1];
+            for (var i = 0; i < product.Length; i++)
+                product[i] = ERational.Zero;
+            for (var i = 0; i < coefficients.Length; i++)
+            {
+                product[i + 1] = product[i + 1].Add(coefficients[i]);
+                product[i] = product[i].Subtract(coefficients[i].Multiply(root));
+            }
+            return product;
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Calculus/RationalIntegralsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/RationalIntegralsTest.cs
@@ -78,5 +78,30 @@ namespace AngouriMath.Tests.Calculus
         [InlineData("x * e ^ x", new[] { 0.3, 1.7 })]
         public void NeighbouringFormsAreUnaffected(string integrand, double[] points) =>
             AssertIsAntiderivative(integrand, points);
+
+        // A denominator whose rational root repeats. Splitting off one factor and giving up
+        // if the quotient still vanished there left 1/(x^4 + x^2) with no antiderivative:
+        // its only rational root is zero, twice. A root of multiplicity m contributes a term
+        // over the m-th power, and taking all m out at once is what the single-root arm was
+        // already doing for m = 1.
+        [Theory]
+        [InlineData("1 / (x ^ 4 + x ^ 2)", new[] { 0.7, 1.3, -1.7 })]
+        [InlineData("1 / (x ^ 3 + x ^ 2)", new[] { 0.7, 1.3, -1.7 })]
+        [InlineData("1 / (x ^ 2 * (x + 1))", new[] { 0.7, 1.3, -1.7 })]
+        [InlineData("1 / ((x - 1) ^ 2 * (x + 2))", new[] { 0.7, 2.3, -1.7 })]
+        [InlineData("x / ((x - 1) ^ 2 * (x ^ 2 + 1))", new[] { 0.7, 2.3, -1.7 })]
+        [InlineData("1 / ((x + 1) ^ 3 * (x - 2))", new[] { 0.7, 2.3, -1.7 })]
+        [InlineData("(x + 1) / (x ^ 3 - x ^ 2)", new[] { 0.7, 1.3, -1.7 })]
+        public void ARepeatedRationalRootDecomposesToo(string integrand, double[] points) =>
+            AssertIsAntiderivative(integrand, points);
+
+        // Denominators with no rational root at all are still out of reach: x^4 + 1 is
+        // irreducible over Q and only factors once real coefficients are allowed. Recorded
+        // so the boundary is visible rather than inferred from an absence.
+        [Theory]
+        [InlineData("x ^ 2 / (x ^ 4 + 1)")]
+        [InlineData("1 / (x ^ 4 + 4)")]
+        public void ADenominatorWithNoRationalRootIsStillDeclined(string integrand) =>
+            Assert.Contains("integral(", integrand.ToEntity().Integrate("x").Stringize());
     }
 }

--- a/propcheck.md
+++ b/propcheck.md
@@ -1,0 +1,13 @@
+# Property check
+
+Each transformation checked against a property it must satisfy, evaluated
+numerically rather than compared as text: Simplify, Expand and Factorize must
+preserve value; Differentiate must agree with a central difference quotient;
+Integrate must differentiate back to the integrand. Points where either side
+is undefined or leaves the reals are skipped rather than counted.
+
+- Corpus: **151** expressions
+- Checks that ran: **1340**
+- Skipped, nothing comparable: **0**
+- **Failures: 0**
+


### PR DESCRIPTION
`TrySplitOffRationalRoot` divided one factor of `(x - r)` out of the denominator and gave up if the quotient still vanished there — the code said so plainly:

```csharp
var atRoot = Evaluate(q, root);
if (atRoot.IsZero)
    continue;                       // repeated root, see above
```

So a denominator whose only rational root is a **repeated** one was never split at all. `1/(x^4 + x^2)` had no antiderivative, though `x^4 + x^2` is `x^2(x^2 + 1)` and the decomposition is just `1/x^2 - 1/(x^2 + 1)`.

## The fix

A root of multiplicity *m* contributes a term over the *m*-th power rather than the first. So divide the root out as many times as it goes, and use the power that came out. **What was already there is this with *m* fixed at 1** — one degree still comes off the denominator each step, so it terminates for exactly the reason the single-root case did.

| | before | after |
|---|---|---|
| `1 / (x^4 + x^2)` | no antiderivative | solved |
| `1 / (x^3 + x^2)` | no antiderivative | solved |
| `1 / (x^2 * (x + 1))` | no antiderivative | solved |
| `1 / ((x - 1)^2 * (x + 2))` | no antiderivative | solved |
| `1 / ((x + 1)^3 * (x - 2))` | no antiderivative | solved |
| `x / ((x - 1)^2 * (x^2 + 1))` | no antiderivative | solved |
| `(x + 1) / (x^3 - x^2)` | no antiderivative | solved |

**Every one is checked by differentiating the answer back** and comparing at points, so a wrong antiderivative cannot pass as a solved one. That is the existing `AssertIsAntiderivative` helper in the file, reused rather than reinvented.

## How it was found

Not by reading the code. Running the `casbench` corpus against master left `x^2/(x^4 + 1)` unsolved, and while probing what was and was not reachable around it, `1/(x^4 + x^2)` turned up — a denominator that factors over `Q` and still had no answer. The corpus had no repeated-root case at all, which is why this went unnoticed; four have been added.

## The boundary, asserted rather than implied

Denominators with **no** rational root stay out of reach: `x^4 + 1` is irreducible over `Q` and only factors once real coefficients are allowed, which needs partial fractions with algebraic coefficients. There is now a test asserting those are declined, so the edge is visible in the suite instead of inferred from an absence.

Worth recording: the pieces past that edge already work. `(x + 1)/(x^2 - sqrt(2)*x + 1)` and `1/(x^2 - sqrt(2)*x + 1)` both integrate in 2 ms, so for `x^4 + 1` the only missing step is the factorisation itself.

## Verification

- 6118 C# tests pass, 0 failed — 9 new
- 130 F# wrapper tests pass
- `propcheck`: 1340 property checks, 0 failures — unchanged
- `casbench`: 117/119 of the problems with an elementary answer, up from 113/115 with the four new cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
