### PR TITLE
Bound a gcd's intermediates separately from its inputs (#920)

### DIFF
--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/MultivariatePolynomial.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/MultivariatePolynomial.cs
@@ -63,6 +63,27 @@ namespace AngouriMath.Functions
         /// </summary>
         internal const int MaxTerms = 512;
 
+        /// <summary>
+        /// The ceiling for an intermediate of a calculation whose input and answer are both
+        /// already inside <see cref="MaxTerms"/>.
+        /// </summary>
+        /// <remarks>
+        /// A multivariate pseudo-remainder multiplies through by a leading coefficient that is
+        /// itself a polynomial, so its intermediates grow in monomial count even when neither
+        /// side is anywhere near the bound — the subresultant divisions bound how big the
+        /// coefficients get, not how many terms there are. Holding those intermediates to the
+        /// input bound refused a gcd of a 19-term and a 29-term pair.
+        /// https://github.com/asc-community/AngouriMath/issues/920
+        ///
+        /// It is deliberately a second constant rather than a larger <see cref="MaxTerms"/>.
+        /// The input bound is what protects the hot path — <c>TryCancel</c> runs on every
+        /// quotient the simplifier builds — and raising it turned three documented refusals
+        /// into answers, including a direct product of two 495-term inputs. What was too small
+        /// was never the bound on what may be asked, only the bound on what may be passed
+        /// through on the way to an answer that is itself small.
+        /// </remarks>
+        internal const int MaxIntermediateTerms = 4096;
+
         private const int BitsPerVariable = 8;
         private const ulong PowerMask = 0xFF;
 
@@ -163,7 +184,7 @@ namespace AngouriMath.Functions
                 into[monomial] = sum;
         }
 
-        internal MultivariatePolynomial? Multiply(MultivariatePolynomial other)
+        internal MultivariatePolynomial? Multiply(MultivariatePolynomial other, int maxTerms = MaxTerms)
         {
             if (IsZero || other.IsZero)
                 return Zero(VariableCount);
@@ -174,13 +195,13 @@ namespace AngouriMath.Functions
                     if (!TryMultiplyMonomials(left.Key, right.Key, VariableCount, out var monomial))
                         return null;
                     Accumulate(result, monomial, left.Value.Multiply(right.Value).ToLowestTerms());
-                    if (result.Count > MaxTerms)
+                    if (result.Count > maxTerms)
                         return null;
                 }
             return new(VariableCount, result);
         }
 
