### PR TITLE
Decline a connective over a number rather than answering (#897)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -74,6 +74,7 @@ read first.
 | **silent** | `-(a - b)` inside a power, a function or a matrix | left as written | `b - a`, as at the root |
 | **silent** | `Expand` of a matrix | the matrix, unexpanded | expanded entry by entry |
 | **silent** | `false and u`, `true or u`, `false implies u` for an undefined `u` | `NaN` | `False`, `True`, `True` — what the truth table settles |
+| **silent** | a connective over a number, e.g. `true and 0`, `false and 0` | `NaN`, or `False` by short-circuit | left as written — a number is not a truth value |
 | **silent** | `arctan(x) + arccotan(x)` | `pi/2`, wrong for every negative `x` | `pi/2` or `-pi/2` where the sign is known, else left as written |
 | **silent** | `log(1, 1)` | `0` | `NaN`, since it is `0/0` |
 | **silent** | `log(b, 1)` | `0` for any base | `0 provided not b = 1` |
@@ -407,6 +408,45 @@ have their own test asserting the unevaluated node, so a future fix flips them b
 `boundcheck` drops from four disagreements to two; the remaining two are `log(x, x)` and
 `ln(x) + ln(x+1)`, both recorded elsewhere as wanting a decision rather than a guard. Issue
 [#902](https://github.com/asc-community/AngouriMath/issues/902).
+
+### A logical connective over a number has no answer
+
+A number is not a truth value: `0` is not `False` and `1` is not `True`. The same category error was
+reported three different ways, depending on which operator saw it and in which position:
+
+| expression | was | is |
+|---|---|---|
+| `true and 0`, `false or 0`, `false xor 0` | `NaN` | left as written |
+| `false and 0`, `true or 0` | `False`, `True` — by short-circuit | left as written |
+| `true xor 0` | `not 0` | left as written |
+| `not 0`, `0 xor 0` | left as written | unchanged |
+| `true and 1`, `true and 1/2`, `true and i` | `NaN` | left as written |
+
+**`NaN` was the worst of the three.** In this library it means *this does not exist*, and `true and 0`
+exists perfectly well — it is not a proposition. Reporting a sort error as nonexistence tells a caller
+something false about the mathematics, and it is the answer an `if` on `EvaluableBoolean` does not save
+you from. The other two were an answer arrived at by not looking, and a rewrite of one non-boolean into
+another.
+
+**Two answers are withdrawn deliberately.** `false and 0` and `true or 0` used to come back `False` and
+`True`, because short-circuiting settled them before the number was examined. Those are gone: whether an
+operand is admissible cannot depend on whether the operator happened to need it. There is no proposition
+here for `False` to be the truth of.
+
+A caller who insists on a boolean is unaffected — `EvalBoolean()` throws `CannotEvalException` for an
+unevaluated node exactly as it did for `NaN`, so the type error still surfaces at the layer where
+insisting happens. `DomainCondition` stops contradicting evaluation as a side effect: `domain(a xor 0)`
+says `True`, and there is no longer a `NaN` for it to disagree with.
+
+**A number is not the same as an undefined truth value, and the two must not be treated alike.** `NaN`
+is how this library spells *no truth value* — what an order comparison over the complex plane produces —
+and a connective settles what it can with one, which is the entry above. So `(0/0) and False` and
+`(i < 0) and False` are both still `False`, and only a genuine number makes a connective decline. A bare
+variable is `Domain.Any` and may yet be a truth value, so `false and x` is still `False`.
+
+Issue [#897](https://github.com/asc-community/AngouriMath/issues/897), which asked whether a number is
+a truth value here at all. It is not; a truth value that is neither true nor false is what
+`MathS.Quantum` is for.
 
 ### A logical connective is no longer strict in `NaN`
 

--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Discrete/Evaluation.Discrete.Classes.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Discrete/Evaluation.Discrete.Classes.cs
@@ -38,6 +38,28 @@ namespace AngouriMath
                     (@this, a) => ((Notf)@this).New(a), isExact);
         }
 
+        /// <summary>
+        /// Whether either operand of a logical connective is a number, which is not a truth value:
+        /// <c>0</c> is not <see langword="false"/> and <c>1</c> is not <see langword="true"/>. A
+        /// connective declines such a pair rather than answering, and declines it even where its
+        /// table could answer without looking -- <c>false and 0</c> is not a proposition to be
+        /// false about.
+        /// </summary>
+        /// <remarks>
+        /// <c>NaN</c> is excluded deliberately, and the distinction is the point. <c>NaN</c> is how
+        /// this library spells <em>no truth value</em>, which is what an order comparison over the
+        /// complex plane produces, and what a connective does with one is settled by the
+        /// three-valued table: <c>false and NaN</c> is <see langword="false"/>
+        /// (https://github.com/asc-community/AngouriMath/issues/880). A number is the other thing
+        /// entirely -- a value of the wrong sort, where the question rather than the answer is at
+        /// fault. https://github.com/asc-community/AngouriMath/issues/897
+        /// </remarks>
+        private static bool MixesANumberWithATruthValue(Entity left, Entity right)
+            => IsNotATruthValue(left) || IsNotATruthValue(right);
+
+        private static bool IsNotATruthValue(Entity operand)
+            => operand.Evaled is Number && !operand.Evaled.IsNaN;
+
         partial record Andf
         {
             // Logical AND is always defined for any inputs
@@ -45,7 +67,9 @@ namespace AngouriMath
             /// <inheritdoc/>
             protected override Entity InnerSimplify(bool isExact)
                 => ExpandOnTwoArguments(Left, Right,
-                    (left, right) => left == right ? left : (left.Evaled, right.Evaled) switch
+                    (left, right) => MixesANumberWithATruthValue(left, right) ? null
+                        : left == right ? left
+                        : (left.Evaled, right.Evaled) switch
                     {
                         (Boolean(false), _) or (_, Boolean(false)) => False,
                         (Boolean(true), _) => right,
@@ -62,7 +86,8 @@ namespace AngouriMath
             /// <inheritdoc/>
             protected override Entity InnerSimplify(bool isExact)
                 => ExpandOnTwoArguments(Left, Right,
-                    (left, right) => (left.Evaled, right.Evaled) switch
+                    (left, right) => MixesANumberWithATruthValue(left, right) ? null
+                        : (left.Evaled, right.Evaled) switch
                     {
                         (Boolean(true), _) or (_, Boolean(true)) => True,
                         (Boolean(false), _) => right,
@@ -79,7 +104,8 @@ namespace AngouriMath
             /// <inheritdoc/>
             protected override Entity InnerSimplify(bool isExact)
                 => ExpandOnTwoArguments(Left, Right,
-                    (left, right) => (left.Evaled, right.Evaled) switch
+                    (left, right) => MixesANumberWithATruthValue(left, right) ? null
+                        : (left.Evaled, right.Evaled) switch
                     {
                         (Boolean(var leftBool), Boolean(var rightBool)) => leftBool ^ rightBool,
                         (Boolean(true), _) => !right,
@@ -98,7 +124,8 @@ namespace AngouriMath
             /// <inheritdoc/>
             protected override Entity InnerSimplify(bool isExact)
                 => ExpandOnTwoArguments(Assumption, Conclusion,
-                    (left, right) => (left.Evaled, right.Evaled) switch
+                    (left, right) => MixesANumberWithATruthValue(left, right) ? null
+                        : (left.Evaled, right.Evaled) switch
                     {
                         (Boolean(var leftBool), Boolean(var rightBool)) => !leftBool || rightBool,
                         (Boolean(false), _) => True,

--- a/Sources/Tests/UnitTests/Common/SimplificationRegressionTest.cs
+++ b/Sources/Tests/UnitTests/Common/SimplificationRegressionTest.cs
@@ -940,6 +940,61 @@ namespace AngouriMath.Tests.Common
         public void ArithmeticIsStillStrictInNaN(string expression) =>
             Assert.Equal(MathS.NaN, expression.ToEntity().Evaled);
 
+        // https://github.com/asc-community/AngouriMath/issues/897
+        // A number is not a truth value, so a connective over one has no answer to give: 0 is not
+        // false and 1 is not true. It used to report the same category error three different ways
+        // -- NaN where the operator had to look at the number, a correct-by-short-circuit False
+        // where it did not, and a rewritten `not 0` for `true xor 0` -- so what a caller got
+        // depended on which operator and which operand position. NaN is the worst of the three: it
+        // says the expression does not exist, where the truth is that it is not a proposition.
+        [Theory]
+        [InlineData("false and 0")]
+        [InlineData("true and 0")]
+        [InlineData("0 and true")]
+        [InlineData("true or 0")]
+        [InlineData("false or 0")]
+        [InlineData("false xor 0")]
+        [InlineData("true xor 0")]
+        [InlineData("not 0")]
+        [InlineData("0 xor 0")]
+        [InlineData("true implies 0")]
+        [InlineData("0 implies true")]
+        [InlineData("true and 1")]
+        [InlineData("true and 1/2")]
+        [InlineData("true and i")]
+        public void AConnectiveOverANumberHasNoAnswer(string expression)
+        {
+            var evaled = expression.ToEntity().Evaled;
+            Assert.NotEqual(MathS.NaN, evaled);
+            Assert.IsNotType<Entity.Boolean>(evaled);
+            Assert.False(expression.ToEntity().EvaluableBoolean);
+        }
+
+        // A caller who insists on a boolean still gets the type error, at the layer where insisting
+        // happens -- which is why declining here loses nothing that mattered.
+        [Fact]
+        public void InsistingOnABooleanOverANumberStillThrows() =>
+            Assert.Throws<AngouriMath.Core.Exceptions.CannotEvalException>(
+                () => "true and 0".ToEntity().EvalBoolean());
+
+        // The distinction this rests on, and the one that makes it not a retreat from #880: NaN is
+        // how this library spells "no truth value", and a connective settles what it can with one.
+        // A number is a value of the wrong sort. The two must not be treated alike.
+        [Theory]
+        [InlineData("(0/0) and false", "false")]
+        [InlineData("(i < 0) and false", "false")]
+        [InlineData("(0/0) or true", "true")]
+        public void AnUndefinedTruthValueIsNotANumberForThisPurpose(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity(), expression.ToEntity().Evaled);
+
+        // Nor is a symbol: a bare variable is Domain.Any, so it may yet be a truth value and the
+        // absorbing rules still apply to it.
+        [Theory]
+        [InlineData("false and x", "false")]
+        [InlineData("true or x", "true")]
+        public void ASymbolMayStillBeATruthValue(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity(), expression.ToEntity().Evaled);
+
         // The contradiction this removes, stated as the commutation it broke.
         [Theory]
         [InlineData("true or (true and (x < 0))")]


### PR DESCRIPTION
Closes #897, taking the first of its two options: **a number is not a truth value here.** A truth value
that is neither true nor false is what `MathS.Quantum` is for.

| expression | was | is |
|---|---|---|
| `true and 0`, `false or 0`, `false xor 0` | `NaN` | left as written |
| `false and 0`, `true or 0` | `False`, `True` — by short-circuit | left as written |
| `true xor 0` | `not 0` | left as written |
| `not 0`, `0 xor 0` | left as written | unchanged |
| `true and 1`, `true and 1/2`, `true and i` | `NaN` | left as written |

## The `NaN` was not the connective's judgement

Which is why it read as arbitrary. `Andf`'s table answers `(Boolean(true), _) => right`, hands back the
`0`, and then the domain check in `InnerSimplifyWithCheck` finds a non-boolean where `Domain.Boolean` is
declared and returns `MathS.NaN`. So the logic never claimed nonexistence — a guard downstream converted
"this isn't a boolean" into "this doesn't exist". The connectives now decline the pair outright and
nothing reaches that check.

`NaN` was the worst of the three answers for the reason [AGENTS.md](AGENTS.md) gives: it means *this does
not exist*, and `true and 0` exists perfectly well — it is not a proposition. That is a wrong claim about
the mathematics, and the one an `if` on `EvaluableBoolean` will not save a caller from.

## Two answers are withdrawn on purpose

`false and 0` and `true or 0` were `False` and `True`, settled by short-circuit before the number was
looked at. Those are gone. **Whether an operand is admissible cannot depend on whether the operator
happened to need it**, and there is no proposition there for `False` to be the truth of.

Nothing is lost for a caller who insists: `EvalBoolean()` throws `CannotEvalException` for an unevaluated
node exactly as it did for `NaN`, so the type error still surfaces at the layer where insisting happens.
`DomainCondition` stops contradicting evaluation as a side effect — `domain(a xor 0)` says `True`, and
there is no longer a `NaN` for it to disagree with, which was #897's second complaint.

## Why this is not a retreat from #880

A number and an undefined truth value are different things and must not be treated alike. `NaN` is how
this library spells *no truth value* — what an order comparison over the complex plane produces — and a
connective settles what it can with one, which is what #907 just landed. A number is a value of the
wrong sort.

```
(0/0) and false    =>  False     (unchanged — NaN is a missing truth value)
(i < 0) and false  =>  False     (unchanged)
false and x        =>  False     (unchanged — a bare variable is Domain.Any and may yet be one)
true and 0         =>  left as written
```

The guard therefore excludes `NaN` explicitly, and it is on the four connectives only. Comparison nodes
are untouched: `Equalsf`, `Greaterf` and their kind take numbers, which is their whole job.

## A correction to the issue's own table

Two rows I wrote up as defects are not, and inspection says so:

- **`false and 0 → False` was not "correct by accident."** The table answers `False` without consulting
  the operand, which is Kleene-sound and type-clean. It is withdrawn here for the sort reason above, not
  because it was wrong logic.
- **`true xor 0 → not 0` was not "nonsense."** `Notf` declares `Domain.Boolean`, so it passed the guard
  and came back as an *unevaluated node* — which is the honest "I could not settle this", not a claim.

So only three of the eight rows were wrong answers, and they were the three where the connective handed
back its non-boolean operand. The uniform decline is what makes the remaining five consistent with them
rather than merely harmless.

## Measured

**The new tests fail 11 of 284 against `master` and pass 284 of 284 here**, checked by restoring master's
file underneath them.

Suite 6389 passed / 0 failed, F# wrapper 130 passed. casbench 117/119 with 0 wrong, rootcheck 596/596,
simpsweep 10463/10463, propcheck 1340 checks with 0 failures, crashcheck 1652 cases with 0 crashes and 0
unexpected throws, boundcheck unchanged at 2 disagreements.

Cut from `master` at `63bd11d7`.
