### PR TITLE
Name a conditional set's binder rather than guessing it from a hash (#891)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -68,6 +68,7 @@ read first.
 | loud | a known gap, e.g. a cubic inequality | `AngouriBugException`, asking to be reported | `NotSufficientlySupportedException` |
 | **silent** | `arcsin(sin(x))` and three siblings | `x`, wrong wherever `x` leaves the principal interval | left as written unless `x` is a real in that interval |
 | **silent** | `abs(sgn(x))` and `sgn(abs(x))` | `1`, wrong at `x = 0` where both are `0` | left as written unless the argument's value can be read |
+| **silent** | `DirectChildren` of a conditional set | a name off the predicate's hash, and one in 26^4 threw | `%1`, fresh by construction |
 | **silent** | `arctan(x) + arccotan(x)` | `pi/2`, wrong for every negative `x` | `pi/2` or `-pi/2` where the sign is known, else left as written |
 | **silent** | `log(1, 1)` | `0` | `NaN`, since it is `0/0` |
 | **silent** | `log(b, 1)` | `0` for any base | `0 provided not b = 1` |
@@ -349,6 +350,34 @@ the sibling `arcsin`/`arccos` case still collapses and still sorts.
 Found by `boundcheck`, a harness that composes every unary function node with every other and
 compares against the original at points where an assumption fails rather than at sampled points.
 Issue [#887](https://github.com/asc-community/AngouriMath/issues/887).
+
+### A conditional set's bound variable is renamed to a temporary
+
+`DirectChildren` of `{ x : P(x) }` renames the binder, so that the bound `x` is not read as an `x`
+that may be free outside the set. The replacement name was four lowercase letters derived from the
+predicate's hash code, and it was produced through `MathS.Var`, which **parses** — so a name that the
+parser reads as something other than a variable did not come back as one.
+
+| | was | is |
+|---|---|---|
+| `new ConditionalSet("x", "x > 0").DirectChildren[0]` | `abcd > 0`, a different name in every process | `%1 > 0` |
+| one predicate in `26^4` | `CannotParseInstanceException: Cannot parse an instance of Variable from `true`` | `%1 > 0` |
+
+Four lowercase letters can spell `true`. They can also spell a variable the predicate already uses, in
+which case the rename captures it and the set means something else — silently, with no exception to
+say so. The name now comes from `Variable.CreateTemp`, which reads the predicate's variables rather
+than its hash and hands back `%1` upward, skipping what is taken: fresh by construction, and with no
+reading as anything but a variable, since the parser does not accept `%`.
+
+**Printed output does not change.** `Stringize` reads the node's own fields, so `{ x : x > 0 }` still
+prints with its own binder, and `Solve` answers containing a conditional set are unaffected. Nothing
+could have depended on the old name either, since string hash codes are randomised per process and it
+was therefore different on every run — which is also why this surfaced as a CI failure that would not
+reproduce.
+
+`Variable.CreateRandom`, which had this one caller, is removed. It was `internal`.
+
+Issue [#891](https://github.com/asc-community/AngouriMath/issues/891).
 
 ### `abs(sgn(x))` and `sgn(abs(x))` are not `1` at zero
 

--- a/Sources/AngouriMath/Core/Entity/Omni/Entity.Omni.Classes.cs
+++ b/Sources/AngouriMath/Core/Entity/Omni/Entity.Omni.Classes.cs
@@ -468,10 +468,23 @@ namespace AngouriMath
 
                 internal override Priority Priority => Priority.Leaf;
 
-                // The predicate is the child, but the set variable X is not the same as X out of the set,
-                // so to avoid ambiguity, we replace it with a random variable name
+                // The predicate is the child, but the set variable X is not the same as X out of the
+                // set, so to avoid ambiguity it is renamed to one that nothing else can be called.
+                //
+                // CreateTemp, rather than a name derived from the predicate's hash code, which is
+                // what this did until #891. That mapped the hash onto four lowercase letters, and
+                // four lowercase letters can spell `true` -- which went through MathS.Var, and
+                // MathS.Var *parses*, so the parser read a boolean and the conversion to Variable
+                // threw. One name in 26^4 does that, and string hash codes are randomised per
+                // process, so it surfaced as a CI failure that would not reproduce. The same four
+                // letters could also coincide with a free variable of the predicate and capture it,
+                // which is silent. CreateTemp is derived from the predicate's variables rather than
+                // its hash: `%1` upward, skipping what is taken, so it is fresh by construction and
+                // has no reading as anything but a variable.
+                // https://github.com/asc-community/AngouriMath/issues/891
                 /// <inheritdoc/>
-                protected override Entity[] InitDirectChildren() => new[] { Predicate.Substitute(Var, Variable.CreateRandom(Predicate)) };
+                protected override Entity[] InitDirectChildren() =>
+                    new[] { Predicate.Substitute(Var, Variable.CreateTemp(Predicate.Vars)) };
 
                 /// <inheritdoc/>
                 public override bool IsSetFinite => false;

--- a/Sources/AngouriMath/Core/Entity/Omni/Entity.Variable.cs
+++ b/Sources/AngouriMath/Core/Entity/Omni/Entity.Variable.cs
@@ -130,18 +130,6 @@ namespace AngouriMath
                 return new Variable("%" + i);
             }
 
-            /// <summary>
-            /// Used for cases, when the variable should be valid, yet should have no intersection with those existing in the expression
-            /// </summary>
-            internal static Variable CreateRandom(Entity expr)
-            {
-                static char IntToChar(uint c)
-                    => (char)(c % (122 - 97 + 1) + 97);
-
-                var hs = (uint)(expr.GetHashCode());
-                var s = new string(new[]{ IntToChar(hs >> 24), IntToChar(hs << 8 >> 24), IntToChar(hs << 16 >> 24), IntToChar(hs << 24 >> 24)});
-                return MathS.Var(s);
-            }
         }
         #endregion
     }

