### PR TITLE
Decompose a rational function over its denominator's factors, not only its roots (#919)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -30,6 +30,48 @@ read first.
 | **silent** | `"x^5 + 2x^3 - 2x^2 - 4".SolveEquation("x")` | three of the five roots, one of them a float | all five, exact |
 | | `"x^4 + x^2 + 1".SolveEquation("x")` | `sqrt((-1 - sqrt(-3)) / 2)` and its three companions | `(-1 - sqrt(-3)) / 2` and its three, with no nested radical |
 | | `"x^4 + 3x^2 + 2".SolveEquation("x")` | `{ sqrt(-2), -sqrt(-2), i, -i }` | the same four, in the order the factors are found |
+| **silent** | `"1/(x^4 + 3x^2 + 2)".Integrate("x")` | unevaluated | `arctan(x) - sqrt(2) * arctan(sqrt(2) * x / 2) / 2 + C` |
+| **silent** | `"1/(x^4 + 4)".Integrate("x")` | unevaluated | the antiderivative over its two quadratic factors |
+
+### A rational function is decomposed over the factors of its denominator, not only its roots
+
+The other consumer of the polynomial layer, and the same blindness one level along. A partial
+fraction decomposition split `N/D` at a **rational root** of `D`, so a denominator with no rational
+root was left whole and its integral came back unevaluated — even where every factor was one the
+integrator already reads. `x^4 + 3x^2 + 2` is `(x^2 + 1)(x^2 + 2)`, and the rule for a linear
+numerator over a quadratic answers both halves.
+
+```
+"1/(x^4 + 3x^2 + 2)".Integrate("x")
+
+was  integral(1 / (x ^ 4 + 3 * x ^ 2 + 2), x)
+is   arctan(x) - sqrt(2) * arctan(sqrt(2) * x / 2) / 2 + C
+```
+
+The step is a coprime split rather than a full decomposition, which is what the step at a root
+already was: the denominator is factored into irreducibles, one irreducible with its multiplicity is
+taken against the product of the rest, the extended Euclidean algorithm in `Q[x]` gives `U*A + V*B =
+1`, and `N/(A*B)` becomes `N*V/A + N*U/B` with each numerator reduced modulo its own denominator.
+Both sides are strictly smaller problems of the same kind, so the integrator recurses into them and
+arrives at the full decomposition either way.
+
+**No condition is attached, and that is a statement rather than an omission.** `A` and `B` being
+coprime, `A*B` is zero exactly where one of them is, so the two sides are undefined at the same
+points. A decomposition that loses a singularity is one that cancels a shared factor, and this does
+not cancel anything.
+
+**What is still declined.** A denominator irreducible over `Q` — `x^4 + 1` is, and only factors once
+real coefficients are allowed — and, more generally, any denominator one of whose factors is a shape
+no integration rule reads: an irreducible of degree three or more, or a quadratic repeated. So
+`(x^2 + 1)^2` is declined, and the ladder that would decompose it is deliberately not built, because
+every term it produces is over `(x^2 + c)^k` and would come back unevaluated in turn.
+
+Deciding that from the factorisation rather than by trying is what keeps the cost of declining to the
+one factorisation. Splitting regardless and recursing made `(1 - x^4)/(1 + x^4 + x^8)`, whose
+factorisation holds the irreducible quartic `x^4 - x^2 + 1`, take 18s to return the same unevaluated
+integral it returns in 203ms — measured, and the reason the guard is there rather than a preference.
+
+[#919](https://github.com/asc-community/AngouriMath/issues/919).
 
 ### A polynomial equation that factors is solved through its factors
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -39,7 +39,7 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [Tests/UnitTests/Core/KnownLimitsAreNotBugsTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
-[AngouriMath/Functions/Algebra/Polynomials/{IntegerPolynomial,PrimeFieldPolynomial,PrimeFieldFactorization,SquareFreeDecomposition,PolynomialFactorization,PolynomialResultant}.cs]
+[AngouriMath/Functions/Algebra/Polynomials/{IntegerPolynomial,PrimeFieldPolynomial,PrimeFieldFactorization,SquareFreeDecomposition,PolynomialFactorization,PolynomialResultant,RationalPolynomial,PartialFractions}.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
 [Tests/UnitTests/Algebra/Polynomials/*.cs]

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/PartialFractions.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/PartialFractions.cs
@@ -1,0 +1,144 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Diagnostics.CodeAnalysis;
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// One step of a partial fraction decomposition, at a coprime pair of factors of the
+    /// denominator rather than at a root of it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The sibling step, <see cref="PolynomialFactoring.TrySplitOffRationalRoot"/>, splits at a
+    /// rational root, which is all the decomposition there was: a denominator with no rational
+    /// root was left whole, so <c>1/(x^4 + 3x^2 + 2)</c> had no antiderivative even though it
+    /// is <c>(x^2 + 1)(x^2 + 2)</c> and both of those are integrated by the rule for a linear
+    /// numerator over a quadratic. Nothing was missing but the split.
+    /// https://github.com/asc-community/AngouriMath/issues/919
+    /// </para>
+    /// <para>
+    /// One step and not the whole decomposition, for the same reason as the sibling: what comes
+    /// out is two strictly smaller problems of the same kind, and the integrator recurses into
+    /// them. Splitting <c>D</c> into coprime <c>A</c> and <c>B</c>, the extended Euclidean
+    /// algorithm gives <c>U*A + V*B = 1</c>, so <c>N = N*V*B + N*U*A</c> and
+    /// <c>N/(A*B) = N*V/A + N*U/B</c>. Each numerator is then reduced modulo its own
+    /// denominator; the polynomial parts that come off cannot survive, since a proper fraction
+    /// minus two proper fractions is a polynomial that vanishes at infinity.
+    /// </para>
+    /// <para>
+    /// <b>No condition is owed.</b> <c>A</c> and <c>B</c> being coprime, <c>A*B</c> is zero
+    /// exactly where one of them is, so the two sides are undefined at the same points and the
+    /// domain neither widens nor narrows. That is what makes this different from cancelling a
+    /// shared factor, which is where a decomposition usually loses a singularity.
+    /// </para>
+    /// <para>
+    /// The decomposition is produced only where every piece of it is a shape an integration
+    /// rule reads — see the guard below, which is what keeps declining cheap. A denominator
+    /// that is a power of one irreducible is declined for the further reason that it has no
+    /// coprime pair to split into at all. The ladder that decomposes that one — <c>N/f^k</c>
+    /// as terms over <c>f^k</c>, <c>f^(k-1)</c>, ... — is deliberately not built here: for
+    /// <c>f</c> linear the sibling step already does it, and for <c>f</c> quadratic every term
+    /// it produces is over <c>(x^2 + c)^k</c>, which nothing reads, so the decomposition would
+    /// end in the same unevaluated integral it started from.
+    /// </para>
+    /// </remarks>
+    internal static class PartialFractions
+    {
+        /// <summary>
+        /// <c>N/D</c> written as two fractions over coprime factors of <paramref name="denominator"/>,
+        /// each a strictly smaller problem of the same kind, or <see langword="false"/> where
+        /// the denominator does not factor into a coprime pair.
+        /// </summary>
+        internal static bool TrySplitIntoCoprimeParts(
+            Entity numerator, Entity denominator, Variable x,
+            [NotNullWhen(true)] out Entity? left,
+            [NotNullWhen(true)] out Entity? right)
+        {
+            left = right = null;
+
+            // Degree four is the first at which a polynomial can factor with no rational root
+            // anywhere in it, x^4 + 3x^2 + 2 being the smallest. Below that a factorisation
+            // implies a root, and the step at a root has already been tried and has failed.
+            if (!PolynomialFactoring.TryGetRationalCoefficients(
+                    denominator, x, leastTerms: 2, leastDegree: 4, IntegerPolynomial.MaxDegree, out var d)
+                || !PolynomialFactoring.TryGetRationalCoefficients(
+                    numerator, x, leastTerms: 1, leastDegree: 0, IntegerPolynomial.MaxDegree, out var n))
+                return false;
+
+            // Only a proper fraction decomposes; an improper one is a polynomial plus a proper
+            // fraction and has to be divided out first, which is not done here.
+            if (n.Length >= d.Length)
+                return false;
+
+            if (PolynomialFactorization.Factor(denominator, x) is not { } factorization)
+                return false;
+
+            // Every piece the decomposition would produce has to be one an integration rule
+            // reads, or the decomposition answers nothing and is not worth producing. A linear
+            // factor is read at any multiplicity, and a quadratic one only at the first: there
+            // is no rule for a numerator over (x^2 + c)^k, and none for an irreducible factor
+            // of degree three or more at all.
+            //
+            // Deleting the guard costs no answer and a great deal of time: a piece with no
+            // rule leaves the whole integral unevaluated either way, but every half of every
+            // split is a fresh problem the whole integrator searches before that is known.
+            // Without it (1 - x^4)/(1 + x^4 + x^8), whose factorisation holds the irreducible
+            // quartic x^4 - x^2 + 1, takes 18s to decline where it took 203ms. Read off the
+            // factorisation, which is already in hand, the cost of declining is that one
+            // factorisation.
+            foreach (var part in factorization.Parts)
+                if (part.Factor.Degree > 2 || (part.Factor.Degree == 2 && part.Multiplicity > 1))
+                    return false;
+
+            // Each part of the factorisation is a distinct irreducible with its multiplicity,
+            // so any one of them raised to that multiplicity is coprime to the product of the
+            // rest. The smallest is taken, which keeps the intermediate coefficients of the
+            // extended Euclidean run down; which one is chosen cannot change what is reachable,
+            // since both sides recurse and the full decomposition is arrived at either way.
+            var chosen = factorization.Parts[0];
+            foreach (var part in factorization.Parts)
+                if (part.Factor.Degree * part.Multiplicity < chosen.Factor.Degree * chosen.Multiplicity)
+                    chosen = part;
+
+            var whole = RationalPolynomial.Create(d);
+            var a = RationalPolynomial.FromInteger(chosen.Factor).Pow(chosen.Multiplicity);
+            if (!whole.TryDivide(a, out var b, out var remainder) || !remainder.IsZero || b.IsConstant)
+                return false;
+
+            if (!RationalPolynomial.TryBezout(a, b, out var u, out var v))
+                return false;
+
+            var wanted = RationalPolynomial.Create(n);
+            if (!wanted.Multiply(v).TryDivide(a, out _, out var overA)
+                || !wanted.Multiply(u).TryDivide(b, out _, out var overB))
+                return false;
+
+            // The identity the two fractions stand for, checked rather than assumed: nothing
+            // above is trusted to have produced a decomposition of this numerator in
+            // particular, and a wrong split would otherwise leave a wrong antiderivative that
+            // only differentiating it back would catch.
+            if (!overA.Multiply(b).Add(overB.Multiply(a)).SameAs(wanted))
+                return false;
+
+            left = AsFraction(overA, a, x);
+            right = AsFraction(overB, b, x);
+            return true;
+        }
+
+        /// <summary>
+        /// A vanishing numerator is answered as zero rather than as a quotient, so that a
+        /// numerator sharing a factor with the denominator does not leave the integrator
+        /// working out the antiderivative of the other side only to multiply it by nothing.
+        /// </summary>
+        private static Entity AsFraction(RationalPolynomial numerator, RationalPolynomial denominator, Variable x)
+            => numerator.IsZero ? Integer.Create(0) : numerator.ToEntity(x) / denominator.ToEntity(x);
+    }
+}

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/RationalPolynomial.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/RationalPolynomial.cs
@@ -1,0 +1,275 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using PeterO.Numbers;
+using System;
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// A polynomial in one variable over the rationals, stored densely.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A third polynomial representation, next to <see cref="IntegerPolynomial"/> and
+    /// <see cref="MultivariatePolynomial"/>, because division is the operation this one exists
+    /// for. Factoring works over <c>Z</c>, where content, primitive parts and Mignotte's bound
+    /// all mean something; a partial fraction decomposition works over <c>Q</c>, where every
+    /// polynomial can be divided by any other and the extended Euclidean algorithm terminates
+    /// with a genuine unit. Doing that over <c>Z</c> means carrying a scaling factor beside
+    /// every intermediate, which is where the sign and content errors live.
+    /// </para>
+    /// <para>
+    /// Trailing zero coefficients are never stored, so <see cref="Degree"/> is
+    /// <c>coefficients.Length - 1</c> and the zero polynomial is the empty array with degree
+    /// <c>-1</c>. Coefficients are lowest power first, the order the rest of
+    /// <c>Functions/Algebra/Polynomials</c> uses.
+    /// </para>
+    /// <para>
+    /// Every coefficient is reduced to lowest terms as it is written. <see cref="ERational"/>
+    /// does not do that on its own, and a remainder sequence that leaves it undone multiplies
+    /// numerator and denominator up at every step: the ratios stay correct and become
+    /// arbitrarily expensive to compare, which is the failure that looks like a hang.
+    /// </para>
+    /// </remarks>
+    internal sealed class RationalPolynomial
+    {
+        [ConstantField] private static readonly ERational[] NoCoefficients = Array.Empty<ERational>();
+
+        /// <summary>Lowest power first, in lowest terms, with no trailing zero.</summary>
+        private readonly ERational[] coefficients;
+
+        private RationalPolynomial(ERational[] coefficients) => this.coefficients = coefficients;
+
+        internal static RationalPolynomial Create(IReadOnlyList<ERational> coefficientsLowestFirst)
+        {
+            var length = coefficientsLowestFirst.Count;
+            while (length > 0 && coefficientsLowestFirst[length - 1].IsZero)
+                length--;
+            if (length == 0)
+                return Zero;
+            var trimmed = new ERational[length];
+            for (var i = 0; i < length; i++)
+                trimmed[i] = coefficientsLowestFirst[i].ToLowestTerms();
+            return new(trimmed);
+        }
+
+        [ConstantField] internal static readonly RationalPolynomial Zero = new(NoCoefficients);
+
+        internal static RationalPolynomial Constant(ERational value)
+            => value.IsZero ? Zero : new(new[] { value.ToLowestTerms() });
+
+        internal static RationalPolynomial One => Constant(ERational.One);
+
+        /// <summary>The same polynomial read over <c>Q</c>, every denominator being one.</summary>
+        internal static RationalPolynomial FromInteger(IntegerPolynomial poly)
+        {
+            var converted = new ERational[poly.Degree + 1];
+            for (var i = 0; i < converted.Length; i++)
+                converted[i] = ERational.Create(poly[i], EInteger.One);
+            return Create(converted);
+        }
+
+        /// <summary>-1 for the zero polynomial.</summary>
+        internal int Degree => coefficients.Length - 1;
+
+        internal bool IsZero => coefficients.Length == 0;
+
+        internal bool IsConstant => coefficients.Length <= 1;
+
+        internal ERational this[int power]
+            => power >= 0 && power < coefficients.Length ? coefficients[power] : ERational.Zero;
+
+        internal ERational Leading => IsZero ? ERational.Zero : coefficients[coefficients.Length - 1];
+
+        internal RationalPolynomial ScaleBy(ERational factor)
+        {
+            if (factor.IsZero)
+                return Zero;
+            var scaled = new ERational[coefficients.Length];
+            for (var i = 0; i < scaled.Length; i++)
+                scaled[i] = coefficients[i].Multiply(factor);
+            return Create(scaled);
+        }
+
+        internal RationalPolynomial Add(RationalPolynomial other) => Combine(other, subtract: false);
+
+        internal RationalPolynomial Subtract(RationalPolynomial other) => Combine(other, subtract: true);
+
+        private RationalPolynomial Combine(RationalPolynomial other, bool subtract)
+        {
+            var length = Math.Max(coefficients.Length, other.coefficients.Length);
+            var combined = new ERational[length];
+            for (var i = 0; i < length; i++)
+            {
+                var right = other[i];
+                combined[i] = subtract ? this[i].Subtract(right) : this[i].Add(right);
+            }
+            return Create(combined);
+        }
+
+        internal RationalPolynomial Multiply(RationalPolynomial other)
+        {
+            if (IsZero || other.IsZero)
+                return Zero;
+            var product = new ERational[coefficients.Length + other.coefficients.Length - 1];
+            for (var i = 0; i < product.Length; i++)
+                product[i] = ERational.Zero;
+            for (var i = 0; i < coefficients.Length; i++)
+            {
+                if (coefficients[i].IsZero)
+                    continue;
+                for (var j = 0; j < other.coefficients.Length; j++)
+                {
+                    if (other.coefficients[j].IsZero)
+                        continue;
+                    product[i + j] = product[i + j].Add(coefficients[i].Multiply(other.coefficients[j])).ToLowestTerms();
+                }
+            }
+            return Create(product);
+        }
+
+        internal RationalPolynomial Pow(int power)
+        {
+            var result = One;
+            for (var i = 0; i < power; i++)
+                result = result.Multiply(this);
+            return result;
+        }
+
+        /// <summary>
+        /// <c>this = quotient * divisor + remainder</c>, the remainder being of lower degree
+        /// than the divisor. <see langword="false"/> only where the divisor is zero.
+        /// </summary>
+        internal bool TryDivide(
+            RationalPolynomial divisor, out RationalPolynomial quotient, out RationalPolynomial remainder)
+        {
+            quotient = remainder = Zero;
+            if (divisor.IsZero)
+                return false;
+            if (Degree < divisor.Degree)
+            {
+                remainder = this;
+                return true;
+            }
+
+            var working = new ERational[coefficients.Length];
+            for (var i = 0; i < working.Length; i++)
+                working[i] = coefficients[i];
+            var quotientCoefficients = new ERational[Degree - divisor.Degree + 1];
+            for (var i = 0; i < quotientCoefficients.Length; i++)
+                quotientCoefficients[i] = ERational.Zero;
+
+            for (var power = Degree; power >= divisor.Degree; power--)
+            {
+                if (working[power].IsZero)
+                    continue;
+                var factor = working[power].Divide(divisor.Leading).ToLowestTerms();
+                quotientCoefficients[power - divisor.Degree] = factor;
+                for (var i = 0; i <= divisor.Degree; i++)
+                    working[power - divisor.Degree + i] =
+                        working[power - divisor.Degree + i].Subtract(factor.Multiply(divisor[i])).ToLowestTerms();
+            }
+
+            quotient = Create(quotientCoefficients);
+            remainder = Create(working);
+            return true;
+        }
+
+        /// <summary>
+        /// <paramref name="left"/> and <paramref name="right"/> being coprime, the pair with
+        /// <c>u*left + v*right = 1</c>. <see langword="false"/> where they share a factor of
+        /// positive degree, or where either is zero.
+        /// </summary>
+        /// <remarks>
+        /// The extended Euclidean algorithm, which over a field ends at a constant remainder
+        /// exactly when the two are coprime — so the test for coprimality and the cofactors
+        /// come out of the same run and neither is asserted separately.
+        /// </remarks>
+        internal static bool TryBezout(
+            RationalPolynomial left, RationalPolynomial right,
+            out RationalPolynomial u, out RationalPolynomial v)
+        {
+            u = v = Zero;
+            if (left.IsZero || right.IsZero)
+                return false;
+
+            var (remainderPrevious, remainderCurrent) = (left, right);
+            var (leftPrevious, leftCurrent) = (One, Zero);
+            var (rightPrevious, rightCurrent) = (Zero, One);
+
+            while (!remainderCurrent.IsZero)
+            {
+                if (!remainderPrevious.TryDivide(remainderCurrent, out var quotient, out var next))
+                    return false;
+                (remainderPrevious, remainderCurrent) = (remainderCurrent, next);
+                (leftPrevious, leftCurrent) =
+                    (leftCurrent, leftPrevious.Subtract(quotient.Multiply(leftCurrent)));
+                (rightPrevious, rightCurrent) =
+                    (rightCurrent, rightPrevious.Subtract(quotient.Multiply(rightCurrent)));
+            }
+
+            // The last non-zero remainder is the greatest common divisor. A constant one is a
+            // unit over Q and divides out; anything of positive degree means the two are not
+            // coprime, and there is no such pair to return.
+            if (!remainderPrevious.IsConstant || remainderPrevious.IsZero)
+                return false;
+            var inverse = ERational.One.Divide(remainderPrevious[0]);
+            u = leftPrevious.ScaleBy(inverse);
+            v = rightPrevious.ScaleBy(inverse);
+            return true;
+        }
+
+        internal bool SameAs(RationalPolynomial other)
+        {
+            if (coefficients.Length != other.coefficients.Length)
+                return false;
+            for (var i = 0; i < coefficients.Length; i++)
+                if (coefficients[i].CompareTo(other.coefficients[i]) != 0)
+                    return false;
+            return true;
+        }
+
+        internal Entity ToEntity(Variable x)
+        {
+            Entity result = Integer.Create(0);
+            for (var i = Degree; i >= 0; i--)
+            {
+                if (coefficients[i].IsZero)
+                    continue;
+                Entity term = Rational.Create(coefficients[i]);
+                if (i == 1)
+                    term = term == Integer.One ? x : term * x;
+                else if (i > 1)
+                    term = term == Integer.One ? x.Pow(i) : term * x.Pow(i);
+                result = result == Integer.Create(0) ? term : result + term;
+            }
+            return result.InnerSimplified;
+        }
+
+        public override string ToString()
+        {
+            if (IsZero)
+                return "0";
+            var parts = new List<string>();
+            for (var i = Degree; i >= 0; i--)
+            {
+                if (coefficients[i].IsZero)
+                    continue;
+                parts.Add(i switch
+                {
+                    0 => coefficients[i].ToString(),
+                    1 => coefficients[i] + "x",
+                    _ => coefficients[i] + "x^" + i
+                });
+            }
+            return string.Join(" + ", parts);
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -24,27 +24,46 @@ namespace AngouriMath.Functions.Algebra
         }
 
         /// <summary>
-        /// A quotient of polynomials whose denominator has a rational root, split at that
-        /// root and integrated in two parts.
+        /// A quotient of polynomials, split into two smaller quotients and integrated in two
+        /// parts — at a rational root of the denominator where it has one, and otherwise at a
+        /// coprime pair of its irreducible factors.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The rules for a linear or a quadratic denominator answer those in one piece, so
         /// what is left over are the denominators of degree three and up, which nothing
         /// read at all: 1/(x^3 + 1) had no antiderivative. Splitting at the root -1 leaves
         /// (1/3)/(x + 1) and (2 - x)/(3(x^2 - x + 1)), and both of those are already
         /// integrable, the second by the rule for a linear numerator over a quadratic.
         /// Each step takes a degree off the denominator, so this ends.
+        /// </para>
+        /// <para>
+        /// The split at a root reaches a denominator only where it has a rational one, which
+        /// left 1/(x^4 + 3x^2 + 2) unevaluated although it is (x^2 + 1)(x^2 + 2) and both of
+        /// those are integrated by the rule above. <see cref="Functions.PartialFractions"/>
+        /// splits those, and is tried when the split at a root either does not apply or
+        /// applies and leaves something that will not integrate — it takes the denominator
+        /// apart differently, so a failure of the one is no evidence about the other.
+        /// </para>
         /// </remarks>
         internal static Entity? SolveByPartialFractions(Entity expr, Entity.Variable x, bool integrateByParts)
         {
-            if (expr is not Entity.Divf(var numerator, var denominator)
-                || !Functions.PolynomialFactoring.TrySplitOffRationalRoot(
-                    numerator, denominator, x, out var simple, out var restNumerator, out var restDenominator))
+            if (expr is not Entity.Divf(var numerator, var denominator))
                 return null;
-            return Integration.ComputeIndefiniteIntegral(simple, x, integrateByParts) is { } first
-                && Integration.ComputeIndefiniteIntegral(restNumerator / restDenominator, x, integrateByParts) is { } rest
-                ? first + rest
-                : null;
+
+            if (Functions.PolynomialFactoring.TrySplitOffRationalRoot(
+                    numerator, denominator, x, out var simple, out var restNumerator, out var restDenominator)
+                && Integration.ComputeIndefiniteIntegral(simple, x, integrateByParts) is { } first
+                && Integration.ComputeIndefiniteIntegral(restNumerator / restDenominator, x, integrateByParts) is { } rest)
+                return first + rest;
+
+            if (Functions.PartialFractions.TrySplitIntoCoprimeParts(
+                    numerator, denominator, x, out var left, out var right)
+                && Integration.ComputeIndefiniteIntegral(left, x, integrateByParts) is { } overOne
+                && Integration.ComputeIndefiniteIntegral(right, x, integrateByParts) is { } overOther)
+                return overOne + overOther;
+
+            return null;
         }
 
         internal static Entity? SolveAsPolynomialTerm(Entity expr, Entity.Variable x, bool integrateByParts = true) => expr switch

--- a/Sources/Tests/UnitTests/Calculus/PartialFractionsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/PartialFractionsTest.cs
@@ -74,13 +74,46 @@ namespace AngouriMath.Tests.Calculus
             AssertIsAntiderivative(integrand, points);
 
         /// <summary>
-        /// A denominator with no rational root is not split, and neither is one whose root
-        /// repeats -- that needs a term over the square as well, which is not produced here.
-        /// Both are left unevaluated rather than answered wrongly.
+        /// A denominator that factors over the rationals with no rational root anywhere in
+        /// it. The step at a root cannot get a foothold on any of these, and each one splits
+        /// into quadratics that the rule for a linear numerator over a quadratic already
+        /// integrates. https://github.com/asc-community/AngouriMath/issues/919
+        /// </summary>
+        [Theory]
+        [InlineData("1 / (x ^ 4 + 3 * x ^ 2 + 2)", new[] { 0.3, 1.7, 3.2, -2.4 })]
+        [InlineData("x / (x ^ 4 + 3 * x ^ 2 + 2)", new[] { 0.3, 1.7, 3.2, -2.4 })]
+        [InlineData("(x + 1) / (x ^ 4 + 3 * x ^ 2 + 2)", new[] { 0.3, 1.7, 3.2, -2.4 })]
+        [InlineData("1 / ((x ^ 2 + 1) * (x ^ 2 + 2))", new[] { 0.3, 1.7, 3.2, -2.4 })]
+        [InlineData("1 / (x ^ 4 + 4)", new[] { 0.3, 1.7, 3.2, -2.4 })]
+        public void ADenominatorThatFactorsWithNoRationalRoot(string integrand, double[] points) =>
+            AssertIsAntiderivative(integrand, points);
+
+        // A numerator that shares a factor with the denominator still has to come out right:
+        // (x^2 + 1) cancels here, so one of the two numerators the split produces is zero.
+        [Theory]
+        [InlineData("(x ^ 2 + 1) / (x ^ 4 + 3 * x ^ 2 + 2)", new[] { 0.3, 1.7, 3.2, -2.4 })]
+        public void ANumeratorThatCancels(string integrand, double[] points) =>
+            AssertIsAntiderivative(integrand, points);
+
+        // A rational root and an irreducible quadratic in the same denominator, which needs
+        // both steps: x^5 + ... + 1 is (x + 1)(x^2 + x + 1)(x^2 - x + 1), so the root at -1
+        // comes off first and what is left has no root to divide out.
+        [Theory]
+        [InlineData("1 / (x ^ 5 + x ^ 4 + x ^ 3 + x ^ 2 + x + 1)", new[] { 0.3, 1.7, 3.2, -2.4 })]
+        public void ARootAndAnIrreducibleFactorTogether(string integrand, double[] points) =>
+            AssertIsAntiderivative(integrand, points);
+
+        /// <summary>
+        /// What is still left unevaluated rather than answered wrongly: a denominator that is
+        /// irreducible, and one that is a power of a single irreducible. The second is not a
+        /// splitting problem -- there is no coprime pair to split it into, and the ladder
+        /// over <c>f^k</c> that would decompose it produces terms over <c>(x^2 + 1)^2</c>
+        /// that no integration rule reads, so decomposing it would answer nothing.
         /// </summary>
         [Theory]
         [InlineData("x ^ 2 / (x ^ 4 + 1)")]
         [InlineData("1 / (x ^ 3 + x ^ 2 + x + 2)")]
+        [InlineData("1 / (x ^ 4 + 2 * x ^ 2 + 1)")]
         public void WhatCannotBeSplitIsLeftAlone(string integrand) =>
             Assert.Contains("integral(", integrand.ToEntity().Integrate("x").Stringize());
     }

--- a/Sources/Tests/UnitTests/Calculus/RationalIntegralsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/RationalIntegralsTest.cs
@@ -95,13 +95,24 @@ namespace AngouriMath.Tests.Calculus
         public void ARepeatedRationalRootDecomposesToo(string integrand, double[] points) =>
             AssertIsAntiderivative(integrand, points);
 
-        // Denominators with no rational root at all are still out of reach: x^4 + 1 is
-        // irreducible over Q and only factors once real coefficients are allowed. Recorded
-        // so the boundary is visible rather than inferred from an absence.
+        // A denominator that factors over Q with no rational root anywhere in it, which the
+        // split at a root cannot get a foothold on. x^4 + 3x^2 + 2 is (x^2 + 1)(x^2 + 2) and
+        // x^4 + 4 is (x^2 - 2x + 2)(x^2 + 2x + 2); the split at a coprime pair of factors
+        // reaches both. https://github.com/asc-community/AngouriMath/issues/919
+        [Theory]
+        [InlineData("1 / (x ^ 4 + 3 * x ^ 2 + 2)", new[] { 0.3, 1.7, 3.2, -2.4 })]
+        [InlineData("1 / (x ^ 4 + 4)", new[] { 0.3, 1.7, 3.2, -2.4 })]
+        public void ADenominatorThatFactorsWithNoRationalRoot(string integrand, double[] points) =>
+            AssertIsAntiderivative(integrand, points);
+
+        // What is out of reach is a denominator that does not factor over Q at all -- x^4 + 1
+        // is irreducible and only factors once real coefficients are allowed -- and one that
+        // is a power of a single irreducible, which has no coprime pair to split into.
+        // Recorded so the boundary is visible rather than inferred from an absence.
         [Theory]
         [InlineData("x ^ 2 / (x ^ 4 + 1)")]
-        [InlineData("1 / (x ^ 4 + 4)")]
-        public void ADenominatorWithNoRationalRootIsStillDeclined(string integrand) =>
+        [InlineData("1 / (x ^ 4 + 2 * x ^ 2 + 1)")]
+        public void ADenominatorThatDoesNotFactorIsStillDeclined(string integrand) =>
             Assert.Contains("integral(", integrand.ToEntity().Integrate("x").Stringize());
     }
 }


### PR DESCRIPTION
Closes #919.

A partial fraction decomposition split `N/D` at a **rational root** of `D`, which was all the decomposition there was. A denominator that factors over ℚ with no rational root anywhere in it was left whole and its integral came back unevaluated — even where every factor was one the integrator already reads.

```
"1/(x^4 + 3x^2 + 2)".Integrate("x")

was  integral(1 / (x ^ 4 + 3 * x ^ 2 + 2), x)
is   arctan(x) - sqrt(2) * arctan(sqrt(2) * x / 2) / 2 + C
```

`x^4 + 3x^2 + 2` is `(x^2 + 1)(x^2 + 2)`, and the rule for a linear numerator over a quadratic answers both halves. Nothing was missing but the split. #918 supplied the factorisation over ℚ that makes it available, so this is the second consumer of the polynomial layer after the equation solver.

## What it does

The same shape as the step at a root: one irreducible factor with its multiplicity against the product of the rest, `U*A + V*B = 1` from the extended Euclidean algorithm in ℚ[x], and `N/(A*B) = N*V/A + N*U/B` with each numerator reduced modulo its own denominator. Both sides are strictly smaller problems of the same kind, so the integrator recurses and reaches the full decomposition whichever factor is peeled first.

The extended Euclid did not exist — there was one over 𝔽ₚ inside the factoriser and `IntegerPolynomial.Gcd` over ℤ without the cofactors — so `RationalPolynomial` is new: dense, lowest power first, coefficients in lowest terms as they are written.

**No condition is attached, and that is a statement rather than an omission.** `A` and `B` being coprime, `A*B` vanishes exactly where one of them does, so the two sides are undefined at the same points. A decomposition loses a singularity when it cancels a shared factor; this cancels nothing. The identity is *checked* — `overA*B + overB*A` against the numerator, over ℚ — rather than trusted, so what survives a failure is a refusal and never a wrong antiderivative.

## The guard, which is the part with a measurement behind it

The decomposition is produced only where every factor is a shape an integration rule reads: linear at any multiplicity, quadratic at the first, nothing else. That costs no answer — a piece with no rule leaves the whole integral unevaluated either way — and it is what keeps declining cheap.

Deciding it by trying instead was measured and is much worse. `(1 - x^4)/(1 + x^4 + x^8)`, whose factorisation holds the irreducible quartic `x^4 - x^2 + 1`, took **18s** to return the same unevaluated integral it returns in **203ms**, because every half of every split is a fresh problem the whole integrator then searches. `intbench` caught this before the guard existed: four problems crossed the 3s budget and one previously-answered problem went with them.

## What is still declined

`x^2/(x^4 + 1)` — irreducible over ℚ, and only factors once real coefficients are allowed — and `1/(x^4 + 2x^2 + 1)`, the power of a single irreducible. The ladder that would decompose the second is deliberately not built: every term it produces is over `(x^2 + c)^k`, which nothing reads, so it would end in the same unevaluated integral it started from.

## One test changed rather than added to

`ADenominatorWithNoRationalRootIsStillDeclined` pinned `1/(x^4 + 4)` as out of reach on the grounds that it has no rational root. It *is* reducible over ℚ — `(x^2 - 2x + 2)(x^2 + 2x + 2)` — and is now answered, so the boundary that test records has moved to what does not factor over ℚ at all. `BREAKING-CHANGES.md` carries the entry.

## Measured

On this branch against a stock build of `master`, same machine.

| | |
|---|---|
| unit suite | 6960 passed, 0 failed |
| F# wrapper | 130/130 |
| `casbench` | 116/119, 0 wrong, 0 error, 0 timeout — equal to master |
| `propcheck` | 1340 checks, 0 failures |
| `rootcheck` | 596/596 clean |
| `simpsweep` | 10463/10463 agree |
| `crashcheck` | 1652 cases, 0 crashed, 0 unexpected throws |
| `intbench` families=0 | 46/191 → **47/191** solved, 0 wrong, 6 timeout either side |
| `intbench` families=1 | 30/228 both, and identical to master problem by problem |

Every antiderivative in the new tests is checked by differentiating it back and comparing to the integrand numerically, never against a written form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
