### PR TITLE
Stop the F# wrapper hardcoding its documentation path

### DIFF
--- a/Sources/Wrappers/AngouriMath.FSharp/AngouriMath.FSharp.fsproj
+++ b/Sources/Wrappers/AngouriMath.FSharp/AngouriMath.FSharp.fsproj
@@ -14,12 +14,8 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\AngouriMath.FSharp.XML</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\AngouriMath.FSharp.XML</DocumentationFile>
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`dotnet build -c release` — lowercase — cannot build `AngouriMath.FSharp` from a clean checkout on
Linux or macOS:

```
FSC : error FS0193: Could not find a part of the path
'.../Sources/Wrappers/AngouriMath.FSharp/bin/Release/netstandard2.0/AngouriMath.FSharp.XML'
```

## Cause

The fsproj set the documentation path literally:

```xml
<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
  <DocumentationFile>bin\Release\netstandard2.0\AngouriMath.FSharp.XML</DocumentationFile>
</PropertyGroup>
```

MSBuild compares strings in a `Condition` **case-insensitively**, so with `-c release` the condition
matches and `DocumentationFile` points at `bin/Release/…`. But `$(OutputPath)` is built from the
configuration as spelled, so the directory that actually gets created is `bin/release/`. On a
case-sensitive filesystem those are two different paths, the second does not exist, and the F#
compiler cannot create the file in it.

## Fix

`<GenerateDocumentationFile>true</GenerateDocumentationFile>`, which puts the XML beside the
assembly whichever way the configuration is spelled and needs no path. `AngouriMath.Terminal.Lib`
already does exactly this, so it is the in-repo precedent rather than a new idea. The main library
was never affected — it uses `bin/$(Configuration)/$(TargetFramework)/…`, which follows the spelling.
`AngouriMath.FSharp` was the only project with a literal.

## Verified from a clean `bin` and `obj`, both spellings

| | |
|---|---|
| `dotnet test -c release` | **130 passed, 0 failed** — this is the command that used to fail |
| `dotnet build -c Release` | succeeds, and still produces `AngouriMath.FSharp.xml` and `AngouriMath.FSharp.2.0.0.nupkg` |

So packaging is unchanged; the only difference is that the file is now `.xml` rather than `.XML`,
which is what every other project here already emits.

## Why nobody hit it

`-c Release` works, and `-c release` also works *once a capitalised build has created the
directory*. It fails only on a clean checkout that has never been built with the capitalised
spelling — which is what CI would do if it ever used the lowercase form, and what I did while
measuring #888. It cost a measurement I had to redo: the first run reported the F# suite as having
been exercised when the build had in fact failed, which is the trap in
`dotnet test` reusing whatever assembly is already there.