--- a/Sources/Tests/UnitTests/Core/Sets/ConditionalSetBinder.cs
+++ b/Sources/Tests/UnitTests/Core/Sets/ConditionalSetBinder.cs
@@ -1,0 +1,94 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath.Core.Exceptions;
+using AngouriMath.Extensions;
+using System.Linq;
+using Xunit;
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Set;
+
+namespace AngouriMath.Tests.Core.Sets
+{
+    /// <summary>
+    /// A conditional set's bound variable is renamed in <see cref="Entity.DirectChildren"/>, so that
+    /// the <c>x</c> inside <c>{ x : x &gt; 0 }</c> is not read as the same <c>x</c> that may be free
+    /// outside it.
+    /// </summary>
+    /// <remarks>
+    /// https://github.com/asc-community/AngouriMath/issues/891 — the replacement name used to be
+    /// four lowercase letters read off the predicate's hash code, and it went through
+    /// <c>MathS.Var</c>, which parses. Four lowercase letters can spell <c>true</c>, which parses to
+    /// a boolean and not a variable, so the conversion threw; and they can spell a variable the
+    /// predicate already uses, which captures it silently. Both are properties of the name, so both
+    /// are tested here as properties of the name.
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class ConditionalSetBinder
+    {
+        private static Variable[] BinderOf(ConditionalSet set) =>
+            set.DirectChildren[0].Vars.Where(variable => variable.Name.StartsWith("%")).ToArray();
+
+        [Theory]
+        [InlineData("x", "x > 0")]
+        [InlineData("y", "y < 0 and y > -2")]
+        [InlineData("x", "x = 0")]
+        [InlineData("x", "x ^ 5 - x - 1 = 0")]
+        public void TheBinderIsRenamedToATemporary(string variable, string predicate)
+        {
+            var set = new ConditionalSet(variable, predicate);
+            Assert.Single(BinderOf(set));
+            Assert.DoesNotContain((Variable)variable, set.DirectChildren[0].Vars);
+        }
+
+        /// <summary>
+        /// A free variable of the predicate is left alone: only the binder is renamed.
+        /// </summary>
+        [Fact]
+        public void AFreeVariableIsUntouched()
+        {
+            var set = new ConditionalSet("x", "x > a");
+            Assert.Contains((Variable)"a", set.DirectChildren[0].Vars);
+            Assert.DoesNotContain((Variable)"x", set.DirectChildren[0].Vars);
+        }
+
+        /// <summary>
+        /// The name a nested set has already taken is not taken again, which is what stops the outer
+        /// binder from capturing the inner one. Reachable only because the inner set's renamed
+        /// predicate is what the outer set is built over.
+        /// </summary>
+        [Fact]
+        public void ANestedBinderDoesNotReuseTheInnerName()
+        {
+            var inner = new ConditionalSet("y", "y > 0").DirectChildren[0];
+            var outer = new ConditionalSet("x", inner & (Entity)"x > 0");
+            var names = outer.DirectChildren[0].Vars
+                .Select(variable => variable.Name)
+                .Where(name => name.StartsWith("%"))
+                .Distinct()
+                .ToArray();
+            Assert.Equal(2, names.Length);
+        }
+
+        /// <summary>
+        /// Why a temporary cannot collide with anything a caller wrote, and the reason a name that
+        /// <em>can</em> be parsed is the wrong choice here: the parser does not read this one, so no
+        /// input can produce a variable of the same name.
+        /// </summary>
+        [Fact]
+        public void ATemporaryIsNotSomethingTheParserProduces() =>
+            Assert.Throws<UnhandledParseException>(() => "%1".ToEntity());
+
+        /// <summary>
+        /// The rename is there to make two sets that differ only in the name of the bound variable
+        /// one set, and it still does.
+        /// </summary>
+        [Fact]
+        public void TwoSetsDifferingOnlyInTheirBinderAgree() =>
+            Assert.Equal(new ConditionalSet("x", "x > 0"), new ConditionalSet("y", "y > 0"));
+    }
+}


