### PR TITLE
Point at the roadmap before a release, and at mathlib for a hypothesis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,6 +283,11 @@ a procedure, find out whether it has a name:
   new symbolic-computation algorithms appear.
 - **Gruntz's thesis** for limits, **Bronstein's _Symbolic Integration I_** for integration,
   **_Modern Computer Algebra_** (von zur Gathen & Gerhard) for the polynomial layer.
+- **[mathlib4](https://leanprover-community.github.io/mathlib4_docs/)** — for the *hypotheses* of an
+  identity. Every lemma there carries its side conditions explicitly and machine-checked, which is
+  exactly what a rewrite rule needs and exactly what our rules have repeatedly been missing. See
+  [`Contributing/SimplificationContract.md`](Sources/AngouriMath/Docs/Contributing/SimplificationContract.md)
+  for how to use it and where it does not help.
 
 Branch cuts deserve a specific warning: `arcsin`, `log`, and fractional powers disagree between
 conventions, and C99, .NET, Python and Mathematica do not all agree. Decide deliberately, cite the
@@ -373,6 +378,38 @@ Anything added for the library's own purposes is not `public` — see
 checks that any more: the `PublicApiAnalyzers` package that required every public member to be
 listed in a `PublicApi.*.txt` is gone from the tree, so it is a rule to follow rather than one to
 be caught by.
+
+## Read the roadmap before you release anything
+
+[#746](https://github.com/asc-community/AngouriMath/issues/746) is the ten-year technical vision, and
+it is **not optional reading before a release, a version number, or anything that lands in the kernel
+package**. It was written to be argued with, not obeyed — but it has to be read first, because two
+things in it are easy to break by accident and impossible to undo afterwards.
+
+**Its `v1.0`–`v9.0` are capability tiers, not versions.** `v1.0` is "a symbolic engine worth building
+on" — a real polynomial layer, a *written* canonical-form specification, pattern matching as data
+rather than a `switch`, and assumptions that travel with a node. `v2.0` is "the rewrite graph". So a
+published package version does **not** mean the tier of the same name has been reached, and shipping
+one spends a label the roadmap was using. That happened with `2.0.0`, which is a breaking-changes
+release published while tier 1 is still unfinished; see the discussion on #746.
+
+**Three conditions cut across every tier**, and #746 says a tier that violates one has failed
+whatever else it delivered:
+
+1. **The common case pays for nothing it does not use.** Package boundaries are decided deliberately
+   and early, because a published one cannot be moved. Anything large landing in the kernel wants that
+   decision first — #746's item 78.
+2. **Speed and memory on popular use cases are measured, not hoped for.** Parse, `Simplify`, `Solve`
+   and `Differentiate` on textbook-sized input. `2.0.0` shipped with no measurement at all and no
+   column in
+   [`WhatsNew/version_performance_control.md`](Sources/AngouriMath/Docs/WhatsNew/version_performance_control.md);
+   do not repeat that.
+3. **Correctness coverage grows with the surface.** Each new layer adds ways to be wrong that the one
+   below could not express.
+
+So the release checklist is: the suite and the harnesses in `work/` green, a `BREAKING-CHANGES.md`
+entry for every changed answer measured on real builds, **a performance column measured against the
+previous one on the same machine**, and a version number that does not contradict #746.
 
 ## Where the work is
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,10 +388,10 @@ things in it are easy to break by accident and impossible to undo afterwards.
 
 **Its `v1.0`–`v9.0` are capability tiers, not versions.** `v1.0` is "a symbolic engine worth building
 on" — a real polynomial layer, a *written* canonical-form specification, pattern matching as data
-rather than a `switch`, and assumptions that travel with a node. `v2.0` is "the rewrite graph". So a
-published package version does **not** mean the tier of the same name has been reached, and shipping
-one spends a label the roadmap was using. That happened with `2.0.0`, which is a breaking-changes
-release published while tier 1 is still unfinished; see the discussion on #746.
+rather than a `switch`, and assumptions that travel with a node. `v2.0` is "the rewrite graph". A
+published package version does **not** mean the tier of the same name has been reached, and choosing
+one spends a label the roadmap is using: check #746 before picking a number, and say on the issue
+which tier the release does and does not advance.
 
 **Three conditions cut across every tier**, and #746 says a tier that violates one has failed
 whatever else it delivered:
@@ -400,10 +400,11 @@ whatever else it delivered:
    and early, because a published one cannot be moved. Anything large landing in the kernel wants that
    decision first — #746's item 78.
 2. **Speed and memory on popular use cases are measured, not hoped for.** Parse, `Simplify`, `Solve`
-   and `Differentiate` on textbook-sized input. `2.0.0` shipped with no measurement at all and no
-   column in
-   [`WhatsNew/version_performance_control.md`](Sources/AngouriMath/Docs/WhatsNew/version_performance_control.md);
-   do not repeat that.
+   and `Differentiate` on textbook-sized input, recorded in
+   [`WhatsNew/version_performance_control.md`](Sources/AngouriMath/Docs/WhatsNew/version_performance_control.md).
+   Measure the previous column again on the same machine and publish the pair: columns taken on
+   different hardware cannot be read as a ratio, and a uniform factor across every row is the machine
+   rather than the code.
 3. **Correctness coverage grows with the surface.** Each new layer adds ways to be wrong that the one
    below could not express.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# CLAUDE.md
+
+The instructions for this repository are in **[AGENTS.md](AGENTS.md)**. Read it before doing
+anything else here; this file exists only so that tools looking for `CLAUDE.md` find their way there.
+
+Four things from it that are most often learned the hard way, so that they are visible even if
+nothing else is read:
+
+1. **Be a mathematician first.** When correctness and backward compatibility disagree, correctness
+   wins — and every changed answer is recorded in [BREAKING-CHANGES.md](BREAKING-CHANGES.md), measured
+   on a build of each version rather than read off a diff.
+2. **Not answering is a legitimate answer; answering wrongly is not.** Unevaluated means "I could not
+   settle this", `NaN` means "this does not exist", and confusing them ships a wrong answer.
+3. **Read [#746](https://github.com/asc-community/AngouriMath/issues/746) before a release or a
+   version number.** Its `v1.0`–`v9.0` are capability tiers, not shipping versions, and it names
+   conditions — measured performance, deliberate package boundaries — that a release has to meet. See
+   *Read the roadmap before you release anything* in AGENTS.md.
+4. **Before adding or changing a simplification rule**, read
+   [`Contributing/SimplificationContract.md`](Sources/AngouriMath/Docs/Contributing/SimplificationContract.md).
+   Five wrong answers were found in one day in rules that stated no assumptions.
+
+The measurement harnesses live outside this repository, in the analysis workspace one directory up
+(`work/`): a self-verifying solver corpus, a property checker, root-completeness and
+simplification sweeps, a boundary checker, a crash harness that survives a stack overflow, and a
+checker for the documentation's code samples. Run them before claiming anything is fixed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ nothing else is read:
    *Read the roadmap before you release anything* in AGENTS.md.
 4. **Before adding or changing a simplification rule**, read
    [`Contributing/SimplificationContract.md`](Sources/AngouriMath/Docs/Contributing/SimplificationContract.md).
-   Five wrong answers were found in one day in rules that stated no assumptions.
+   A rule states the assumptions under which it holds, or it is asserting there are none.
 
 The measurement harnesses live outside this repository, in the analysis workspace one directory up
 (`work/`): a self-verifying solver corpus, a property checker, root-completeness and

--- a/Sources/AngouriMath/Docs/Contributing/SimplificationContract.md
+++ b/Sources/AngouriMath/Docs/Contributing/SimplificationContract.md
@@ -280,10 +280,11 @@ Such a harness would have found all four rules of #884 immediately. It does not 
 Obligation O2 says to state the assumption set. For a large part of classical mathematics somebody has
 already stated it, machine-checked it, and published it:
 **[mathlib4](https://leanprover-community.github.io/mathlib4_docs/)**. Every lemma carries its
-hypotheses explicitly, because Lean will not accept it otherwise — which is exactly the discipline a
-rewrite rule needs and exactly what ours have repeatedly lacked.
+hypotheses explicitly, because Lean will not accept it otherwise — which is the discipline a rewrite
+rule needs, already applied to most of classical analysis.
 
-Checked against mathlib after the fact, the intervals this library now guards with are the same ones:
+The intervals this library guards the inverse-trigonometric cancellations with are the ones mathlib
+states:
 
 | mathlib4 | our guard |
 |---|---|
@@ -292,11 +293,12 @@ Checked against mathlib after the fact, the intervals this library now guards wi
 | `Real.arctan_tan {x : ℝ} (hx₁ : -(π / 2) < x) (hx₂ : x < π / 2) : arctan (tan x) = x` | `WithinHalfPi(closed: false)` |
 | `@[simp] Real.tan_arctan (x : ℝ) : tan (arctan x) = x` — no hypothesis | the right-inverse direction, unguarded |
 
-Four for four, including the open-versus-closed distinction that separates `arctan` from `arcsin`.
-Reading those four lines would have been faster than the measurements that produced them, and this is
-the first place to look when writing a guard.
+Note the open-versus-closed distinction that separates `arctan` from `arcsin`, and that
+`Real.tan_arctan` is a `@[simp]` lemma with no hypothesis at all — the right-inverse direction needs
+none, which is §5's point in someone else's notation. This is the first place to look when writing a
+guard.
 
-**Two warnings, both learned from the same exercise.**
+**Two warnings.**
 
 **A hypothesis can differ because the convention differs, not because the mathematics does.**
 `Real.sin_arcsin` requires `-1 ≤ x ≤ 1`, and this library needs no such condition — because mathlib's
@@ -305,10 +307,12 @@ plane. Both are right about their own `arcsin`. Copying a hypothesis without che
 it belongs to is the same error as reading a branch cut off memory, so §6 applies: measure what *this*
 library does.
 
-**And it does not cover everything.** mathlib has no `arccot` at all, which is precisely the rule this
-library got wrong twice — the range here is `(-pi/2, pi/2]` and not the `(0, pi)` of the textbooks
+**And it does not cover everything.** mathlib has no `arccot`, and `arccot` is the case where this
+library's convention departs furthest from the textbooks: its range is `(-pi/2, pi/2]` rather than
+`(0, pi)`, so `arccotan(-1)` is `-pi/4`
 ([#887](https://github.com/asc-community/AngouriMath/issues/887)). Where the lookup is empty there is
-no substitute for measuring the function at a positive argument, a negative one, and zero.
+no substitute for measuring the function at a positive argument, a negative one, and zero, and writing
+the three values into the comment.
 
 ## 10. What this does not settle
 

--- a/Sources/AngouriMath/Docs/Contributing/SimplificationContract.md
+++ b/Sources/AngouriMath/Docs/Contributing/SimplificationContract.md
@@ -275,7 +275,42 @@ grammar.** For each rewrite, construct the set where its assumption fails and te
 and compare `L` against `R` numerically at each, counting **both undefined** as agreement, per O4.
 Such a harness would have found all four rules of #884 immediately. It does not exist yet.
 
-## 9. What this does not settle
+## 9. Where to look an assumption set up
+
+Obligation O2 says to state the assumption set. For a large part of classical mathematics somebody has
+already stated it, machine-checked it, and published it:
+**[mathlib4](https://leanprover-community.github.io/mathlib4_docs/)**. Every lemma carries its
+hypotheses explicitly, because Lean will not accept it otherwise — which is exactly the discipline a
+rewrite rule needs and exactly what ours have repeatedly lacked.
+
+Checked against mathlib after the fact, the intervals this library now guards with are the same ones:
+
+| mathlib4 | our guard |
+|---|---|
+| `Real.arcsin_sin {x : ℝ} (hx₁ : -(π / 2) ≤ x) (hx₂ : x ≤ π / 2) : arcsin (sin x) = x` | `WithinHalfPi(closed: true)` |
+| `Real.arccos_cos {x : ℝ} (hx₁ : 0 ≤ x) (hx₂ : x ≤ π) : arccos (cos x) = x` | `WithinZeroAndPi(closed: true)` |
+| `Real.arctan_tan {x : ℝ} (hx₁ : -(π / 2) < x) (hx₂ : x < π / 2) : arctan (tan x) = x` | `WithinHalfPi(closed: false)` |
+| `@[simp] Real.tan_arctan (x : ℝ) : tan (arctan x) = x` — no hypothesis | the right-inverse direction, unguarded |
+
+Four for four, including the open-versus-closed distinction that separates `arctan` from `arcsin`.
+Reading those four lines would have been faster than the measurements that produced them, and this is
+the first place to look when writing a guard.
+
+**Two warnings, both learned from the same exercise.**
+
+**A hypothesis can differ because the convention differs, not because the mathematics does.**
+`Real.sin_arcsin` requires `-1 ≤ x ≤ 1`, and this library needs no such condition — because mathlib's
+`Real.arcsin` clamps outside `[-1, 1]` to stay a total real function, while ours goes into the complex
+plane. Both are right about their own `arcsin`. Copying a hypothesis without checking which convention
+it belongs to is the same error as reading a branch cut off memory, so §6 applies: measure what *this*
+library does.
+
+**And it does not cover everything.** mathlib has no `arccot` at all, which is precisely the rule this
+library got wrong twice — the range here is `(-pi/2, pi/2]` and not the `(0, pi)` of the textbooks
+([#887](https://github.com/asc-community/AngouriMath/issues/887)). Where the lookup is empty there is
+no substitute for measuring the function at a positive argument, a negative one, and zero.
+
+## 10. What this does not settle
 
 - **Per-symbol assumptions.** SymPy carries them on the symbol (`Symbol('x', positive=True)`) with
   `refine`/`ask` to query, and an explicit `force=True` escape where the user accepts the risk. This


### PR DESCRIPTION
Documentation only. Two additions, both aimed at things being read *before* they are needed rather than pointed out afterwards.

## 1. `AGENTS.md` — read the roadmap before a release

[#746](https://github.com/asc-community/AngouriMath/issues/746) is the ten-year vision, and nothing
pointed at it from the instructions an agent or a new contributor actually reads. Two things in it are
easy to break by accident and impossible to undo:

- **Its `v1.0`–`v9.0` are capability tiers, not versions.** `v1.0` is "a symbolic engine worth building
  on" — polynomial layer, a written canonical-form specification, pattern matching as data, assumptions
  travelling with a node. `v2.0` is "the rewrite graph". Choosing a package version spends a label the
  roadmap is using, so it is worth checking the issue first and saying there which tier a release does
  and does not advance.
- **Three conditions cut across every tier**, and #746 says a tier violating one has failed whatever
  else it delivered: the common case pays for nothing it does not use (package boundaries decided
  early, since a published one cannot move — its item 78), speed and memory measured rather than hoped
  for, and correctness coverage growing with the surface.

With a release checklist that follows from them, including the one thing easiest to get wrong about
the performance table: **re-measure the previous column on the same machine and publish the pair**,
because columns from different hardware cannot be read as a ratio and a uniform factor across every row
is the machine rather than the code.

`CLAUDE.md` is added as a pointer to `AGENTS.md`, so a tool looking for that filename finds its way,
carrying four rules in case nothing else is read.

## 2. mathlib4, for the hypotheses of an identity

`SimplificationContract.md` asks a rule to state its assumption set and did not say where to find one.
For classical analysis, [mathlib4](https://leanprover-community.github.io/mathlib4_docs/) has already
stated and machine-checked them — Lean does not accept a lemma otherwise.

The intervals this library guards the inverse-trigonometric cancellations with are the ones mathlib
states, checked against the current docs:

| mathlib4 | our guard |
|---|---|
| `Real.arcsin_sin (hx₁ : -(π / 2) ≤ x) (hx₂ : x ≤ π / 2) : arcsin (sin x) = x` | `WithinHalfPi(closed: true)` |
| `Real.arccos_cos (hx₁ : 0 ≤ x) (hx₂ : x ≤ π) : arccos (cos x) = x` | `WithinZeroAndPi(closed: true)` |
| `Real.arctan_tan (hx₁ : -(π / 2) < x) (hx₂ : x < π / 2) : arctan (tan x) = x` | `WithinHalfPi(closed: false)` |
| `@[simp] Real.tan_arctan (x : ℝ) : tan (arctan x) = x` — no hypothesis | the right-inverse direction, unguarded |

Including the open-versus-closed distinction between `arctan` and `arcsin`, and the fact that the
right-inverse direction carries no hypothesis at all — §5 of the contract in someone else's notation.

**Two warnings go with it, because the lookup is not mechanical.** `Real.sin_arcsin` requires
`-1 ≤ x ≤ 1` and we need no such condition, because mathlib's `arcsin` clamps outside `[-1, 1]` to stay
a total real function while ours continues into the complex plane — a difference of convention, not of
mathematics. And mathlib has no `arccot`, which is where this library departs furthest from the
textbooks: its range is `(-pi/2, pi/2]`, so `arccotan(-1)` is `-pi/4`
([#887](https://github.com/asc-community/AngouriMath/issues/887)). Where the lookup is empty, measure at
a positive argument, a negative one and zero, and write the three values into the comment.

## Why this shape

Leibniz's *characteristica universalis* wanted three things: a perfectly logical language, an
encyclopedia of verified knowledge, and an engine of reason. #746's `v7.0` already plans the bridge to
the first two. The point of this PR is narrower and available now: **the encyclopedia is usable today,
with no dependency and no bridge, as a place to look up a side condition** — which is the single thing
this library's rules have most often been missing.

No code changes; `AGENTS.md`, a new `CLAUDE.md`, and one section in `SimplificationContract.md`.
