### PR TITLE
Put every node type through the pipelines, and hold printing to being parsing's inverse

### DIFF
--- a/Sources/Tests/UnitTests/Common/EveryNodeSurvivesEveryPipelineTest.cs
+++ b/Sources/Tests/UnitTests/Common/EveryNodeSurvivesEveryPipelineTest.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using AngouriMath;
+using AngouriMath.Core;
 using AngouriMath.Extensions;
 using Xunit;
 
@@ -36,6 +37,11 @@ namespace AngouriMath.Tests.Common
     /// Not that the answer is right — the per-node tests are for that — and not that there
     /// is one at all, since an unevaluated node is a legitimate answer here.
     /// </para>
+    /// <para>
+    /// One pipeline owes more than that and gets its own assertion,
+    /// <see cref="StringizeRoundTripsToTheSameNode"/>: printing is the inverse of parsing or it
+    /// is nothing. The same enumeration answers it for every node type at once.
+    /// </para>
     /// https://github.com/asc-community/AngouriMath/issues/829
     /// </remarks>
     [Trait("Area", "Common")]
@@ -43,12 +49,59 @@ namespace AngouriMath.Tests.Common
     {
         private static readonly Entity.Variable X = MathS.Var("x");
 
+        /// <summary>
+        /// Every node type there is: concrete, and an <see cref="Entity"/>. Abstract is the only
+        /// exclusion — <see cref="Entity.Number.Complex"/>, <see cref="Entity.Number.Rational"/>
+        /// and <see cref="Entity.Number.Real"/> are concrete but not sealed, and a filter for
+        /// sealed types silently dropped all three.
+        /// </summary>
+        private static IEnumerable<Type> ConcreteNodeTypes =>
+            typeof(Entity).Assembly.GetTypes()
+                .Where(t => !t.IsAbstract && typeof(Entity).IsAssignableFrom(t))
+                .OrderBy(t => t.FullName, StringComparer.Ordinal);
+
+        /// <summary>
+        /// One sample per node type that <see cref="EveryNodeType"/>'s reflective construction
+        /// cannot reach: the constructor takes something that is not an <see cref="Entity"/>
+        /// (a count, a flag, a range, a list), or there is no public one at all and the node
+        /// comes from a factory.
+        /// </summary>
+        /// <remarks>
+        /// A hand-written list is what the reflective half exists to avoid, so nothing relies on
+        /// it being complete: <see cref="EveryNodeType"/> asserts that the two halves together
+        /// cover <see cref="ConcreteNodeTypes"/>, and names whatever they miss. A new node type
+        /// therefore fails this test the day it is added, rather than going untested in silence.
+        /// </remarks>
+        private static readonly Entity[] HandBuilt =
+        {
+            MathS.Apply(X, X),                                  // Application
+            Entity.Boolean.True,                                // Boolean
+            MathS.Derivative(X, X, 2),                          // Derivativef, with an iteration count
+            MathS.Integral(X, X),                               // Integralf, indefinite
+            MathS.Integral(X, X, 0, 1),                         // Integralf, over a range
+            MathS.Lambda(X, X),                                 // Lambda
+            MathS.Limit(X, X, 0),                               // Limitf
+            MathS.Vector(1, 2),                                 // Matrix, one row
+            MathS.Matrix(new Entity[,] { { 1, 2 }, { 3, 4 } }), // Matrix, two by two
+            3,                                                  // Integer
+            Entity.Number.Rational.Create(1, 2),                // Rational
+            MathS.pi.Evaled,                                    // Real — a decimal literal downcasts to Rational
+            Entity.Number.Complex.Create(1, 2),                 // Complex
+            MathS.Piecewise((X, X > 0), ((Entity)1, X <= 0)),   // Piecewise
+            MathS.Sets.Finite(1, 2),                            // FiniteSet
+            MathS.Interval(0, 1),                               // Interval
+            MathS.Sets.C,                                       // Complexes
+            MathS.Sets.R,                                       // Reals
+            MathS.Sets.Q,                                       // Rationals
+            MathS.Sets.Z,                                       // Integers
+            Entity.Set.SpecialSet.Create(Domain.Boolean),       // Booleans
+            X,                                                  // Variable
+        };
+
         public static IEnumerable<object[]> EveryNodeType()
         {
             var built = new List<Entity>();
-            foreach (var type in typeof(Entity).Assembly.GetTypes()
-                         .Where(t => t.IsSealed && !t.IsAbstract && typeof(Entity).IsAssignableFrom(t))
-                         .OrderBy(t => t.FullName, StringComparer.Ordinal))
+            foreach (var type in ConcreteNodeTypes)
             {
                 var constructor = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
                     .Where(c => c.GetParameters().Length > 0
@@ -64,7 +117,14 @@ namespace AngouriMath.Tests.Common
                 }
                 catch (Exception) { /* a node that will not take a bare variable is not the subject */ }
             }
-            Assert.NotEmpty(built);
+            built.AddRange(HandBuilt);
+
+            var covered = new HashSet<Type>(built.Select(n => n.GetType()));
+            var uncovered = ConcreteNodeTypes.Where(t => !covered.Contains(t)).ToList();
+            Assert.True(uncovered.Count is 0,
+                "no sample is built for these node types, so no pipeline is tested against them — "
+                + $"add one to {nameof(HandBuilt)}:\n  " + string.Join("\n  ", uncovered.Select(t => t.FullName)));
+
             return built.Select(n => new object[] { n });
         }
 
@@ -117,6 +177,55 @@ namespace AngouriMath.Tests.Common
 
             Assert.True(broken.Count is 0,
                 $"{node.Stringize()} [{node.GetType().Name}]:\n  " + string.Join("\n  ", broken));
+        }
+
+        /// <summary>
+        /// The round trips that do not hold, keyed by what the node prints as, with the reason.
+        /// </summary>
+        /// <remarks>
+        /// Both entries are a number that prints as an operator: the printed form is the right
+        /// one to read, and re-parsing it gives the operator rather than the number. So this is
+        /// a statement about where the two forms part company, not a list of things to fix —
+        /// what it buys is that no *other* node type may join them unnoticed.
+        /// </remarks>
+        private static readonly Dictionary<string, string> KnownRoundTripFailures = new(StringComparer.Ordinal)
+        {
+            ["1/2"] = "a Rational prints as a quotient, and a quotient parses as Divf(1, 2)",
+            ["1 + 2i"] = "a Complex prints as a sum, and a sum parses as Sumf(1, 2i)",
+        };
+
+        /// <summary>
+        /// Printing a node and parsing the result gives the node back.
+        /// </summary>
+        /// <remarks>
+        /// The pipelines above ask only that a node survives; this asks that it survives
+        /// unchanged, which is the one property of <see cref="Entity.Stringize"/> a caller can
+        /// build on — a printed expression is the library's own input format, so a node that
+        /// prints as something else is a hole in it. Held strictly in both directions: a node
+        /// listed in <see cref="KnownRoundTripFailures"/> that starts round tripping fails too,
+        /// so the list cannot outlive what it describes.
+        /// </remarks>
+        [Theory]
+        [MemberData(nameof(EveryNodeType))]
+        public void StringizeRoundTripsToTheSameNode(Entity node)
+        {
+            var printed = node.Stringize();
+
+            Entity? parsed = null;
+            string? threw = null;
+            try { parsed = MathS.FromString(printed); }
+            catch (Exception e) { threw = e.GetType().Name + ": " + e.Message.Split('\n')[0]; }
+            var roundTrips = threw is null && parsed == node;
+
+            if (KnownRoundTripFailures.TryGetValue(printed, out var reason))
+                Assert.False(roundTrips,
+                    $"{printed} [{node.GetType().Name}] round trips now, so it is no longer a known "
+                    + $"failure — drop it from {nameof(KnownRoundTripFailures)}, where it reads "
+                    + $"\"{reason}\"");
+            else
+                Assert.True(roundTrips,
+                    $"{printed} [{node.GetType().Name}] does not round trip: "
+                    + (threw ?? $"parsed back as {parsed!.Stringize()} [{parsed.GetType().Name}]"));
         }
     }
 }


