### PR TITLE
Emit SymPy code that runs (#909)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -28,6 +28,8 @@ read first.
 | **silent** | `sqrt(x^2)`, `sqrt(-x)` and their kind | `x`, `i*sqrt(x)` — wrong for negative x | left as written |
 | loud | `mod` as a variable name | a variable | a keyword, so a parse error |
 | loud | `NaN` as a variable name | a variable | a keyword, so the NaN value |
+| loud | `MathS.ToSympyCode` of any non-integer rational | `SyntaxError` — a parenthesis was never closed | code that runs |
+| loud | `MathS.ToSympyCode` of `NaN`, `+oo`, `-oo` | `NameError` — the name is never bound | `sympy.nan`, `sympy.oo`, `-sympy.oo` |
 | **silent** | `NaN` printed and read back | a variable of that name, which cancels and collects | the NaN value |
 | **silent** | `Stringize` of powers, lambdas, applications, piecewises | did not parse back | parses back |
 | **silent** | `Stringize` of a complex number with a fractional imaginary part | read back as its negation, or as a power | parses back |
@@ -1008,6 +1010,35 @@ disagreements over 10463 expressions goes **30 to 0**.
 
 [#752](https://github.com/asc-community/AngouriMath/issues/752), PR
 [#758](https://github.com/asc-community/AngouriMath/pull/758).
+
+### `MathS.ToSympyCode` emits Python that runs
+
+Its documented purpose is code you can run in SymPy, and for two whole classes of expression it
+emitted code that did not run at all.
+
+| expression | was | is |
+|---|---|---|
+| `1/2`, `1/3 + 1/6` | `sympy.Rational(1, 2` — `SyntaxError: '(' was never closed` | `sympy.Rational(1, 2)` |
+| `0/0`, `1/0` | `NaN` — `NameError: name 'NaN' is not defined` | `sympy.nan` |
+| `+oo`, `-oo` | `+oo`, `-oo` — `NameError` | `sympy.oo`, `-sympy.oo` |
+
+The first is a missing parenthesis, and it broke **every** expression carrying a non-integer rational,
+which is most of what a computer algebra system hands back. The second is a value with no binding: the
+generated preamble declares a `sympy.Symbol` for each free *variable*, and a `NaN` or an infinity is
+neither a variable nor something SymPy names the same way this library does.
+
+Both were checked by running the emitted programs against SymPy 1.14 rather than by reading them, which
+is also how it was established that they now come back **exact** — `1/2` arrives as SymPy's `Half` and
+not as the float `0.5`.
+
+Nothing else about the exporter changes. `pi`, `e` and `i` were already emitted as `sympy.pi`,
+`sympy.E` and `sympy.I`, and `sqrt` as `sympy.sqrt`.
+
+Two tests now hold the properties that failed, without needing an interpreter in the suite: the
+parentheses balance, and every name in the emitted body is either declared in the preamble or reached
+through `sympy.`. 17 of their 23 cases fail against the old exporter.
+
+Issue [#909](https://github.com/asc-community/AngouriMath/issues/909).
 
 ### `NaN` is now a keyword, and the printed form of NaN reads back
 

--- a/Sources/AngouriMath/Functions/Output/ToSympy/ToSympy.Number.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/ToSympy/ToSympy.Number.Classes.cs
@@ -25,14 +25,34 @@ namespace AngouriMath
 
             partial record Real
             {
+                /// <summary>
+                /// A finite real prints as its decimal, which Python reads as a float. The three
+                /// non-finite ones have no such reading: this library spells them <c>NaN</c>,
+                /// <c>+oo</c> and <c>-oo</c>, and <c>ToSympyCode</c>'s preamble binds a name only
+                /// for each free <em>variable</em>, so they arrived in the generated program as
+                /// bare names and it stopped with <c>NameError: name 'NaN' is not defined</c>.
+                /// SymPy's own spellings are used instead.
+                /// https://github.com/asc-community/AngouriMath/issues/909
+                /// </summary>
                 internal override string ToSymPy()
-                    => Stringize();
+                    => this switch
+                    {
+                        { IsFinite: true } => Stringize(),
+                        { IsNaN: true } => "sympy.nan",
+                        { IsNegative: true } => "-sympy.oo",
+                        _ => "sympy.oo",
+                    };
             }
 
             partial record Rational
             {
+                // The closing parenthesis was missing, so every expression carrying a non-integer
+                // rational -- which is most of what a CAS hands back -- emitted Python that would
+                // not even parse: `sympy.Rational(1, 2` is `SyntaxError: '(' was never closed`.
+                // Nothing caught it because nothing runs the generated code.
+                // https://github.com/asc-community/AngouriMath/issues/909
                 internal override string ToSymPy()
-                    => $"sympy.Rational({Numerator.ToSymPy()}, {Denominator.ToSymPy()}";
+                    => $"sympy.Rational({Numerator.ToSymPy()}, {Denominator.ToSymPy()})";
             }
 
             partial record Integer

--- a/Sources/Tests/UnitTests/Convenience/ToSympyCodeTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/ToSympyCodeTest.cs
@@ -1,0 +1,115 @@
+//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath.Extensions;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AngouriMath.Tests.Convenience
+{
+    /// <summary>
+    /// <see cref="MathS.ToSympyCode(Entity)"/> is documented as generating code you can run in
+    /// SymPy, so code that cannot run is the whole of the defect.
+    /// </summary>
+    /// <remarks>
+    /// Nothing here executes Python — the suite cannot depend on an interpreter — so these check
+    /// the two properties that made the generated programs fail without one:
+    /// <list type="bullet">
+    /// <item>the parentheses balance, which <c>sympy.Rational(1, 2</c> did not;</item>
+    /// <item>every name the body mentions is either declared in the preamble or reached through
+    /// <c>sympy.</c>, which a bare <c>NaN</c> or <c>+oo</c> was not.</item>
+    /// </list>
+    /// https://github.com/asc-community/AngouriMath/issues/909
+    /// </remarks>
+    [Trait("Area", "Convenience")]
+    public sealed class ToSympyCodeTest
+    {
+        private static (IReadOnlySet<string> Declared, string Body) Split(string code)
+        {
+            var declared = new HashSet<string>();
+            string body = "";
+            foreach (var line in code.Split('\n'))
+            {
+                var declaration = Regex.Match(line, @"^(\S+) = sympy\.Symbol\(");
+                if (declaration.Success)
+                    declared.Add(declaration.Groups[1].Value);
+                else if (line.StartsWith("expr = "))
+                    body = line.Substring("expr = ".Length);
+            }
+            return (declared, body);
+        }
+
+        /// <summary>
+        /// Every name in the emitted body is bound: declared as a symbol above, or qualified with
+        /// <c>sympy.</c>. A bare name is a <c>NameError</c> waiting to happen, and that is how
+        /// <c>NaN</c>, <c>+oo</c> and <c>-oo</c> used to leave here.
+        /// </summary>
+        [Theory]
+        [InlineData("0/0")]
+        [InlineData("1/0")]
+        [InlineData("-1/0")]
+        [InlineData("+oo")]
+        [InlineData("-oo")]
+        [InlineData("+oo + 1")]
+        [InlineData("NaN")]
+        [InlineData("x + 1/2")]
+        [InlineData("sqrt(2) + pi")]
+        [InlineData("sin(x) / 2")]
+        [InlineData("x + y + e")]
+        [InlineData("i")]
+        [InlineData("2 + 3 * i")]
+        public void EveryNameInTheEmittedBodyIsBound(string expression)
+        {
+            var (declared, body) = Split(MathS.ToSympyCode(expression.ToEntity().Simplify()));
+            // Whatever is reached through sympy. is bound by the import, so take those out first
+            // and require the rest to have been declared.
+            var unqualified = Regex.Replace(body, @"sympy\.\w+", " ");
+            var loose = Regex.Matches(unqualified, @"[A-Za-z_]\w*")
+                .Select(match => match.Value)
+                .Where(name => !declared.Contains(name))
+                .Distinct()
+                .ToArray();
+            Assert.True(loose.Length == 0,
+                $"{expression} emitted `{body}`, which mentions {string.Join(", ", loose)} "
+                + "without binding it");
+        }
+
+        /// <summary>
+        /// The parentheses balance. <c>Rational</c>'s exporter was missing its closing one, so any
+        /// expression carrying a non-integer rational -- most of what a CAS hands back -- emitted
+        /// `SyntaxError: '(' was never closed`.
+        /// </summary>
+        [Theory]
+        [InlineData("1/2")]
+        [InlineData("1/3 + 1/6")]
+        [InlineData("x + 1/2")]
+        [InlineData("2/3 * x ^ (1/2)")]
+        [InlineData("sin(x) / 2 + 1/4")]
+        public void TheEmittedCodeHasBalancedParentheses(string expression)
+        {
+            var code = MathS.ToSympyCode(expression.ToEntity().Simplify());
+            Assert.Equal(code.Count(character => character == '('),
+                         code.Count(character => character == ')'));
+        }
+
+        /// <summary>
+        /// And a rational keeps its exactness, which is the reason to emit
+        /// <c>sympy.Rational</c> rather than a division of two Python integers: <c>1 / 2</c> is
+        /// <c>0.5</c> there, a float.
+        /// </summary>
+        [Theory]
+        [InlineData("1/2", "sympy.Rational(1, 2)")]
+        [InlineData("1/3 + 1/6", "sympy.Rational(1, 2)")]
+        [InlineData("0/0", "sympy.nan")]
+        [InlineData("+oo", "sympy.oo")]
+        [InlineData("-oo", "-sympy.oo")]
+        public void AValueIsEmittedWithSympysOwnSpelling(string expression, string expected) =>
+            Assert.Contains(expected, MathS.ToSympyCode(expression.ToEntity().Simplify()));
+    }
+}


### PR DESCRIPTION
Closes #909, and it turned out to be worse than that issue described — the issue named the unbound names,
and the same file also had a missing parenthesis.

| expression | was | is |
|---|---|---|
| `1/2`, `1/3 + 1/6` | `sympy.Rational(1, 2` — `SyntaxError: '(' was never closed` | `sympy.Rational(1, 2)` |
| `0/0`, `1/0` | `NaN` — `NameError: name 'NaN' is not defined` | `sympy.nan` |
| `+oo`, `-oo` | `+oo`, `-oo` — `NameError` | `sympy.oo`, `-sympy.oo` |

The parenthesis broke **every** expression carrying a non-integer rational, which is most of what a
computer algebra system hands back. `MathS.ToSympyCode`'s documented purpose is code you can run in
SymPy, so this was not a cosmetic defect.

## Measured by running it

SymPy 1.14 locally, eight expressions emitted and executed. Before: two `NameError`s and the rationals
refusing to parse. After: **zero failures**, and the values come back *exact* rather than merely valid —

```
sympy(simplify(1/2))         ran, expr = 1/2         (Half)
sympy(simplify(0/0))         ran, expr = nan         (NaN)
sympy(simplify(x + 1/2))     ran, expr = x + 1/2     (Add)
sympy(simplify(sqrt(2) + pi))ran, expr = sqrt(2) + pi(Add)
```

`Half`, not the float `0.5`, which is the whole reason to emit `sympy.Rational` rather than a division of
two Python integers.

## What was already right

Checked before touching anything, because the "what else is the same shape" guess was wrong here: `pi`,
`e` and `i` already emitted `sympy.pi`, `sympy.E` and `sympy.I`, and `sqrt` already emitted `sympy.sqrt`.
Only the two number cases above were broken.

## The tests, without an interpreter in the suite

The suite cannot depend on Python, so the two properties that actually failed are what get asserted:

- **the parentheses balance** — what `sympy.Rational(1, 2` violated;
- **every name in the emitted body is bound** — declared as a `sympy.Symbol` in the preamble, or reached
  through `sympy.` — which is what a bare `NaN` or `+oo` violated.

The second generalises: any future value that leaves here as a bare name fails it. **17 of the 23 cases
fail against the old exporter**, 23 of 23 pass here.

## Not in this PR

`1/2` *before* simplification is a `Divf` of two integers and emits `1 / 2`, which Python evaluates to the
float `0.5` — exactness lost silently. Fixing it means deciding how much to sympify: emitting
`sympy.Integer(n)` for every integer is faithful but makes `x + sympy.Integer(1)` of `x + 1`. That is a
design choice rather than a defect fix, so it is filed separately as #911 with a recommendation.

`ToSymPy` is reached only from `ToSympyCode`, so evaluation and simplification cannot see any of this —
verified by grep rather than assumed. Suite 6474 passed / 0 failed, F# wrapper 130 passed, casbench
117/119 with 0 wrong.

Cut from `master` at `548ea178`.
