### PR TITLE
A polynomial layer: factorisation over Q and F_p, resultants, square-free decomposition (#746 item 43)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -25,6 +25,61 @@ read first.
 | **silent** | `DomainCondition` of a logarithm, under the default reading | the real condition, so `log(-3, -3)` was declared undefined while evaluating to `1` | `not b = 0 and not b = 1 and not a = 0` |
 | **silent** | `ln(x).DomainCondition` | `x > 0` | `not x = 0` |
 | **silent** | `"x ^ n".Differentiate("x").Simplify()` | `x ^ n * n / x provided x > 0` — `NaN` at every negative `x` | `x ^ n * n / x provided not x = 0` |
+| **silent** | `"x^5 + 2x^3 - 2x^2 - 4".SolveEquation("x")` | three of the five roots, one of them a float | all five, exact |
+| | `"x^4 + x^2 + 1".SolveEquation("x")` | `sqrt((-1 - sqrt(-3)) / 2)` and its three companions | `(-1 - sqrt(-3)) / 2` and its three, with no nested radical |
+| | `"x^4 + 3x^2 + 2".SolveEquation("x")` | `{ sqrt(-2), -sqrt(-2), i, -i }` | the same four, in the order the factors are found |
+
+### A polynomial equation that factors is solved through its factors
+
+A polynomial of degree four or more may factor over the rationals with no rational root anywhere in
+it — `x^4 + 3x^2 + 2` is `(x^2 + 1)(x^2 + 2)` — and nothing in the solver could see that. The
+rational-root split that runs first is by construction blind to it, and what followed was the
+general machinery for the degree: Ferrari at four, and at five and above no general solution exists
+to reach for. A real polynomial layer
+([#746](https://github.com/asc-community/AngouriMath/issues/746) item 43) is what was missing, and
+the equation solver is its first consumer: where the polynomial factors, each factor is now solved
+as a lower-degree equation of its own.
+
+The change is confined to degree four and up, and that is not a threshold chosen for caution. A
+quadratic or a cubic that factors at all has a rational root — a cubic splits as a linear factor
+times a quadratic, or into three linear factors, and either way there is a linear factor to find —
+so the step that runs before this one has already divided it out. Four is the first degree at which
+a polynomial can factor with nothing rational to catch. A two-termed `a*x^n + b` is also left alone,
+for the reason already written down where the rational-root split declines one: inverting the power
+answers it whole and in polar form.
+
+**The one that was wrong rather than merely differently written.** An incomplete solution set is not
+a partial answer, it is a false one — it says these are the roots.
+
+```
+"x^5 + 2x^3 - 2x^2 - 4".SolveEquation("x")
+
+was  { sqrt(-2), -sqrt(-2), sqrt(1.5874010519681995834417875812505371868610382080078125) }
+is   { sqrt(-2), -sqrt(-2), 2 ^ (1/3),
+       (-1/2 + i * 1/2 * sqrt(3)) * 2 ^ (1/3), (-1/2 + i * -1/2 * sqrt(3)) * 2 ^ (1/3) }
+```
+
+The polynomial is `(x^2 + 2)(x^3 - 2)`. Two of its five roots were missing, and the one real root of
+`x^3 - 2` came back as the square root of a float where `2 ^ (1/3)` is exact — an inexact answer to a
+question that has an exact one. It also took 4.6 seconds and now takes under a quarter of one.
+
+**The others are the same numbers, written better or written in a different order.** Factoring first
+means each root comes out of a quadratic or a cubic rather than out of the resolvent of a quartic,
+and the forms are correspondingly plainer:
+
+```
+"x^4 + x^2 + 1".SolveEquation("x")
+was  { sqrt((-1 - sqrt(-3)) / 2), -sqrt((-1 - sqrt(-3)) / 2), ... }
+is   { (-1 - sqrt(-3)) / 2, (-1 + sqrt(-3)) / 2, (1 - sqrt(-3)) / 2, (1 + sqrt(-3)) / 2 }
+
+"x^4 + 3x^3 + 6x^2 + 5x + 3".SolveEquation("x")
+was  { -3/4 + (-1/2 + -sqrt(-8)) / 2, ... }
+is   { (-1 - sqrt(-3)) / 2, (-1 + sqrt(-3)) / 2, (-2 - sqrt(-8)) / 2, (-2 + sqrt(-8)) / 2 }
+```
+
+Both sets are unchanged as sets — the members were checked to be equal, not merely to look it. Where
+a solution set is only reordered, as for `x^4 + 3x^2 + 2` and `2x^4 + 6x^2 + 4`, code that indexed
+into the result rather than searching it will see different elements at the same positions.
 
 ### The logarithm's domain follows the reading, as every other node's already did
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -39,6 +39,12 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [Tests/UnitTests/Core/KnownLimitsAreNotBugsTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[AngouriMath/Functions/Algebra/Polynomials/{IntegerPolynomial,PrimeFieldPolynomial,PrimeFieldFactorization,SquareFreeDecomposition,PolynomialFactorization,PolynomialResultant}.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Algebra/Polynomials/*.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 # A new file in a directory whose other files predate it, so the section is on the file
 # rather than the folder.
 [AngouriMath/Core/Entity/Continuous/Entity.Continuous.{Floors,Rounding}.Classes.cs]

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/IntegerPolynomial.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/IntegerPolynomial.cs
@@ -1,0 +1,480 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using PeterO.Numbers;
+using System;
+using static AngouriMath.Entity;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// A polynomial in one variable over the integers, stored densely.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A second polynomial representation next to <see cref="MultivariatePolynomial"/>, and
+    /// deliberately so. That one is sparse, packs eight exponents into a <c>ulong</c> and
+    /// carries coefficients over <c>Q</c>, which is what a multivariate greatest common
+    /// divisor wants. Factoring wants the opposite of all three: one variable, dense
+    /// coefficient access by degree, and coefficients over <c>Z</c>, because every bound the
+    /// algorithm relies on — Mignotte's on the size of a factor, the modulus a Hensel lift
+    /// has to reach — is a statement about integers. Sharing one type between the two would
+    /// mean paying a dictionary lookup per coefficient in the inner loop of the lift and
+    /// re-deriving a denominator that is known to be one.
+    /// </para>
+    /// <para>
+    /// Trailing zero coefficients are never stored, so <see cref="Degree"/> is
+    /// <c>coefficients.Length - 1</c> and the zero polynomial is the empty array with degree
+    /// <c>-1</c>. Coefficients are ordered lowest power first, which is the order the rest of
+    /// <c>Functions/Algebra/Polynomials</c> already uses.
+    /// </para>
+    /// </remarks>
+    internal sealed class IntegerPolynomial
+    {
+        /// <summary>
+        /// Past this the factoriser refuses. Recombination is exponential in the number of
+        /// modular factors and that number is bounded by the degree, so the ceiling is on
+        /// the one quantity that bounds every stage.
+        /// </summary>
+        internal const int MaxDegree = 32;
+
+        [ConstantField] private static readonly EInteger[] NoCoefficients = Array.Empty<EInteger>();
+
+        /// <summary>Lowest power first, with no trailing zero.</summary>
+        private readonly EInteger[] coefficients;
+
+        private IntegerPolynomial(EInteger[] coefficients) => this.coefficients = coefficients;
+
+        internal static IntegerPolynomial Create(IReadOnlyList<EInteger> coefficientsLowestFirst)
+        {
+            var length = coefficientsLowestFirst.Count;
+            while (length > 0 && coefficientsLowestFirst[length - 1].IsZero)
+                length--;
+            if (length == 0)
+                return Zero;
+            var trimmed = new EInteger[length];
+            for (var i = 0; i < length; i++)
+                trimmed[i] = coefficientsLowestFirst[i];
+            return new(trimmed);
+        }
+
+        [ConstantField] internal static readonly IntegerPolynomial Zero = new(NoCoefficients);
+
+        internal static IntegerPolynomial Constant(EInteger value)
+            => value.IsZero ? Zero : new(new[] { value });
+
+        internal static IntegerPolynomial One => Constant(EInteger.One);
+
+        /// <summary><c>-1</c> for the zero polynomial, so that a degree comparison is total.</summary>
+        internal int Degree => coefficients.Length - 1;
+
+        internal bool IsZero => coefficients.Length == 0;
+
+        internal bool IsConstant => coefficients.Length <= 1;
+
+        internal EInteger this[int power]
+            => power >= 0 && power < coefficients.Length ? coefficients[power] : EInteger.Zero;
+
+        internal EInteger Leading => IsZero ? EInteger.Zero : coefficients[coefficients.Length - 1];
+
+        internal IntegerPolynomial Negate() => ScaleBy(EInteger.FromInt32(-1));
+
+        internal IntegerPolynomial ScaleBy(EInteger factor)
+        {
+            if (factor.IsZero || IsZero)
+                return Zero;
+            var scaled = new EInteger[coefficients.Length];
+            for (var i = 0; i < scaled.Length; i++)
+                scaled[i] = coefficients[i].Multiply(factor);
+            return new(scaled);
+        }
+
+        internal IntegerPolynomial Add(IntegerPolynomial other) => Combine(other, subtract: false);
+
+        internal IntegerPolynomial Subtract(IntegerPolynomial other) => Combine(other, subtract: true);
+
+        private IntegerPolynomial Combine(IntegerPolynomial other, bool subtract)
+        {
+            var length = Math.Max(coefficients.Length, other.coefficients.Length);
+            var result = new EInteger[length];
+            for (var i = 0; i < length; i++)
+            {
+                var right = other[i];
+                result[i] = subtract ? this[i].Subtract(right) : this[i].Add(right);
+            }
+            return Create(result);
+        }
+
+        internal IntegerPolynomial? Multiply(IntegerPolynomial other)
+        {
+            if (IsZero || other.IsZero)
+                return Zero;
+            if (Degree + other.Degree > MaxDegree)
+                return null;
+            var result = new EInteger[Degree + other.Degree + 1];
+            for (var i = 0; i < result.Length; i++)
+                result[i] = EInteger.Zero;
+            for (var i = 0; i < coefficients.Length; i++)
+                for (var j = 0; j < other.coefficients.Length; j++)
+                    result[i + j] = result[i + j].Add(coefficients[i].Multiply(other.coefficients[j]));
+            return Create(result);
+        }
+
+        /// <summary>Multiplied by <c>x ^ power</c>.</summary>
+        internal IntegerPolynomial ShiftedBy(int power)
+        {
+            if (IsZero || power == 0)
+                return this;
+            var result = new EInteger[coefficients.Length + power];
+            for (var i = 0; i < power; i++)
+                result[i] = EInteger.Zero;
+            Array.Copy(coefficients, 0, result, power, coefficients.Length);
+            return new(result);
+        }
+
+        internal IntegerPolynomial Derivative()
+        {
+            if (coefficients.Length <= 1)
+                return Zero;
+            var result = new EInteger[coefficients.Length - 1];
+            for (var i = 1; i < coefficients.Length; i++)
+                result[i - 1] = coefficients[i].Multiply(EInteger.FromInt32(i));
+            return Create(result);
+        }
+
+        /// <summary>
+        /// <paramref name="divisor"/> divided out over the integers, or <see langword="null"/>
+        /// where the division leaves a remainder or a coefficient that is not whole.
+        /// </summary>
+        /// <remarks>
+        /// Exactness over <c>Z</c> rather than over <c>Q</c> is the point: this is what every
+        /// candidate factor is tested with, and a candidate that only divides over <c>Q</c> is
+        /// not a factor of an integer polynomial.
+        /// </remarks>
+        internal IntegerPolynomial? DivideExact(IntegerPolynomial divisor)
+        {
+            if (divisor.IsZero)
+                return null;
+            if (IsZero)
+                return Zero;
+            if (Degree < divisor.Degree)
+                return null;
+
+            var remainder = new EInteger[coefficients.Length];
+            Array.Copy(coefficients, remainder, coefficients.Length);
+            var quotient = new EInteger[Degree - divisor.Degree + 1];
+            for (var i = 0; i < quotient.Length; i++)
+                quotient[i] = EInteger.Zero;
+            var divisorLead = divisor.Leading;
+
+            for (var power = Degree; power >= divisor.Degree; power--)
+            {
+                if (remainder[power].IsZero)
+                    continue;
+                if (!remainder[power].Remainder(divisorLead).IsZero)
+                    return null;
+                var divided = remainder[power].Divide(divisorLead);
+                var shift = power - divisor.Degree;
+                quotient[shift] = divided;
+                for (var i = 0; i <= divisor.Degree; i++)
+                    remainder[i + shift] = remainder[i + shift].Subtract(divided.Multiply(divisor[i]));
+            }
+            for (var i = 0; i < remainder.Length; i++)
+                if (!remainder[i].IsZero)
+                    return null;
+            return Create(quotient);
+        }
+
+        /// <summary>The greatest common divisor of the coefficients, positive; zero for the zero polynomial.</summary>
+        internal EInteger Content()
+        {
+            var content = EInteger.Zero;
+            foreach (var coefficient in coefficients)
+                content = content.Gcd(coefficient);
+            return content;
+        }
+
+        /// <summary>
+        /// The same polynomial divided by its content and signed so that the leading
+        /// coefficient is positive — the representative of its class up to a unit of
+        /// <c>Z</c>, which is what makes two greatest common divisors comparable.
+        /// </summary>
+        internal IntegerPolynomial PrimitivePart()
+        {
+            if (IsZero)
+                return Zero;
+            var content = Content();
+            if (Leading.Sign < 0)
+                content = content.Negate();
+            var result = new EInteger[coefficients.Length];
+            for (var i = 0; i < result.Length; i++)
+                result[i] = coefficients[i].Divide(content);
+            return new(result);
+        }
+
+        /// <summary>
+        /// <c>lc(divisor) ^ (deg(dividend) - deg(divisor) + 1) * dividend</c> reduced modulo
+        /// <paramref name="divisor"/>. The power in front is what keeps every division by the
+        /// leading coefficient whole, so no denominator enters the coefficient ring.
+        /// </summary>
+        private static IntegerPolynomial? PseudoRemainder(IntegerPolynomial dividend, IntegerPolynomial divisor)
+        {
+            if (divisor.IsZero)
+                return null;
+            if (dividend.Degree < divisor.Degree)
+                return dividend;
+            var divisorLead = divisor.Leading;
+            var remainder = dividend;
+            var outstanding = dividend.Degree - divisor.Degree + 1;
+            while (!remainder.IsZero && remainder.Degree >= divisor.Degree)
+            {
+                var shift = remainder.Degree - divisor.Degree;
+                var scaled = remainder.ScaleBy(divisorLead);
+                var cancelling = divisor.ScaleBy(remainder.Leading).ShiftedBy(shift);
+                remainder = scaled.Subtract(cancelling);
+                outstanding--;
+            }
+            for (var i = 0; i < outstanding; i++)
+                remainder = remainder.ScaleBy(divisorLead);
+            return remainder;
+        }
+
+        /// <summary>
+        /// The greatest common divisor in <c>Z[x]</c>, with a positive leading coefficient.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// By Gauss's lemma the divisor splits as the greatest common divisor of the two
+        /// integer contents times that of the two primitive parts, so the integer part is
+        /// taken out first and the polynomial part is left to a remainder sequence.
+        /// </para>
+        /// <para>
+        /// The sequence is the <i>primitive</i> one: the primitive part is taken at every
+        /// step, which is the cheapest way to stop pseudo-division's exponential coefficient
+        /// growth — the alternative, the subresultant sequence used by
+        /// <see cref="PolynomialGcd"/>, is faster but needs bookkeeping that buys nothing at
+        /// the degrees this type is capped at. Knuth, <i>TAOCP</i> vol. 2, §4.6.1, algorithm E.
+        /// </para>
+        /// <para>
+        /// The result really is a divisor of both: it is the last nonzero member of a
+        /// sequence in which each member divides the previous two, and callers that cannot
+        /// afford to be wrong about it — <see cref="SquareFreeDecomposition"/> divides by it —
+        /// use <see cref="DivideExact"/>, which answers <see langword="null"/> rather than
+        /// rounding.
+        /// </para>
+        /// </remarks>
+        internal static IntegerPolynomial Gcd(IntegerPolynomial left, IntegerPolynomial right)
+        {
+            if (left.IsZero && right.IsZero)
+                return Zero;
+            if (left.IsZero)
+                return right.PrimitivePart().ScaleBy(right.Content());
+            if (right.IsZero)
+                return left.PrimitivePart().ScaleBy(left.Content());
+
+            var contentGcd = left.Content().Gcd(right.Content());
+            var a = left.PrimitivePart();
+            var b = right.PrimitivePart();
+            if (a.Degree < b.Degree)
+                (a, b) = (b, a);
+
+            // As long as the degree strictly falls each round the loop ends; the ceiling is
+            // there so that a divisor that unexpectedly declines shows up as a refusal
+            // rather than a hang.
+            for (var step = 0; step <= MaxDegree + 1; step++)
+            {
+                if (b.IsZero)
+                    return a.ScaleBy(contentGcd);
+                if (b.IsConstant)
+                    return Constant(contentGcd);
+                if (PseudoRemainder(a, b) is not { } remainder)
+                    return Constant(contentGcd);
+                if (remainder.IsZero)
+                    return b.ScaleBy(contentGcd);
+                a = b;
+                b = remainder.PrimitivePart();
+            }
+            return Constant(contentGcd);
+        }
+
+        /// <summary>
+        /// An upper bound on the absolute value of any coefficient of any divisor of this
+        /// polynomial in <c>Z[x]</c>.
+        /// </summary>
+        /// <remarks>
+        /// Mignotte's bound: a factor of degree <c>m</c> of a polynomial <c>f</c> of degree
+        /// <c>n</c> has every coefficient at most <c>2^m * |f|_2</c> in absolute value, and
+        /// <c>m &lt;= n</c> gives the uniform bound used here. It is what tells the Hensel
+        /// lift when to stop: once the modulus exceeds twice this, a coefficient in the
+        /// symmetric range modulo it is the coefficient itself rather than a residue.
+        /// Mignotte, <i>An inequality about factors of polynomials</i>, Math. Comp. 28 (1974);
+        /// von zur Gathen and Gerhard, <i>Modern Computer Algebra</i>, §6.6 and §15.2.
+        /// </remarks>
+        internal EInteger FactorCoefficientBound()
+        {
+            var squared = EInteger.Zero;
+            foreach (var coefficient in coefficients)
+                squared = squared.Add(coefficient.Multiply(coefficient));
+            // Rounded up, since the integer square root rounds down and the bound has to hold.
+            var norm = squared.Sqrt().Add(EInteger.One);
+            return norm.Multiply(EInteger.FromInt32(2).Pow(Degree < 0 ? 0 : Degree));
+        }
+
+        /// <summary>Every coefficient divided by <paramref name="divisor"/>, or
+        /// <see langword="null"/> where one of them does not divide.</summary>
+        internal IntegerPolynomial? DivideByInteger(EInteger divisor)
+        {
+            if (divisor.IsZero)
+                return null;
+            var result = new EInteger[coefficients.Length];
+            for (var i = 0; i < result.Length; i++)
+            {
+                if (!coefficients[i].Remainder(divisor).IsZero)
+                    return null;
+                result[i] = coefficients[i].Divide(divisor);
+            }
+            return Create(result);
+        }
+
+        /// <summary>The coefficients reduced into <c>[0, modulus)</c>.</summary>
+        internal IntegerPolynomial Modulo(EInteger modulus)
+        {
+            var result = new EInteger[coefficients.Length];
+            for (var i = 0; i < result.Length; i++)
+            {
+                var residue = coefficients[i].Remainder(modulus);
+                result[i] = residue.Sign < 0 ? residue.Add(modulus) : residue;
+            }
+            return Create(result);
+        }
+
+        /// <summary>
+        /// The coefficients taken in the symmetric range <c>(-modulus/2, modulus/2]</c> — the
+        /// representative that is the integer itself, rather than a residue standing for it,
+        /// once the modulus has passed twice <see cref="FactorCoefficientBound"/>.
+        /// </summary>
+        internal IntegerPolynomial SymmetricModulo(EInteger modulus)
+        {
+            var half = modulus.Divide(EInteger.FromInt32(2));
+            var result = new EInteger[coefficients.Length];
+            for (var i = 0; i < result.Length; i++)
+            {
+                var residue = coefficients[i].Remainder(modulus);
+                if (residue.Sign < 0)
+                    residue = residue.Add(modulus);
+                result[i] = residue.CompareTo(half) > 0 ? residue.Subtract(modulus) : residue;
+            }
+            return Create(result);
+        }
+
+        /// <summary>
+        /// The reduction modulo <paramref name="prime"/>, whatever it does to the degree.
+        /// <see cref="ToPrimeField"/> is the one to use where a dropped degree matters.
+        /// </summary>
+        internal PrimeFieldPolynomial ReduceModuloPrime(long prime)
+        {
+            var modulus = EInteger.FromInt64(prime);
+            var residues = new long[coefficients.Length];
+            for (var i = 0; i < residues.Length; i++)
+            {
+                var residue = coefficients[i].Remainder(modulus);
+                if (residue.Sign < 0)
+                    residue = residue.Add(modulus);
+                residues[i] = residue.ToInt64Checked();
+            }
+            return PrimeFieldPolynomial.Create(residues, prime);
+        }
+
+        internal bool SameAs(IntegerPolynomial other)
+        {
+            if (coefficients.Length != other.coefficients.Length)
+                return false;
+            for (var i = 0; i < coefficients.Length; i++)
+                if (coefficients[i].CompareTo(other.coefficients[i]) != 0)
+                    return false;
+            return true;
+        }
+
+        /// <summary>
+        /// The polynomial over <c>F_p</c> this one reduces to, or <see langword="null"/> if
+        /// the reduction drops the degree — which happens exactly when <c>p</c> divides the
+        /// leading coefficient, and which makes the reduction useless for factoring.
+        /// </summary>
+        internal PrimeFieldPolynomial? ToPrimeField(long prime)
+        {
+            if (IsZero)
+                return null;
+            var modulus = EInteger.FromInt64(prime);
+            var residues = new long[coefficients.Length];
+            for (var i = 0; i < residues.Length; i++)
+            {
+                var residue = coefficients[i].Remainder(modulus);
+                if (residue.Sign < 0)
+                    residue = residue.Add(modulus);
+                residues[i] = residue.ToInt64Checked();
+            }
+            var reduced = PrimeFieldPolynomial.Create(residues, prime);
+            return reduced.Degree == Degree ? reduced : null;
+        }
+
+        internal static IntegerPolynomial FromPrimeField(PrimeFieldPolynomial poly)
+        {
+            var lifted = new EInteger[poly.Degree + 1];
+            for (var i = 0; i < lifted.Length; i++)
+                lifted[i] = EInteger.FromInt64(poly.Coefficients[i]);
+            return Create(lifted);
+        }
+
+        /// <summary>
+        /// The same polynomial as an expression in <paramref name="x"/>, highest power first
+        /// and with a negative coefficient written as a subtraction rather than as the
+        /// addition of a negative.
+        /// </summary>
+        internal Entity ToEntity(Variable x)
+        {
+            Entity? result = null;
+            for (var power = coefficients.Length - 1; power >= 0; power--)
+            {
+                var coefficient = coefficients[power];
+                if (coefficient.IsZero)
+                    continue;
+                var negative = coefficient.Sign < 0;
+                var magnitude = negative ? coefficient.Negate() : coefficient;
+                Entity term;
+                if (power == 0)
+                    term = Integer.Create(magnitude);
+                else
+                {
+                    Entity raised = power == 1 ? x : MathS.Pow(x, power);
+                    term = magnitude.CompareTo(EInteger.One) == 0
+                        ? raised
+                        : Integer.Create(magnitude) * raised;
+                }
+                result = result is null
+                    ? negative ? -term : term
+                    : negative ? result - term : result + term;
+            }
+            return result ?? Integer.Create(0);
+        }
+
+        public override string ToString()
+        {
+            if (IsZero)
+                return "0";
+            var parts = new List<string>();
+            for (var i = coefficients.Length - 1; i >= 0; i--)
+            {
+                if (coefficients[i].IsZero)
+                    continue;
+                parts.Add(i == 0 ? coefficients[i].ToString()
+                    : i == 1 ? coefficients[i] + "x"
+                    : coefficients[i] + "x^" + i);
+            }
+            return string.Join(" + ", parts);
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/MultivariatePolynomial.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/MultivariatePolynomial.cs
@@ -250,6 +250,25 @@ namespace AngouriMath.Functions
             return result;
         }
 
+        /// <summary>
+        /// The partial derivative with respect to <paramref name="variable"/>. Nothing here
+        /// can leave the type's bounds: every exponent falls by one and no monomial is
+        /// created that was not already present.
+        /// </summary>
+        internal MultivariatePolynomial DerivativeIn(int variable)
+        {
+            var result = new Dictionary<ulong, ERational>();
+            foreach (var term in terms)
+            {
+                var power = PowerOf(term.Key, variable);
+                if (power == 0)
+                    continue;
+                Accumulate(result, Without(term.Key, variable) | Pack(variable, power - 1),
+                    term.Value.Multiply(ERational.FromInt32(power)).ToLowestTerms());
+            }
+            return new(VariableCount, result);
+        }
+
         internal MultivariatePolynomial LeadingCoefficientIn(int variable)
         {
             var degree = DegreeIn(variable);

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/MultivariatePolynomial.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/MultivariatePolynomial.cs
@@ -393,7 +393,12 @@ namespace AngouriMath.Functions
         /// before it is built rather than after.
         /// </remarks>
         internal static MultivariatePolynomial? TryParse(Entity expr, IReadOnlyDictionary<Variable, int> variables)
-            => expr switch
+            // A ninth variable has no byte of the packed monomial to live in, and the shift
+            // that would address it is negative, which the language turns into a shift by
+            // 56 -- the first variable's byte. So it would not fail, it would silently be
+            // the first variable, and x_1 - x_9 would read as the zero polynomial. Refused
+            // here rather than guarded at each caller, since the packing is this type's.
+            => variables.Count > MaxVariables ? null : expr switch
             {
                 // Integer is a Rational, so this arm takes both.
                 Rational rational => Constant(variables.Count, rational.ERational),

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialFactoring.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialFactoring.cs
@@ -292,10 +292,26 @@ namespace AngouriMath.Functions
         /// <paramref name="x"/> with rational coefficients alone.
         /// </summary>
         private static bool TryGetRationalCoefficients(Entity expr, Variable x, out ERational[] coefficients)
-            => TryGetRationalCoefficients(expr, x, leastTerms: 2, leastDegree: 2, out coefficients);
+            => TryGetRationalCoefficients(expr, x, leastTerms: 2, leastDegree: 2, MaxDegree, out coefficients);
 
         private static bool TryGetRationalCoefficients(
             Entity expr, Variable x, int leastTerms, int leastDegree, out ERational[] coefficients)
+            => TryGetRationalCoefficients(expr, x, leastTerms, leastDegree, MaxDegree, out coefficients);
+
+        /// <summary>
+        /// The coefficients of <paramref name="expr"/> in <paramref name="x"/>, lowest power
+        /// first, or <see langword="false"/> if it is not a polynomial in <paramref name="x"/>
+        /// with rational coefficients alone.
+        /// </summary>
+        /// <remarks>
+        /// The degree ceiling is the caller's because it is a statement about what that caller
+        /// can afford, not about what a polynomial is: root-finding here gives up at sixteen,
+        /// while <see cref="PolynomialFactorization"/> reaches further because Berlekamp and
+        /// the Hensel lift stay cheap where a divisor search does not.
+        /// </remarks>
+        internal static bool TryGetRationalCoefficients(
+            Entity expr, Variable x, int leastTerms, int leastDegree, int maxDegree,
+            out ERational[] coefficients)
         {
             coefficients = System.Array.Empty<ERational>();
             var monomials = PolynomialSolver.GatherMonomialInformation<EInteger, TreeAnalyzer.PrimitiveInteger>(
@@ -304,7 +320,7 @@ namespace AngouriMath.Functions
                 return false;
 
             var degree = monomials.Keys.Max();
-            if (degree is null || degree > MaxDegree || degree < leastDegree)
+            if (degree is null || degree > maxDegree || degree < leastDegree)
                 return false;
 
             var found = new ERational[degree.ToInt32Checked() + 1];

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialFactorization.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialFactorization.cs
@@ -1,0 +1,555 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath.Core.Multithreading;
+using PeterO.Numbers;
+using System.Diagnostics.CodeAnalysis;
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// Factors a polynomial in one variable over the rationals into irreducibles:
+    /// <c>x^4 + 3x^2 + 2</c> becomes <c>(x^2 + 1)(x^2 + 2)</c>, which no search for roots can
+    /// find because it has none.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is what <see cref="PolynomialFactoring"/> is not. That one tries the candidates of
+    /// the rational root theorem and divides out the linear factors it finds, which answers
+    /// the question only when the polynomial splits into linear pieces. A factor of degree two
+    /// or more with no rational root is invisible to it, and those are the common case above
+    /// degree three.
+    /// </para>
+    /// <para>
+    /// The route is Zassenhaus's, in four steps. Clear denominators and take the primitive
+    /// part, so the problem is over <c>Z</c>. Split off the repeated factors with
+    /// <see cref="SquareFreeDecomposition"/>, so every remaining problem is square-free.
+    /// Factor what is left modulo a small prime, where
+    /// <see cref="PrimeFieldFactorization">Berlekamp</see> answers completely and cheaply.
+    /// Then lift that factorisation from <c>p</c> to <c>p^k</c> by Hensel's construction and
+    /// try products of the lifted pieces against the original, which is where the true
+    /// factors are recovered — an irreducible factor over <c>Z</c> may well split further
+    /// modulo <c>p</c>, so the modular factors have to be recombined rather than read off.
+    /// Zassenhaus, <i>On Hensel factorization I</i>, J. Number Theory 1 (1969); von zur Gathen
+    /// and Gerhard, <i>Modern Computer Algebra</i>, ch. 15.
+    /// </para>
+    /// <para>
+    /// Two things bound the cost, and both are refusals rather than approximations. The
+    /// recombination is exponential in the number of modular factors, so it is given a budget
+    /// and declines past it. And <c>k</c> is chosen from Mignotte's bound so that a
+    /// coefficient in the symmetric range modulo <c>p^k</c> is the coefficient itself; a
+    /// smaller <c>k</c> would not make an answer wrong, since every candidate is confirmed by
+    /// exact division over <c>Z</c> before it is accepted, but it would make the search miss
+    /// factors and call a reducible polynomial irreducible.
+    /// </para>
+    /// <para>
+    /// Nothing here is trusted. Every candidate factor is divided out exactly over <c>Z</c>,
+    /// and the factors are multiplied back and compared with what they came from before the
+    /// answer is returned. The failure mode that survives all of that is an incomplete
+    /// factorisation, never a wrong one.
+    /// </para>
+    /// </remarks>
+    internal static class PolynomialFactorization
+    {
+        /// <summary>
+        /// Small primes to reduce modulo. Berlekamp's splitting loop runs over the whole
+        /// field, so the cost grows with the prime and there is no reason to reach for a
+        /// large one: a prime is only unusable when it divides the leading coefficient or
+        /// makes the polynomial repeat a factor, and both are rare.
+        /// </summary>
+        [ConstantField]
+        private static readonly long[] Primes =
+        {
+            5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97
+        };
+
+        /// <summary>
+        /// How many usable primes to weigh against each other. The number of modular factors
+        /// is an upper bound on the number of true ones and the recombination is exponential
+        /// in it, so the cheapest thing that pays for itself is trying a few primes and
+        /// keeping the one that splits the polynomial least.
+        /// </summary>
+        private const int MaxPrimeAttempts = 5;
+
+        /// <summary>
+        /// Subsets of modular factors to try before giving up. Reached only by polynomials
+        /// that split into many pieces modulo every prime tried, which is the case
+        /// recombination is exponential on.
+        /// </summary>
+        private const int MaxRecombinationCandidates = 20000;
+
+        /// <summary>
+        /// A leading coefficient is cleared by rescaling the variable, which raises it to the
+        /// degree; past this the intermediate polynomial costs more than the answer is worth.
+        /// </summary>
+        [ConstantField]
+        private static readonly EInteger MaxMonicScale = EInteger.FromInt32(2).Pow(512);
+
+        /// <summary>
+        /// <paramref name="expr"/> written as a product of powers of irreducible polynomials
+        /// over <c>Q</c>, or <see langword="false"/> where it is not a polynomial in
+        /// <paramref name="x"/>, where it is already irreducible, or where the machinery
+        /// declines.
+        /// </summary>
+        /// <remarks>
+        /// An irreducible polynomial is reported as a refusal rather than as a one-element
+        /// product: the caller asked for a factorisation and there is not one to give, and
+        /// answering with the input unchanged would have every caller test for that case.
+        /// </remarks>
+        internal static bool TryFactorIntoIrreducibles(
+            Entity expr, Variable x, [NotNullWhen(true)] out Entity? factored)
+        {
+            factored = null;
+            if (Factor(expr, x) is not { } factorization)
+                return false;
+
+            Entity? product = null;
+            foreach (var part in factorization.Parts)
+            {
+                var piece = part.Factor.ToEntity(x);
+                if (part.Multiplicity > 1)
+                    piece = piece.Pow(part.Multiplicity);
+                product = product is null ? piece : product * piece;
+            }
+            if (product is null)
+                return false;
+            if (factorization.Constant.CompareTo(ERational.One) != 0)
+                product = Rational.Create(factorization.Constant) * product;
+            factored = product;
+            return true;
+        }
+
+        /// <summary>
+        /// Whether <paramref name="expr"/> is <c>a * x^n + b</c> — a polynomial in
+        /// <paramref name="x"/> with only two terms in it.
+        /// </summary>
+        /// <remarks>
+        /// Asked by callers for which such a polynomial is better left whole than factored.
+        /// Solving is the case: <c>x^n = -b/a</c> inverts in one step and gives the roots in
+        /// polar form, where factoring first divides out the rational ones and leaves the
+        /// rest to be recovered from a quotient — <c>x^3 - 8</c> reads as <c>2</c> and
+        /// <c>(-1/2 +- i sqrt(3)/2) * 2</c> one way and as <c>2</c> and
+        /// <c>(-2 -+ sqrt(-12))/2</c> the other. This is the same judgement
+        /// <see cref="PolynomialFactoring.TrySplitOffRationalRoots"/> makes, and it is here
+        /// rather than inside the factoriser because it is a statement about what a caller
+        /// wants, not about what factors.
+        /// </remarks>
+        internal static bool IsTwoTermed(Entity expr, Variable x)
+            => PolynomialFactoring.TryGetRationalCoefficients(
+                   expr, x, leastTerms: 1, leastDegree: 0, IntegerPolynomial.MaxDegree, out var coefficients)
+               && coefficients.Count(coefficient => !coefficient.IsZero) <= 2;
+
+        /// <summary>
+        /// The irreducible factors of <paramref name="expr"/> over <c>Q</c> with their
+        /// multiplicities, and the rational constant left in front. <see langword="null"/>
+        /// where there is nothing to say — including where the polynomial is irreducible.
+        /// </summary>
+        internal static Factorization? Factor(Entity expr, Variable x)
+        {
+            if (!PolynomialFactoring.TryGetRationalCoefficients(
+                    expr, x, leastTerms: 2, leastDegree: 2, IntegerPolynomial.MaxDegree, out var rational))
+                return null;
+
+            // Cleared of denominators, so the whole of the rest of this works over Z; the
+            // divisor comes back out in the constant at the end.
+            var denominator = EInteger.One;
+            foreach (var coefficient in rational)
+                denominator = Lcm(denominator, coefficient.Denominator);
+            var whole = new EInteger[rational.Length];
+            for (var i = 0; i < whole.Length; i++)
+                whole[i] = rational[i].Numerator.Multiply(denominator.Divide(rational[i].Denominator));
+
+            var poly = IntegerPolynomial.Create(whole);
+            if (poly.Degree < 2)
+                return null;
+
+            var primitive = poly.PrimitivePart();
+            var content = poly.Content();
+            if (poly.Leading.Sign < 0)
+                content = content.Negate();
+
+            if (FactorPrimitive(primitive) is not { } parts)
+                return null;
+            // One factor to the first power is the input back again, which is not a
+            // factorisation of it.
+            if (parts.Count == 1 && parts[0].Multiplicity == 1)
+                return null;
+
+            return new Factorization(ERational.Create(content, denominator).ToLowestTerms(), parts);
+        }
+
+        /// <summary>
+        /// The irreducible factors of a primitive integer polynomial with their
+        /// multiplicities, verified to multiply back to it.
+        /// </summary>
+        internal static IReadOnlyList<SquareFreeDecomposition.SquareFreePart>? FactorPrimitive(
+            IntegerPolynomial primitive)
+        {
+            if (SquareFreeDecomposition.Decompose(primitive) is not { } squareFree)
+                return null;
+
+            var parts = new List<SquareFreeDecomposition.SquareFreePart>();
+            foreach (var part in squareFree)
+            {
+                if (FactorSquareFree(part.Factor) is not { } irreducibles)
+                    return null;
+                foreach (var irreducible in irreducibles)
+                    parts.Add(new SquareFreeDecomposition.SquareFreePart(irreducible, part.Multiplicity));
+            }
+
+            // Multiplied back independently of the machinery that produced them. An
+            // incomplete factorisation is a tolerable answer and a wrong one is not, so the
+            // product is what decides whether this is returned at all.
+            var product = IntegerPolynomial.One;
+            foreach (var part in parts)
+                for (var i = 0; i < part.Multiplicity; i++)
+                {
+                    if (product.Multiply(part.Factor) is not { } multiplied)
+                        return null;
+                    product = multiplied;
+                }
+            return product.SameAs(primitive) ? parts : null;
+        }
+
+        /// <summary>
+        /// The irreducible factors of a primitive square-free integer polynomial.
+        /// </summary>
+        /// <remarks>
+        /// A leading coefficient other than one is cleared first, by the substitution that
+        /// turns <c>f</c> of degree <c>n</c> into the monic
+        /// <c>lc^(n-1) * f(x / lc)</c>. Everything below it can then assume monic input,
+        /// which is what makes the Hensel step below keep the degrees it starts with. The
+        /// factors come back through the inverse substitution, and their primitive parts are
+        /// the factors of the original — Gauss's lemma is what makes that last step legal.
+        /// </remarks>
+        private static IReadOnlyList<IntegerPolynomial>? FactorSquareFree(IntegerPolynomial primitive)
+        {
+            if (primitive.Degree <= 1)
+                return new[] { primitive };
+
+            var lead = primitive.Leading;
+            if (lead.CompareTo(EInteger.One) == 0)
+                return FactorMonic(primitive);
+
+            var degree = primitive.Degree;
+            if (lead.Abs().Pow(degree - 1).CompareTo(MaxMonicScale) > 0)
+                return null;
+
+            var scaled = new EInteger[degree + 1];
+            for (var i = 0; i < degree; i++)
+                scaled[i] = primitive[i].Multiply(lead.Pow(degree - 1 - i));
+            scaled[degree] = EInteger.One;
+
+            if (FactorMonic(IntegerPolynomial.Create(scaled)) is not { } monicFactors)
+                return null;
+
+            var recovered = new List<IntegerPolynomial>(monicFactors.Count);
+            foreach (var factor in monicFactors)
+            {
+                var back = new EInteger[factor.Degree + 1];
+                for (var i = 0; i < back.Length; i++)
+                    back[i] = factor[i].Multiply(lead.Pow(i));
+                recovered.Add(IntegerPolynomial.Create(back).PrimitivePart());
+            }
+            return recovered;
+        }
+
+        /// <summary>The irreducible factors of a monic square-free integer polynomial.</summary>
+        private static IReadOnlyList<IntegerPolynomial>? FactorMonic(IntegerPolynomial poly)
+        {
+            if (poly.Degree <= 1)
+                return new[] { poly };
+
+            long chosenPrime = 0;
+            IReadOnlyList<PrimeFieldPolynomial>? chosen = null;
+            var attempts = 0;
+            foreach (var prime in Primes)
+            {
+                if (attempts >= MaxPrimeAttempts)
+                    break;
+                MultithreadingFunctional.ExitIfCancelled();
+                // A prime dividing the leading coefficient drops the degree, and the
+                // reduction then says nothing about the factors of what it came from.
+                if (poly.ToPrimeField(prime) is not { } reduced || !reduced.IsSquareFree)
+                    continue;
+                if (PrimeFieldFactorization.Factor(reduced.MakeMonic()) is not { } modular)
+                    continue;
+                attempts++;
+                // Irreducible modulo a prime that keeps the degree is irreducible over Z: a
+                // proper factorisation over Z would reduce to one modulo p.
+                if (modular.Count == 1)
+                    return new[] { poly };
+                if (chosen is null || modular.Count < chosen.Count)
+                {
+                    chosen = modular;
+                    chosenPrime = prime;
+                }
+                if (chosen.Count == 2)
+                    break;
+            }
+            if (chosen is null)
+                return null;
+
+            // Far enough that a coefficient in the symmetric range modulo the result is the
+            // coefficient itself rather than a residue standing in for it.
+            var target = poly.FactorCoefficientBound().Multiply(EInteger.FromInt32(2)).Add(EInteger.One);
+            var prime2 = EInteger.FromInt64(chosenPrime);
+            var modulus = prime2;
+            while (modulus.CompareTo(target) < 0)
+                modulus = modulus.Multiply(prime2);
+
+            if (HenselLift(poly, chosen, chosenPrime, modulus) is not { } lifted)
+                return null;
+            return Recombine(poly, lifted, modulus);
+        }
+
+        /// <summary>
+        /// The modular factors lifted from <paramref name="prime"/> to
+        /// <paramref name="modulus"/>, a power of it.
+        /// </summary>
+        /// <remarks>
+        /// One factor is peeled off at a time and the rest are carried as a single cofactor,
+        /// which turns the many-factor lift into a sequence of two-factor ones. The cofactor
+        /// is kept as residues rather than as an integer polynomial: it is a product of some
+        /// of the true factors only when the modular factors happen to group that way, so
+        /// reading it as an integer polynomial part-way through would be reading something
+        /// that need not exist.
+        /// </remarks>
+        private static IReadOnlyList<IntegerPolynomial>? HenselLift(
+            IntegerPolynomial poly, IReadOnlyList<PrimeFieldPolynomial> modular, long prime, EInteger modulus)
+        {
+            var lifted = new List<IntegerPolynomial>(modular.Count);
+            var remaining = poly;
+            for (var i = 0; i < modular.Count - 1; i++)
+            {
+                MultithreadingFunctional.ExitIfCancelled();
+                var cofactor = PrimeFieldPolynomial.One(prime);
+                for (var j = i + 1; j < modular.Count; j++)
+                    cofactor = cofactor.Multiply(modular[j]);
+                if (!LiftPair(remaining, modular[i], cofactor, prime, modulus, out var factor, out var rest))
+                    return null;
+                lifted.Add(factor);
+                remaining = rest;
+            }
+            lifted.Add(remaining);
+            return lifted;
+        }
+
+        /// <summary>
+        /// Lifts <c>poly = left * right</c> from modulo <paramref name="prime"/> to modulo
+        /// <paramref name="modulus"/>, one power at a time.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Writing the next pair as <c>A + m*alpha</c> and <c>B + m*beta</c> and asking that
+        /// the product match one power further leaves <c>alpha*B + beta*A = e</c> modulo the
+        /// prime, where <c>e</c> is the error so far divided by <c>m</c>. The Bezout pair for
+        /// <c>A</c> and <c>B</c> modulo the prime solves that immediately, and reducing
+        /// <c>alpha</c> below the degree of <c>A</c> — pushing the quotient into <c>beta</c> —
+        /// is what keeps both sides at the degree they started with, so that the product stays
+        /// the degree of the polynomial being factored. Knuth, <i>TAOCP</i> vol. 2, §4.6.2,
+        /// algorithm H.
+        /// </para>
+        /// <para>
+        /// Each round checks that the product really does agree with the input to the power
+        /// just reached, and declines if it does not. The Bezout pair is computed once, from
+        /// the factors modulo the prime, and stays correct because neither factor changes
+        /// modulo the prime as it is lifted.
+        /// </para>
+        /// </remarks>
+        private static bool LiftPair(
+            IntegerPolynomial poly, PrimeFieldPolynomial left, PrimeFieldPolynomial right,
+            long prime, EInteger modulus,
+            [NotNullWhen(true)] out IntegerPolynomial? liftedLeft,
+            [NotNullWhen(true)] out IntegerPolynomial? liftedRight)
+        {
+            liftedLeft = liftedRight = null;
+            if (!TryBezout(left, right, out var leftInverse, out var rightInverse))
+                return false;
+
+            var a = IntegerPolynomial.FromPrimeField(left);
+            var b = IntegerPolynomial.FromPrimeField(right);
+            var step = EInteger.FromInt64(prime);
+            var reached = step;
+
+            while (reached.CompareTo(modulus) < 0)
+            {
+                MultithreadingFunctional.ExitIfCancelled();
+                if (a.Multiply(b) is not { } product)
+                    return false;
+                if (poly.Subtract(product).DivideByInteger(reached) is not { } error)
+                    return false;
+
+                var e = error.ReduceModuloPrime(prime);
+                var scaled = e.Multiply(rightInverse);
+                var quotient = scaled.Quotient(left);
+                var alpha = scaled.Subtract(quotient.Multiply(left));
+                var beta = e.Multiply(leftInverse).Add(quotient.Multiply(right));
+                // Both must stay under the degree of the factor they correct, or the lifted
+                // pair stops being monic of the degree it started at and the product drifts
+                // away from the polynomial being factored.
+                if (alpha.Degree >= left.Degree || beta.Degree >= right.Degree)
+                    return false;
+
+                a = a.Add(IntegerPolynomial.FromPrimeField(alpha).ScaleBy(reached));
+                b = b.Add(IntegerPolynomial.FromPrimeField(beta).ScaleBy(reached));
+                reached = reached.Multiply(step);
+
+                if (a.Multiply(b) is not { } check || !poly.Subtract(check).Modulo(reached).IsZero)
+                    return false;
+            }
+
+            liftedLeft = a.Modulo(modulus);
+            liftedRight = b.Modulo(modulus);
+            return true;
+        }
+
+        /// <summary>
+        /// The pair with <c>leftInverse * left + rightInverse * right = 1</c> over
+        /// <c>F_p</c>, or <see langword="false"/> where the two are not coprime there.
+        /// </summary>
+        private static bool TryBezout(
+            PrimeFieldPolynomial left, PrimeFieldPolynomial right,
+            [NotNullWhen(true)] out PrimeFieldPolynomial? leftInverse,
+            [NotNullWhen(true)] out PrimeFieldPolynomial? rightInverse)
+        {
+            leftInverse = rightInverse = null;
+            var prime = left.Prime;
+            var remainderOld = left;
+            var remainder = right;
+            var leftOld = PrimeFieldPolynomial.One(prime);
+            var leftNew = PrimeFieldPolynomial.Zero(prime);
+            var rightOld = PrimeFieldPolynomial.Zero(prime);
+            var rightNew = PrimeFieldPolynomial.One(prime);
+
+            while (!remainder.IsZero)
+            {
+                var quotient = remainderOld.Quotient(remainder);
+                var nextRemainder = remainderOld.Subtract(quotient.Multiply(remainder));
+                var nextLeft = leftOld.Subtract(quotient.Multiply(leftNew));
+                var nextRight = rightOld.Subtract(quotient.Multiply(rightNew));
+                remainderOld = remainder;
+                remainder = nextRemainder;
+                leftOld = leftNew;
+                leftNew = nextLeft;
+                rightOld = rightNew;
+                rightNew = nextRight;
+            }
+            // A common factor of positive degree means the two modular factors were not
+            // distinct, which the square-free step upstream should already have ruled out.
+            if (remainderOld.Degree != 0)
+                return false;
+
+            var inverse = PrimeFieldPolynomial.Inverse(remainderOld.Coefficients[0], prime);
+            if (inverse == 0)
+                return false;
+            var unit = PrimeFieldPolynomial.Create(new[] { inverse }, prime);
+            leftInverse = leftOld.Multiply(unit);
+            rightInverse = rightOld.Multiply(unit);
+            return true;
+        }
+
+        /// <summary>
+        /// The true factors, recovered by trying products of the lifted modular ones against
+        /// the polynomial itself.
+        /// </summary>
+        /// <remarks>
+        /// Subsets are tried smallest first, and once one divides it is taken out and the
+        /// search starts again at the same size — a factor found early shrinks every later
+        /// subset. Only sizes up to half the pool are tried, because the complement of a
+        /// larger subset is a smaller one that has already been offered; whatever is left at
+        /// the end is irreducible for exactly that reason.
+        /// </remarks>
+        private static IReadOnlyList<IntegerPolynomial>? Recombine(
+            IntegerPolynomial poly, IReadOnlyList<IntegerPolynomial> lifted, EInteger modulus)
+        {
+            var pool = new List<IntegerPolynomial>(lifted);
+            var factors = new List<IntegerPolynomial>();
+            var remaining = poly;
+            var budget = MaxRecombinationCandidates;
+
+            for (var size = 1; size * 2 <= pool.Count;)
+            {
+                MultithreadingFunctional.ExitIfCancelled();
+                var indices = new int[size];
+                for (var i = 0; i < size; i++)
+                    indices[i] = i;
+
+                var found = false;
+                do
+                {
+                    if (--budget < 0)
+                        return null;
+                    var product = IntegerPolynomial.One;
+                    foreach (var index in indices)
+                    {
+                        if (product.Multiply(pool[index]) is not { } multiplied)
+                            return null;
+                        product = multiplied.Modulo(modulus);
+                    }
+
+                    var candidate = product.SymmetricModulo(modulus);
+                    if (candidate.IsConstant || remaining.DivideExact(candidate) is not { } quotient)
+                        continue;
+
+                    factors.Add(candidate);
+                    remaining = quotient;
+                    for (var i = indices.Length - 1; i >= 0; i--)
+                        pool.RemoveAt(indices[i]);
+                    found = true;
+                }
+                while (!found && NextCombination(indices, pool.Count));
+
+                if (!found)
+                    size++;
+            }
+
+            if (!remaining.IsConstant)
+                factors.Add(remaining);
+            return factors;
+        }
+
+        /// <summary>
+        /// Advances <paramref name="indices"/> to the next combination in lexicographic
+        /// order, or answers <see langword="false"/> when it was the last. The order is fixed
+        /// so that the same polynomial factors the same way every time.
+        /// </summary>
+        private static bool NextCombination(int[] indices, int poolCount)
+        {
+            var size = indices.Length;
+            if (size > poolCount)
+                return false;
+            var position = size - 1;
+            while (position >= 0 && indices[position] == poolCount - size + position)
+                position--;
+            if (position < 0)
+                return false;
+            indices[position]++;
+            for (var i = position + 1; i < size; i++)
+                indices[i] = indices[i - 1] + 1;
+            return true;
+        }
+
+        private static EInteger Lcm(EInteger a, EInteger b) => a.Divide(a.Gcd(b)).Multiply(b);
+
+        /// <summary>A polynomial written as a rational constant times powers of irreducibles.</summary>
+        internal readonly struct Factorization
+        {
+            internal Factorization(ERational constant, IReadOnlyList<SquareFreeDecomposition.SquareFreePart> parts)
+            {
+                Constant = constant;
+                Parts = parts;
+            }
+
+            internal ERational Constant { get; }
+
+            internal IReadOnlyList<SquareFreeDecomposition.SquareFreePart> Parts { get; }
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialFactorization.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialFactorization.cs
@@ -126,24 +126,31 @@ namespace AngouriMath.Functions
         }
 
         /// <summary>
-        /// Whether <paramref name="expr"/> is <c>a * x^n + b</c> — a polynomial in
-        /// <paramref name="x"/> with only two terms in it.
+        /// Whether factoring <paramref name="expr"/> is worth trying on the way to solving
+        /// it for <paramref name="x"/>.
         /// </summary>
         /// <remarks>
-        /// Asked by callers for which such a polynomial is better left whole than factored.
-        /// Solving is the case: <c>x^n = -b/a</c> inverts in one step and gives the roots in
-        /// polar form, where factoring first divides out the rational ones and leaves the
-        /// rest to be recovered from a quotient — <c>x^3 - 8</c> reads as <c>2</c> and
-        /// <c>(-1/2 +- i sqrt(3)/2) * 2</c> one way and as <c>2</c> and
-        /// <c>(-2 -+ sqrt(-12))/2</c> the other. This is the same judgement
-        /// <see cref="PolynomialFactoring.TrySplitOffRationalRoots"/> makes, and it is here
-        /// rather than inside the factoriser because it is a statement about what a caller
-        /// wants, not about what factors.
+        /// <para>
+        /// Both conditions are about what the step before this one has already done, not
+        /// about what factors. Below degree four there is nothing left to find: a quadratic
+        /// or a cubic that factors at all has a rational root — a cubic splits as a linear
+        /// factor times a quadratic, or into three linear ones, and either way a linear
+        /// factor is there to be found — so
+        /// <see cref="PolynomialFactoring.TrySplitOffRationalRoots"/> has already divided it
+        /// out. Four is the first degree at which a polynomial can factor with no rational
+        /// root anywhere in it, <c>x^4 + 3x^2 + 2</c> being <c>(x^2 + 1)(x^2 + 2)</c>.
+        /// </para>
+        /// <para>
+        /// And a two-termed <c>a*x^n + b</c> is left whole, because inverting the power
+        /// answers it in one step and in polar form, where factoring first divides out the
+        /// rational roots and leaves the rest to be recovered from a quotient. That is the
+        /// judgement <c>TrySplitOffRationalRoots</c> already makes, for the same reason.
+        /// </para>
         /// </remarks>
-        internal static bool IsTwoTermed(Entity expr, Variable x)
+        internal static bool IsWorthFactoringToSolve(Entity expr, Variable x)
             => PolynomialFactoring.TryGetRationalCoefficients(
-                   expr, x, leastTerms: 1, leastDegree: 0, IntegerPolynomial.MaxDegree, out var coefficients)
-               && coefficients.Count(coefficient => !coefficient.IsZero) <= 2;
+                   expr, x, leastTerms: 2, leastDegree: 4, IntegerPolynomial.MaxDegree, out var coefficients)
+               && coefficients.Count(coefficient => !coefficient.IsZero) > 2;
 
         /// <summary>
         /// The irreducible factors of <paramref name="expr"/> over <c>Q</c> with their

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialGcd.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialGcd.cs
@@ -189,7 +189,7 @@ namespace AngouriMath.Functions
         /// as a polynomial in <paramref name="main"/> — a polynomial in the remaining
         /// variables.
         /// </summary>
-        private static MultivariatePolynomial? ContentIn(
+        internal static MultivariatePolynomial? ContentIn(
             MultivariatePolynomial poly, int main, IReadOnlyList<int> rest, int depth)
         {
             MultivariatePolynomial? content = null;

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialResultant.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialResultant.cs
@@ -1,0 +1,261 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath.Core.Multithreading;
+using PeterO.Numbers;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// The resultant of two polynomials in several variables over the rationals, and the
+    /// discriminant that follows from it. Eliminating a variable between two equations is
+    /// what these are for: <c>Res(f, g)</c> taken in <c>y</c> vanishes exactly where
+    /// <c>f</c> and <c>g</c> have a common <c>y</c>, so it is the condition on the
+    /// remaining variables that the pair be solvable.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The resultant is defined here as the determinant of the Sylvester matrix, and it is
+    /// computed as one. That is deliberate. The remainder-sequence formulations are faster,
+    /// but each carries a factor <c>(-1)^k</c> and a power of a leading coefficient that has
+    /// to be tracked through every step, and a sign convention got wrong there is a wrong
+    /// answer that looks entirely plausible. Taken as a determinant, the sign convention is
+    /// the one property that cannot be got wrong: <c>Res(f, g) = (-1)^(deg f * deg g)
+    /// Res(g, f)</c> and <c>Res(f, g) = lc(f)^deg g * lc(g)^deg f * prod (a_i - b_j)</c>
+    /// both fall out of the matrix rather than being imposed on it.
+    /// </para>
+    /// <para>
+    /// The determinant is taken by one-step fraction-free elimination, which is the same
+    /// idea as the subresultant remainder sequence in <see cref="PolynomialGcd"/> and for
+    /// the same reason: every intermediate entry is a minor of the original matrix, so the
+    /// division at each step comes out exact and the coefficients stay the size of those
+    /// minors instead of compounding. Bareiss, <i>Sylvester's identity and multistep
+    /// integer-preserving Gaussian elimination</i>, Math. Comp. 22 (1968); Geddes, Czapor
+    /// and Labahn, <i>Algorithms for Computer Algebra</i>, §9.3; Knuth, <i>TAOCP</i> vol. 2,
+    /// §4.6.1.
+    /// </para>
+    /// <para>
+    /// The degenerate cases are the ones implementations usually differ on, and these were
+    /// measured against SymPy 1.14 rather than recalled: a zero argument gives zero whatever
+    /// the other side is, two arguments free of the main variable give one, and
+    /// <c>Res(f, c) = c^deg f</c>. All three are what the Sylvester matrix already says once
+    /// a polynomial free of the main variable is read as having degree zero — the matrix is
+    /// then diagonal, or empty, and an empty determinant is one.
+    /// </para>
+    /// <para>
+    /// Part of the polynomial layer of
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a>, item 43.
+    /// </para>
+    /// </remarks>
+    internal static class PolynomialResultant
+    {
+        /// <summary>
+        /// The elimination is cubic in the size of the Sylvester matrix, with a
+        /// multiplication of two multivariate polynomials at every step, so the size is what
+        /// decides whether this finishes. The bound is on <c>deg f + deg g</c>; 24 leaves a
+        /// 13824-step elimination as the worst case admitted, and admits the discriminant of
+        /// anything up to degree 12, since <c>deg f + deg f'</c> is <c>2 deg f - 1</c>.
+        /// </summary>
+        private const int MaxSylvesterSize = 24;
+
+        [ConstantField] private static readonly ERational MinusOne = ERational.One.Negate();
+
+        /// <summary>
+        /// The resultant of two polynomials with respect to <paramref name="mainVariable"/>,
+        /// itself a polynomial in the remaining variables; null where a step declines.
+        /// </summary>
+        /// <remarks>
+        /// Identically zero exactly when the two share a factor of positive degree in
+        /// <paramref name="mainVariable"/>. Where it is not identically zero it vanishes at
+        /// a point of the remaining variables exactly where the two polynomials specialised
+        /// there have a common root, or where both of their leading coefficients in
+        /// <paramref name="mainVariable"/> vanish — the second is why an eliminant can carry
+        /// a root the original system does not have.
+        /// </remarks>
+        internal static MultivariatePolynomial? Resultant(
+            MultivariatePolynomial left, MultivariatePolynomial right,
+            int mainVariable, IReadOnlyList<int> otherVariables)
+        {
+            var variableCount = left.VariableCount;
+
+            // Zero is divisible by everything, so the two share a factor of every degree
+            // there is; SymPy answers zero here even against a nonzero constant.
+            if (left.IsZero || right.IsZero)
+                return MultivariatePolynomial.Zero(variableCount);
+
+            var leftDegree = left.DegreeIn(mainVariable);
+            var rightDegree = right.DegreeIn(mainVariable);
+            if (leftDegree == 0 && rightDegree == 0)
+                return MultivariatePolynomial.One(variableCount);
+            if (leftDegree + rightDegree > MaxSylvesterSize)
+                return null;
+
+            // Res(c * f, g) = c^deg g * Res(f, g) for a c free of the main variable, and
+            // symmetrically on the right. Taking the content out first keeps the entries of
+            // the matrix — and every minor built from them — clear of a factor that would
+            // otherwise be carried through the whole elimination and raised to a power of
+            // the size of the matrix.
+            var leftContent = ContentOrOne(left, mainVariable, otherVariables);
+            var rightContent = ContentOrOne(right, mainVariable, otherVariables);
+            var primitiveLeft = left;
+            var primitiveRight = right;
+            var restored = MultivariatePolynomial.One(variableCount);
+            if (!leftContent.IsConstant || !rightContent.IsConstant)
+            {
+                if (leftContent.Power(rightDegree) is not { } leftFactor
+                    || rightContent.Power(leftDegree) is not { } rightFactor
+                    || leftFactor.Multiply(rightFactor) is not { } factor
+                    || !TryDivideOut(left, leftContent, out primitiveLeft)
+                    || !TryDivideOut(right, rightContent, out primitiveRight))
+                {
+                    // Nothing is lost by leaving the content in: the split is worth doing
+                    // and not worth refusing over.
+                    primitiveLeft = left;
+                    primitiveRight = right;
+                }
+                else
+                    restored = factor;
+            }
+
+            if (SylvesterDeterminant(primitiveLeft, primitiveRight, mainVariable) is not { } determinant)
+                return null;
+            return restored.Multiply(determinant);
+        }
+
+        /// <summary>
+        /// disc(f) with respect to <paramref name="mainVariable"/>, related to the resultant
+        /// of f and its derivative by disc(f) = (-1)^(n(n-1)/2) * Res(f, f') / lc(f).
+        /// </summary>
+        /// <remarks>
+        /// Zero exactly when f has a repeated factor in <paramref name="mainVariable"/> —
+        /// including when it has no <paramref name="mainVariable"/> at all, where the
+        /// derivative vanishes and the resultant with it.
+        /// </remarks>
+        internal static MultivariatePolynomial? Discriminant(
+            MultivariatePolynomial poly, int mainVariable, IReadOnlyList<int> otherVariables)
+        {
+            var degree = poly.DegreeIn(mainVariable);
+            if (Resultant(poly, poly.DerivativeIn(mainVariable), mainVariable, otherVariables)
+                is not { } resultant)
+                return null;
+            if (resultant.IsZero)
+                return resultant;
+
+            // The quotient is a polynomial in the coefficients of f, so this division is
+            // exact whenever the resultant was computed at all.
+            if (resultant.DivideExact(poly.LeadingCoefficientIn(mainVariable)) is not { } quotient)
+                return null;
+            return degree * (degree - 1) / 2 % 2 == 0 ? quotient : quotient.ScaleBy(MinusOne);
+        }
+
+        /// <summary>
+        /// The greatest common divisor of the coefficients in
+        /// <paramref name="mainVariable"/>, or one where that could not be settled — the
+        /// caller only wants it to make the elimination smaller.
+        /// </summary>
+        private static MultivariatePolynomial ContentOrOne(
+            MultivariatePolynomial poly, int mainVariable, IReadOnlyList<int> otherVariables)
+            => PolynomialGcd.ContentIn(poly, mainVariable, otherVariables, 0)
+                ?? MultivariatePolynomial.One(poly.VariableCount);
+
+        /// <summary>
+        /// <paramref name="poly"/> divided by <paramref name="factor"/>, accepted only once
+        /// multiplying it back has given the original — the same discipline
+        /// <see cref="PolynomialGcd.TryCancel"/> applies, and for the same reason: a factor
+        /// wrongly divided out is a wrong answer rather than a missing one.
+        /// </summary>
+        private static bool TryDivideOut(
+            MultivariatePolynomial poly, MultivariatePolynomial factor, out MultivariatePolynomial quotient)
+        {
+            quotient = poly;
+            if (poly.DivideExact(factor) is not { } divided
+                || divided.Multiply(factor) is not { } remultiplied
+                || !remultiplied.SameAs(poly))
+                return false;
+            quotient = divided;
+            return true;
+        }
+
+        /// <summary>
+        /// The determinant of the Sylvester matrix of the two polynomials, read in
+        /// <paramref name="mainVariable"/>: as many rows of <paramref name="left"/>'s
+        /// coefficients as <paramref name="right"/> has degree, then as many rows of
+        /// <paramref name="right"/>'s as <paramref name="left"/> has degree, each row
+        /// shifted one place right of the one above it. That order is what makes this
+        /// <c>Res(left, right)</c> rather than <c>Res(right, left)</c>, and the two differ
+        /// by <c>(-1)^(deg left * deg right)</c>.
+        /// </summary>
+        private static MultivariatePolynomial? SylvesterDeterminant(
+            MultivariatePolynomial left, MultivariatePolynomial right, int mainVariable)
+        {
+            var variableCount = left.VariableCount;
+            var zero = MultivariatePolynomial.Zero(variableCount);
+            var leftDegree = left.DegreeIn(mainVariable);
+            var rightDegree = right.DegreeIn(mainVariable);
+            var size = leftDegree + rightDegree;
+
+            var matrix = new MultivariatePolynomial[size][];
+            for (var row = 0; row < size; row++)
+            {
+                matrix[row] = new MultivariatePolynomial[size];
+                for (var column = 0; column < size; column++)
+                    matrix[row][column] = zero;
+            }
+            var leftCoefficients = left.CoefficientsIn(mainVariable);
+            for (var row = 0; row < rightDegree; row++)
+                for (var power = 0; power <= leftDegree; power++)
+                    if (leftCoefficients.TryGetValue(power, out var coefficient))
+                        matrix[row][row + leftDegree - power] = coefficient;
+            var rightCoefficients = right.CoefficientsIn(mainVariable);
+            for (var row = 0; row < leftDegree; row++)
+                for (var power = 0; power <= rightDegree; power++)
+                    if (rightCoefficients.TryGetValue(power, out var coefficient))
+                        matrix[rightDegree + row][row + rightDegree - power] = coefficient;
+
+            var negated = false;
+            var previous = MultivariatePolynomial.One(variableCount);
+            for (var pivot = 0; pivot + 1 < size; pivot++)
+            {
+                MultithreadingFunctional.ExitIfCancelled();
+                if (matrix[pivot][pivot].IsZero)
+                {
+                    var replacement = -1;
+                    for (var row = pivot + 1; row < size && replacement < 0; row++)
+                        if (!matrix[row][pivot].IsZero)
+                            replacement = row;
+                    // Nothing below the pivot to bring up means the column is a combination
+                    // of the ones before it, so the matrix is singular and its determinant
+                    // is zero. That is an answer, not a failure: the two polynomials have a
+                    // common factor.
+                    if (replacement < 0)
+                        return zero;
+                    (matrix[pivot], matrix[replacement]) = (matrix[replacement], matrix[pivot]);
+                    negated = !negated;
+                }
+                var head = matrix[pivot][pivot];
+                for (var row = pivot + 1; row < size; row++)
+                {
+                    MultithreadingFunctional.ExitIfCancelled();
+                    var leading = matrix[row][pivot];
+                    for (var column = pivot + 1; column < size; column++)
+                    {
+                        if (head.Multiply(matrix[row][column]) is not { } kept
+                            || leading.Multiply(matrix[pivot][column]) is not { } removed
+                            || kept.Subtract(removed).DivideExact(previous) is not { } reduced)
+                            return null;
+                        matrix[row][column] = reduced;
+                    }
+                    matrix[row][pivot] = zero;
+                }
+                previous = head;
+            }
+
+            var determinant = matrix[size - 1][size - 1];
+            return negated ? determinant.ScaleBy(MinusOne) : determinant;
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/PrimeFieldFactorization.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/PrimeFieldFactorization.cs
@@ -1,0 +1,323 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using PeterO.Numbers;
+using System;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// Factorisation of a monic square-free polynomial over the prime field <c>F_p</c> into
+    /// monic irreducibles, by Berlekamp's algorithm.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The algorithm rests on one observation. Raising to the <c>p</c>-th power is a field
+    /// automorphism fixing <c>F_p</c> pointwise, so on the quotient ring <c>F_p[x]/(f)</c>
+    /// it is a linear map, and the polynomials it fixes — the <i>Berlekamp subalgebra</i>
+    /// <c>{ v : v^p = v mod f }</c> — form a vector space. By the Chinese remainder theorem
+    /// <c>F_p[x]/(f)</c> is the product of the fields <c>F_p[x]/(f_i)</c> over the
+    /// irreducible factors of <c>f</c>, and in each of those the fixed elements are exactly
+    /// the constants. So the subalgebra is a product of <c>r</c> copies of <c>F_p</c>, its
+    /// dimension is <c>r</c>, and that dimension <i>is</i> the number of irreducible
+    /// factors — which is what gives the loop below an exact termination test rather than a
+    /// heuristic one. Knuth, <i>TAOCP</i> vol. 2, §4.6.2, algorithm B; von zur Gathen and
+    /// Gerhard, <i>Modern Computer Algebra</i>, §14.8.
+    /// </para>
+    /// <para>
+    /// Given a <c>v</c> in that subalgebra, <c>v^p - v = prod_{s in F_p} (v - s)</c>
+    /// vanishes modulo <c>f</c>, and the factors on the right are pairwise coprime, so
+    /// <c>f = prod_s gcd(f, v - s)</c>. A <c>v</c> that is not constant takes different
+    /// values in different components and therefore separates them; running over a basis of
+    /// the subalgebra separates all of them.
+    /// </para>
+    /// <para>
+    /// Berlekamp rather than Cantor–Zassenhaus, and the reason is not speed — for a large
+    /// modulus Cantor–Zassenhaus wins, because it replaces the <c>O(p)</c> sweep over
+    /// <c>s</c> with a random probe. It is that Cantor–Zassenhaus is randomised, and design
+    /// principle 3 of
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> requires
+    /// the same input to give the same answer on every platform and in every thread count.
+    /// Berlekamp is deterministic by construction: the matrix, its null space and the sweep
+    /// over <c>s</c> are all fixed by the input.
+    /// </para>
+    /// <para>
+    /// The price is that the sweep costs <c>O(p n^3)</c> field operations in the worst case,
+    /// linear in the modulus, so this is only sensible for a small one — hence
+    /// <see cref="MaxPrime"/>. That is not a restriction in practice, because the caller
+    /// chooses the modulus: factoring over the integers means picking a prime at which the
+    /// polynomial stays square-free and lifting the result, and there is no reason for that
+    /// prime to be large.
+    /// </para>
+    /// </remarks>
+    internal static class PrimeFieldFactorization
+    {
+        /// <summary>
+        /// Moduli past this are refused. The splitting sweep runs over every element of the
+        /// field, so the cost is linear in the modulus where nothing else here is; at this
+        /// value together with <see cref="MaxDegree"/> the worst case is under 3*10^8 field
+        /// operations, which is a ceiling on a pathological input rather than a typical
+        /// cost. This is far below <see cref="PrimeFieldPolynomial.MaxPrime"/>, which bounds
+        /// what the arithmetic can represent rather than what this can afford.
+        /// </summary>
+        internal const long MaxPrime = 1024L;
+
+        /// <summary>
+        /// Degrees past this are refused. Building the Berlekamp matrix is <c>O(n^3)</c> and
+        /// splitting is <c>O(p n^3)</c>; the bound is a ceiling so that a caller handing
+        /// over something outsized gets a refusal rather than a hang.
+        /// </summary>
+        internal const int MaxDegree = 64;
+
+        /// <summary>
+        /// The monic irreducible factors of a monic square-free polynomial over
+        /// <c>F_p</c>, in a deterministic order — by degree, then by coefficient from the
+        /// leading one down. Their product is the input.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Answers <see langword="null"/> where it declines, which is every case it is not
+        /// contracted for rather than only the expensive ones, since a caller that hands
+        /// over the wrong shape wants to hear so:
+        /// </para>
+        /// <list type="bullet">
+        /// <item><description>the modulus is composite, or above <see cref="MaxPrime"/>;</description></item>
+        /// <item><description>the degree is above <see cref="MaxDegree"/>;</description></item>
+        /// <item><description>
+        /// the polynomial is not monic — which includes the zero polynomial. A non-monic
+        /// one is the caller's to normalise, because the unit it drops belongs in whatever
+        /// the caller is reassembling;
+        /// </description></item>
+        /// <item><description>
+        /// the polynomial is not square-free. Berlekamp counts the <i>distinct</i>
+        /// irreducible factors, so on a repeated one it would return a product short of the
+        /// input, and that is a wrong answer rather than a partial one. Square-free
+        /// decomposition comes first, and is the caller's.
+        /// </description></item>
+        /// </list>
+        /// <para>
+        /// The constant polynomial 1 is monic and square-free, and its factorisation is the
+        /// empty product — so an empty list, not <see langword="null"/>.
+        /// </para>
+        /// </remarks>
+        internal static IReadOnlyList<PrimeFieldPolynomial>? Factor(PrimeFieldPolynomial poly)
+        {
+            var prime = poly.Prime;
+            if (prime > MaxPrime || !IsPrime(prime))
+                return null;
+            if (!poly.IsMonic || poly.Degree > MaxDegree)
+                return null;
+            if (poly.Degree == 0)
+                return Array.Empty<PrimeFieldPolynomial>();
+            if (!poly.IsSquareFree)
+                return null;
+
+            var subalgebra = SubalgebraBasis(poly);
+            // The dimension of the Berlekamp subalgebra is the number of irreducible
+            // factors exactly, so this is a count and not an estimate.
+            var expected = subalgebra.Count;
+            if (expected == 1)
+                return new[] { poly };
+
+            var factors = new List<PrimeFieldPolynomial> { poly };
+            foreach (var separator in subalgebra)
+            {
+                if (factors.Count == expected)
+                    break;
+                // The constants lie in the subalgebra and take one value everywhere, so
+                // they separate nothing; one of them is always in the basis.
+                if (separator.Degree <= 0)
+                    continue;
+                factors = SplitBy(factors, separator, prime);
+            }
+
+            // Unreachable on the mathematics — a basis of the subalgebra separates every
+            // pair of factors — so this is the guard that says so rather than returning a
+            // product that is not the input.
+            if (factors.Count != expected)
+                return null;
+
+            factors.Sort(Compare);
+            return factors;
+        }
+
+        /// <summary>
+        /// Each element of <paramref name="factors"/> replaced by the pieces
+        /// <paramref name="separator"/> cuts it into. Since <c>g</c> divides the input and
+        /// the input divides <c>prod_s (v - s)</c>, the greatest common divisors taken here
+        /// multiply back to <c>g</c> whether or not any of them is proper.
+        /// </summary>
+        private static List<PrimeFieldPolynomial> SplitBy(
+            List<PrimeFieldPolynomial> factors, PrimeFieldPolynomial separator, long prime)
+        {
+            var split = new List<PrimeFieldPolynomial>(factors.Count);
+            var constant = new long[1];
+            foreach (var factor in factors)
+            {
+                if (factor.Degree <= 1)
+                {
+                    split.Add(factor);
+                    continue;
+                }
+                for (var value = 0L; value < prime; value++)
+                {
+                    constant[0] = value;
+                    var piece = factor.Gcd(separator.Subtract(PrimeFieldPolynomial.Create(constant, prime)));
+                    if (piece.Degree >= 1)
+                        split.Add(piece);
+                }
+            }
+            return split;
+        }
+
+        /// <summary>
+        /// A basis of <c>{ v : v^p = v mod f }</c>, as polynomials of degree below that of
+        /// <paramref name="poly"/>.
+        /// </summary>
+        private static List<PrimeFieldPolynomial> SubalgebraBasis(PrimeFieldPolynomial poly)
+        {
+            var size = poly.Degree;
+            var prime = poly.Prime;
+
+            // Row i of the Berlekamp matrix is x^(p*i) mod f, which is where the Frobenius
+            // map sends x^i. One modular exponentiation gives x^p; the rest are one
+            // multiplication each, which is what keeps this O(n^3) rather than O(n^3 log p).
+            var frobenius = PrimeFieldPolynomial.Monomial(1, prime).PowMod(EInteger.FromInt64(prime), poly);
+            var image = new long[size][];
+            var power = PrimeFieldPolynomial.One(prime);
+            for (var i = 0; i < size; i++)
+            {
+                image[i] = new long[size];
+                var coefficients = power.Coefficients;
+                for (var j = 0; j < coefficients.Count; j++)
+                    image[i][j] = coefficients[j];
+                if (i + 1 < size)
+                    power = power.Multiply(frobenius).Remainder(poly);
+            }
+
+            // v is fixed iff the row vector of its coefficients is annihilated by Q - I on
+            // the right, so the system to solve is the transpose of that.
+            var system = new long[size][];
+            for (var row = 0; row < size; row++)
+            {
+                system[row] = new long[size];
+                for (var column = 0; column < size; column++)
+                {
+                    var value = image[column][row] - (column == row ? 1 : 0);
+                    system[row][column] = value < 0 ? value + prime : value;
+                }
+            }
+
+            var basis = new List<PrimeFieldPolynomial>();
+            foreach (var vector in NullSpace(system, size, prime))
+                basis.Add(PrimeFieldPolynomial.Create(vector, prime));
+            return basis;
+        }
+
+        /// <summary>
+        /// A basis of the null space of a square matrix over <c>F_p</c>, one vector per
+        /// column left without a pivot by reduction to row echelon form. The order is by
+        /// that column, so it depends on the matrix alone.
+        /// </summary>
+        private static List<long[]> NullSpace(long[][] matrix, int size, long prime)
+        {
+            var pivotRowOfColumn = new int[size];
+            for (var column = 0; column < size; column++)
+                pivotRowOfColumn[column] = -1;
+
+            var pivotRow = 0;
+            for (var column = 0; column < size && pivotRow < size; column++)
+            {
+                var found = -1;
+                for (var row = pivotRow; row < size; row++)
+                    if (matrix[row][column] != 0)
+                    {
+                        found = row;
+                        break;
+                    }
+                if (found < 0)
+                    continue;
+                (matrix[pivotRow], matrix[found]) = (matrix[found], matrix[pivotRow]);
+
+                var inverse = PrimeFieldPolynomial.Inverse(matrix[pivotRow][column], prime);
+                for (var c = column; c < size; c++)
+                    matrix[pivotRow][c] = matrix[pivotRow][c] * inverse % prime;
+
+                // Eliminating above as well as below leaves the matrix in reduced echelon
+                // form, which is what lets a free column be read off in one pass below.
+                for (var row = 0; row < size; row++)
+                {
+                    if (row == pivotRow || matrix[row][column] == 0)
+                        continue;
+                    var factor = matrix[row][column];
+                    for (var c = column; c < size; c++)
+                    {
+                        var value = matrix[row][c] - factor * matrix[pivotRow][c] % prime;
+                        matrix[row][c] = value < 0 ? value + prime : value;
+                    }
+                }
+
+                pivotRowOfColumn[column] = pivotRow;
+                pivotRow++;
+            }
+
+            var basis = new List<long[]>(size - pivotRow);
+            for (var free = 0; free < size; free++)
+            {
+                if (pivotRowOfColumn[free] >= 0)
+                    continue;
+                var vector = new long[size];
+                vector[free] = 1;
+                // Setting the free coordinate to one forces every pivot coordinate, since
+                // its row reads "pivot + (the free ones) = 0".
+                for (var column = 0; column < size; column++)
+                {
+                    var row = pivotRowOfColumn[column];
+                    if (row >= 0 && matrix[row][free] != 0)
+                        vector[column] = prime - matrix[row][free];
+                }
+                basis.Add(vector);
+            }
+            return basis;
+        }
+
+        /// <summary>
+        /// A total order on the factors: shorter first, then by coefficient from the
+        /// leading one down. Any total order would do; what matters is that the output does
+        /// not depend on the order in which the splitting happened to find them.
+        /// </summary>
+        private static int Compare(PrimeFieldPolynomial left, PrimeFieldPolynomial right)
+        {
+            if (left.Degree != right.Degree)
+                return left.Degree.CompareTo(right.Degree);
+            for (var i = left.Degree; i >= 0; i--)
+            {
+                var order = left.Coefficients[i].CompareTo(right.Coefficients[i]);
+                if (order != 0)
+                    return order;
+            }
+            return 0;
+        }
+
+        /// <summary>
+        /// Trial division, which is ample below <see cref="MaxPrime"/> and is the only
+        /// place the modulus is checked at all — the arithmetic itself takes primality on
+        /// trust, see <see cref="PrimeFieldPolynomial"/>.
+        /// </summary>
+        private static bool IsPrime(long value)
+        {
+            if (value < 2)
+                return false;
+            if (value % 2 == 0)
+                return value == 2;
+            for (var divisor = 3L; divisor * divisor <= value; divisor += 2)
+                if (value % divisor == 0)
+                    return false;
+            return true;
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/PrimeFieldPolynomial.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/PrimeFieldPolynomial.cs
@@ -1,0 +1,454 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using PeterO.Numbers;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// A univariate polynomial over the prime field <c>F_p</c>, stored densely as its
+    /// coefficients with the constant term first.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The point of a prime field is that it is a field with no growth in it. Over the
+    /// rationals the Euclidean algorithm is unusable directly because the coefficients of
+    /// the remainder sequence explode — which is why <see cref="PolynomialGcd"/> has to
+    /// carry the whole subresultant apparatus. Here every coefficient is one machine word
+    /// no matter how long the computation runs, so the textbook algorithms are the ones
+    /// that are actually used: plain Euclid for the greatest common divisor, plain long
+    /// division, square-and-multiply for powers.
+    /// </para>
+    /// <para>
+    /// That is what makes the field the working surface for factorisation. A polynomial
+    /// over the integers is factored by factoring it modulo a prime, where the problem is
+    /// finite, and lifting the result back — von zur Gathen and Gerhard,
+    /// <i>Modern Computer Algebra</i>, ch. 14, and Knuth, <i>TAOCP</i> vol. 2, §4.6.2.
+    /// <see cref="PrimeFieldFactorization"/> is the first half of that.
+    /// </para>
+    /// <para>
+    /// Arithmetic is <see cref="long"/> throughout, and every product of two reduced
+    /// coefficients has to fit without overflow. A reduced coefficient is at most
+    /// <c>p - 1</c>, an accumulator holds at most another <c>p - 1</c> before the next
+    /// reduction, so the largest intermediate is <c>p(p - 1)</c> and the field is bounded
+    /// by <see cref="MaxPrime"/> accordingly. Nothing here uses a wider type, because
+    /// factorisation moduli are three digits and paying <see cref="EInteger"/> for them on
+    /// the inner loop would be the wrong trade.
+    /// </para>
+    /// <para>
+    /// Instances are immutable, and the coefficient array of a live instance is never
+    /// written to after construction; the operations all build a fresh array. That is what
+    /// lets <see cref="Coefficients"/> hand the array out rather than copying it.
+    /// </para>
+    /// <para>
+    /// The modulus is required to be prime and this does not check it, because a check
+    /// costs <c>O(sqrt p)</c> on every construction and every caller inside the library
+    /// knows its own modulus. Where a composite one does reach the arithmetic it surfaces
+    /// as a failure to invert rather than as a wrong answer, and
+    /// <see cref="PrimeFieldFactorization.Factor"/> — the one entry point a modulus could
+    /// arrive at from outside — checks primality itself.
+    /// </para>
+    /// </remarks>
+    internal sealed class PrimeFieldPolynomial
+    {
+        /// <summary>
+        /// The largest modulus the <see cref="long"/> arithmetic below is valid for. The
+        /// binding intermediate is <c>p(p - 1)</c>, an accumulator plus one product of two
+        /// reduced coefficients; at this value that is 9223372033963249500 against a
+        /// <see cref="long"/> ceiling of 9223372036854775807, and one more would overflow.
+        /// </summary>
+        internal const long MaxPrime = 3_037_000_500L;
+
+        /// <summary>
+        /// Constant term first, no trailing zeros, each entry in <c>[0, Prime)</c>. The
+        /// zero polynomial is the empty array, so the degree is the length minus one and
+        /// comes out as -1 for it.
+        /// </summary>
+        private readonly long[] coefficients;
+
+        private PrimeFieldPolynomial(long[] coefficients, long prime)
+        {
+            this.coefficients = coefficients;
+            Prime = prime;
+        }
+
+        /// <summary>The characteristic of the field, in <c>[2, <see cref="MaxPrime"/>]</c>.</summary>
+        internal long Prime { get; }
+
+        /// <summary>The degree, or -1 for the zero polynomial.</summary>
+        internal int Degree => coefficients.Length - 1;
+
+        internal bool IsZero => coefficients.Length == 0;
+
+        /// <summary>
+        /// Whether the leading coefficient is one. The zero polynomial has no leading
+        /// coefficient and so is not monic.
+        /// </summary>
+        internal bool IsMonic => coefficients.Length > 0 && coefficients[coefficients.Length - 1] == 1;
+
+        /// <summary>
+        /// Constant term first, each entry in <c>[0, <see cref="Prime"/>)</c>, with no
+        /// trailing zeros — so the last entry is the leading coefficient, and the list is
+        /// empty exactly for the zero polynomial.
+        /// </summary>
+        internal IReadOnlyList<long> Coefficients => coefficients;
+
+        /// <summary>
+        /// The polynomial with the given coefficients, constant term first, over
+        /// <c>F_prime</c>. Coefficients outside <c>[0, prime)</c>, negative ones included,
+        /// are reduced into it, and trailing zeros are dropped.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="prime"/> is below 2 or above <see cref="MaxPrime"/>.
+        /// </exception>
+        internal static PrimeFieldPolynomial Create(IReadOnlyList<long> coefficientsLowestFirst, long prime)
+        {
+            CheckPrime(prime);
+            var reduced = new long[coefficientsLowestFirst.Count];
+            for (var i = 0; i < reduced.Length; i++)
+                reduced[i] = Reduce(coefficientsLowestFirst[i], prime);
+            return new PrimeFieldPolynomial(Trim(reduced), prime);
+        }
+
+        internal static PrimeFieldPolynomial Zero(long prime)
+        {
+            CheckPrime(prime);
+            return new PrimeFieldPolynomial(Array.Empty<long>(), prime);
+        }
+
+        internal static PrimeFieldPolynomial One(long prime)
+        {
+            CheckPrime(prime);
+            return new PrimeFieldPolynomial(new long[] { 1 }, prime);
+        }
+
+        /// <summary><c>x^degree</c>.</summary>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="degree"/> is negative.</exception>
+        internal static PrimeFieldPolynomial Monomial(int degree, long prime)
+        {
+            CheckPrime(prime);
+            if (degree < 0)
+                throw new ArgumentOutOfRangeException(nameof(degree), degree, "A monomial has a non-negative degree.");
+            var monomial = new long[degree + 1];
+            monomial[degree] = 1;
+            return new PrimeFieldPolynomial(monomial, prime);
+        }
+
+        internal PrimeFieldPolynomial Add(PrimeFieldPolynomial other)
+        {
+            CheckSameField(other, nameof(other));
+            var length = Math.Max(coefficients.Length, other.coefficients.Length);
+            var sum = new long[length];
+            for (var i = 0; i < length; i++)
+            {
+                // Both addends are already in [0, p), so one conditional subtraction is the
+                // whole reduction and no division is needed on this path.
+                var value = At(i) + other.At(i);
+                sum[i] = value >= Prime ? value - Prime : value;
+            }
+            return new PrimeFieldPolynomial(Trim(sum), Prime);
+        }
+
+        internal PrimeFieldPolynomial Subtract(PrimeFieldPolynomial other)
+        {
+            CheckSameField(other, nameof(other));
+            var length = Math.Max(coefficients.Length, other.coefficients.Length);
+            var difference = new long[length];
+            for (var i = 0; i < length; i++)
+            {
+                var value = At(i) - other.At(i);
+                difference[i] = value < 0 ? value + Prime : value;
+            }
+            return new PrimeFieldPolynomial(Trim(difference), Prime);
+        }
+
+        internal PrimeFieldPolynomial Multiply(PrimeFieldPolynomial other)
+        {
+            CheckSameField(other, nameof(other));
+            if (IsZero || other.IsZero)
+                return Zero(Prime);
+            var product = new long[coefficients.Length + other.coefficients.Length - 1];
+            for (var i = 0; i < coefficients.Length; i++)
+            {
+                var left = coefficients[i];
+                if (left == 0)
+                    continue;
+                for (var j = 0; j < other.coefficients.Length; j++)
+                    product[i + j] = (product[i + j] + left * other.coefficients[j]) % Prime;
+            }
+            // A product of two monic polynomials is monic, so no leading term can have
+            // cancelled; Trim is here for the general case, where one can.
+            return new PrimeFieldPolynomial(Trim(product), Prime);
+        }
+
+        /// <summary>
+        /// The quotient of the division of this by <paramref name="divisor"/>, which over a
+        /// field is exact in the sense that <c>this == quotient * divisor + remainder</c>
+        /// with the remainder of lower degree than the divisor.
+        /// </summary>
+        /// <exception cref="DivideByZeroException"><paramref name="divisor"/> is zero.</exception>
+        internal PrimeFieldPolynomial Quotient(PrimeFieldPolynomial divisor)
+        {
+            CheckSameField(divisor, nameof(divisor));
+            Divide(divisor, out var quotient, out _);
+            return new PrimeFieldPolynomial(Trim(quotient), Prime);
+        }
+
+        /// <summary>
+        /// The remainder of the division of this by <paramref name="divisor"/>: of lower
+        /// degree than the divisor, and zero exactly when the divisor divides this.
+        /// </summary>
+        /// <exception cref="DivideByZeroException"><paramref name="divisor"/> is zero.</exception>
+        internal PrimeFieldPolynomial Remainder(PrimeFieldPolynomial divisor)
+        {
+            CheckSameField(divisor, nameof(divisor));
+            Divide(divisor, out _, out var remainder);
+            return new PrimeFieldPolynomial(Trim(remainder), Prime);
+        }
+
+        /// <summary>
+        /// The monic greatest common divisor. Zero exactly when both are zero; otherwise
+        /// <c>gcd(f, 0)</c> is <c>f</c> made monic, and <c>gcd(f, f)</c> likewise.
+        /// </summary>
+        internal PrimeFieldPolynomial Gcd(PrimeFieldPolynomial other)
+        {
+            CheckSameField(other, nameof(other));
+            // Plain Euclid, with no content or subresultant machinery, because over a field
+            // there is no coefficient growth for either of them to control. Each remainder
+            // drops the degree by at least one, so the loop is bounded by the degree.
+            var left = this;
+            var right = other;
+            while (!right.IsZero)
+            {
+                var next = left.Remainder(right);
+                left = right;
+                right = next;
+            }
+            return left.MakeMonic();
+        }
+
+        /// <summary>
+        /// This divided by its leading coefficient, so that the result is monic. The zero
+        /// polynomial has no leading coefficient and is returned unchanged.
+        /// </summary>
+        internal PrimeFieldPolynomial MakeMonic()
+        {
+            if (IsZero || IsMonic)
+                return this;
+            var inverse = Inverse(coefficients[coefficients.Length - 1], Prime);
+            var scaled = new long[coefficients.Length];
+            for (var i = 0; i < scaled.Length; i++)
+                scaled[i] = coefficients[i] * inverse % Prime;
+            return new PrimeFieldPolynomial(scaled, Prime);
+        }
+
+        /// <summary>
+        /// The formal derivative. In characteristic <c>p</c> this is not degree-lowering by
+        /// one: the derivative of <c>x^p</c> is <c>p x^(p-1)</c>, which is zero, and more
+        /// generally the derivative vanishes identically exactly on the polynomials in
+        /// <c>x^p</c> — which is why a zero derivative is evidence of a <c>p</c>-th power
+        /// rather than of a constant.
+        /// </summary>
+        internal PrimeFieldPolynomial Derivative()
+        {
+            if (coefficients.Length <= 1)
+                return Zero(Prime);
+            var derivative = new long[coefficients.Length - 1];
+            for (var i = 1; i < coefficients.Length; i++)
+                derivative[i - 1] = coefficients[i] * (i % Prime) % Prime;
+            return new PrimeFieldPolynomial(Trim(derivative), Prime);
+        }
+
+        /// <summary>
+        /// <c>this^exponent mod modulus</c>, by square-and-multiply. The exponent is an
+        /// <see cref="EInteger"/> because the caller that needs this is raising to the
+        /// power <c>p^k</c>, which leaves the range of <see cref="long"/> long before the
+        /// computation becomes expensive.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="exponent"/> is negative.</exception>
+        /// <exception cref="DivideByZeroException"><paramref name="modulus"/> is zero.</exception>
+        internal PrimeFieldPolynomial PowMod(EInteger exponent, PrimeFieldPolynomial modulus)
+        {
+            CheckSameField(modulus, nameof(modulus));
+            if (exponent.Sign < 0)
+                throw new ArgumentOutOfRangeException(
+                    nameof(exponent), exponent, "A polynomial cannot be raised to a negative power.");
+            // Reducing first also settles the degenerate case: modulo a nonzero constant
+            // the quotient ring is trivial and every power of everything is zero there.
+            var result = One(Prime).Remainder(modulus);
+            var square = Remainder(modulus);
+            var remaining = exponent;
+            while (remaining.Sign > 0)
+            {
+                if (!remaining.IsEven)
+                    result = result.Multiply(square).Remainder(modulus);
+                remaining = remaining.ShiftRight(1);
+                if (remaining.Sign > 0)
+                    square = square.Multiply(square).Remainder(modulus);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Whether no irreducible factor occurs twice. False for the zero polynomial, which
+        /// is divisible by every square.
+        /// </summary>
+        /// <remarks>
+        /// A repeated factor survives differentiation once, so it divides both the
+        /// polynomial and its derivative, and over a field the converse holds too — hence
+        /// the test on <c>gcd(f, f')</c>. The characteristic-<c>p</c> case has to be taken
+        /// separately: <c>f' = 0</c> makes that gcd <c>f</c> itself, and it happens exactly
+        /// when <c>f</c> is a polynomial in <c>x^p</c>, which by the Frobenius map is the
+        /// <c>p</c>-th power of another polynomial and so is not square-free.
+        /// </remarks>
+        internal bool IsSquareFree
+        {
+            get
+            {
+                if (IsZero)
+                    return false;
+                if (Degree == 0)
+                    return true;
+                var derivative = Derivative();
+                if (derivative.IsZero)
+                    return false;
+                return Gcd(derivative).Degree == 0;
+            }
+        }
+
+        /// <summary>
+        /// Whether the two are the same polynomial over the same field. Polynomials over
+        /// different fields are never the same, rather than an error.
+        /// </summary>
+        internal bool SameAs(PrimeFieldPolynomial other)
+        {
+            if (Prime != other.Prime || coefficients.Length != other.coefficients.Length)
+                return false;
+            for (var i = 0; i < coefficients.Length; i++)
+                if (coefficients[i] != other.coefficients[i])
+                    return false;
+            return true;
+        }
+
+        /// <summary>
+        /// The inverse of <paramref name="value"/> modulo <paramref name="prime"/>, by the
+        /// extended Euclidean algorithm. Exposed because the Gaussian elimination in
+        /// <see cref="PrimeFieldFactorization"/> works on the field rather than on
+        /// polynomials over it and needs the same inversion.
+        /// </summary>
+        /// <exception cref="DivideByZeroException">
+        /// <paramref name="value"/> has no inverse — it is zero modulo
+        /// <paramref name="prime"/>, or the modulus is not prime.
+        /// </exception>
+        internal static long Inverse(long value, long prime)
+        {
+            var reduced = Reduce(value, prime);
+            if (reduced == 0)
+                throw new DivideByZeroException("Zero is not invertible in a field.");
+            // Bezout coefficients of (reduced, prime); the one on reduced is the inverse
+            // once the gcd has come out as one. Both stay bounded by the modulus, so this
+            // cannot overflow where the modulus itself is within range.
+            long remainder = reduced, previousRemainder = prime;
+            long coefficient = 1, previousCoefficient = 0;
+            while (remainder != 0)
+            {
+                var quotient = previousRemainder / remainder;
+                (previousRemainder, remainder) = (remainder, previousRemainder - quotient * remainder);
+                (previousCoefficient, coefficient) = (coefficient, previousCoefficient - quotient * coefficient);
+            }
+            if (previousRemainder != 1)
+                throw new DivideByZeroException(
+                    $"{reduced} is not invertible modulo {prime}, so {prime} is not prime.");
+            return Reduce(previousCoefficient, prime);
+        }
+
+        public override string ToString()
+        {
+            if (IsZero)
+                return $"0 (mod {Prime})";
+            var written = new System.Text.StringBuilder();
+            for (var i = coefficients.Length - 1; i >= 0; i--)
+            {
+                if (coefficients[i] == 0)
+                    continue;
+                if (written.Length > 0)
+                    written.Append(" + ");
+                written.Append(coefficients[i]);
+                if (i > 0)
+                    written.Append("x^").Append(i);
+            }
+            return $"{written} (mod {Prime})";
+        }
+
+        private long At(int power) => power < coefficients.Length ? coefficients[power] : 0;
+
+        private static long Reduce(long value, long prime)
+        {
+            // C#'s % takes the sign of the dividend, and every invariant here is that a
+            // coefficient lies in [0, p), so a negative input needs the one correction.
+            var reduced = value % prime;
+            return reduced < 0 ? reduced + prime : reduced;
+        }
+
+        private static void CheckPrime(long prime)
+        {
+            if (prime < 2 || prime > MaxPrime)
+                throw new ArgumentOutOfRangeException(
+                    nameof(prime), prime, $"A modulus has to lie in [2, {MaxPrime}] for the arithmetic to be exact.");
+        }
+
+        private void CheckSameField(PrimeFieldPolynomial other, string parameterName)
+        {
+            if (other.Prime != Prime)
+                throw new ArgumentException(
+                    $"Cannot combine a polynomial over F_{Prime} with one over F_{other.Prime}.", parameterName);
+        }
+
+        /// <summary>
+        /// Drops trailing zeros, so that the length of the array is one more than the
+        /// degree and every representation of a given polynomial is the same array.
+        /// </summary>
+        private static long[] Trim(long[] coefficients)
+        {
+            var degree = coefficients.Length - 1;
+            while (degree >= 0 && coefficients[degree] == 0)
+                degree--;
+            if (degree == coefficients.Length - 1)
+                return coefficients;
+            var trimmed = new long[degree + 1];
+            Array.Copy(coefficients, trimmed, degree + 1);
+            return trimmed;
+        }
+
+        /// <summary>
+        /// Schoolbook long division. Both outputs are untrimmed and belong to the caller.
+        /// </summary>
+        private void Divide(PrimeFieldPolynomial divisor, out long[] quotient, out long[] remainder)
+        {
+            if (divisor.IsZero)
+                throw new DivideByZeroException("A polynomial cannot be divided by the zero polynomial.");
+            remainder = new long[coefficients.Length];
+            Array.Copy(coefficients, remainder, coefficients.Length);
+            var divisorDegree = divisor.Degree;
+            quotient = new long[Math.Max(0, coefficients.Length - divisorDegree)];
+            var leadInverse = Inverse(divisor.coefficients[divisorDegree], Prime);
+            for (var shift = Degree - divisorDegree; shift >= 0; shift--)
+            {
+                if (remainder[shift + divisorDegree] == 0)
+                    continue;
+                var factor = remainder[shift + divisorDegree] * leadInverse % Prime;
+                quotient[shift] = factor;
+                for (var i = 0; i <= divisorDegree; i++)
+                {
+                    var value = remainder[shift + i] - factor * divisor.coefficients[i] % Prime;
+                    remainder[shift + i] = value < 0 ? value + Prime : value;
+                }
+            }
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/SquareFreeDecomposition.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/SquareFreeDecomposition.cs
@@ -1,0 +1,127 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// Splits a polynomial into square-free parts: <c>f = a_1 * a_2^2 * a_3^3 * ...</c> with
+    /// each <c>a_i</c> square-free and any two of them coprime.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The first step of every factorisation, and useful on its own. A repeated factor is
+    /// exactly a factor shared with the derivative — <c>(x - r)^k</c> contributes
+    /// <c>(x - r)^(k-1)</c> to <c>f'</c> — so <c>gcd(f, f')</c> collects every repetition and
+    /// dividing by it leaves each distinct factor standing once. That is why factoring only
+    /// ever has to deal with square-free input, and why a square-free routine is worth having
+    /// before the factoriser that consumes it.
+    /// </para>
+    /// <para>
+    /// Yun's algorithm rather than the older Tobey-Horowitz one: both start from
+    /// <c>gcd(f, f')</c>, but Yun's carries the derivative quotient forward so that each
+    /// round's greatest common divisor is taken between polynomials whose degrees have
+    /// already fallen, instead of re-dividing the original every time. The cost is one extra
+    /// subtraction a round and the saving is an order of magnitude on high multiplicities.
+    /// Yun, <i>On square-free decomposition algorithms</i>, SYMSAC '76; Geddes, Czapor and
+    /// Labahn, <i>Algorithms for Computer Algebra</i>, §8.1.
+    /// </para>
+    /// <para>
+    /// Characteristic zero only. Over <c>F_p</c> the derivative of <c>x^p</c> vanishes and
+    /// the argument above breaks, which is why the finite-field side handles its own
+    /// square-free step rather than calling this.
+    /// </para>
+    /// </remarks>
+    internal static class SquareFreeDecomposition
+    {
+        /// <summary>
+        /// The square-free parts of <paramref name="poly"/> paired with the multiplicity each
+        /// carries, or <see langword="null"/> where a step declined. Parts of multiplicity
+        /// with nothing in them are omitted, so the list is never padded with constants.
+        /// </summary>
+        /// <remarks>
+        /// The product of the parts raised to their multiplicities is checked against the
+        /// primitive part of the input before the answer is handed back. A decomposition that
+        /// does not multiply back is refused rather than returned: the factoriser above this
+        /// treats each part as a complete account of one multiplicity, and a part that is
+        /// missing a factor would silently drop it from the final answer.
+        /// </remarks>
+        internal static IReadOnlyList<SquareFreePart>? Decompose(IntegerPolynomial poly)
+        {
+            if (poly.IsZero)
+                return null;
+            var primitive = poly.PrimitivePart();
+            if (primitive.IsConstant)
+                return System.Array.Empty<SquareFreePart>();
+
+            var derivative = primitive.Derivative();
+            // Only a constant has a vanishing derivative in characteristic zero, and that
+            // was answered above.
+            if (derivative.IsZero)
+                return null;
+
+            var repeated = IntegerPolynomial.Gcd(primitive, derivative);
+            if (primitive.DivideExact(repeated) is not { } distinct
+                || derivative.DivideExact(repeated) is not { } quotient)
+                return null;
+            var difference = quotient.Subtract(distinct.Derivative());
+
+            var parts = new List<SquareFreePart>();
+            for (var multiplicity = 1; multiplicity <= IntegerPolynomial.MaxDegree; multiplicity++)
+            {
+                if (distinct.IsConstant)
+                {
+                    // Every part accounted for; the leftover is the unit that PrimitivePart
+                    // already normalised away.
+                    return Verify(parts, primitive) ? parts : null;
+                }
+
+                var part = IntegerPolynomial.Gcd(distinct, difference);
+                if (distinct.DivideExact(part) is not { } nextDistinct
+                    || difference.DivideExact(part) is not { } nextQuotient)
+                    return null;
+
+                if (!part.IsConstant)
+                    parts.Add(new SquareFreePart(part.PrimitivePart(), multiplicity));
+
+                distinct = nextDistinct;
+                difference = nextQuotient.Subtract(nextDistinct.Derivative());
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Whether the parts multiply back to what they came from, up to the sign that
+        /// <see cref="IntegerPolynomial.PrimitivePart"/> fixes on both sides.
+        /// </summary>
+        private static bool Verify(IReadOnlyList<SquareFreePart> parts, IntegerPolynomial primitive)
+        {
+            var product = IntegerPolynomial.One;
+            foreach (var part in parts)
+                for (var i = 0; i < part.Multiplicity; i++)
+                {
+                    if (product.Multiply(part.Factor) is not { } multiplied)
+                        return false;
+                    product = multiplied;
+                }
+            return product.PrimitivePart().SameAs(primitive);
+        }
+
+        /// <summary>One square-free part of a decomposition, and the power it is raised to.</summary>
+        internal readonly struct SquareFreePart
+        {
+            internal SquareFreePart(IntegerPolynomial factor, int multiplicity)
+            {
+                Factor = factor;
+                Multiplicity = multiplicity;
+            }
+
+            internal IntegerPolynomial Factor { get; }
+
+            internal int Multiplicity { get; }
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
@@ -233,6 +233,18 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
                 && split is Mulf)
                 return Solve(split, x, compensateSolving);
 
+            // A polynomial with no rational root at all may still factor, and then each
+            // factor is a lower-degree equation the product case above answers exactly.
+            // x^5 + 2x^3 - 2x^2 - 4 is (x^2 + 2)(x^3 - 2): three of its five roots are
+            // cube roots of two, which no search for a rational root can reach and which
+            // the general machinery below reaches only numerically, if at all.
+            // A two-termed polynomial is left alone here for the reason given just above.
+            // https://github.com/asc-community/AngouriMath/issues/746
+            if (!Functions.PolynomialFactorization.IsTwoTermed(expr, x)
+                && Functions.PolynomialFactorization.TryFactorIntoIrreducibles(expr, x, out var factored)
+                && factored is Mulf)
+                return Solve(factored, x, compensateSolving);
+
             if (PolynomialSolver.SolveAsPolynomial(expr, x, out var isIdentity) is { } poly)
                 return poly.Select(e => TryDowncast(expr, x, e.InnerSimplified)).ToSet();
             if (isIdentity)

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
@@ -238,9 +238,10 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
             // x^5 + 2x^3 - 2x^2 - 4 is (x^2 + 2)(x^3 - 2): three of its five roots are
             // cube roots of two, which no search for a rational root can reach and which
             // the general machinery below reaches only numerically, if at all.
-            // A two-termed polynomial is left alone here for the reason given just above.
+            // Degree four and up, and not two-termed -- see IsWorthFactoringToSolve for why
+            // anything smaller has already been dealt with by the line above.
             // https://github.com/asc-community/AngouriMath/issues/746
-            if (!Functions.PolynomialFactorization.IsTwoTermed(expr, x)
+            if (Functions.PolynomialFactorization.IsWorthFactoringToSolve(expr, x)
                 && Functions.PolynomialFactorization.TryFactorIntoIrreducibles(expr, x, out var factored)
                 && factored is Mulf)
                 return Solve(factored, x, compensateSolving);

--- a/Sources/AngouriMath/Functions/InternalAMExtensions.cs
+++ b/Sources/AngouriMath/Functions/InternalAMExtensions.cs
@@ -10,7 +10,20 @@ using System.Numerics;
 using AngouriMath.Core.Exceptions;
 using PeterO.Numbers;
 using AngouriMath.Extensions;
-//[assembly:System.Runtime.CompilerServices.InternalsVisibleTo("UnitTests")]
+
+// The kernel algebra in Functions/Algebra/Polynomials is internal and is reached from the
+// public surface only through Simplify, Solve and Integrate, which means a test driven from
+// outside cannot separate a defect in a greatest common divisor from a defect in whichever
+// caller happened to invoke it. The pieces that carry their own mathematics -- Berlekamp over
+// a prime field, the Hensel lift, the subresultant sequence -- are checked against exhaustive
+// or independently computed answers of their own, and that needs them to be nameable there.
+// The key is this assembly's own, so the test project signs with key.snk too; the alternative
+// to naming it is dropping the strong name, which is a published property of the package.
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("UnitTests, PublicKey="
+    + "0024000004800000940000000602000000240000525341310004000001000100f54ef0f5905ba32e"
+    + "cae04751103c5565283a4c4fa2b07627ff7a7e556b287f198203a09935d998ce9d812a696aa2e71c"
+    + "552aeb08b7a67f49a5557ef4faab3d9f033182be1a646b24c932399732107462848dcb97acecc844"
+    + "9997b1b77e6bd337e1116878226dd4954e004f11193ccd8e29fc156615c798f733712923ffe8d6c5")]
 
 namespace AngouriMath
 {

--- a/Sources/Tests/UnitTests/Algebra/Polynomials/MultivariateGcdTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/Polynomials/MultivariateGcdTest.cs
@@ -1,0 +1,661 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using AngouriMath;
+using AngouriMath.Core.Transformations;
+using AngouriMath.Extensions;
+using AngouriMath.Functions;
+using PeterO.Numbers;
+using Xunit;
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Tests.Algebra.Polynomials
+{
+    /// <summary>
+    /// The multivariate polynomial greatest common divisor, and the cancellation it drives —
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/55">#55</a>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The divisor itself is checked against <see cref="PolynomialGcd"/> directly, because the
+    /// only thing the public surface shows of one is the condition a cancellation carries, and
+    /// half the surface — a zero argument, a constant one, the ceilings — is not reachable
+    /// from a quotient at all.
+    /// </para>
+    /// <para>
+    /// The cancellation is checked through <see cref="RewriteRules.PolynomialGcdCancellation"/>
+    /// rather than through <c>Simplify</c>: that rule set is the gcd's only caller, so a
+    /// failure names it rather than the dozen other rule sets a simplification runs, and
+    /// nothing else gets to rearrange the answer before it is read.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Algebra")]
+    public sealed class MultivariateGcdTest
+    {
+        #region Reading polynomials in
+
+        static Dictionary<Variable, int> Index(string[] variables)
+        {
+            var index = new Dictionary<Variable, int>(variables.Length);
+            for (var i = 0; i < variables.Length; i++)
+                index[(Variable)variables[i]] = i;
+            return index;
+        }
+
+        static Variable[] Vars(string[] names)
+        {
+            var variables = new Variable[names.Length];
+            for (var i = 0; i < names.Length; i++)
+                variables[i] = (Variable)names[i];
+            return variables;
+        }
+
+        static MultivariatePolynomial Polynomial(string source, params string[] variables)
+        {
+            var parsed = MultivariatePolynomial.TryParse(source.ToEntity(), Index(variables));
+            Assert.True(parsed is not null, $"{source} was not read as a polynomial");
+            return parsed!;
+        }
+
+        static MultivariatePolynomial? Gcd(MultivariatePolynomial left, MultivariatePolynomial right, int variableCount)
+        {
+            var order = new int[variableCount];
+            for (var i = 0; i < order.Length; i++)
+                order[i] = i;
+            return PolynomialGcd.Gcd(left, right, order, 0);
+        }
+
+        #endregion
+
+        #region The defining property
+
+        /// <summary>
+        /// The two halves of "greatest common divisor": it divides both, and what is left over
+        /// shares nothing further. Together those say it is the greatest one, so nothing else
+        /// has to be assumed about it.
+        /// </summary>
+        /// <remarks>
+        /// The quotients are multiplied back with the operands the other way round from the
+        /// check the implementation makes, and the expected divisor every caller passes is
+        /// built by reading a product in rather than by dividing anything — asking the
+        /// division to confirm its own quotient would only be asking it to agree with itself.
+        /// </remarks>
+        static void AssertIsGreatestCommonDivisor(
+            MultivariatePolynomial left, MultivariatePolynomial right,
+            MultivariatePolynomial divisor, int variableCount)
+        {
+            var leftQuotient = left.DivideExact(divisor);
+            var rightQuotient = right.DivideExact(divisor);
+            Assert.True(leftQuotient is not null, "the divisor does not divide the first argument");
+            Assert.True(rightQuotient is not null, "the divisor does not divide the second argument");
+            Assert.True(divisor.Multiply(leftQuotient!)?.SameAs(left) is true,
+                "the first quotient does not multiply back");
+            Assert.True(divisor.Multiply(rightQuotient!)?.SameAs(right) is true,
+                "the second quotient does not multiply back");
+
+            var leftOver = Gcd(leftQuotient!, rightQuotient!, variableCount);
+            Assert.True(leftOver is not null, "the gcd of the two quotients declined");
+            Assert.True(leftOver!.IsConstant, "the two quotients still share a factor");
+        }
+
+        /// <summary>
+        /// <paramref name="expected"/> is what the gcd answers, and it really is the gcd. Both
+        /// halves are needed: the first would pass an answer that is systematically too small
+        /// if the expectation were computed the same way, and the second would pass any answer
+        /// at all if the same blindness lost the factor left over.
+        /// </summary>
+        static void AssertGcd(string expected, string left, string right, params string[] variables)
+        {
+            var first = Polynomial(left, variables);
+            var second = Polynomial(right, variables);
+            var divisor = Gcd(first, second, variables.Length);
+            Assert.True(divisor is not null, $"gcd({left}, {right}) declined");
+            Assert.True(divisor!.SameAs(Polynomial(expected, variables)),
+                $"gcd({left}, {right}) is {divisor.ToEntity(Vars(variables)).Stringize()}, expected {expected}");
+            AssertIsGreatestCommonDivisor(first, second, divisor, variables.Length);
+        }
+
+        #endregion
+
+        #region Divisors computed by hand
+
+        [Theory]
+        // One variable.
+        [InlineData("x - 1", "x ^ 2 - 1", "x ^ 2 - 2 * x + 1", "x")]
+        [InlineData("x ^ 2 + x + 1", "x ^ 3 - 1", "x ^ 4 + x ^ 2 + 1", "x")]
+        // Two variables: #55's own example and its neighbours.
+        [InlineData("x + y", "x ^ 2 + 2 * x * y + y ^ 2", "x ^ 2 - y ^ 2", "x", "y")]
+        [InlineData("x - y", "x ^ 3 - y ^ 3", "x ^ 2 - y ^ 2", "x", "y")]
+        // Three variables, the common factor carrying all three.
+        [InlineData("x + y + z", "(x + y + z) * (x - y)", "(x + y + z) * (y - z)", "x", "y", "z")]
+        [InlineData("x * y - z", "(x * y - z) * (x + z)", "(x * y - z) * (y + z)", "x", "y", "z")]
+        // Four variables.
+        [InlineData("x + y + z + w", "(x + y + z + w) * (x - y)", "(x + y + z + w) * (z - w)", "x", "y", "z", "w")]
+        [InlineData("x * y - z * w", "(x * y - z * w) * (x + w)", "(x * y - z * w) * (y + z)", "x", "y", "z", "w")]
+        // One argument divides the other, so one quotient comes out 1.
+        [InlineData("x ^ 2 - y ^ 2", "x ^ 2 - y ^ 2", "(x ^ 2 - y ^ 2) * (x + 2 * y)", "x", "y")]
+        [InlineData("(x + y) * (x + z)", "(x + y) * (x + z) * (y + z)", "(x + y) * (x + z)", "x", "y", "z")]
+        // The common factor lives in the content -- the part free of the main variable -- so
+        // it is only found once the content has been split off and recursed into.
+        [InlineData("x * y + y", "2 * x * y + 2 * y", "3 * x * y + 3 * y", "x", "y")]
+        [InlineData("x * y + y", "x ^ 2 * y - y", "x ^ 2 * y * z + x * y * z", "x", "y", "z")]
+        [InlineData("y * z + z", "(y * z + z) * (x ^ 2 + 1)", "(y * z + z) * (x - 1)", "x", "y", "z")]
+        // Only one variable is shared, so it is the only one a common factor may carry.
+        [InlineData("y + 1", "(y + 1) * (x + 2)", "(y + 1) * (z + 3)", "x", "y", "z")]
+        [InlineData("y ^ 2 - 1", "(y ^ 2 - 1) * (x ^ 2 + x + 1)", "(y ^ 2 - 1) * (z ^ 3 + 2)", "x", "y", "z")]
+        public void KnownDivisor(string expected, string left, string right, params string[] variables) =>
+            AssertGcd(expected, left, right, variables);
+
+        [Theory]
+        // Coprime: the greatest common divisor is a unit, and over Q that is written 1.
+        [InlineData("x + y", "x - y", "x", "y")]
+        [InlineData("x ^ 2 + y ^ 2", "x + y", "x", "y")]
+        [InlineData("x * y + 1", "x * y - 1", "x", "y")]
+        [InlineData("x + y + z", "x + y - z", "x", "y", "z")]
+        [InlineData("(x + y) * (x + z)", "(x - y) * (x - z)", "x", "y", "z")]
+        // No variable in common: the two lie in rings meeting only in the constants.
+        [InlineData("x + 1", "y + 1", "x", "y")]
+        [InlineData("x ^ 3 - 1", "y ^ 3 - 1", "x", "y")]
+        public void CoprimeArgumentsGiveOne(string left, string right, params string[] variables) =>
+            AssertGcd("1", left, right, variables);
+
+        #endregion
+
+        #region The construction-based sweep
+
+        /// <summary>
+        /// Pairwise coprime and irreducible, each primitive over the integers with a positive
+        /// leading coefficient in the lexicographic order the gcd normalizes to. That is what
+        /// lets an expected answer below be written as a plain product: by Gauss's lemma a
+        /// product of such polynomials is again one, so it is already its own normal form and
+        /// the assertion can be equality rather than equality up to a unit.
+        /// </summary>
+        static string[] Factors => new[]
+        {
+            "a + b",              //  0
+            "a - b",              //  1
+            "a + c",              //  2
+            "a - d",              //  3
+            "b + c + 1",          //  4
+            "b - d",              //  5
+            "c + d + 2",          //  6
+            "a * b - 1",          //  7
+            "a * c + 1",          //  8
+            "b * c - d",          //  9
+            "a + b + c + d",      // 10
+            "a ^ 2 + b * c + d",  // 11
+        };
+
+        static string[] SweepVariables => new[] { "a", "b", "c", "d" };
+
+        /// <summary>
+        /// Pairs of index lists into <see cref="Factors"/>, and the indices their two products
+        /// share. Written out rather than generated, so that the case list is the same on
+        /// every machine and every run.
+        /// </summary>
+        static IEnumerable<(int[] Left, int[] Right, int[] Shared)> Pairs()
+        {
+            yield return (new[] { 0 }, new[] { 1 }, new int[0]);
+            yield return (new[] { 1 }, new[] { 2 }, new int[0]);
+            yield return (new[] { 7 }, new[] { 0 }, new int[0]);
+            yield return (new[] { 4 }, new[] { 7 }, new int[0]);
+            yield return (new[] { 9 }, new[] { 6 }, new int[0]);
+            yield return (new[] { 10 }, new[] { 11 }, new int[0]);
+            yield return (new[] { 11 }, new[] { 0 }, new int[0]);
+            yield return (new[] { 0, 1 }, new[] { 1, 2 }, new[] { 1 });
+            yield return (new[] { 0, 4 }, new[] { 2, 4 }, new[] { 4 });
+            yield return (new[] { 7, 10 }, new[] { 10, 11 }, new[] { 10 });
+            yield return (new[] { 0, 1, 2 }, new[] { 1, 2, 4 }, new[] { 1, 2 });
+        }
+
+        /// <summary>
+        /// The factors a common multiplier is built from. One of them is a repeated factor, so
+        /// that the divisor to be found is not square-free.
+        /// </summary>
+        static IEnumerable<int[]> Multipliers()
+        {
+            yield return new[] { 0 };
+            yield return new[] { 2 };
+            yield return new[] { 7 };
+            yield return new[] { 9 };
+            yield return new[] { 10 };
+            yield return new[] { 11 };
+            yield return new[] { 0, 2 };
+            yield return new[] { 1, 1 };
+        }
+
+        static string Product(IEnumerable<int> indices)
+        {
+            string? product = null;
+            foreach (var index in indices)
+                product = product is null ? $"({Factors[index]})" : $"{product} * ({Factors[index]})";
+            return product ?? "1";
+        }
+
+        static List<int> Joined(IEnumerable<int> first, IEnumerable<int> second)
+        {
+            var joined = new List<int>(first);
+            joined.AddRange(second);
+            return joined;
+        }
+
+        public static IEnumerable<object[]> Sweep()
+        {
+            foreach (var (left, right, shared) in Pairs())
+                foreach (var multiplier in Multipliers())
+                    yield return new object[]
+                    {
+                        Product(Joined(shared, multiplier)),
+                        Product(Joined(left, multiplier)),
+                        Product(Joined(right, multiplier))
+                    };
+        }
+
+        /// <summary>
+        /// <c>gcd(a g, b g) = g gcd(a, b)</c>, on products built from the table above. This is
+        /// the case that does not depend on anyone having guessed which inputs are hard: a
+        /// factor the algorithm loses, or one it invents, shows up here whatever shape it has.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(Sweep))]
+        public void GcdIsMultiplicativeOverACommonFactor(string expected, string left, string right) =>
+            AssertGcd(expected, left, right, SweepVariables);
+
+        /// <summary>The multiset intersection: a repeated factor is shared as often as both have it.</summary>
+        static List<int> SharedFactors(IEnumerable<int> left, IReadOnlyList<int> right)
+        {
+            var remaining = new List<int>(right);
+            var shared = new List<int>();
+            foreach (var factor in left)
+                if (remaining.Remove(factor))
+                    shared.Add(factor);
+            return shared;
+        }
+
+        static int[] Draw(Random random)
+        {
+            var drawn = new int[random.Next(1, 3)];
+            for (var i = 0; i < drawn.Length; i++)
+                drawn[i] = random.Next(Factors.Length);
+            return drawn;
+        }
+
+        /// <summary>
+        /// The same property over far more triples from the same table. The seed is fixed, so
+        /// the case list is identical on every machine and every run — a generated case that
+        /// cannot be reproduced is not a finding, and #746's determinism condition rules a
+        /// clock-seeded generator out.
+        /// </summary>
+        /// <remarks>
+        /// Seven of these three thousand are declined rather than answered, and the count is
+        /// asserted rather than ignored: <see cref="TheTermCeilingIsReachedByAnIntermediate"/>
+        /// is what reaches the ceiling and why the inputs that do it are so small. The bound
+        /// is an upper one, so finding fewer never fails.
+        /// </remarks>
+        [Fact]
+        public void GcdIsMultiplicativeOverManyDrawnTriples()
+        {
+            var random = new Random(20260813);
+            var declined = 0;
+            for (var trial = 0; trial < 3000; trial++)
+            {
+                var left = Draw(random);
+                var right = Draw(random);
+                var multiplier = Draw(random);
+                var first = Polynomial(Product(Joined(left, multiplier)), SweepVariables);
+                var second = Polynomial(Product(Joined(right, multiplier)), SweepVariables);
+                var expected = Polynomial(Product(Joined(SharedFactors(left, right), multiplier)), SweepVariables);
+                var divisor = Gcd(first, second, SweepVariables.Length);
+                if (divisor is null)
+                {
+                    declined++;
+                    continue;
+                }
+                Assert.True(divisor.SameAs(expected), $"trial {trial}: the divisor is not the expected one");
+                AssertIsGreatestCommonDivisor(first, second, divisor, SweepVariables.Length);
+            }
+            Assert.True(declined <= 7, $"{declined} of 3000 triples were declined");
+        }
+
+        #endregion
+
+        #region Coefficient growth
+
+        /// <summary>
+        /// Knuth's degree-8 pair (<i>TAOCP</i> vol. 2, §4.6.1), the standing example of a
+        /// remainder sequence whose coefficients explode: taken as a plain pseudo-remainder
+        /// sequence it reaches a coefficient near 10^35, and the subresultant divisions are
+        /// what hold it to the size of the subresultants. The two are coprime, so the whole
+        /// sequence is walked before the answer is known — there is no early exit to hide in.
+        /// </summary>
+        static string KnuthU => "x ^ 8 + x ^ 6 - 3 * x ^ 4 - 3 * x ^ 3 + 8 * x ^ 2 + 2 * x - 5";
+
+        static string KnuthV => "3 * x ^ 6 + 5 * x ^ 4 - 4 * x ^ 2 - 9 * x + 21";
+
+        [Fact]
+        public void KnuthsDegreeEightPairIsCoprime() => AssertGcd("1", KnuthU, KnuthV, "x");
+
+        /// <summary>
+        /// The same sequence with a factor to find at the end of it, and a clock on it. The
+        /// bound is loose on purpose: it is there to catch a change of algorithm, not to
+        /// measure this machine. At degree 8 an implementation that had dropped back to a
+        /// plain pseudo-remainder sequence would still come in well inside it, since a
+        /// coefficient of 10^35 is four machine words; what that change really costs shows up
+        /// in the multivariate sweep above, where the intermediates stop fitting under the
+        /// term ceiling at all and the answer becomes a refusal.
+        /// </summary>
+        [Fact]
+        public void KnuthsDegreeEightPairWithACommonFactor()
+        {
+            var clock = Stopwatch.StartNew();
+            AssertGcd("x ^ 2 + 1", $"({KnuthU}) * (x ^ 2 + 1)", $"({KnuthV}) * (x ^ 2 + 1)", "x");
+            Assert.True(clock.Elapsed.TotalSeconds < 20, $"took {clock.Elapsed}");
+        }
+
+        #endregion
+
+        #region Normalisation
+
+        /// <summary>
+        /// A greatest common divisor is only defined up to a unit and over Q every nonzero
+        /// rational is one, so a representative has to be chosen: whole coprime coefficients
+        /// with a positive leading one. Asserted on the polynomial rather than on a printed
+        /// form, since it is the choice of representative that is under test and a string
+        /// would also be asserting the printer.
+        /// </summary>
+        [Theory]
+        [InlineData("x + y", "(-x - y) * (x - y)", "(-x - y) * (x + 2 * y)")]
+        [InlineData("x + y", "(x / 2 + y / 2) * (x - y)", "(x / 2 + y / 2) * (x + 2 * y)")]
+        [InlineData("x + y", "(-3 * x - 3 * y) * (x - y)", "(-3 * x - 3 * y) * (x + 2 * y)")]
+        [InlineData("2 * x - y", "(x / 3 - y / 6) * (x + y)", "(x / 3 - y / 6) * (x + 2 * y)")]
+        public void TheDivisorIsNormalized(string expected, string left, string right) =>
+            AssertGcd(expected, left, right, "x", "y");
+
+        /// <summary>
+        /// Which of the two signs "positive leading coefficient" picks depends on which
+        /// monomial leads, and that is the lexicographic order on the variables as the caller
+        /// listed them — so the same divisor comes back with either sign depending on that
+        /// list. Pinned because it is a convention rather than a consequence, and because
+        /// <see cref="PolynomialGcd.TryCancel"/> builds the list by sorting the names: with w
+        /// sorting first, w z leads and x y - z w is returned negated.
+        /// </summary>
+        [Fact]
+        public void TheDivisorsSignFollowsTheVariableOrder()
+        {
+            AssertGcd("z * w - x * y", "(x * y - z * w) * (x + w)", "(x * y - z * w) * (y + z)",
+                "w", "x", "y", "z");
+            AssertGcd("x * y - z * w", "(x * y - z * w) * (x + w)", "(x * y - z * w) * (y + z)",
+                "x", "y", "z", "w");
+        }
+
+        #endregion
+
+        #region Zero, constants, and the ceilings
+
+        /// <summary>
+        /// Everything divides zero, so the gcd of zero and anything is that thing normalized.
+        /// Answering 1 here, or declining, would be wrong rather than merely unhelpful.
+        /// </summary>
+        [Fact]
+        public void ZeroArguments()
+        {
+            var zero = MultivariatePolynomial.Zero(2);
+            var polynomial = Polynomial("2 * x + 2 * y", "x", "y");
+            var expected = Polynomial("x + y", "x", "y");
+
+            Assert.True(Gcd(zero, polynomial, 2)?.SameAs(expected) is true);
+            Assert.True(Gcd(polynomial, zero, 2)?.SameAs(expected) is true);
+            // gcd(0, 0) is 0: it is the only common divisor that every common divisor divides.
+            Assert.True(Gcd(zero, zero, 2)?.IsZero is true);
+        }
+
+        [Fact]
+        public void ConstantArguments()
+        {
+            var polynomial = Polynomial("x ^ 2 - y ^ 2", "x", "y");
+            var five = MultivariatePolynomial.Constant(2, ERational.FromInt32(5));
+            var half = MultivariatePolynomial.Constant(2, ERational.Create(EInteger.One, EInteger.FromInt32(2)));
+            var one = MultivariatePolynomial.One(2);
+
+            // Every nonzero rational is a unit over Q, so a constant argument leaves 1.
+            Assert.True(Gcd(five, polynomial, 2)?.SameAs(one) is true);
+            Assert.True(Gcd(polynomial, half, 2)?.SameAs(one) is true);
+            Assert.True(Gcd(five, half, 2)?.SameAs(one) is true);
+        }
+
+        [Fact]
+        public void EqualArgumentsGiveThemselves() =>
+            AssertGcd("x ^ 2 - y ^ 2", "2 * x ^ 2 - 2 * y ^ 2", "3 * x ^ 2 - 3 * y ^ 2", "x", "y");
+
+        /// <summary>
+        /// A ninth variable has no byte in the packed exponent vector, and the shift that
+        /// would address it is negative — which the language turns into a shift by 56, the
+        /// first variable's byte. Read that way <c>x_1 - x_9</c> is the zero polynomial, so
+        /// the parse is refused instead. Both callers check the count themselves, which is why
+        /// this never reached anybody; the refusal is at the door so the next one need not.
+        /// </summary>
+        [Fact]
+        public void MoreVariablesThanFitAreRefused()
+        {
+            var eight = new[] { "x_1", "x_2", "x_3", "x_4", "x_5", "x_6", "x_7", "x_8" };
+            var nine = new[] { "x_1", "x_2", "x_3", "x_4", "x_5", "x_6", "x_7", "x_8", "x_9" };
+            Assert.Equal(MultivariatePolynomial.MaxVariables, eight.Length);
+
+            Assert.NotNull(MultivariatePolynomial.TryParse("x_1 - x_8".ToEntity(), Index(eight)));
+            Assert.Null(MultivariatePolynomial.TryParse("x_1 - x_9".ToEntity(), Index(nine)));
+            // Refused for the whole parse, not only where the ninth variable is mentioned: a
+            // polynomial in the first eight would still carry a variable count of nine into
+            // every monomial multiplication, which reads the same aliased byte.
+            Assert.Null(MultivariatePolynomial.TryParse("x_1 + x_2".ToEntity(), Index(nine)));
+        }
+
+        /// <summary>
+        /// Half of what a byte holds is the most one exponent may carry if the sum of two is
+        /// to stay in the byte, so the cap is 127 and going past it is a refusal, not a wrap.
+        /// </summary>
+        [Fact]
+        public void DegreesPastTheCapAreRefused()
+        {
+            var x = Polynomial("x", "x");
+            Assert.NotNull(x.Power(MultivariatePolynomial.MaxDegree));
+            Assert.Null(x.Power(MultivariatePolynomial.MaxDegree + 1));
+            Assert.Null(MultivariatePolynomial.TryParse("x ^ 130".ToEntity(), Index(new[] { "x" })));
+
+            // The cap is really on the sum, and neither of these is past it on its own.
+            var high = x.Power(100);
+            Assert.NotNull(high);
+            Assert.Null(high!.Multiply(high));
+            Assert.Null(high.ShiftedBy(0, 100));
+            Assert.NotNull(high.ShiftedBy(0, 27));
+        }
+
+        [Fact]
+        public void TermCountsPastTheCeilingAreRefused()
+        {
+            var variables = new[] { "a", "b", "c", "d", "e" };
+            // (a + b + c + d + e)^8 has C(12, 4) = 495 monomials, just inside the ceiling.
+            var large = Polynomial("(a + b + c + d + e) ^ 8", variables);
+            Assert.Equal(495, large.TermCount);
+            Assert.True(large.TermCount <= MultivariatePolynomial.MaxTerms);
+
+            Assert.Null(large.Multiply(large));
+            // The ninth power has 1287 and is stopped while it is built, not after.
+            Assert.Null(MultivariatePolynomial.TryParse("(a + b + c + d + e) ^ 9".ToEntity(), Index(variables)));
+        }
+
+        /// <summary>
+        /// The ceiling that is actually reached in practice, and it is not reached by the
+        /// input. These two have 19 and 29 terms and share <c>a + b + c + d</c>, but a
+        /// multivariate pseudo-remainder multiplies through by a leading coefficient that is
+        /// itself a polynomial, and three steps in, the product of a 25-term and a 159-term
+        /// intermediate goes past 512. The subresultant divisions bound the coefficients, not
+        /// the number of monomials, so nothing in the algorithm prevents this; what prevents a
+        /// wrong answer is that the step declines.
+        /// </summary>
+        /// <remarks>
+        /// Pinned as a refusal, which is a legitimate answer. Should the ceiling be raised, or
+        /// the sequence learn to keep its intermediates primitive, this becomes an answer and
+        /// the test should be changed to assert that answer deliberately.
+        /// </remarks>
+        [Fact]
+        public void TheTermCeilingIsReachedByAnIntermediate()
+        {
+            var variables = new[] { "a", "b", "c", "d" };
+            var left = Polynomial("(b + c + 1) * (a + b) * (a + b + c + d)", variables);
+            var right = Polynomial("(a ^ 2 + b * c + d) * (a + b + c + d) * (a + b + c + d)", variables);
+            Assert.Equal(19, left.TermCount);
+            Assert.Equal(29, right.TermCount);
+
+            // a + b + c + d divides both, and is not found.
+            var common = Polynomial("a + b + c + d", variables);
+            Assert.NotNull(left.DivideExact(common));
+            Assert.NotNull(right.DivideExact(common));
+            Assert.Null(Gcd(left, right, variables.Length));
+        }
+
+        #endregion
+
+        #region TryCancel, end to end
+
+        /// <summary>
+        /// The cancelled numerator and denominator together with the divisor named by the
+        /// condition, or <see langword="null"/> where the rule set declined — in which case it
+        /// must have left the expression exactly as it was.
+        /// </summary>
+        static (Entity Numerator, Entity Denominator, Entity Divisor)? Cancelled(Entity quotient)
+        {
+            var rewritten = RewriteRules.PolynomialGcdCancellation.ApplyOnce(quotient);
+            if (rewritten is Providedf(Divf(var top, var bottom), Notf(Equalsf(var divisor, var zero))))
+            {
+                Assert.Equal(Integer.Create(0), zero);
+                return (top, bottom, divisor);
+            }
+            Assert.Equal(quotient, rewritten);
+            return null;
+        }
+
+        /// <summary>Asserts that <paramref name="expression"/> is the zero polynomial.</summary>
+        static void AssertIsZero(Entity expression, string because)
+        {
+            var difference = expression.Expand();
+            if (!Integer.Create(0).Equals(difference))
+            {
+                difference = difference.Simplify();
+                while (difference is Providedf(var inner, _))
+                    difference = inner;
+            }
+            Assert.True(Integer.Create(0).Equals(difference), $"{because}; left over: {difference.Stringize()}");
+        }
+
+        /// <summary>
+        /// The same property as <see cref="AssertIsGreatestCommonDivisor"/>, one layer up and
+        /// on expressions rather than on packed monomials — so that a defect in the packing
+        /// could not hide behind a check that used the packing to make it.
+        /// </summary>
+        [Theory]
+        [InlineData("x ^ 2 + 2 * x * y + y ^ 2", "x ^ 2 - y ^ 2")]
+        [InlineData("x ^ 3 - y ^ 3", "x ^ 2 - y ^ 2")]
+        [InlineData("(x * y - z) * (x + z)", "(x * y - z) * (y + z)")]
+        [InlineData("2 * x * y + 2 * y", "3 * x * y + 3 * y")]
+        [InlineData("6 * x ^ 2 - 6 * y ^ 2", "4 * x + 4 * y")]
+        public void ACancellationMultipliesBackToWhatItCameFrom(string numerator, string denominator)
+        {
+            var cancelled = Cancelled(numerator.ToEntity() / denominator.ToEntity());
+            Assert.True(cancelled.HasValue, $"({numerator}) / ({denominator}) was not cancelled");
+            var (top, bottom, divisor) = cancelled!.Value;
+            AssertIsZero(top * divisor - numerator.ToEntity(), "the divisor does not divide the numerator");
+            AssertIsZero(bottom * divisor - denominator.ToEntity(), "the divisor does not divide the denominator");
+            Assert.False(Cancelled(top / bottom).HasValue, "the reduced quotient still cancels");
+        }
+
+        /// <summary>
+        /// <c>(x^2 + 2xy + y^2) / (x^2 - y^2)</c> is <c>(x + y) / (x - y)</c> only away from
+        /// <c>x + y = 0</c>, where the original is <c>0/0</c> and the reduced form is
+        /// definite. Dropping the condition would widen the domain and claim a value where
+        /// there is none, so the answer is asserted node by node rather than as a string.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/55">#55</a>.
+        /// </summary>
+        [Fact]
+        public void TheCancelledFactorTravelsAsACondition()
+        {
+            var rewritten = RewriteRules.PolynomialGcdCancellation.ApplyOnce(
+                "(x ^ 2 + 2 * x * y + y ^ 2) / (x ^ 2 - y ^ 2)".ToEntity());
+            var provided = Assert.IsType<Providedf>(rewritten);
+            var quotient = Assert.IsType<Divf>(provided.Expression);
+            Assert.Equal("x + y".ToEntity(), quotient.Dividend);
+            Assert.Equal("x - y".ToEntity(), quotient.Divisor);
+            var negated = Assert.IsType<Notf>(provided.Predicate);
+            var equality = Assert.IsType<Equalsf>(negated.Argument);
+            Assert.Equal("x + y".ToEntity(), equality.Left);
+            Assert.Equal(Integer.Create(0), equality.Right);
+        }
+
+        /// <summary>And the condition has to bite where the cancelled factor vanishes.</summary>
+        [Fact]
+        public void TheConditionMakesTheCancelledPointsUndefined()
+        {
+            var rewritten = RewriteRules.PolynomialGcdCancellation.ApplyOnce(
+                "(x ^ 2 + 2 * x * y + y ^ 2) / (x ^ 2 - y ^ 2)".ToEntity());
+            Assert.Equal(MathS.NaN, rewritten.Substitute("x", 1).Substitute("y", -1).Evaled);
+            Assert.Equal(Integer.Create(3), rewritten.Substitute("x", 2).Substitute("y", 1).Evaled);
+        }
+
+        [Theory]
+        // Already coprime, so there is nothing to do and no condition to invent.
+        [InlineData("(x + y) / (x - y)")]
+        [InlineData("(x ^ 2 + y ^ 2) / (x + y)")]
+        [InlineData("(x + y + z) / (x + y - z)")]
+        // Zero and constants: nothing to have in common.
+        [InlineData("0 / (x + y)")]
+        [InlineData("(x + y) / 0")]
+        [InlineData("0 / 0")]
+        [InlineData("7 / (x + y)")]
+        [InlineData("(x ^ 2 - y ^ 2) / 7")]
+        // No variable in common.
+        [InlineData("(x + 1) / (y + 1)")]
+        [InlineData("(x ^ 2 - 1) / (y ^ 2 - 1)")]
+        // Nine variables, one more than a packed exponent vector holds. Named x_1..x_9 rather
+        // than a..i because i is the imaginary unit, and a quotient carrying that would be
+        // refused for not being a polynomial -- the same answer for the wrong reason.
+        [InlineData("((x_1 + x_2) * (x_3 + x_4)) / ((x_1 + x_2) * (x_5 + x_6 + x_7 + x_8 + x_9))")]
+        // Degree past the cap of 127, and more terms than the ceiling; in both the common
+        // factor is plainly there.
+        [InlineData("((x ^ 130 - y ^ 130) * (x + y)) / ((x ^ 130 - y ^ 130) * (x - y))")]
+        [InlineData("((x + y + z + v + w) ^ 10 * (x + y)) / ((x + y + z + v + w) ^ 10 * (x - y))")]
+        // Not a polynomial over Q: a transcendental factor, a genuine 1/x, a fractional power.
+        [InlineData("(sin(x) * (x + y)) / ((x + y) * (x - y))")]
+        [InlineData("((1 / x + y) * (x + y)) / ((x + y) * (x - y))")]
+        [InlineData("((x + y) ^ 0.5 * (x + y)) / ((x + y) * (x - y))")]
+        public void RefusedRatherThanAnsweredWrongly(string quotient) =>
+            Assert.False(Cancelled(quotient.ToEntity()).HasValue, $"{quotient} was cancelled");
+
+        /// <summary>
+        /// The complexity bound is on the input's node count, and it is there because this runs
+        /// on every quotient the simplifier builds rather than because a larger one would be
+        /// wrong. So it is a refusal, and the same quotient written compactly is cancelled.
+        /// </summary>
+        [Fact]
+        public void AQuotientPastTheComplexityBoundIsLeftAlone()
+        {
+            Entity numerator = "x + y".ToEntity();
+            Entity denominator = "x - y".ToEntity();
+            for (var i = 0; i < 40; i++)
+            {
+                numerator *= $"x + {i} * y + 1".ToEntity();
+                denominator *= $"x + {i} * y + 1".ToEntity();
+            }
+            Assert.True(numerator.Complexity + denominator.Complexity > 256);
+            Assert.False(Cancelled(numerator / denominator).HasValue);
+        }
+
+        #endregion
+    }
+}

--- a/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialFactorizationTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialFactorizationTest.cs
@@ -391,7 +391,7 @@ namespace AngouriMath.Tests.Algebra.Polynomials
                 .OrderBy(s => s, System.StringComparer.Ordinal).ToArray();
             Assert.Equal(4, got.Length);
             Assert.All(parts, p => Assert.Equal(1, p.Multiplicity));
-            var rebuilt = Product(parts.Select(p => p.Factor).ToArray());
+            var rebuilt = Product(parts!.Select(p => p.Factor).ToArray());
             Assert.True(rebuilt.SameAs(P(-1, 0, 0, 0, 0, 0, 1)));
         }
 

--- a/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialFactorizationTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialFactorizationTest.cs
@@ -1,0 +1,477 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Extensions;
+using AngouriMath.Functions;
+using PeterO.Numbers;
+using Xunit;
+using static AngouriMath.Entity;
+
+namespace AngouriMath.Tests.Algebra.Polynomials
+{
+    /// <summary>
+    /// Univariate factorisation over the rationals — square-free decomposition, then
+    /// Berlekamp modulo a prime, then a Hensel lift and recombination.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> item 43.
+    /// </summary>
+    [Trait("Area", "Polynomials")]
+    public sealed class PolynomialFactorizationTest
+    {
+        /// <summary>Coefficients lowest power first, the order the layer uses throughout.</summary>
+        private static IntegerPolynomial P(params long[] coefficients)
+            => IntegerPolynomial.Create(coefficients.Select(EInteger.FromInt64).ToArray());
+
+        private static IntegerPolynomial Product(params IntegerPolynomial[] factors)
+        {
+            var product = IntegerPolynomial.One;
+            foreach (var factor in factors)
+            {
+                Assert.NotNull(product.Multiply(factor));
+                product = product.Multiply(factor)!;
+            }
+            return product;
+        }
+
+        #region the dense integer polynomial itself
+
+        [Fact]
+        public void TrailingZeroesAreNotStored()
+        {
+            Assert.Equal(-1, P().Degree);
+            Assert.Equal(-1, P(0, 0, 0).Degree);
+            Assert.True(P(0, 0).IsZero);
+            Assert.Equal(1, P(1, 2, 0, 0).Degree);
+        }
+
+        [Fact]
+        public void ArithmeticIsWhatItSays()
+        {
+            // (1 + x) + (1 - x) = 2
+            Assert.True(P(1, 1).Add(P(1, -1)).SameAs(P(2)));
+            // (1 + x) - (1 - x) = 2x
+            Assert.True(P(1, 1).Subtract(P(1, -1)).SameAs(P(0, 2)));
+            // (1 + x)(1 - x) = 1 - x^2
+            Assert.True(P(1, 1).Multiply(P(1, -1))!.SameAs(P(1, 0, -1)));
+            // (x - 1)(x^2 + x + 1) = x^3 - 1
+            Assert.True(P(-1, 1).Multiply(P(1, 1, 1))!.SameAs(P(-1, 0, 0, 1)));
+        }
+
+        [Fact]
+        public void ExactDivisionRefusesWhatItCannotDivide()
+        {
+            Assert.True(P(-1, 0, 0, 1).DivideExact(P(-1, 1))!.SameAs(P(1, 1, 1)));
+            // x^2 + 1 has no linear factor over Z, and the division must say so rather
+            // than round: this is the check every candidate factor is accepted on.
+            Assert.Null(P(1, 0, 1).DivideExact(P(-1, 1)));
+            // Exact over Q but not over Z, which is not good enough here.
+            Assert.Null(P(1, 1).DivideExact(P(2)));
+            Assert.True(P(2, 2).DivideExact(P(2))!.SameAs(P(1, 1)));
+            Assert.Null(P(1, 1).DivideExact(IntegerPolynomial.Zero));
+        }
+
+        [Fact]
+        public void DerivativeAndContent()
+        {
+            // (x^3 - 1)' = 3x^2
+            Assert.True(P(-1, 0, 0, 1).Derivative().SameAs(P(0, 0, 3)));
+            Assert.True(P(7).Derivative().IsZero);
+            Assert.Equal(EInteger.FromInt32(6), P(6, 12, -18).Content());
+            // The primitive part carries the sign, so that two greatest common divisors
+            // computed by different routes are comparable rather than merely associate.
+            Assert.True(P(-2, -4).PrimitivePart().SameAs(P(1, 2)));
+            Assert.True(P(6, 12, -18).PrimitivePart().SameAs(P(-1, -2, 3)));
+        }
+
+        #endregion
+
+        #region greatest common divisor over Z
+
+        [Theory]
+        // gcd(x^2 - 1, x^2 + 2x + 1) = x + 1
+        [InlineData(new long[] { -1, 0, 1 }, new long[] { 1, 2, 1 }, new long[] { 1, 1 })]
+        // gcd(x^3 - 1, x^2 - 1) = x - 1
+        [InlineData(new long[] { -1, 0, 0, 1 }, new long[] { -1, 0, 1 }, new long[] { -1, 1 })]
+        // Coprime.
+        [InlineData(new long[] { 1, 0, 1 }, new long[] { 2, 0, 1 }, new long[] { 1 })]
+        // The content is part of the divisor: gcd(2x^2 - 2, 4x + 4) = 2x + 2.
+        [InlineData(new long[] { -2, 0, 2 }, new long[] { 4, 4 }, new long[] { 2, 2 })]
+        // One divides the other.
+        [InlineData(new long[] { -1, 0, 1 }, new long[] { -1, 1 }, new long[] { -1, 1 })]
+        public void GcdIsWhatItShouldBe(long[] left, long[] right, long[] expected)
+        {
+            var gcd = IntegerPolynomial.Gcd(P(left), P(right));
+            Assert.True(gcd.SameAs(P(expected)), $"expected {P(expected)}, got {gcd}");
+            // Symmetric, and a divisor of both — checked by dividing, not by trusting.
+            Assert.True(IntegerPolynomial.Gcd(P(right), P(left)).SameAs(P(expected)));
+            Assert.NotNull(P(left).DivideExact(gcd));
+            Assert.NotNull(P(right).DivideExact(gcd));
+        }
+
+        [Fact]
+        public void GcdWithZeroIsTheOtherOne()
+        {
+            Assert.True(IntegerPolynomial.Gcd(P(-2, -2), IntegerPolynomial.Zero).SameAs(P(2, 2)));
+            Assert.True(IntegerPolynomial.Gcd(IntegerPolynomial.Zero, IntegerPolynomial.Zero).IsZero);
+        }
+
+        /// <summary>
+        /// The quotients by the greatest common divisor share nothing further, which is the
+        /// half of the definition that a merely-common divisor would fail.
+        /// </summary>
+        [Fact]
+        public void QuotientsByTheGcdAreCoprime()
+        {
+            var left = Product(P(1, 1), P(1, 1), P(-2, 1));
+            var right = Product(P(1, 1), P(3, 1));
+            var gcd = IntegerPolynomial.Gcd(left, right);
+            Assert.True(gcd.SameAs(P(1, 1)));
+            var quotientLeft = left.DivideExact(gcd);
+            var quotientRight = right.DivideExact(gcd);
+            Assert.NotNull(quotientLeft);
+            Assert.NotNull(quotientRight);
+            Assert.True(IntegerPolynomial.Gcd(quotientLeft!, quotientRight!).IsConstant);
+        }
+
+        #endregion
+
+        #region square-free decomposition
+
+        [Fact]
+        public void YunSeparatesTheMultiplicities()
+        {
+            // (x + 1)^2 (x + 2)
+            var poly = Product(P(1, 1), P(1, 1), P(2, 1));
+            var parts = SquareFreeDecomposition.Decompose(poly);
+            Assert.NotNull(parts);
+            Assert.Equal(2, parts!.Count);
+            Assert.True(parts.Single(p => p.Multiplicity == 1).Factor.SameAs(P(2, 1)));
+            Assert.True(parts.Single(p => p.Multiplicity == 2).Factor.SameAs(P(1, 1)));
+        }
+
+        [Fact]
+        public void ASquareFreeInputComesBackWhole()
+        {
+            var poly = P(-1, 0, 1);                       // x^2 - 1
+            var parts = SquareFreeDecomposition.Decompose(poly);
+            Assert.NotNull(parts);
+            var part = Assert.Single(parts!);
+            Assert.Equal(1, part.Multiplicity);
+            Assert.True(part.Factor.SameAs(poly));
+        }
+
+        [Fact]
+        public void APurePowerIsOnePartAtItsMultiplicity()
+        {
+            // (x^2 + 1)^3, whose repeated factor has no rational root at all — the case a
+            // root-finding factoriser cannot see.
+            var poly = Product(P(1, 0, 1), P(1, 0, 1), P(1, 0, 1));
+            var parts = SquareFreeDecomposition.Decompose(poly);
+            Assert.NotNull(parts);
+            var part = Assert.Single(parts!);
+            Assert.Equal(3, part.Multiplicity);
+            Assert.True(part.Factor.SameAs(P(1, 0, 1)));
+        }
+
+        /// <summary>
+        /// The three properties that define the decomposition, on a spread of inputs built
+        /// so that the multiplicities are known in advance but the routine is not told them.
+        /// </summary>
+        [Theory]
+        [InlineData(2, 1, 1)]
+        [InlineData(1, 2, 1)]
+        [InlineData(3, 1, 2)]
+        [InlineData(1, 1, 4)]
+        [InlineData(2, 3, 1)]
+        public void TheDecompositionMultipliesBackAndIsSquareFree(int first, int second, int third)
+        {
+            var bases = new[] { P(-1, 1), P(1, 0, 1), P(2, 1) };
+            var powers = new[] { first, second, third };
+            var poly = IntegerPolynomial.One;
+            for (var i = 0; i < bases.Length; i++)
+                for (var j = 0; j < powers[i]; j++)
+                    poly = poly.Multiply(bases[i])!;
+
+            var parts = SquareFreeDecomposition.Decompose(poly);
+            Assert.NotNull(parts);
+
+            var rebuilt = IntegerPolynomial.One;
+            foreach (var part in parts!)
+            {
+                // Square-free: sharing nothing with its own derivative.
+                Assert.True(IntegerPolynomial.Gcd(part.Factor, part.Factor.Derivative()).IsConstant);
+                for (var i = 0; i < part.Multiplicity; i++)
+                    rebuilt = rebuilt.Multiply(part.Factor)!;
+            }
+            Assert.True(rebuilt.SameAs(poly.PrimitivePart()));
+
+            // Pairwise coprime.
+            for (var i = 0; i < parts.Count; i++)
+                for (var j = i + 1; j < parts.Count; j++)
+                    Assert.True(IntegerPolynomial.Gcd(parts[i].Factor, parts[j].Factor).IsConstant);
+        }
+
+        #endregion
+
+        #region factorisation into irreducibles
+
+        /// <summary>
+        /// A deterministic table of polynomials irreducible over <c>Q</c>. Products of these
+        /// are the inputs of the sweep below, so that the answer is known before the
+        /// factoriser is asked.
+        /// </summary>
+        private static readonly IntegerPolynomial[] Irreducibles =
+        {
+            P(1, 1),            // x + 1
+            P(-1, 1),           // x - 1
+            P(2, 1),            // x + 2
+            P(-3, 1),           // x - 3
+            P(1, 2),            // 2x + 1
+            P(1, 0, 1),         // x^2 + 1
+            P(2, 0, 1),         // x^2 + 2
+            P(-2, 0, 1),        // x^2 - 2
+            P(1, 1, 1),         // x^2 + x + 1
+            P(-2, 0, 0, 1),     // x^3 - 2, Eisenstein at 2
+        };
+
+        public static IEnumerable<object[]> IrreduciblePairs()
+        {
+            for (var i = 0; i < Irreducibles.Length; i++)
+                for (var j = i; j < Irreducibles.Length; j++)
+                    yield return new object[] { i, j };
+        }
+
+        /// <summary>
+        /// Every product of two irreducibles from the table factors back into exactly those
+        /// two. Squares are included, so this covers the repeated case as well.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(IrreduciblePairs))]
+        public void AProductOfTwoIrreduciblesFactorsBackIntoThem(int first, int second)
+        {
+            var expected = new[] { Irreducibles[first], Irreducibles[second] };
+            var poly = Product(expected);
+
+            var parts = PolynomialFactorization.FactorPrimitive(poly.PrimitivePart());
+            Assert.NotNull(parts);
+
+            var got = new List<string>();
+            foreach (var part in parts!)
+                for (var i = 0; i < part.Multiplicity; i++)
+                    got.Add(part.Factor.ToString());
+            Assert.Equal(
+                expected.Select(f => f.ToString()).OrderBy(s => s, System.StringComparer.Ordinal).ToArray(),
+                got.OrderBy(s => s, System.StringComparer.Ordinal).ToArray());
+        }
+
+        public static IEnumerable<object[]> IrreducibleTriples()
+        {
+            for (var i = 0; i < Irreducibles.Length; i += 2)
+                for (var j = i; j < Irreducibles.Length; j += 3)
+                    for (var k = j; k < Irreducibles.Length; k += 4)
+                        yield return new object[] { i, j, k };
+        }
+
+        [Theory]
+        [MemberData(nameof(IrreducibleTriples))]
+        public void AProductOfThreeIrreduciblesFactorsBackIntoThem(int first, int second, int third)
+        {
+            var expected = new[] { Irreducibles[first], Irreducibles[second], Irreducibles[third] };
+            var poly = Product(expected);
+            if (poly.Degree > IntegerPolynomial.MaxDegree)
+                return;
+
+            var parts = PolynomialFactorization.FactorPrimitive(poly.PrimitivePart());
+            Assert.NotNull(parts);
+
+            var got = new List<string>();
+            foreach (var part in parts!)
+                for (var i = 0; i < part.Multiplicity; i++)
+                    got.Add(part.Factor.ToString());
+            Assert.Equal(
+                expected.Select(f => f.ToString()).OrderBy(s => s, System.StringComparer.Ordinal).ToArray(),
+                got.OrderBy(s => s, System.StringComparer.Ordinal).ToArray());
+        }
+
+        /// <summary>
+        /// Irreducible over <c>Q</c>, and each of these is a trap for a different reason.
+        /// <c>x^4 + 1</c> and <c>x^4 - 10x^2 + 1</c> are the classical ones: both factor
+        /// modulo <i>every</i> prime, so a factoriser that reads its answer off the modular
+        /// factorisation instead of recombining and dividing will split them and be wrong.
+        /// </summary>
+        [Theory]
+        [InlineData(new long[] { -2, 0, 1 })]              // x^2 - 2
+        [InlineData(new long[] { 1, 1, 1 })]               // x^2 + x + 1
+        [InlineData(new long[] { -2, 0, 0, 1 })]           // x^3 - 2
+        [InlineData(new long[] { 1, 0, 0, 0, 1 })]         // x^4 + 1
+        [InlineData(new long[] { 1, 0, -10, 0, 1 })]       // x^4 - 10x^2 + 1
+        [InlineData(new long[] { -1, -1, 0, 0, 0, 1 })]    // x^5 - x - 1
+        public void AnIrreduciblePolynomialIsReportedAsOneFactor(long[] coefficients)
+        {
+            var parts = PolynomialFactorization.FactorPrimitive(P(coefficients));
+            Assert.NotNull(parts);
+            var part = Assert.Single(parts!);
+            Assert.Equal(1, part.Multiplicity);
+            Assert.True(part.Factor.SameAs(P(coefficients)));
+        }
+
+        /// <summary>
+        /// The Swinnerton-Dyer polynomial with roots <c>±√2 ±√3 ±√5</c>. It is irreducible
+        /// over <c>Q</c> and yet has no irreducible factor of degree above two modulo
+        /// <i>any</i> prime, so the recombination has to try every subset of the four modular
+        /// quadratics, find that none of them divides, and conclude irreducibility from the
+        /// search being exhausted. Nothing smaller exercises that path.
+        /// </summary>
+        [Fact]
+        public void TheSwinnertonDyerOctichIsIrreducible()
+        {
+            var poly = P(576, 0, -960, 0, 352, 0, -40, 0, 1);
+            var parts = PolynomialFactorization.FactorPrimitive(poly);
+            Assert.NotNull(parts);
+            var part = Assert.Single(parts!);
+            Assert.Equal(1, part.Multiplicity);
+            Assert.True(part.Factor.SameAs(poly));
+
+            // The defining property, asserted rather than assumed — and with it, evidence
+            // that the answer above came from an exhausted recombination and not from the
+            // shortcut that returns early when the polynomial is irreducible modulo a prime.
+            var usable = 0;
+            foreach (var prime in new long[] { 7, 11, 13, 17, 19, 23 })
+            {
+                var reduced = poly.ToPrimeField(prime);
+                if (reduced is null || !reduced.IsSquareFree)
+                    continue;
+                var modular = PrimeFieldFactorization.Factor(reduced.MakeMonic());
+                Assert.NotNull(modular);
+                Assert.True(modular!.Count >= 2, $"expected a split modulo {prime}, got {modular.Count}");
+                usable++;
+            }
+            Assert.True(usable > 0, "no usable prime, so the property above went unchecked");
+        }
+
+        /// <summary>
+        /// Three quadratics with no rational roots between them. Modulo a prime each may
+        /// split into linear factors, so the recombination has to pair the right ones back
+        /// together rather than returning six linear factors that do not exist over <c>Q</c>.
+        /// </summary>
+        [Fact]
+        public void ThreeRootlessQuadraticsAreRecombinedCorrectly()
+        {
+            var poly = Product(P(1, 0, 1), P(2, 0, 1), P(3, 0, 1));
+            var parts = PolynomialFactorization.FactorPrimitive(poly);
+            Assert.NotNull(parts);
+            Assert.Equal(3, parts!.Count);
+            Assert.All(parts, p => Assert.Equal(2, p.Factor.Degree));
+            Assert.True(Product(parts.Select(p => p.Factor).ToArray()).SameAs(poly));
+        }
+
+        [Fact]
+        public void SixDistinctLinearFactorsAreAllFound()
+        {
+            var expected = new[] { P(-1, 1), P(-2, 1), P(-3, 1), P(-4, 1), P(-5, 1), P(-6, 1) };
+            var parts = PolynomialFactorization.FactorPrimitive(Product(expected));
+            Assert.NotNull(parts);
+            Assert.Equal(6, parts!.Count);
+            Assert.All(parts, p => Assert.Equal(1, p.Factor.Degree));
+        }
+
+        [Fact]
+        public void CyclotomicSixSplitsIntoFour()
+        {
+            // x^6 - 1 = (x - 1)(x + 1)(x^2 + x + 1)(x^2 - x + 1)
+            var parts = PolynomialFactorization.FactorPrimitive(P(-1, 0, 0, 0, 0, 0, 1));
+            Assert.NotNull(parts);
+            var got = parts!.Select(p => p.Factor.ToString())
+                .OrderBy(s => s, System.StringComparer.Ordinal).ToArray();
+            Assert.Equal(4, got.Length);
+            Assert.All(parts, p => Assert.Equal(1, p.Multiplicity));
+            var rebuilt = Product(parts.Select(p => p.Factor).ToArray());
+            Assert.True(rebuilt.SameAs(P(-1, 0, 0, 0, 0, 0, 1)));
+        }
+
+        /// <summary>
+        /// Whatever comes out, multiplying it back has to give what went in. This is the
+        /// property that separates an incomplete factorisation, which is a tolerable answer,
+        /// from a wrong one, which is not.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(IrreduciblePairs))]
+        public void FactoringNeverChangesThePolynomial(int first, int second)
+        {
+            var poly = Product(Irreducibles[first], Irreducibles[second]).PrimitivePart();
+            var parts = PolynomialFactorization.FactorPrimitive(poly);
+            if (parts is null)
+                return;                                   // a refusal is allowed; a wrong answer is not
+            var rebuilt = IntegerPolynomial.One;
+            foreach (var part in parts)
+                for (var i = 0; i < part.Multiplicity; i++)
+                    rebuilt = rebuilt.Multiply(part.Factor)!;
+            Assert.True(rebuilt.SameAs(poly));
+        }
+
+        [Fact]
+        public void FactoringIsDeterministic()
+        {
+            var poly = P(2, 0, 3, 0, 1);                  // (x^2 + 1)(x^2 + 2)
+            var first = PolynomialFactorization.FactorPrimitive(poly);
+            var second = PolynomialFactorization.FactorPrimitive(poly);
+            Assert.NotNull(first);
+            Assert.NotNull(second);
+            Assert.Equal(
+                first!.Select(p => p.Factor.ToString() + "^" + p.Multiplicity).ToArray(),
+                second!.Select(p => p.Factor.ToString() + "^" + p.Multiplicity).ToArray());
+        }
+
+        #endregion
+
+        #region the entity-level entry point
+
+        [Theory]
+        // The case the rational-root factoriser cannot reach: neither factor has a root.
+        [InlineData("x ^ 4 + 3 * x ^ 2 + 2")]
+        [InlineData("x ^ 4 - 5 * x ^ 2 + 4")]
+        [InlineData("x ^ 6 - 1")]
+        [InlineData("x ^ 4 - 1")]
+        [InlineData("2 * x ^ 2 + 3 * x + 1")]
+        [InlineData("6 * x ^ 2 + 18 * x + 12")]
+        [InlineData("x ^ 2 / 2 + 3 * x / 2 + 1")]
+        [InlineData("x ^ 5 + x ^ 4 + x ^ 3 + x ^ 2 + x + 1")]
+        public void TheFactoredFormIsTheSamePolynomial(string input)
+        {
+            Assert.True(PolynomialFactorization.TryFactorIntoIrreducibles(
+                input.ToEntity(), "x", out var factored));
+            var difference = (input.ToEntity() - factored!).Expand().Simplify();
+            while (difference is Providedf(var inner, _))
+                difference = inner;
+            Assert.Equal(Number.Integer.Create(0), difference);
+        }
+
+        [Fact]
+        public void QuarticWithNoRootsStillFactors()
+        {
+            Assert.True(PolynomialFactorization.TryFactorIntoIrreducibles(
+                "x ^ 4 + 3 * x ^ 2 + 2".ToEntity(), "x", out var factored));
+            // Two quadratic factors, neither of which a search for rational roots could find.
+            var product = Assert.IsType<Mulf>(factored);
+            Assert.Equal(2, Mulf.LinearChildren(product).Count());
+        }
+
+        [Theory]
+        [InlineData("x ^ 2 - 2")]
+        [InlineData("x ^ 4 + 1")]
+        [InlineData("x ^ 2 + x + 1")]
+        [InlineData("sin(x) + x ^ 2")]
+        [InlineData("x + 1")]
+        public void NothingIsOfferedWhereThereIsNoFactorisation(string input)
+            => Assert.False(PolynomialFactorization.TryFactorIntoIrreducibles(
+                input.ToEntity(), "x", out _));
+
+        #endregion
+    }
+}

--- a/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialResultantTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialResultantTest.cs
@@ -1,0 +1,546 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath.Functions;
+using PeterO.Numbers;
+using Xunit;
+using static AngouriMath.Entity;
+
+namespace AngouriMath.Tests.Algebra.Polynomials
+{
+    /// <summary>
+    /// The resultant and the discriminant, checked against two oracles that know nothing
+    /// about how the library computes them: the product over the differences of the roots,
+    /// and the determinant of the Sylvester matrix taken by cofactor expansion.
+    /// </summary>
+    /// <remarks>
+    /// The oracles are the point of this file. A resultant is easy to compute in a way that
+    /// is wrong only in its sign, or only on an argument free of the main variable, and a
+    /// test that reproduced the implementation's own reasoning would agree with it in every
+    /// one of those cases. Both oracles here are definitions rather than algorithms, and the
+    /// second is deliberately the slowest way of taking a determinant there is — which is
+    /// what a test is the right place for.
+    /// </remarks>
+    [Trait("Area", "Algebra")]
+    public sealed class PolynomialResultantTest
+    {
+        private static readonly int[] NoOtherVariables = Array.Empty<int>();
+
+        private static ERational Rational(int numerator, int denominator = 1)
+            => ERational.Create(EInteger.FromInt32(numerator), EInteger.FromInt32(denominator));
+
+        private static ERational[] Rationals(IReadOnlyList<int> values)
+        {
+            var result = new ERational[values.Count];
+            for (var i = 0; i < values.Count; i++)
+                result[i] = Rational(values[i]);
+            return result;
+        }
+
+        private static ERational Raise(ERational value, int power)
+        {
+            var result = ERational.One;
+            for (var i = 0; i < power; i++)
+                result = result.Multiply(value).ToLowestTerms();
+            return result;
+        }
+
+        private static Variable[] Vars(params string[] names)
+            => names.Select(name => (Variable)name).ToArray();
+
+        /// <summary>One variable, coefficients from the constant term upwards.</summary>
+        private static MultivariatePolynomial Univariate(IReadOnlyList<ERational> coefficients)
+        {
+            var result = MultivariatePolynomial.Zero(1);
+            for (var power = 0; power < coefficients.Count; power++)
+                if (!coefficients[power].IsZero)
+                    result = result.Add(
+                        MultivariatePolynomial.Constant(1, coefficients[power]).ShiftedBy(0, power)!);
+            return result;
+        }
+
+        private static MultivariatePolynomial Parse(string expression, params string[] variables)
+        {
+            var indices = new Dictionary<Variable, int>(variables.Length);
+            for (var i = 0; i < variables.Length; i++)
+                indices[(Variable)variables[i]] = i;
+            return MultivariatePolynomial.TryParse(MathS.FromString(expression), indices)
+                ?? throw new InvalidOperationException($"'{expression}' did not read as a polynomial");
+        }
+
+        private static void AssertConstant(ERational expected, MultivariatePolynomial? actual, string what)
+        {
+            Assert.NotNull(actual);
+            Assert.True(actual!.SameAs(MultivariatePolynomial.Constant(actual.VariableCount, expected)),
+                $"{what}: expected {expected}, got {actual.ToEntity(Vars("x"))}");
+        }
+
+        private static void AssertSame(
+            MultivariatePolynomial expected, MultivariatePolynomial? actual, Variable[] variables, string what)
+        {
+            Assert.NotNull(actual);
+            Assert.True(actual!.SameAs(expected),
+                $"{what}: expected {expected.ToEntity(variables)}, got {actual.ToEntity(variables)}");
+        }
+
+        // ---------------------------------------------------------------------------------
+        // The oracles.
+        // ---------------------------------------------------------------------------------
+
+        /// <summary>
+        /// <c>Res(f, g) = lc(f)^deg g * lc(g)^deg f * prod over i, j of (a_i - b_j)</c>, the
+        /// property that makes the resultant worth having in the first place.
+        /// </summary>
+        private static ERational ResultantFromRoots(
+            int leadingLeft, IReadOnlyList<int> leftRoots, int leadingRight, IReadOnlyList<int> rightRoots)
+        {
+            var result = Raise(Rational(leadingLeft), rightRoots.Count)
+                .Multiply(Raise(Rational(leadingRight), leftRoots.Count));
+            foreach (var left in leftRoots)
+                foreach (var right in rightRoots)
+                    result = result.Multiply(Rational(left - right));
+            return result.ToLowestTerms();
+        }
+
+        /// <summary>
+        /// <c>disc(f) = lc(f)^(2n - 2) * prod over i &lt; j of (a_i - a_j)^2</c>.
+        /// </summary>
+        private static ERational DiscriminantFromRoots(int leading, IReadOnlyList<int> roots)
+        {
+            var result = Raise(Rational(leading), 2 * roots.Count - 2);
+            for (var i = 0; i < roots.Count; i++)
+                for (var j = i + 1; j < roots.Count; j++)
+                    result = result.Multiply(Raise(Rational(roots[i] - roots[j]), 2));
+            return result.ToLowestTerms();
+        }
+
+        /// <summary>
+        /// The determinant of the Sylvester matrix by cofactor expansion. Both coefficient
+        /// lists run from the constant term upwards and end in a nonzero entry.
+        /// </summary>
+        private static ERational SylvesterResultant(
+            IReadOnlyList<ERational> left, IReadOnlyList<ERational> right)
+        {
+            var leftDegree = left.Count - 1;
+            var rightDegree = right.Count - 1;
+            var size = leftDegree + rightDegree;
+            var matrix = new ERational[size][];
+            for (var row = 0; row < size; row++)
+            {
+                matrix[row] = new ERational[size];
+                for (var column = 0; column < size; column++)
+                    matrix[row][column] = ERational.Zero;
+            }
+            for (var row = 0; row < rightDegree; row++)
+                for (var power = 0; power <= leftDegree; power++)
+                    matrix[row][row + leftDegree - power] = left[power];
+            for (var row = 0; row < leftDegree; row++)
+                for (var power = 0; power <= rightDegree; power++)
+                    matrix[rightDegree + row][row + rightDegree - power] = right[power];
+            return Determinant(matrix);
+        }
+
+        private static ERational Determinant(ERational[][] matrix)
+        {
+            var size = matrix.Length;
+            if (size == 0)
+                return ERational.One;
+            if (size == 1)
+                return matrix[0][0];
+            var total = ERational.Zero;
+            for (var column = 0; column < size; column++)
+            {
+                if (matrix[0][column].IsZero)
+                    continue;
+                var minor = new ERational[size - 1][];
+                for (var row = 1; row < size; row++)
+                {
+                    minor[row - 1] = new ERational[size - 1];
+                    var target = 0;
+                    for (var other = 0; other < size; other++)
+                        if (other != column)
+                            minor[row - 1][target++] = matrix[row][other];
+                }
+                var term = matrix[0][column].Multiply(Determinant(minor));
+                total = column % 2 == 0 ? total.Add(term) : total.Subtract(term);
+            }
+            return total.ToLowestTerms();
+        }
+
+        /// <summary>Multiplied out from <c>leading * prod (x - root)</c>, constant term first.</summary>
+        private static ERational[] FromRoots(int leading, IReadOnlyList<int> roots)
+        {
+            var coefficients = new[] { Rational(leading) };
+            foreach (var root in roots)
+            {
+                var next = new ERational[coefficients.Length + 1];
+                for (var i = 0; i < next.Length; i++)
+                    next[i] = ERational.Zero;
+                for (var i = 0; i < coefficients.Length; i++)
+                {
+                    next[i + 1] = next[i + 1].Add(coefficients[i]);
+                    next[i] = next[i].Subtract(coefficients[i].Multiply(Rational(root)));
+                }
+                coefficients = next;
+            }
+            return coefficients;
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Oracle 1 — the product over the differences of the roots.
+        // ---------------------------------------------------------------------------------
+
+        public static IEnumerable<object[]> RootCases => new[]
+        {
+            // Two monic linears, the smallest case in which the sign can be wrong.
+            new object[] { 1, new[] { 2 }, 1, new[] { 5 } },
+            new object[] { 1, new[] { 1, 2 }, 1, new[] { 3, 4, 5 } },
+            new object[] { 1, new[] { 3, 4, 5 }, 1, new[] { 1, 2 } },
+            // Non-monic on both sides, and a negative leading coefficient.
+            new object[] { 3, new[] { 1, -2 }, -2, new[] { 0, 5, 5 } },
+            new object[] { -1, new[] { 7 }, 4, new[] { -3, -3, -3, 2 } },
+            // A shared root, so the resultant has to come out exactly zero.
+            new object[] { 2, new[] { 1, 3 }, 5, new[] { 3, -1 } },
+            new object[] { 1, new[] { -4 }, 6, new[] { -4 } },
+            // A repeated root on one side only.
+            new object[] { 1, new[] { 2, 2, 2 }, 1, new[] { 0, 1 } },
+            // Degree zero against a positive degree, both ways round, and two constants.
+            new object[] { 7, Array.Empty<int>(), 1, new[] { 1, 2, 3 } },
+            new object[] { 1, new[] { 1, 2, 3 }, 7, Array.Empty<int>() },
+            new object[] { 5, Array.Empty<int>(), 3, Array.Empty<int>() },
+        };
+
+        [Theory]
+        [MemberData(nameof(RootCases))]
+        public void ResultantIsTheProductOverTheDifferencesOfTheRoots(
+            int leadingLeft, int[] leftRoots, int leadingRight, int[] rightRoots)
+        {
+            var left = Univariate(FromRoots(leadingLeft, leftRoots));
+            var right = Univariate(FromRoots(leadingRight, rightRoots));
+            AssertConstant(
+                ResultantFromRoots(leadingLeft, leftRoots, leadingRight, rightRoots),
+                PolynomialResultant.Resultant(left, right, 0, NoOtherVariables),
+                "Res(f, g)");
+        }
+
+        [Theory]
+        [MemberData(nameof(RootCases))]
+        public void SwappingTheArgumentsTurnsTheSignAroundExactlyWhenBothDegreesAreOdd(
+            int leadingLeft, int[] leftRoots, int leadingRight, int[] rightRoots)
+        {
+            var left = Univariate(FromRoots(leadingLeft, leftRoots));
+            var right = Univariate(FromRoots(leadingRight, rightRoots));
+            var forwards = ResultantFromRoots(leadingLeft, leftRoots, leadingRight, rightRoots);
+            var expected = leftRoots.Length * rightRoots.Length % 2 == 0 ? forwards : forwards.Negate();
+            AssertConstant(expected,
+                PolynomialResultant.Resultant(right, left, 0, NoOtherVariables), "Res(g, f)");
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Oracle 2 — the Sylvester determinant.
+        // ---------------------------------------------------------------------------------
+
+        public static IEnumerable<object[]> CoefficientCases => new[]
+        {
+            // Constant term first throughout.
+            new object[] { new[] { 1, 1 }, new[] { -1, 1 } },
+            new object[] { new[] { -1, 0, 1 }, new[] { 2, 3 } },
+            new object[] { new[] { 5, 0, 0, 2 }, new[] { 1, 0, 7 } },
+            // Gaps, so that the elimination meets a zero where it wants a pivot.
+            new object[] { new[] { 1, 0, 0, 0, 1 }, new[] { 0, 1, 0, 1 } },
+            new object[] { new[] { 0, 0, 1 }, new[] { 0, 0, 0, 1 } },
+            // The degree of the remainder falling by more than one, which is where a
+            // remainder-sequence implementation needs its correction factor.
+            new object[] { new[] { 1, 0, 0, 0, 1 }, new[] { 1, 0, 1 } },
+            new object[] { new[] { 3, 0, 0, 0, 0, 1 }, new[] { -1, 0, 0, 4 } },
+            // Negative and non-monic.
+            new object[] { new[] { -7, 2, -5, 3 }, new[] { 4, -4, 1 } },
+            new object[] { new[] { 6, -5, 1 }, new[] { -6, 11, -6, 1 } },
+            // Sharing a factor.
+            new object[] { new[] { -1, 0, 1 }, new[] { -1, -1, 1, 1 } },
+            // An odd number of row interchanges in the elimination, which is the one place
+            // the sign of the determinant can go missing without any other case noticing.
+            // These were searched for rather than guessed: one interchange, then two, then
+            // three, each with a resultant that is not zero.
+            new object[] { new[] { -1, 0, 1 }, new[] { 0, 1 } },
+            new object[] { new[] { -1, -1, -1 }, new[] { 2, 2 } },
+            new object[] { new[] { -2, -2, -2, -2 }, new[] { -2, -2, -2, -1 } },
+            new object[] { new[] { -2, -2, -2, -2, -2 }, new[] { -2, -2, -2, -2 } },
+            // One side, then the other, then both free of the variable.
+            new object[] { new[] { 4 }, new[] { 1, 2, 3 } },
+            new object[] { new[] { 1, 2, 3 }, new[] { 4 } },
+            new object[] { new[] { 4 }, new[] { 9 } },
+        };
+
+        [Theory]
+        [MemberData(nameof(CoefficientCases))]
+        public void ResultantIsTheSylvesterDeterminant(int[] left, int[] right)
+        {
+            var leftCoefficients = Rationals(left);
+            var rightCoefficients = Rationals(right);
+            var first = Univariate(leftCoefficients);
+            var second = Univariate(rightCoefficients);
+            AssertConstant(SylvesterResultant(leftCoefficients, rightCoefficients),
+                PolynomialResultant.Resultant(first, second, 0, NoOtherVariables), "Res(f, g)");
+            AssertConstant(SylvesterResultant(rightCoefficients, leftCoefficients),
+                PolynomialResultant.Resultant(second, first, 0, NoOtherVariables), "Res(g, f)");
+        }
+
+        [Fact]
+        public void RationalCoefficientsAgreeWithTheSylvesterDeterminant()
+        {
+            var left = new[] { Rational(1, 3), Rational(-5, 2), ERational.Zero, Rational(7, 4) };
+            var right = new[] { Rational(-2, 9), Rational(1, 6), Rational(3, 5) };
+            AssertConstant(SylvesterResultant(left, right),
+                PolynomialResultant.Resultant(Univariate(left), Univariate(right), 0, NoOtherVariables),
+                "Res(f, g) over Q");
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Where the resultant vanishes.
+        // ---------------------------------------------------------------------------------
+
+        [Theory]
+        [MemberData(nameof(CoefficientCases))]
+        public void ResultantVanishesExactlyWhereTheGcdHasPositiveDegree(int[] left, int[] right)
+        {
+            var first = Univariate(Rationals(left));
+            var second = Univariate(Rationals(right));
+            var resultant = PolynomialResultant.Resultant(first, second, 0, NoOtherVariables);
+            Assert.NotNull(resultant);
+            var gcd = PolynomialGcd.Gcd(first, second, new[] { 0 }, 0);
+            Assert.NotNull(gcd);
+            Assert.Equal(gcd!.DegreeIn(0) > 0, resultant!.IsZero);
+        }
+
+        // ---------------------------------------------------------------------------------
+        // The conventions on degenerate arguments. Measured against SymPy 1.14 rather than
+        // recalled: there resultant(0, x^2 - 1, x), resultant(3, 0, x) and resultant(0, 0, x)
+        // are all 0, resultant(3, 5, x) is 1, and resultant(x^3 - 1, 5, x) is 125.
+        // ---------------------------------------------------------------------------------
+
+        [Fact]
+        public void AZeroArgumentGivesZeroWhateverTheOtherSideIs()
+        {
+            var zero = Univariate(Array.Empty<ERational>());
+            var quadratic = Univariate(Rationals(new[] { -1, 0, 1 }));
+            var constant = Univariate(Rationals(new[] { 3 }));
+            AssertConstant(ERational.Zero,
+                PolynomialResultant.Resultant(zero, quadratic, 0, NoOtherVariables), "Res(0, f)");
+            AssertConstant(ERational.Zero,
+                PolynomialResultant.Resultant(quadratic, zero, 0, NoOtherVariables), "Res(f, 0)");
+            AssertConstant(ERational.Zero,
+                PolynomialResultant.Resultant(zero, constant, 0, NoOtherVariables), "Res(0, c)");
+            AssertConstant(ERational.Zero,
+                PolynomialResultant.Resultant(constant, zero, 0, NoOtherVariables), "Res(c, 0)");
+            AssertConstant(ERational.Zero,
+                PolynomialResultant.Resultant(zero, zero, 0, NoOtherVariables), "Res(0, 0)");
+        }
+
+        [Fact]
+        public void AConstantArgumentIsRaisedToTheDegreeOfTheOther()
+        {
+            var cubic = Univariate(Rationals(new[] { -1, 0, 0, 1 }));
+            var five = Univariate(Rationals(new[] { 5 }));
+            var three = Univariate(Rationals(new[] { 3 }));
+            AssertConstant(Rational(125),
+                PolynomialResultant.Resultant(five, cubic, 0, NoOtherVariables), "Res(5, f)");
+            AssertConstant(Rational(125),
+                PolynomialResultant.Resultant(cubic, five, 0, NoOtherVariables), "Res(f, 5)");
+            AssertConstant(ERational.One,
+                PolynomialResultant.Resultant(three, five, 0, NoOtherVariables), "Res(3, 5)");
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Discriminants.
+        // ---------------------------------------------------------------------------------
+
+        [Fact]
+        public void DiscriminantOfTheGeneralQuadraticIsBSquaredMinusFourAC()
+        {
+            var names = Vars("a", "b", "c", "x");
+            var quadratic = Parse("a * x ^ 2 + b * x + c", "a", "b", "c", "x");
+            AssertSame(Parse("b ^ 2 - 4 * a * c", "a", "b", "c", "x"),
+                PolynomialResultant.Discriminant(quadratic, 3, new[] { 0, 1, 2 }), names, "disc(a x^2 + b x + c)");
+        }
+
+        [Fact]
+        public void DiscriminantOfTheDepressedCubicIsMinusFourPCubedMinusTwentySevenQSquared()
+        {
+            var names = Vars("p", "q", "x");
+            var cubic = Parse("x ^ 3 + p * x + q", "p", "q", "x");
+            AssertSame(Parse("-4 * p ^ 3 - 27 * q ^ 2", "p", "q", "x"),
+                PolynomialResultant.Discriminant(cubic, 2, new[] { 0, 1 }), names, "disc(x^3 + p x + q)");
+        }
+
+        public static IEnumerable<object[]> DiscriminantRootCases => new[]
+        {
+            new object[] { 1, new[] { 1, 2 } },
+            new object[] { 3, new[] { -1, 4 } },
+            new object[] { 1, new[] { 0, 1, 2 } },
+            new object[] { -2, new[] { 5, -3, 1 } },
+            new object[] { 1, new[] { 1, 2, 3, 4 } },
+            new object[] { 2, new[] { -2, 0, 3, 7 } },
+            // Repeated roots, where the discriminant is zero.
+            new object[] { 1, new[] { 1, 1, 3 } },
+            new object[] { 4, new[] { 2, 2 } },
+            new object[] { 1, new[] { 0, 1, 2, 3, 4 } },
+        };
+
+        [Theory]
+        [MemberData(nameof(DiscriminantRootCases))]
+        public void DiscriminantIsTheSquaredProductOverTheDifferencesOfTheRoots(int leading, int[] roots)
+            => AssertConstant(DiscriminantFromRoots(leading, roots),
+                PolynomialResultant.Discriminant(Univariate(FromRoots(leading, roots)), 0, NoOtherVariables),
+                "disc(f)");
+
+        [Fact]
+        public void DiscriminantOfALinearPolynomialIsOneAndOfAConstantIsZero()
+        {
+            // f' is a nonzero constant for a linear f, so Res(f, f') is lc(f) and dividing it
+            // out leaves 1. For a constant f the derivative is zero and so is Res(f, 0),
+            // which is what SymPy answers for discriminant(5, x) as well.
+            AssertConstant(ERational.One,
+                PolynomialResultant.Discriminant(
+                    Univariate(Rationals(new[] { 7, -3 })), 0, NoOtherVariables), "disc(a x + b)");
+            AssertConstant(ERational.Zero,
+                PolynomialResultant.Discriminant(
+                    Univariate(Rationals(new[] { 5 })), 0, NoOtherVariables), "disc(c)");
+            AssertConstant(ERational.Zero,
+                PolynomialResultant.Discriminant(
+                    Univariate(Array.Empty<ERational>()), 0, NoOtherVariables), "disc(0)");
+        }
+
+        [Fact]
+        public void ANonMonicCubicAgreesWithSympy()
+        {
+            // SymPy 1.14, f = 2 x^3 - 3 x + 1: resultant(f, diff(f, x), x) is -216 and
+            // discriminant(f, x) is 108, so (-1)^(n (n - 1) / 2) is -1 at n = 3.
+            var cubic = Univariate(Rationals(new[] { 1, -3, 0, 2 }));
+            var derivative = Univariate(Rationals(new[] { -3, 0, 6 }));
+            AssertConstant(Rational(-216),
+                PolynomialResultant.Resultant(cubic, derivative, 0, NoOtherVariables), "Res(f, f')");
+            AssertConstant(Rational(108),
+                PolynomialResultant.Discriminant(cubic, 0, NoOtherVariables), "disc(f)");
+        }
+
+        [Fact]
+        public void TheDerivativeTheDiscriminantUsesIsTheDerivative()
+        {
+            var poly = Parse("3 * x ^ 4 * y ^ 2 - 5 * x * y + 7 * y + 2", "x", "y");
+            AssertSame(Parse("12 * x ^ 3 * y ^ 2 - 5 * y", "x", "y"),
+                poly.DerivativeIn(0), Vars("x", "y"), "d/dx");
+            AssertSame(Parse("6 * x ^ 4 * y - 5 * x + 7", "x", "y"),
+                poly.DerivativeIn(1), Vars("x", "y"), "d/dy");
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Genuinely several variables.
+        // ---------------------------------------------------------------------------------
+
+        [Fact]
+        public void EliminatingYBetweenACircleAndALineLeavesTheXCoordinatesOfTheIntersections()
+        {
+            // x^2 + y^2 = 1 meets x + y = 1 at (1, 0) and (0, 1), so the eliminant vanishes
+            // at x = 0 and x = 1 and nowhere else. By hand: substituting y = 1 - x into the
+            // circle gives x^2 + (1 - x)^2 - 1, which is 2 x^2 - 2 x.
+            var names = Vars("x", "y");
+            var circle = Parse("x ^ 2 + y ^ 2 - 1", "x", "y");
+            var line = Parse("x + y - 1", "x", "y");
+            var expected = Parse("2 * x ^ 2 - 2 * x", "x", "y");
+            AssertSame(expected, PolynomialResultant.Resultant(circle, line, 1, new[] { 0 }),
+                names, "Res(circle, line)");
+            // deg f * deg g is even here, so the two orders agree.
+            AssertSame(expected, PolynomialResultant.Resultant(line, circle, 1, new[] { 0 }),
+                names, "Res(line, circle)");
+        }
+
+        [Fact]
+        public void EliminatingYBetweenACircleAndAHyperbolaIsTheHandComputedQuartic()
+        {
+            // x^2 + y^2 = 4 and x y = 1: substituting y = 1 / x and clearing the denominator
+            // gives x^4 - 4 x^2 + 1.
+            var circle = Parse("x ^ 2 + y ^ 2 - 4", "x", "y");
+            var hyperbola = Parse("x * y - 1", "x", "y");
+            AssertSame(Parse("x ^ 4 - 4 * x ^ 2 + 1", "x", "y"),
+                PolynomialResultant.Resultant(circle, hyperbola, 1, new[] { 0 }),
+                Vars("x", "y"), "Res(circle, hyperbola)");
+        }
+
+        [Fact]
+        public void AFactorFreeOfTheMainVariableComesOutAsAPowerOfItself()
+        {
+            // Res(c f, g) = c^deg g Res(f, g) and Res(f, c g) = c^deg f Res(f, g), which is
+            // what taking the content out before the elimination relies on. The two degrees
+            // are deliberately different, since equal ones would hide the two exponents
+            // being the wrong way round.
+            var names = Vars("x", "y");
+            var f = Parse("x ^ 3 + 3 * x + 2", "x", "y");
+            var g = Parse("2 * x ^ 2 - x + 5", "x", "y");
+            Assert.Equal(3, f.DegreeIn(0));
+            Assert.Equal(2, g.DegreeIn(0));
+
+            var plain = PolynomialResultant.Resultant(f, g, 0, new[] { 1 });
+            Assert.NotNull(plain);
+            foreach (var content in new[] { Parse("y", "x", "y"), Parse("y + 1", "x", "y") })
+            {
+                AssertSame(plain!.Multiply(content.Power(2)!)!,
+                    PolynomialResultant.Resultant(f.Multiply(content)!, g, 0, new[] { 1 }),
+                    names, "Res(c f, g)");
+                AssertSame(plain.Multiply(content.Power(3)!)!,
+                    PolynomialResultant.Resultant(f, g.Multiply(content)!, 0, new[] { 1 }),
+                    names, "Res(f, c g)");
+                // Both sides at once: c^deg g from the left and c^deg f from the right.
+                AssertSame(plain.Multiply(content.Power(5)!)!,
+                    PolynomialResultant.Resultant(f.Multiply(content)!, g.Multiply(content)!, 0, new[] { 1 }),
+                    names, "Res(c f, c g)");
+            }
+        }
+
+        [Fact]
+        public void TheDiscriminantOfAQuadraticInOneVariableSeesTheOther()
+        {
+            // y x^2 + (y + 1) x + 3 read in x, so b^2 - 4 a c is (y + 1)^2 - 12 y.
+            var poly = Parse("y * x ^ 2 + (y + 1) * x + 3", "x", "y");
+            AssertSame(Parse("y ^ 2 - 10 * y + 1", "x", "y"),
+                PolynomialResultant.Discriminant(poly, 0, new[] { 1 }), Vars("x", "y"), "disc in x");
+        }
+
+        // ---------------------------------------------------------------------------------
+        // Refusal.
+        // ---------------------------------------------------------------------------------
+
+        [Fact]
+        public void InputTooLargeForTheEliminationIsRefusedRatherThanAttempted()
+        {
+            var coefficients = new ERational[21];
+            for (var power = 0; power < coefficients.Length; power++)
+                coefficients[power] = Rational(power % 5 + 1);
+            var poly = Univariate(coefficients);
+            Assert.Null(PolynomialResultant.Resultant(poly, poly, 0, NoOtherVariables));
+            Assert.Null(PolynomialResultant.Discriminant(poly, 0, NoOtherVariables));
+        }
+
+        [Fact]
+        public void TheLargestAdmittedEliminationStillAnswers()
+        {
+            // deg f + deg g of exactly the ceiling, so that the refusal above reads as a
+            // bound rather than as a description of everything past a handful of terms.
+            var leftRoots = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
+            var rightRoots = new[] { 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24 };
+            AssertConstant(
+                ResultantFromRoots(1, leftRoots, 1, rightRoots),
+                PolynomialResultant.Resultant(
+                    Univariate(FromRoots(1, leftRoots)), Univariate(FromRoots(1, rightRoots)),
+                    0, NoOtherVariables),
+                "Res(f, g) at the ceiling");
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Algebra/Polynomials/PrimeFieldFactorizationTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/Polynomials/PrimeFieldFactorizationTest.cs
@@ -1,0 +1,482 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath.Functions;
+using PeterO.Numbers;
+using Xunit;
+
+namespace AngouriMath.Tests.Algebra.Polynomials
+{
+    /// <summary>
+    /// Arithmetic over <c>F_p</c> and Berlekamp factorisation on it.
+    /// </summary>
+    /// <remarks>
+    /// The test that carries the weight is
+    /// <see cref="EveryMonicPolynomialOfSmallDegreeFactorsCorrectly"/>: every monic
+    /// polynomial of degree 2 to 4 over <c>F_2</c>, <c>F_3</c> and <c>F_5</c>, checked
+    /// against a brute-force trial division that shares no code with the algorithm under
+    /// test. The hand-computed cases above it say what a given answer should be; only the
+    /// exhaustive one says that nothing in between is wrong. Its oracle is itself checked,
+    /// in <see cref="TrialDivisionAgreesWithGausssCount"/>, against Gauss's count of the
+    /// monic irreducibles — otherwise an oracle that called everything irreducible would
+    /// pass silently.
+    /// </remarks>
+    [Trait("Area", "Algebra")]
+    public sealed class PrimeFieldFactorizationTest
+    {
+        private static PrimeFieldPolynomial Poly(long prime, params long[] coefficientsLowestFirst)
+            => PrimeFieldPolynomial.Create(coefficientsLowestFirst, prime);
+
+        private static void AssertSame(PrimeFieldPolynomial expected, PrimeFieldPolynomial actual)
+            => Assert.True(expected.SameAs(actual), $"expected {expected}, got {actual}");
+
+        /// <summary>The factorisation, having asserted that there is one.</summary>
+        private static IReadOnlyList<PrimeFieldPolynomial> Factored(PrimeFieldPolynomial poly)
+        {
+            var factors = PrimeFieldFactorization.Factor(poly);
+            Assert.True(factors is not null, $"declined to factor {poly}");
+            return factors!;
+        }
+
+        /// <summary>Every monic polynomial of the given degree, in a fixed order.</summary>
+        private static IEnumerable<PrimeFieldPolynomial> MonicPolynomials(long prime, int degree)
+        {
+            var count = 1L;
+            for (var i = 0; i < degree; i++)
+                count *= prime;
+            for (var index = 0L; index < count; index++)
+            {
+                var coefficients = new long[degree + 1];
+                coefficients[degree] = 1;
+                var rest = index;
+                for (var i = 0; i < degree; i++)
+                {
+                    coefficients[i] = rest % prime;
+                    rest /= prime;
+                }
+                yield return PrimeFieldPolynomial.Create(coefficients, prime);
+            }
+        }
+
+        /// <summary>
+        /// Irreducibility decided by dividing by every monic polynomial that could be a
+        /// proper factor. Deliberately shares nothing with Berlekamp beyond the division.
+        /// </summary>
+        private static bool IsIrreducibleByTrialDivision(PrimeFieldPolynomial poly)
+        {
+            if (poly.Degree < 1)
+                return false;
+            for (var degree = 1; 2 * degree <= poly.Degree; degree++)
+                foreach (var candidate in MonicPolynomials(poly.Prime, degree))
+                    if (poly.Remainder(candidate).IsZero)
+                        return false;
+            return true;
+        }
+
+        // --- construction and the shape of the representation ---
+
+        [Fact]
+        public void CreateReducesIntoTheFieldAndDropsTrailingZeros()
+        {
+            // -1 is 4 and -7 is 3 modulo 5; 10 and 15 are 0 and so are not stored at all.
+            var poly = Poly(5, -1, -7, 10, 15);
+            Assert.Equal(new long[] { 4, 3 }, poly.Coefficients);
+            Assert.Equal(1, poly.Degree);
+            Assert.False(poly.IsZero);
+            Assert.False(poly.IsMonic);
+        }
+
+        [Fact]
+        public void ZeroHasDegreeMinusOneAndIsNotMonic()
+        {
+            var zero = PrimeFieldPolynomial.Zero(7);
+            Assert.True(zero.IsZero);
+            Assert.Equal(-1, zero.Degree);
+            Assert.False(zero.IsMonic);
+            Assert.Empty(zero.Coefficients);
+            AssertSame(zero, Poly(7, 0, 0, 0));
+        }
+
+        [Fact]
+        public void OneAndMonomialAreWhatTheySay()
+        {
+            Assert.Equal(new long[] { 1 }, PrimeFieldPolynomial.One(7).Coefficients);
+            Assert.True(PrimeFieldPolynomial.One(7).IsMonic);
+            Assert.Equal(new long[] { 0, 0, 0, 1 }, PrimeFieldPolynomial.Monomial(3, 7).Coefficients);
+            Assert.Equal(3, PrimeFieldPolynomial.Monomial(3, 7).Degree);
+        }
+
+        [Theory]
+        [InlineData(1L)]
+        [InlineData(0L)]
+        [InlineData(-5L)]
+        [InlineData(PrimeFieldPolynomial.MaxPrime + 1)]
+        public void AModulusOutOfRangeIsRefused(long prime)
+            => Assert.Throws<ArgumentOutOfRangeException>(() => PrimeFieldPolynomial.Zero(prime));
+
+        [Fact]
+        public void ANegativeMonomialDegreeIsRefused()
+            => Assert.Throws<ArgumentOutOfRangeException>(() => PrimeFieldPolynomial.Monomial(-1, 5));
+
+        [Fact]
+        public void MixingTwoFieldsIsRefused()
+        {
+            var left = Poly(5, 1, 1);
+            var right = Poly(7, 1, 1);
+            Assert.Throws<ArgumentException>(() => left.Add(right));
+            Assert.Throws<ArgumentException>(() => left.Multiply(right));
+            Assert.Throws<ArgumentException>(() => left.Remainder(right));
+            Assert.False(left.SameAs(right));
+        }
+
+        // --- field arithmetic against hand-computed results ---
+
+        [Fact]
+        public void AdditionAndSubtractionReduceIntoTheField()
+        {
+            // (3 + 5x) + (6 + 4x) = 9 + 9x = 2 + 2x over F_7.
+            AssertSame(Poly(7, 2, 2), Poly(7, 3, 5).Add(Poly(7, 6, 4)));
+            // (3 + 5x) - (6 + 4x) = -3 + x = 4 + x.
+            AssertSame(Poly(7, 4, 1), Poly(7, 3, 5).Subtract(Poly(7, 6, 4)));
+            // A subtraction whose leading terms cancel loses the degree.
+            AssertSame(Poly(7, 4), Poly(7, 3, 5).Subtract(Poly(7, 6, 5)));
+            AssertSame(PrimeFieldPolynomial.Zero(7), Poly(7, 3, 5).Subtract(Poly(7, 3, 5)));
+        }
+
+        [Fact]
+        public void MultiplicationIsConvolutionModuloThePrime()
+        {
+            // (1 + 2x)(3 + 4x) = 3 + 10x + 8x^2 = 3 + 3x^2 over F_5.
+            AssertSame(Poly(5, 3, 0, 3), Poly(5, 1, 2).Multiply(Poly(5, 3, 4)));
+            AssertSame(PrimeFieldPolynomial.Zero(5), Poly(5, 1, 2).Multiply(PrimeFieldPolynomial.Zero(5)));
+            AssertSame(Poly(5, 1, 2), Poly(5, 1, 2).Multiply(PrimeFieldPolynomial.One(5)));
+        }
+
+        [Fact]
+        public void DivisionMatchesTheHandComputation()
+        {
+            // (x^3 + 2x + 1) = (x + 3)(x^2 + 4x + 4) + 3 over F_7.
+            var dividend = Poly(7, 1, 2, 0, 1);
+            var divisor = Poly(7, 3, 1);
+            AssertSame(Poly(7, 4, 4, 1), dividend.Quotient(divisor));
+            AssertSame(Poly(7, 3), dividend.Remainder(divisor));
+        }
+
+        [Fact]
+        public void DivisionByALowerDegreeOrNonMonicDivisorStillReconstructs()
+        {
+            // A divisor of higher degree leaves the dividend untouched as the remainder.
+            var small = Poly(11, 1, 1);
+            var big = Poly(11, 5, 0, 0, 2);
+            Assert.True(small.Quotient(big).IsZero);
+            AssertSame(small, small.Remainder(big));
+
+            // Nothing above assumed a monic divisor; the leading coefficient is inverted.
+            foreach (var dividend in MonicPolynomials(5, 3))
+                foreach (var divisor in new[] { Poly(5, 1, 3), Poly(5, 4, 0, 2), Poly(5, 2) })
+                {
+                    var quotient = dividend.Quotient(divisor);
+                    var remainder = dividend.Remainder(divisor);
+                    Assert.True(remainder.Degree < divisor.Degree);
+                    AssertSame(dividend, quotient.Multiply(divisor).Add(remainder));
+                }
+        }
+
+        [Fact]
+        public void DivisionByZeroIsRefused()
+        {
+            var zero = PrimeFieldPolynomial.Zero(5);
+            Assert.Throws<DivideByZeroException>(() => Poly(5, 1, 1).Quotient(zero));
+            Assert.Throws<DivideByZeroException>(() => Poly(5, 1, 1).Remainder(zero));
+        }
+
+        [Fact]
+        public void MakeMonicDividesByTheLeadingCoefficient()
+        {
+            // 3^-1 is 2 modulo 5, so 4 + 3x becomes 8 + 6x = 3 + x.
+            AssertSame(Poly(5, 3, 1), Poly(5, 4, 3).MakeMonic());
+            AssertSame(PrimeFieldPolynomial.Zero(5), PrimeFieldPolynomial.Zero(5).MakeMonic());
+            AssertSame(PrimeFieldPolynomial.One(5), Poly(5, 4).MakeMonic());
+        }
+
+        // --- greatest common divisor ---
+
+        [Fact]
+        public void GcdOfKnownCases()
+        {
+            // x^2 - 1 = (x - 1)(x + 1) over F_7, so the gcd with x - 1 is x - 1 = x + 6.
+            AssertSame(Poly(7, 6, 1), Poly(7, -1, 0, 1).Gcd(Poly(7, -1, 1)));
+            // x^2 + 1 and x + 1 are coprime over F_7 (-1 is not a square there).
+            AssertSame(PrimeFieldPolynomial.One(7), Poly(7, 1, 0, 1).Gcd(Poly(7, 1, 1)));
+            // The result is monic even where neither argument is.
+            AssertSame(Poly(5, 3, 1), Poly(5, 2, 4).Gcd(Poly(5, 4, 3)));
+        }
+
+        [Fact]
+        public void GcdWithItselfAndWithZero()
+        {
+            foreach (var poly in MonicPolynomials(5, 3).Concat(new[] { Poly(5, 2, 4), Poly(5, 3) }))
+            {
+                AssertSame(poly.MakeMonic(), poly.Gcd(poly));
+                AssertSame(poly.MakeMonic(), poly.Gcd(PrimeFieldPolynomial.Zero(5)));
+                AssertSame(poly.MakeMonic(), PrimeFieldPolynomial.Zero(5).Gcd(poly));
+            }
+            Assert.True(PrimeFieldPolynomial.Zero(5).Gcd(PrimeFieldPolynomial.Zero(5)).IsZero);
+        }
+
+        [Fact]
+        public void GcdDividesBothAndIsDivisibleByEveryCommonDivisor()
+        {
+            foreach (var left in MonicPolynomials(3, 3))
+                foreach (var right in MonicPolynomials(3, 2))
+                {
+                    var gcd = left.Gcd(right);
+                    Assert.True(gcd.IsMonic);
+                    Assert.True(left.Remainder(gcd).IsZero, $"{gcd} does not divide {left}");
+                    Assert.True(right.Remainder(gcd).IsZero, $"{gcd} does not divide {right}");
+                    // Greatest, not merely common: anything dividing both divides it.
+                    foreach (var common in MonicPolynomials(3, 1).Concat(MonicPolynomials(3, 2)))
+                        if (left.Remainder(common).IsZero && right.Remainder(common).IsZero)
+                            Assert.True(gcd.Remainder(common).IsZero, $"{common} divides both but not {gcd}");
+                }
+        }
+
+        // --- powers ---
+
+        [Fact]
+        public void PowModAgreesWithRepeatedMultiplication()
+        {
+            var modulus = Poly(5, 1, 1, 0, 1);
+            foreach (var basePoly in new[] { Poly(5, 3, 2), Poly(5, 0, 1), Poly(5, 4), PrimeFieldPolynomial.Zero(5) })
+            {
+                var expected = PrimeFieldPolynomial.One(5).Remainder(modulus);
+                for (var exponent = 0; exponent <= 20; exponent++)
+                {
+                    AssertSame(expected, basePoly.PowMod(EInteger.FromInt32(exponent), modulus));
+                    expected = expected.Multiply(basePoly).Remainder(modulus);
+                }
+            }
+        }
+
+        [Fact]
+        public void PowModRefusesANegativeExponent()
+            => Assert.Throws<ArgumentOutOfRangeException>(
+                () => Poly(5, 0, 1).PowMod(EInteger.FromInt32(-1), Poly(5, 1, 0, 1)));
+
+        [Fact]
+        public void PowModHandlesAnExponentBeyondLong()
+        {
+            // Fermat in F_p[x]/(f) for an irreducible f of degree 3: the multiplicative
+            // group has p^3 - 1 elements, so anything nonzero raised to it is one.
+            var modulus = Poly(2, 1, 1, 0, 1);
+            var order = EInteger.FromInt32(2).Pow(3).Subtract(EInteger.One);
+            var big = order.Multiply(EInteger.FromString("100000000000000000000000"));
+            AssertSame(PrimeFieldPolynomial.One(2), Poly(2, 0, 1).PowMod(big, modulus));
+        }
+
+        // --- the derivative, including characteristic p ---
+
+        [Fact]
+        public void DerivativeOfTheUsualKind()
+        {
+            // d/dx (3x^2 + 4x + 1) = 6x + 4 over F_7.
+            AssertSame(Poly(7, 4, 6), Poly(7, 1, 4, 3).Derivative());
+            Assert.True(Poly(7, 5).Derivative().IsZero);
+            Assert.True(PrimeFieldPolynomial.Zero(7).Derivative().IsZero);
+        }
+
+        [Theory]
+        [InlineData(2L)]
+        [InlineData(3L)]
+        [InlineData(5L)]
+        [InlineData(7L)]
+        public void TheDerivativeOfXToThePVanishes(long prime)
+        {
+            Assert.True(PrimeFieldPolynomial.Monomial((int)prime, prime).Derivative().IsZero);
+            // And so the whole derivative of any polynomial in x^p does.
+            var poly = PrimeFieldPolynomial.Monomial(2 * (int)prime, prime)
+                .Add(PrimeFieldPolynomial.Monomial((int)prime, prime))
+                .Add(PrimeFieldPolynomial.One(prime));
+            Assert.True(poly.Derivative().IsZero);
+            // Which is exactly the p-th power it is: x^2p + x^p + 1 = (x^2 + x + 1)^p.
+            var root = Poly(prime, 1, 1, 1);
+            var power = PrimeFieldPolynomial.One(prime);
+            for (var i = 0; i < prime; i++)
+                power = power.Multiply(root);
+            AssertSame(poly, power);
+        }
+
+        [Fact]
+        public void SquareFreedomAgreesWithTheDefinition()
+        {
+            Assert.True(Poly(5, 1, 0, 1).IsSquareFree);
+            // x^2 + 1 = (x + 1)^2 over F_2.
+            Assert.False(Poly(2, 1, 0, 1).IsSquareFree);
+            Assert.False(Poly(5, 0, 0, 1).IsSquareFree);
+            // A p-th power has a vanishing derivative rather than a nontrivial gcd with it.
+            Assert.False(PrimeFieldPolynomial.Monomial(5, 5).IsSquareFree);
+            Assert.False(PrimeFieldPolynomial.Zero(5).IsSquareFree);
+            Assert.True(PrimeFieldPolynomial.One(5).IsSquareFree);
+
+            // Against the definition: no monic polynomial of degree >= 1 squares into it.
+            foreach (var poly in MonicPolynomials(3, 4))
+            {
+                var hasSquare = MonicPolynomials(3, 1).Concat(MonicPolynomials(3, 2))
+                    .Any(divisor => poly.Remainder(divisor.Multiply(divisor)).IsZero);
+                Assert.Equal(!hasSquare, poly.IsSquareFree);
+            }
+        }
+
+        // --- known factorisations ---
+
+        [Fact]
+        public void KnownFactorisations()
+        {
+            // x^2 + 1 = (x + 2)(x + 3) over F_5.
+            var overFive = Factored(Poly(5, 1, 0, 1));
+            Assert.Equal(2, overFive.Count);
+            AssertSame(Poly(5, 2, 1), overFive[0]);
+            AssertSame(Poly(5, 3, 1), overFive[1]);
+
+            // x^3 + x + 1 has no root in F_2 and so, being a cubic, is irreducible.
+            var cubic = Poly(2, 1, 1, 0, 1);
+            var overTwo = Factored(cubic);
+            Assert.Equal(1, overTwo.Count);
+            AssertSame(cubic, overTwo[0]);
+
+            // A linear polynomial is its own factorisation.
+            var linear = Poly(5, 4, 1);
+            var linearFactors = Factored(linear);
+            Assert.Equal(1, linearFactors.Count);
+            AssertSame(linear, linearFactors[0]);
+
+            // The unit has no irreducible factors, which is an empty list and not a refusal.
+            Assert.Empty(Factored(PrimeFieldPolynomial.One(5)));
+        }
+
+        [Theory]
+        [InlineData(2L)]
+        [InlineData(3L)]
+        [InlineData(5L)]
+        [InlineData(7L)]
+        public void XToThePMinusXIsTheProductOfEveryLinearFactor(long prime)
+        {
+            var poly = PrimeFieldPolynomial.Monomial((int)prime, prime)
+                .Subtract(PrimeFieldPolynomial.Monomial(1, prime));
+            Assert.True(poly.IsMonic);
+            Assert.True(poly.IsSquareFree);
+
+            var factors = Factored(poly);
+            Assert.Equal((int)prime, factors.Count);
+
+            // Every element of the field is a root, each exactly once.
+            var roots = new HashSet<long>();
+            var product = PrimeFieldPolynomial.One(prime);
+            foreach (var factor in factors)
+            {
+                Assert.Equal(1, factor.Degree);
+                Assert.True(factor.IsMonic);
+                roots.Add((prime - factor.Coefficients[0]) % prime);
+                product = product.Multiply(factor);
+            }
+            Assert.Equal((int)prime, roots.Count);
+            AssertSame(poly, product);
+        }
+
+        [Fact]
+        public void FactorDeclinesWhatItIsNotContractedFor()
+        {
+            // Not square-free: x^2 + 1 = (x + 1)^2 over F_2.
+            Assert.Null(PrimeFieldFactorization.Factor(Poly(2, 1, 0, 1)));
+            // Not monic.
+            Assert.Null(PrimeFieldFactorization.Factor(Poly(5, 1, 0, 2)));
+            // The zero polynomial, which is not monic either.
+            Assert.Null(PrimeFieldFactorization.Factor(PrimeFieldPolynomial.Zero(5)));
+            // A composite modulus is not a field, and the arithmetic itself does not check.
+            Assert.Null(PrimeFieldFactorization.Factor(Poly(4, 1, 0, 1)));
+            // Past the guards rather than hanging on them.
+            Assert.Null(PrimeFieldFactorization.Factor(Poly(1031, 1, 0, 1)));
+            Assert.Null(PrimeFieldFactorization.Factor(
+                PrimeFieldPolynomial.Monomial(PrimeFieldFactorization.MaxDegree + 1, 2)
+                    .Add(PrimeFieldPolynomial.One(2))));
+        }
+
+        [Fact]
+        public void FactoringTwiceGivesTheIdenticalSequence()
+        {
+            // x^6 - 1 splits into all six nonzero linear factors over F_7, so there is
+            // plenty of room for two runs to disagree on an order.
+            var poly = PrimeFieldPolynomial.Monomial(6, 7).Subtract(PrimeFieldPolynomial.One(7));
+            var first = Factored(poly);
+            var second = Factored(poly);
+            Assert.Equal(6, first.Count);
+            Assert.Equal(first.Count, second.Count);
+            for (var i = 0; i < first.Count; i++)
+                AssertSame(first[i], second[i]);
+        }
+
+        // --- the exhaustive cross-check, and the check on its oracle ---
+
+        [Theory]
+        [InlineData(2L)]
+        [InlineData(3L)]
+        [InlineData(5L)]
+        public void TrialDivisionAgreesWithGausssCount(long prime)
+        {
+            // Gauss's count of the monic irreducibles of degree d over F_p is
+            // (1/d) sum over e dividing d of mu(e) p^(d/e). If the oracle below were
+            // wrong in either direction -- and one that answered "irreducible" always
+            // would leave the exhaustive test toothless -- these would not match.
+            var expected = new[]
+            {
+                prime,
+                (prime * prime - prime) / 2,
+                (prime * prime * prime - prime) / 3,
+                (prime * prime * prime * prime - prime * prime) / 4,
+            };
+            for (var degree = 1; degree <= 4; degree++)
+                Assert.Equal(
+                    expected[degree - 1],
+                    MonicPolynomials(prime, degree).Count(IsIrreducibleByTrialDivision));
+        }
+
+        [Theory]
+        [InlineData(2L)]
+        [InlineData(3L)]
+        [InlineData(5L)]
+        public void EveryMonicPolynomialOfSmallDegreeFactorsCorrectly(long prime)
+        {
+            for (var degree = 2; degree <= 4; degree++)
+                foreach (var poly in MonicPolynomials(prime, degree))
+                {
+                    if (!poly.IsSquareFree)
+                    {
+                        Assert.Null(PrimeFieldFactorization.Factor(poly));
+                        continue;
+                    }
+                    var factors = Factored(poly);
+
+                    var product = PrimeFieldPolynomial.One(prime);
+                    foreach (var factor in factors)
+                    {
+                        Assert.True(factor.IsMonic, $"{factor} is a factor of {poly} but is not monic");
+                        Assert.True(factor.Degree >= 1, $"{poly} was given the unit {factor} as a factor");
+                        Assert.True(
+                            IsIrreducibleByTrialDivision(factor),
+                            $"{factor} is a factor of {poly} but is not irreducible");
+                        product = product.Multiply(factor);
+                    }
+                    Assert.True(
+                        product.SameAs(poly),
+                        $"{poly} is not the product of {string.Join(" * ", factors)}");
+                }
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/UnitTests.csproj
+++ b/Sources/Tests/UnitTests/UnitTests.csproj
@@ -4,6 +4,11 @@
     <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <!-- Signed with the library's own key so that its InternalsVisibleTo can name this
+         assembly: a strong-named assembly may only befriend another strong-named one. -->
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\AngouriMath\key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes the four pieces named by item 43 of #746 — *"the single highest-leverage piece of work on this list"*: multivariate GCD, resultants, factorisation over ℚ and 𝔽ₚ, and square-free decomposition.

## What was actually missing

Of the four, only the multivariate GCD existed. It was also **untestable**: everything in `Functions/Algebra/Polynomials` is `internal`, `InternalsVisibleTo` was commented out, so the only coverage was seventeen cases reading answers off `Simplify()`. That is why `GroebnerSystemTest` goes through the public `Solve` — not a style choice.

| Piece | Before | Now |
|---|---|---|
| multivariate GCD | subresultant PRS, no direct tests | 149 tests; one latent defect fixed |
| resultants | absent | `Resultant` + `Discriminant`, Sylvester determinant by Bareiss elimination; 79 tests |
| factorisation over 𝔽ₚ | absent | Berlekamp; 40 tests |
| factorisation over ℚ | rational roots only | Zassenhaus: square-free → Berlekamp → Hensel lift → recombination; 172 tests |
| square-free decomposition | absent | Yun |

**Berlekamp rather than Cantor–Zassenhaus, deliberately.** CZ is randomised; design principle 3 of #746 requires the same input to give the same answer on every platform and thread count. Berlekamp is deterministic by construction, and the dimension of its subalgebra is an exact factor count rather than an estimate, which gives a precise termination test.

## The consumer

Infrastructure with nothing consuming it is speculative code, so the equation solver uses it. Where no rational root can be divided out, a polynomial may still factor, and each factor is then a lower-degree equation the existing product case answers exactly.

`x^5 + 2x^3 - 2x^2 - 4` is `(x^2 + 2)(x^3 - 2)`, and has no rational root:

```
was  { sqrt(-2), -sqrt(-2), sqrt(1.5874010519681995834417875812505371868610382080078125) }   4.6 s
is   { sqrt(-2), -sqrt(-2), 2^(1/3), (-1/2 ± i·1/2·sqrt(3))·2^(1/3) }                        0.09 s
```

Three of five roots, and the one it found came back as the square root of a float where an exact value exists. An incomplete solution set is not a partial answer, it is a false one.

## What this does *not* do

- **Factorisation and square-free decomposition are univariate.** GCD and resultants are multivariate. Multivariate factorisation is not here.
- **Nothing is wired into `Simplify`.** Measured first: `SimplifiedRate` prefers the expanded form in every case tried (`x^6 - 1` rates 12 expanded against 58 factored), so a factored candidate offered there could never win. That is a cost-model question, and #746 puts a pluggable cost model at v2.0.
- **Resultants have no caller yet.** They are additive and unreferenced; no existing input changes its answer because of them.
- **The layer stays `internal`.** #746 item 78 says published API boundaries must be settled deliberately, so this proposes none.
- **Factoring is only attempted from degree four.** Not caution — a quadratic or cubic that factors at all has a rational root, so the step before this one has already divided it out. Four is the first degree at which a polynomial can factor with nothing rational to catch.
- **A two-termed `a*x^n + b` is left whole**, for the reason `TrySplitOffRationalRoots` already gives for declining one.

## One change that needs a decision, not just a review

`InternalsVisibleTo("UnitTests")` is now enabled, and because the package is strong-named it carries the public key and `UnitTests.csproj` signs with the same `key.snk`. Without it none of this machinery can be tested other than through `Solve`, and the exhaustive checks below are what make it trustworthy. **If you would rather not widen the friend surface, say so and I will split it into its own PR so the discussion is not tangled with the mathematics** — but the tests do depend on it.

## Evidence

Full suite **6944 passed / 0 failed / 14 skipped**, against 6504 on `master` — exactly +172 +40 +149 +79. F# wrapper 130. Measurement harnesses (they live outside this repo): root-completeness 596/596 clean, solver corpus 117/119 with 0 wrong / 0 error / 0 timeout, property checker 1340 checks 0 failures, simplification sweep 10463/10463 agreeing, boundary checker byte-identical to its baseline, crash harness 1652 cases 0 crashes.

The tests bind, checked by mutation rather than asserted:

| mutation | tests that fail |
|---|---|
| transpose the Berlekamp matrix | 3 |
| drop the row-interchange sign in the Sylvester determinant | 3 |
| swap the content exponents in the resultant | fails |
| drop `(-1)^(n(n-1)/2)` in the discriminant | 8 |
| reverse the Sylvester block order | 5 |

Two of those mutations initially failed *nothing*, which found two real gaps in the resultant tests; the cases that close them were added.

The factoriser's hardest case is the Swinnerton-Dyer octic with roots `±√2 ±√3 ±√5`: irreducible over ℚ but split into quadratics modulo **every** prime, so recombination must try every subset, find none divides, and conclude irreducibility from the search being exhausted. The test asserts that the splitting actually happens before asserting irreducibility, so it cannot pass by short-circuiting. `x^4 + 1` and `x^4 - 10x^2 + 1` are there for the same reason.

Every candidate factor is confirmed by exact division over ℤ, and the factors are multiplied back and compared before any answer is returned, so the surviving failure mode is an incomplete factorisation and never a wrong one. Resultant conventions were checked against SymPy 1.14 rather than recalled — one of them was wrong by a factor of `x^2` before it was checked.

## Defect found on the way

`MultivariatePolynomial.TryParse` accepted a ninth variable and silently aliased it onto the first: `ShiftOf(8)` is `-8`, and C# masks a shift count to six bits, so `x_1 - x_9` read as the zero polynomial. Unreachable today — both callers check the count first — so no entry in BREAKING-CHANGES.md, but it is fixed at the door rather than at each caller, since the packing belongs to that type.

## Behaviour changes

BREAKING-CHANGES.md records five, with before and after measured on builds of each version from a clean worktree at `origin/master`, not read off the diff. One is the missing roots above; the rest are the same solution sets written more plainly or in a different order, and the members were checked to be equal rather than merely to look it.

## Reviewing it

The commits are separable and in dependency order, so it reads commit-by-commit: header scoping, the friend-assembly change, Berlekamp, the ℚ factoriser and its consumer, the GCD tests and their defect, resultants, then the degree guard.

Two limits are documented rather than fixed, and are filed separately: the GCD's 512-term ceiling is reached by *intermediates* of the remainder sequence rather than by the input (#920 — 7 refusals in 3000 random triples, refusals and never wrong answers), and `MaxSylvesterSize = 24` is a judgement rather than a measurement (#921). The first consumer this unblocks but does not include is partial-fraction integration over irreducible factors (#919).