### PR DESCRIPTION
`EveryNodeSurvivesEveryPipelineTest` gathered node types that were **sealed** and had a constructor taking nothing but `Entity`. That is 44 of the 64 concrete `Entity` types, and the 20 it dropped were dropped silently:

`Matrix`, `Piecewise`, `Lambda`, `Application`, `Limitf`, `Derivativef`, `Integralf`, `Interval`, `FiniteSet`, `Boolean`, `Variable`, the five special sets, and every number — `Integer`, `Rational`, `Real`, `Complex`.

`Rational`, `Real` and `Complex` are concrete but not sealed, so the sealed filter alone lost all three. The rest take a count, a flag, a range or a list, or have no public constructor.

## What changed

Reflection still does what it can; a hand-written table covers the rest; and an assertion covers the seam — the two halves together must reach every concrete `Entity` type, and the failure names whatever they miss. A node type added tomorrow fails this test the day it is added, which is what enumerating instead of listing was for and was only half true before.

**67 samples, up from 45. All 20 newly reached types survive all 15 pipelines**, so the widening needed no production fix; the payoff is the guarantee.

## Round-trip identity

Second assertion: `Stringize` is the inverse of parsing. Nobody knew how many node types round trip. **65 of 67.** Both failures are a number that prints as an operator:

| node | prints as | parses back as |
|---|---|---|
| `Rational.Create(1, 2)` | `1/2` | `Divf(1, 2)` |
| `Complex.Create(1, 2)` | `1 + 2i` | `Sumf(1, 2i)` |

Both are recorded as known failures with the reason, and the list is checked **in both directions** — an entry that starts round tripping fails the test too, so it cannot outlive what it describes.

The guards were verified by breaking them: deleting a sample (the coverage assertion named the type), deleting a known failure (`Rational` failed, reporting the form it came back as), and adding a fabricated one (`Sumf` failed for round tripping).

## On #847

`integral(f, x, n)` is **not** reachable this way. `Integralf`'s third field is a range, not an iteration count, so `Stringize` only ever emits the two- and four-argument forms and both round trip. #847 is that the parser rejects input the library never prints, which no round trip over nodes can observe. It needs its own test at the parser.

Verified: 6215 C# tests pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)