### PR TITLE
Re-measure the branch conventions on 2.1.0

### DIFF
--- a/Sources/AngouriMath/Docs/Contributing/SimplificationContract.md
+++ b/Sources/AngouriMath/Docs/Contributing/SimplificationContract.md
@@ -214,8 +214,9 @@ Worked examples, each measured.
 
 ## 6. The conventions this library commits to
 
-Branch cuts disagree between systems, so these are measured on a 2.0.0 build rather than assumed. A
-rewrite that changes any of them changes answers.
+Branch cuts disagree between systems, so these are measured rather than assumed — on a 2.0.0 build
+when this table was written, and re-measured unchanged on 2.1.0, which is worth doing whenever a
+release touches a branch. A rewrite that changes any of them changes answers.
 
 | | value | convention |
 |---|---|---|


### PR DESCRIPTION
`SimplificationContract.md` §6 said its table of branch choices was "measured on a 2.0.0 build". True, and now incomplete: 2.1.0 changes logarithm behaviour ([#902](https://github.com/asc-community/AngouriMath/issues/902) guards the exponent pull) and `abs` ([#881](https://github.com/asc-community/AngouriMath/issues/881)), so a reader is entitled to ask whether the branch choices moved with them.

**All nine are unchanged**, measured on a 2.1.0 build: `sqrt(-4)` is `2i`, `(-1)^(1/2)` is `i`, `ln(-1)` is `pi*i`, `i^i` is `0.2078...`, and the five negative-base powers including the trap the section exists for — `(-8)^(1/3)` is `-2` while `(-8)^0.3333333333` is `1 + 1.732i`.

The sentence now says to re-measure whenever a release touches a branch, rather than naming one build, since that is what the section is for.

Doc only.