-        internal MultivariatePolynomial? Power(int exponent)
+        internal MultivariatePolynomial? Power(int exponent, int maxTerms = MaxTerms)
         {
             if (exponent < 0 || exponent > MaxDegree)
                 return null;
@@ -190,14 +211,14 @@ namespace AngouriMath.Functions
             {
                 if ((exponent & 1) == 1)
                 {
-                    if (result.Multiply(square) is not { } multiplied)
+                    if (result.Multiply(square, maxTerms) is not { } multiplied)
                         return null;
                     result = multiplied;
                 }
                 exponent >>= 1;
                 if (exponent == 0)
                     break;
-                if (square.Multiply(square) is not { } squared)
+                if (square.Multiply(square, maxTerms) is not { } squared)
                     return null;
                 square = squared;
             }
@@ -292,7 +313,7 @@ namespace AngouriMath.Functions
         /// That is the check the caller relies on: nothing is cancelled that has not been
         /// divided out and seen to leave nothing behind.
         /// </remarks>
-        internal MultivariatePolynomial? DivideExact(MultivariatePolynomial divisor)
+        internal MultivariatePolynomial? DivideExact(MultivariatePolynomial divisor, int maxTerms = MaxTerms)
         {
             if (divisor.IsZero)
                 return null;
@@ -305,7 +326,7 @@ namespace AngouriMath.Functions
             var divisorValue = divisor.terms[divisorLead];
             var quotient = new Dictionary<ulong, ERational>();
             var rest = this;
-            for (var step = 0; step <= MaxTerms; step++)
+            for (var step = 0; step <= maxTerms; step++)
             {
                 if (rest.IsZero)
                     return new(VariableCount, quotient);
@@ -317,7 +338,7 @@ namespace AngouriMath.Functions
                 if (divisor.MultiplyByTerm(monomial, value) is not { } product)
                     return null;
                 rest = rest.Subtract(product);
-                if (rest.TermCount > MaxTerms)
+                if (rest.TermCount > maxTerms)
                     return null;
             }
             return null;

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialGcd.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialGcd.cs
@@ -240,9 +240,9 @@ namespace AngouriMath.Functions
                 // The division below is the whole point of the subresultant sequence: what
                 // it leaves is a subresultant, so it comes out exact, and the coefficients
                 // stay the size of the subresultants instead of compounding.
-                if (scale.Power(delta) is not { } scalePower
-                    || previousLead.Multiply(scalePower) is not { } factor
-                    || remainder.DivideExact(factor) is not { } next)
+                if (scale.Power(delta, MultivariatePolynomial.MaxIntermediateTerms) is not { } scalePower
+                    || previousLead.Multiply(scalePower, MultivariatePolynomial.MaxIntermediateTerms) is not { } factor
+                    || remainder.DivideExact(factor, MultivariatePolynomial.MaxIntermediateTerms) is not { } next)
                     return null;
 
                 left = right;
@@ -252,9 +252,9 @@ namespace AngouriMath.Functions
                     scale = previousLead;
                 else if (delta > 1)
                 {
-                    if (previousLead.Power(delta) is not { } raised
-                        || scale.Power(delta - 1) is not { } divisor
-                        || raised.DivideExact(divisor) is not { } updated)
+                    if (previousLead.Power(delta, MultivariatePolynomial.MaxIntermediateTerms) is not { } raised
+                        || scale.Power(delta - 1, MultivariatePolynomial.MaxIntermediateTerms) is not { } divisor
+                        || raised.DivideExact(divisor, MultivariatePolynomial.MaxIntermediateTerms) is not { } updated)
                         return null;
                     scale = updated;
                 }
@@ -281,8 +281,8 @@ namespace AngouriMath.Functions
                     break;
                 MultithreadingFunctional.ExitIfCancelled();
                 var shift = remainder.DegreeIn(main) - divisorDegree;
-                if (divisorLead.Multiply(remainder) is not { } scaled
-                    || remainder.LeadingCoefficientIn(main).Multiply(divisor) is not { } cancelling
+                if (divisorLead.Multiply(remainder, MultivariatePolynomial.MaxIntermediateTerms) is not { } scaled
+                    || remainder.LeadingCoefficientIn(main).Multiply(divisor, MultivariatePolynomial.MaxIntermediateTerms) is not { } cancelling
                     || cancelling.ShiftedBy(main, shift) is not { } shifted)
                     return null;
                 remainder = scaled.Subtract(shifted);
@@ -292,7 +292,7 @@ namespace AngouriMath.Functions
                 return remainder;
             for (var i = 0; i < outstanding; i++)
             {
-                if (divisorLead.Multiply(remainder) is not { } scaled)
+                if (divisorLead.Multiply(remainder, MultivariatePolynomial.MaxIntermediateTerms) is not { } scaled)
                     return null;
                 remainder = scaled;
             }

--- a/Sources/Tests/UnitTests/Algebra/Polynomials/MultivariateGcdTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/Polynomials/MultivariateGcdTest.cs
@@ -295,10 +295,13 @@ namespace AngouriMath.Tests.Algebra.Polynomials
         /// clock-seeded generator out.
         /// </summary>
         /// <remarks>
-        /// Seven of these three thousand are declined rather than answered, and the count is
-        /// asserted rather than ignored: <see cref="TheTermCeilingIsReachedByAnIntermediate"/>
-        /// is what reaches the ceiling and why the inputs that do it are so small. The bound
-        /// is an upper one, so finding fewer never fails.
+        /// Seven of these three thousand used to be declined rather than answered, all of them
+        /// for the reason in <see cref="AnIntermediatePastTheInputCeilingIsStillAnswered"/> —
+        /// an intermediate past the input bound on the way to a small answer. Since
+        /// <see cref="MultivariatePolynomial.MaxIntermediateTerms"/> that is none of them, and
+        /// the count is asserted at zero rather than bounded, so a refusal reappearing fails
+        /// here instead of passing quietly under a ceiling.
+        /// https://github.com/asc-community/AngouriMath/issues/920
         /// </remarks>
         [Fact]
         public void GcdIsMultiplicativeOverManyDrawnTriples()
@@ -322,7 +325,7 @@ namespace AngouriMath.Tests.Algebra.Polynomials
                 Assert.True(divisor.SameAs(expected), $"trial {trial}: the divisor is not the expected one");
                 AssertIsGreatestCommonDivisor(first, second, divisor, SweepVariables.Length);
             }
-            Assert.True(declined <= 7, $"{declined} of 3000 triples were declined");
+            Assert.True(declined == 0, $"{declined} of 3000 triples were declined");
         }
 
         #endregion
@@ -501,12 +504,14 @@ namespace AngouriMath.Tests.Algebra.Polynomials
         /// wrong answer is that the step declines.
         /// </summary>
         /// <remarks>
-        /// Pinned as a refusal, which is a legitimate answer. Should the ceiling be raised, or
-        /// the sequence learn to keep its intermediates primitive, this becomes an answer and
-        /// the test should be changed to assert that answer deliberately.
+        /// This was pinned as a refusal, and is now the answer. The intermediate is held to
+        /// <see cref="MultivariatePolynomial.MaxIntermediateTerms"/> rather than to the input
+        /// bound, which is the distinction the refusal was missing: nothing about the question
+        /// asked here is large, only something passed through on the way to it.
+        /// https://github.com/asc-community/AngouriMath/issues/920
         /// </remarks>
         [Fact]
-        public void TheTermCeilingIsReachedByAnIntermediate()
+        public void AnIntermediatePastTheInputCeilingIsStillAnswered()
         {
             var variables = new[] { "a", "b", "c", "d" };
             var left = Polynomial("(b + c + 1) * (a + b) * (a + b + c + d)", variables);
@@ -514,11 +519,15 @@ namespace AngouriMath.Tests.Algebra.Polynomials
             Assert.Equal(19, left.TermCount);
             Assert.Equal(29, right.TermCount);
 
-            // a + b + c + d divides both, and is not found.
+            // a + b + c + d divides both, and is now found rather than declined.
             var common = Polynomial("a + b + c + d", variables);
             Assert.NotNull(left.DivideExact(common));
             Assert.NotNull(right.DivideExact(common));
-            Assert.Null(Gcd(left, right, variables.Length));
+
+            var divisor = Gcd(left, right, variables.Length);
+            Assert.NotNull(divisor);
+            Assert.True(divisor.SameAs(common), "the divisor found is not a + b + c + d");
+            AssertIsGreatestCommonDivisor(left, right, divisor, variables.Length);
         }
 
         #endregion


### PR DESCRIPTION
Closes #920.

`PolynomialGcd.Gcd` declined on inputs well inside every documented limit, because an intermediate of the subresultant remainder sequence went past `MultivariatePolynomial.MaxTerms` while neither input nor answer came close:

```
left   (b + c + 1) * (a + b) * (a + b + c + d)                 19 terms
right  (a^2 + b*c + d) * (a + b + c + d) * (a + b + c + d)     29 terms
gcd    a + b + c + d                                            4 terms   was declined
```

A multivariate pseudo-remainder multiplies through by a leading coefficient that is itself a polynomial. The subresultant divisions bound how large the **coefficients** get — which is what the class remark is about, and it holds — but nothing bounds the **monomial count**, and three steps in, a 25-term lead times a 159-term remainder passes 512.

## Why not just raise `MaxTerms`

#920 offers that as the one-line option and asks for a measurement rather than a guess. The measurement rules it out. At `MaxTerms = 2048`, **three documented refusals become answers**:

- `TermCountsPastTheCeilingAreRefused` — whose subject is a *direct* product of two 495-term inputs
- `RefusedRatherThanAnsweredWrongly` — whose input has 1001 terms and is meant to be stopped at the door
- the #920 case itself

Only the third is the bug. The bound on what may be **asked** was never too small; what was too small was the bound on what may be **passed through** on the way to an answer that is itself small.

## The shape

`MaxIntermediateTerms = 4096` is a second constant, threaded as an optional argument through `Multiply`, `Power` and `DivideExact`, and passed **only** by the gcd's remainder sequence. Everything reached any other way keeps `MaxTerms` by default, so the entry bound protecting the hot path is untouched and all three refusals above still refuse.

```
3000 drawn triples   7 declined  ->  0 declined
the pair above       declined    ->  a + b + c + d, checked as a greatest common divisor
```

The sweep now asserts the count is **zero** rather than at most seven, so a refusal coming back fails there instead of passing quietly under a ceiling. The pinned refusal test is rewritten to assert the answer deliberately, as its own remark asked for.

## Performance

`TryCancel` runs on every quotient the simplifier builds, so `simpsweep` is the hot path.

| ceiling | run |
|---|---|
| 4096 | 3m26.8s |
| 4096 | 3m40.7s |
| 512 (old behaviour) | 3m45.3s |

The spread between repeats of the *same* setting is as large as the gap between the settings. This supports **no regression**; it does not support a speedup, and I am not claiming one. The gcd test class is unchanged at 1 s.

## Verification

- 6944 C# tests, 130 F# tests — 0 failures
- `propcheck` 1340 checks, 0 failures
- `simpsweep` 10463/10463 agree, 0 disagreements, 0 timeouts
- `rootcheck` 596/596 clean, 0 incomplete, 0 unsound
- `casbench` 117/119, 0 wrong, 0 error, 0 timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)