### PR TITLE
Say what the three-argument integral actually cost, measured on 1.3.0

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -1795,7 +1795,8 @@ until a string is parsed.
 | | 1.3.0 | 1.4.0 onwards |
 |---|---|---|
 | `integral(f, x, 1)` | accepted, read as `integral(f, x)` | `FunctionArgumentCountException` |
-| `integral(f, x, a, b)` | — | the definite integral from `a` to `b` |
+| `integral(x, x, 2)` | the second antiderivative, `x ^ 3 / 6` | `FunctionArgumentCountException` |
+| `integral(x, x, 0, 1)` | `FunctionArgumentCountException` | the definite integral from `0` to `1` |
 
 The third argument used to be a repetition count and is now the lower bound of a range, so three
 arguments name neither form and are refused. `derivative(f, x, n)` is unaffected and still takes an
@@ -1808,7 +1809,11 @@ against 1.4.0 since January without anyone seeing it, because they were pinned t
 [#846](https://github.com/asc-community/AngouriMath/pull/846) is what surfaced it.
 
 **What to do.** `integral(f, x, 1)` becomes `integral(f, x)` — identical in meaning, since 1.3.0
-turned the former into the latter anyway. For a repeated antiderivative, nest the calls.
+turned the former into the latter anyway. A count of two or more was not a no-op and is the part
+that is actually gone: nest the calls instead, `integral(integral(f, x), x)`, which 1.3.0 accepted
+as well. Expect the answer to differ by the constants of integration, which the same PR began
+adding — where `integral(x, x, 2)` gave `x ^ 3 / 6` on 1.3.0, the nested form gives
+`C_1 + C * x + x ^ 3 / 6` from 1.4.0 onwards.
 
 ---
 


### PR DESCRIPTION
Finishes #847. Its two remaining items — `Syntax.md` omitting the definite form, and 1.4.0 having no home in `BREAKING-CHANGES.md` — are both already done. What was left is that the 1.4.0 entry understates the change, in a way that would mislead someone acting on it.

## The removal was not a no-op

The table showed one row, `integral(f, x, 1)`, which 1.3.0 read as `integral(f, x)`. That makes it look like a no-op form being dropped. A count of two or more was a genuine iterated integral:

```
1.3.0   integral(x, x, 2)   ->  x ^ 3 / 6
1.4.0   integral(x, x, 2)   ->  FunctionArgumentCountException
```

## The migration path is right, but not answer-for-answer

The entry already said "for a repeated antiderivative, nest the calls" — correct, and now the table shows why it is needed. But #657 also began adding the constants of integration, so following the advice does not give back the old answer:

```
1.3.0   integral(x, x, 2)             ->  x ^ 3 / 6
1.3.0   integral(integral(x, x), x)   ->  x ^ 3 / 6
1.4.0   integral(integral(x, x), x)   ->  C_1 + C * x + x ^ 3 / 6
master  integral(integral(x, x), x)   ->  C_1 + C * x + x ^ 3 / 6
```

Someone who takes the migration path and diffs the output should be told which difference to expect rather than discover it.

## A dash where a value was asked for

The `integral(f, x, a, b)` row read `—` for 1.3.0. Measured, it is a `FunctionArgumentCountException` naming "3 arguments or 2 arguments" — the mirror of the message 1.4.0 gives for three. This file's own preamble asks for the value on the previous release, so it now gives it.

## How it was measured

Each line comes from parsing the string in a process referencing that published package — 1.3.0 and 1.4.0 from nuget, master built from source. Not read off the diff.

Documentation only; no code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)