### PR DESCRIPTION
Closes #891 — the intermittent CI failure that arrived on a documentation-only PR and passed on a
re-run of the same commit. It has a cause, and it is not a race.

## What it was

A conditional set renames its bound variable in `DirectChildren`, so the `x` inside `{ x : P(x) }` is
not read as an `x` that may be free outside it. The name came from `Variable.CreateRandom`:

```csharp
var hs = (uint)(expr.GetHashCode());
var s = new string(new[]{ IntToChar(hs >> 24), ... });   // four letters, a-z
return MathS.Var(s);
```

Two things collide there.

**`MathS.Var` parses.** It is `public static Variable Var(string name) => name;` — the implicit
conversion, which runs the string through the parser and casts. So a generated name that the parser
reads as something other than a variable does not come back as one.

**Four lowercase letters can spell `true`.** The parser reads that as a boolean, and the conversion
throws `CannotParseInstanceException: Cannot parse an instance of Variable from 'true'` — the exact
message in the issue. One name in `26^4`, and .NET randomises string hash codes per process, so the
same expression picks a different name on every run. That is why it could not be reproduced: three
attempts are recorded in the issue, including the full suite at `maxParallelThreads=2` three times.

The same four letters can also spell a variable the predicate already uses, and then the rename
captures it and the set means something else. No exception for that one.

## The fix

`Variable.CreateTemp(Predicate.Vars)`, which the class already trusts for this exact purpose two
methods below — `GetHashCode` alpha-normalises with `CreateVariableUnchecked("%")`. It reads the
predicate's variables rather than its hash and returns `%1` upward, skipping indices already taken, so
it is fresh by construction, deterministic across processes, and unreadable as anything but a variable:
`%` is not a token the parser accepts, so no parsed input can collide with it. Nesting works out
because the inner set's renamed predicate is part of the outer's variables, so the outer binder takes
`%2`.

`CreateRandom` had this one caller and is removed.

## What a caller sees

Nothing, unless they read `DirectChildren` directly:

| | was | is |
|---|---|---|
| `new ConditionalSet("x", "x > 0").DirectChildren[0]` | `abcd > 0`, a different name every process | `%1 > 0` |
| one predicate in `26^4` | throws | `%1 > 0` |
| `{ x : x > 0 }.Stringize()` | unchanged | unchanged |
| `Solve` answers containing a conditional set | unchanged | unchanged |

`Stringize` reads the node's own fields, not its `DirectChildren`, so printed output is untouched —
checked on `(x - a)(x + a) <= 0`, whose answer carries a conditional set, and it still prints `{ x :
... }` with its own binder. It is in `BREAKING-CHANGES.md` regardless, because `DirectChildren` is
public. Nothing could have depended on the old name, which differed from run to run.

## Measured

**The new tests fail 5 of 8 against `master` and pass 8 of 8 here**, so they pin the fix rather than
describe it. They assert the two properties the name has to have — that it is a temporary, and that a
nested binder does not reuse the inner one's — plus that a free variable is untouched, that
alpha-equivalent sets still compare equal, and that `%1` is not something the parser produces, which is
what makes the name safe.

Suite 6341 passed / 0 failed. casbench 117/119 with 0 wrong, rootcheck 596/596, simpsweep
10463/10463, propcheck 1340 checks with 0 failures, crashcheck 1652 cases with 0 crashes and 0
unexpected throws, boundcheck unchanged at master's 4 disagreements.

Cut from `master` at `5397c6f9`. It shares no file with #901 or #903 except `BREAKING-CHANGES.md`,
where the three sections sit in different places — #901 and #903 merged cleanly against each other for
that reason.
