### PR TITLE
Release 2.0.0

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -15,7 +15,7 @@ read first.
 
 ---
 
-## 2.0.0 (unreleased) — since 1.4.0
+## 2.0.0 — since 1.4.0
 
 ### At a glance
 
@@ -134,9 +134,9 @@ This was not three separate defects. One conversion made *every* `params Entity[
 the library uncallable with a list, including any added later.
 
 **This one moves between previews.** The conversion is in `2.0.0-preview.1` and
-`2.0.0-preview.2`, both published, and is removed in the release that follows them. It is so
-far the only entry here that changes between two previews rather than between releases: a
-reader coming from 1.3.0 or 1.4.0 can ignore the distinction, one already on a preview cannot.
+`2.0.0-preview.2`, both published, and is gone in `2.0.0`. It is the only entry here that
+changes between two previews rather than between releases: a reader coming from 1.3.0 or
+1.4.0 can ignore the distinction, one already on a preview cannot.
 
 **What breaks.** Assigning a list where an `Entity` is expected:
 

--- a/Sources/Package.Build.props
+++ b/Sources/Package.Build.props
@@ -17,7 +17,7 @@
     release tag, so what ships is named by the tag; this is what a local build and the
     assembly metadata carry.
     -->
-    <Version>2.0.0-preview.2</Version>
+    <Version>2.0.0</Version>
 
     <!--
     Pinned to the major for the whole of 2.x, and deliberately not tracking Version.


### PR DESCRIPTION
Names the version `2.0.0` instead of `2.0.0-preview.2`, and drops "(unreleased)" from the
2.0.0 heading in `BREAKING-CHANGES.md`. That is the whole diff.

### Why now

The two previews are published and the surface has settled. The last thing that moved
between them — the implicit conversion from `Entity[]` / `List<Entity>` / `(Entity, Entity)`
to `Entity`, which made every `params Entity[]` overload in the library uncallable with a
list — is removed and recorded, and nothing else in `BREAKING-CHANGES.md` is waiting on a
decision.

`AssemblyVersion` stays pinned at `2.0.0.0` and is deliberately not tracking `Version`: the
assembly is strong-named, so for a consumer without a binding redirect every
`AssemblyVersion` change breaks binding, and holding it makes each 2.x release a drop-in
replacement. The NuGet workflow takes the package version from the release tag, so `Version`
is what a local build and the assembly metadata carry.

### Measured on this commit, .NET 10

| | |
|---|---|
| C# tests | 6253 passed, **0 failed**, 14 skipped |
| F# tests | 130 passed, **0 failed** |
| `casbench` | 117/119 with an elementary answer, 2 unsolved, 2 correctly refused, **0 wrong, 0 error, 0 timeout** |

### What has to happen for the release itself

Merging this does not publish anything — `Nuget.yml` fires on a published release and takes
the version from the tag. So after merge:

```sh
gh release create v2.0.0 --title "v2.0.0" --latest --notes-file <notes>
```

That publishes `AngouriMath`, `AngouriMath.FSharp`, `AngouriMath.Interactive` and
`AngouriMath.Terminal` at `2.0.0` to nuget.org, and a pushed NuGet package cannot be
deleted, only unlisted — so it is deliberately left as one explicit step rather than done
from a branch.

### The docs side, which is the other half of this

Two things go with the release and are not in this repository:

- **The wiki** is corrected and now machine-checked against a 2.0.0 build: 86 samples, 0
  compile errors, 0 output mismatches, 57 stated outputs verified. Before that, 23 of 90
  samples did not compile — `Latexise` had become `Latexize`, `Exceptions` documented the
  `FutureReleaseException` that #872 removed, and the entire F# page named a
  `` `dy/dx` `` that has always been `` `d/dx` ``.
- **[AngouriMathSite](https://github.com/asc-community/AngouriMathSite)** has a PR that
  drops `--prerelease` from the quickstart, removes the dead MyGet feed, adds the 2.0.0
  entry to *What's new* — which is where `PackageReleaseNotes` sends readers — and repairs
  the docs build, which has been broken since the library moved up a folder in `f0db3eef`
  on 2026-01-03: `amsite.fsx` and `NaiveStaticGenerator` both still published and read from
  `Sources/AngouriMath/AngouriMath/`. **That PR should merge after the release**, since its
  quickstart tells the reader to install a version that has to exist first.

### Found while doing it, filed rather than smuggled in

- #881 — `abs` folds a numeric argument and nothing else, so `abs(-sqrt(6))` survives
  `Simplify`. It shows up in the documented answer to a quadratic inequality, and it
  falsifies the claim that #757's closed form "collapses to exactly the old output when the
  roots are concrete".
- #882 — `Simplify` rewrites the root node only: `-(5 - sqrt(-11))` becomes `sqrt(-11) - 5`
  on its own and is left alone inside a matrix, a power or a sum. Not the complexity metric
  — the better form scores 7 against 9 — and `FiniteSet` works only because
  `Simplificator.Alternate` special-cases it.
- #585 is rewritten around a measurement instead of two merged pull requests: 184 of 1831
  documented members carry an `<example>`, and `AngouriMath.Extensions` has 0 of 89.
