### PR TITLE
Bound the resultant's elimination by measured work rather than by reasoned size (#921)

### DIFF
--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialResultant.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialResultant.cs
@@ -54,13 +54,51 @@ namespace AngouriMath.Functions
     internal static class PolynomialResultant
     {
         /// <summary>
-        /// The elimination is cubic in the size of the Sylvester matrix, with a
-        /// multiplication of two multivariate polynomials at every step, so the size is what
-        /// decides whether this finishes. The bound is on <c>deg f + deg g</c>; 24 leaves a
-        /// 13824-step elimination as the worst case admitted, and admits the discriminant of
-        /// anything up to degree 12, since <c>deg f + deg f'</c> is <c>2 deg f - 1</c>.
+        /// The bound on <c>deg f + deg g</c>. It exists to stop the matrix being built at
+        /// all; what the elimination then costs is bounded by
+        /// <see cref="MaxEliminationWork"/> instead, and the two are not the same question.
         /// </summary>
-        private const int MaxSylvesterSize = 24;
+        /// <remarks>
+        /// Size is the cheap axis, which is why this is generous. With scalar entries the
+        /// elimination does <c>size^3 / 3</c> units of the work counted below, and 40 measured
+        /// 31ms and 35MB of allocation — where the same size with three-term entries costs 22
+        /// seconds and 79GB. So a ceiling on size alone can only be right for one shape of
+        /// input at a time, and this one is set for the shape it can actually decide: 40
+        /// admits the discriminant of anything up to degree 20, since <c>deg f + deg f'</c> is
+        /// <c>2 deg f - 1</c>. https://github.com/asc-community/AngouriMath/issues/921
+        /// </remarks>
+        private const int MaxSylvesterSize = 40;
+
+        /// <summary>
+        /// The budget on the elimination itself, in units of one coefficient-pair
+        /// multiplication: each step adds the product of the term counts of the two operands
+        /// of each of its two products, which is what a sparse multiplication costs.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Measured rather than reasoned, across the two axes that matter — Sylvester size,
+        /// and terms per entry. Over the whole range the unit predicts both resources
+        /// linearly and tightly: <b>1.4KB of allocation and 0.4µs per unit</b>. So this budget
+        /// is about a second, and about three gigabytes of garbage, and moving it moves both
+        /// together.
+        /// </para>
+        /// <para>
+        /// A bound on the input shape cannot do this job, which is the measurement's real
+        /// finding. The cost is mild in size and violent in terms per entry — between the
+        /// fifth and the eighth power of it over the range — so no product of the two is the
+        /// right law. Worse, <b>the most expensive input is not the widest</b>: entries wide
+        /// enough trip <see cref="MultivariatePolynomial.MaxTerms"/> early and the elimination
+        /// declines cheaply, while three-term entries grow just slowly enough to spend 6
+        /// seconds and 21GB before declining at size 24. The shape that costs the most is the
+        /// one just inside the term ceiling, and no bound read off the degrees can see it.
+        /// </para>
+        /// <para>
+        /// Set to admit every case that answered at all in the sweep bar one — two-term
+        /// entries at size 40, which answers in 2.9 seconds having allocated 8.4GB — and to
+        /// refuse the expensive refusals, which is where it earns its keep.
+        /// </para>
+        /// </remarks>
+        private const long MaxEliminationWork = 2_500_000;
 
         [ConstantField] private static readonly ERational MinusOne = ERational.One.Negate();
 
@@ -217,6 +255,7 @@ namespace AngouriMath.Functions
                         matrix[rightDegree + row][row + rightDegree - power] = coefficient;
 
             var negated = false;
+            var work = 0L;
             var previous = MultivariatePolynomial.One(variableCount);
             for (var pivot = 0; pivot + 1 < size; pivot++)
             {
@@ -243,6 +282,13 @@ namespace AngouriMath.Functions
                     var leading = matrix[row][pivot];
                     for (var column = pivot + 1; column < size; column++)
                     {
+                        // Charged before the multiplication rather than after it, so that the
+                        // budget cannot be overshot by the one step that was going to be the
+                        // most expensive of them.
+                        work += (long)head.TermCount * matrix[row][column].TermCount
+                            + (long)leading.TermCount * matrix[pivot][column].TermCount;
+                        if (work > MaxEliminationWork)
+                            return null;
                         if (head.Multiply(matrix[row][column]) is not { } kept
                             || leading.Multiply(matrix[pivot][column]) is not { } removed
                             || kept.Subtract(removed).DivideExact(previous) is not { } reduced)

--- a/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialResultantTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialResultantTest.cs
@@ -520,7 +520,8 @@ namespace AngouriMath.Tests.Algebra.Polynomials
         [Fact]
         public void InputTooLargeForTheEliminationIsRefusedRatherThanAttempted()
         {
-            var coefficients = new ERational[21];
+            // deg f + deg g of 42, one past the ceiling on size.
+            var coefficients = new ERational[22];
             for (var power = 0; power < coefficients.Length; power++)
                 coefficients[power] = Rational(power % 5 + 1);
             var poly = Univariate(coefficients);
@@ -533,14 +534,52 @@ namespace AngouriMath.Tests.Algebra.Polynomials
         {
             // deg f + deg g of exactly the ceiling, so that the refusal above reads as a
             // bound rather than as a description of everything past a handful of terms.
-            var leftRoots = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
-            var rightRoots = new[] { 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24 };
+            var leftRoots = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 };
+            var rightRoots = new[] { 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40 };
             AssertConstant(
                 ResultantFromRoots(1, leftRoots, 1, rightRoots),
                 PolynomialResultant.Resultant(
                     Univariate(FromRoots(1, leftRoots)), Univariate(FromRoots(1, rightRoots)),
                     0, NoOtherVariables),
                 "Res(f, g) at the ceiling");
+        }
+
+        /// <summary>
+        /// Three variables, every coefficient in the main one carrying two monomials in the
+        /// other two, at a Sylvester size the ceiling admits. The elimination is refused all
+        /// the same, on the budget rather than on the size — which is the whole point of
+        /// there being two bounds: the cost of an elimination is not readable off its degrees.
+        /// https://github.com/asc-community/AngouriMath/issues/921
+        /// </summary>
+        [Fact]
+        public void AnEliminationPastTheWorkBudgetIsRefusedThoughItsSizeIsAdmitted()
+        {
+            var left = Wide(20, 2, seed: 1);
+            var right = Wide(20, 2, seed: 2);
+            Assert.Equal(20, left.DegreeIn(0));
+            Assert.Equal(20, right.DegreeIn(0));
+            Assert.Null(PolynomialResultant.Resultant(left, right, 0, new[] { 1, 2 }));
+        }
+
+        /// <summary>
+        /// A polynomial of the given degree in variable 0, each of whose coefficients carries
+        /// <paramref name="width"/> distinct monomials in variables 1 and 2.
+        /// </summary>
+        private static MultivariatePolynomial Wide(int degree, int width, int seed)
+        {
+            var shape = new[] { (A: 0, B: 0), (A: 1, B: 0), (A: 0, B: 1), (A: 1, B: 1) };
+            var result = MultivariatePolynomial.Zero(3);
+            for (var power = 0; power <= degree; power++)
+                for (var term = 0; term < width; term++)
+                {
+                    var value = Rational(1 + (seed * 7 + power * 3 + term * 5) % 11);
+                    var monomial = MultivariatePolynomial.Constant(3, value).ShiftedBy(0, power)
+                        ?.ShiftedBy(1, shape[term % shape.Length].A)
+                        ?.ShiftedBy(2, shape[term % shape.Length].B);
+                    Assert.NotNull(monomial);
+                    result = result.Add(monomial!);
+                }
+            return result;
         }
     }
 }


### PR DESCRIPTION
Closes #921.

`MaxSylvesterSize = 24` was arithmetic about a step count, not a measurement of anything, and the issue asked for the two axes that actually matter to be measured — Sylvester size, and terms per entry. They were, across 5 widths and 9 sizes, timing and allocation both.

**The answer is that a bound on the input shape cannot do this job.**

## What was measured

Sylvester size against terms per coefficient, with the ceiling lifted so the shape past 24 is visible. Time and allocated bytes, one thread, warmed.

| terms/entry | size | ms | allocated | outcome |
|--:|--:|--:|--:|---|
| 1 | 40 | 31 | 35 MB | answered |
| 2 | 24 | 422 | 689 MB | answered |
| 2 | 40 | 2880 | 8.4 GB | answered |
| 3 | 16 | 838 | 2.9 GB | answered |
| 3 | 24 | 6248 | 21 GB | **declined** |
| 3 | 40 | 21980 | 79 GB | **declined** |
| 8 | 24 | 2233 | 8.4 GB | **declined** |

Three findings, none of them visible from the step count:

1. **Size is the cheap axis, and 24 was far too mean for it.** With scalar entries the elimination does `size^3/3` units of work; size 40 costs 31 ms and 35 MB.
2. **Cost is violent in terms per entry** — between the fifth and the eighth power of it over the range — so no *product* of the two axes is the right law either.
3. **The most expensive input is not the widest.** Entries wide enough trip `MultivariatePolynomial.MaxTerms` early and decline cheaply; three-term entries grow just slowly enough to spend 6 seconds and 21 GB before declining at size 24. The shape that costs the most is the one just inside the term ceiling, and nothing read off the degrees can see it.

## What changed

**`MaxSylvesterSize` 24 → 40.** It now exists only to stop the matrix being built at all. 40 admits the discriminant of anything up to degree 20 rather than 12.

**New `MaxEliminationWork = 2_500_000`** — a budget on the work *done* rather than the work predicted. Each step charges the product of the term counts of the operands of each of its two products, which is what a sparse multiplication costs, and it is charged *before* the multiplication so the budget cannot be overshot by the step that was going to be the worst.

Over the whole sweep that unit predicts both resources linearly and tightly — **1.4 KB of allocation and 0.4 µs per unit** — so the budget is about a second and about three gigabytes, and moving it moves both together.

## What it buys

| | before | after |
|---|---|---|
| every refusal in the sweep | up to 22 s and 79 GB | 1.0–1.2 s and 3.5–4.2 GB |
| the sweep as a whole | 2 m 50 s | 37 s |

Nothing that answered within the old ceiling stops answering, and cases that declined there decline up to six times faster. Above it the raise adds answers: scalar entries to size 40, two-term entries to size 32, the discriminant of a degree-16 polynomial.

**The two costs, stated plainly.** One case is refused that the sweep showed answering — two-term entries at size 40, 2.9 s and 8.4 GB — and the old ceiling refused that one too. And a large wide input now takes up to a second to be refused where a ceiling of 24 refused it for nothing; that is the price of no longer refusing the cheap ones along with it.

## Tests

- `TheLargestAdmittedEliminationStillAnswers` moves to the new ceiling: two degree-20 polynomials with roots 1..20 and 21..40, checked against the product over the differences of the roots. 35 ms.
- `InputTooLargeForTheEliminationIsRefusedRatherThanAttempted` moves to size 42, one past the ceiling.
- `AnEliminationPastTheWorkBudgetIsRefusedThoughItsSizeIsAdmitted` is new, and is the point of there being two bounds: three variables, two monomials per coefficient, size 40 — admitted by the ceiling and refused on work.

No `BREAKING-CHANGES.md` entry: `PolynomialResultant` is `internal` and nothing in the library calls it yet, which is also why #921 said this blocks nothing and is worth settling before something does.

## Measured

Suite 6961 passed / 0 failed; F# wrapper 130/130; casbench 116/119 with 0 wrong, 0 error, 0 timeout; propcheck 1340 checks / 0 failures; rootcheck 596/596 clean; simpsweep 10463/10463 agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
