### PR TITLE
Apply the parity identities, so that sin(-x) + sin(x) reaches zero (#929)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -32,6 +32,48 @@ read first.
 | | `"x^4 + 3x^2 + 2".SolveEquation("x")` | `{ sqrt(-2), -sqrt(-2), i, -i }` | the same four, in the order the factors are found |
 | **silent** | `"1/(x^4 + 3x^2 + 2)".Integrate("x")` | unevaluated | `arctan(x) - sqrt(2) * arctan(sqrt(2) * x / 2) / 2 + C` |
 | **silent** | `"1/(x^4 + 4)".Integrate("x")` | unevaluated | the antiderivative over its two quadratic factors |
+| **silent** | `"sin(-x) + sin(x)".Simplify()` | `sin(-x) + sin(x)` | `0` |
+| **silent** | `"cos(-x)".Simplify()` and `"abs(-x)".Simplify()` | unchanged | `cos(x)`, `abs(x)` |
+
+### The parity identities are applied
+
+`cos(-u) = cos(u)`, `sin(-u) = -sin(u)` and the rest of the family were absent, so an expression that
+cancels exactly did not:
+
+```
+"sin(-x) + sin(x)".Simplify()
+
+was  sin(-x) + sin(x)
+is   0
+```
+
+Nothing false was being asserted, so this is a coverage change rather than a wrong answer put right —
+but an expression that is identically zero was left standing, and anything testing a residual against
+zero saw a non-zero residual where there was none.
+
+The one case that already folded, `cos(-2 * x)`, folded by accident: the multiple-angle expansion
+fires for a coefficient of magnitude two or more, and `-x` is a coefficient of `-1`, which it skips.
+That is why `cos(-2 * x)` worked and `cos(-x)`, `sin(-2 * x)`, `tan(-2 * x)` and `abs(-2 * x)` did
+not. What is matched now is a product with a negative real coefficient, which `-x` and `-2 * x` both
+are.
+
+Even: `cos`, `sec`, `abs`. Odd: `sin`, `tan`, `cotan`, `cosec`, `sgn`. Each holds on the whole
+complex plane, and the poles of the odd ones sit symmetrically about zero — `tan(-z)` is undefined
+exactly where `tan(z)` is — so **no condition is acquired**, which is pinned by its own test. Where a
+cancellation is between two reciprocal functions the condition that was already there survives:
+`tan(-x) + tan(x)` is `0 provided not cos(x) = 0`, which is right, since it is undefined at the poles
+rather than zero there.
+
+**A lone `sin(-x)` still prints as `sin(-x)` rather than `-sin(x)`**, and that is a tie rather than a
+failure: both rate exactly 14 under the complexity criteria, and a tie goes to whichever candidate
+was generated first. The identity is applied — it is what makes the cancellation above work — but it
+does not win a comparison it was never going to win. The tests assert the cancellation for that
+reason, rather than pinning the tie-break.
+
+The inverse functions are deliberately untouched: `arcsin` and `arctan` are odd and `arccos` is not,
+and this library's `arccotan` has range `(-pi/2, pi/2]` rather than the textbook `(0, pi)`, so each
+wants measuring before anything is written down.
+[#929](https://github.com/asc-community/AngouriMath/issues/929).
 
 ### A rational function is decomposed over the factors of its denominator, not only its roots
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -42,6 +42,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [AngouriMath/Functions/Algebra/Polynomials/{IntegerPolynomial,PrimeFieldPolynomial,PrimeFieldFactorization,SquareFreeDecomposition,PolynomialFactorization,PolynomialResultant,RationalPolynomial,PartialFractions}.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[Tests/UnitTests/PatternsTest/ParityTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [Tests/UnitTests/Algebra/Polynomials/*.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Common.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Common.cs
@@ -232,6 +232,30 @@ namespace AngouriMath.Functions
             Mulf(Rational(var mOne, var den), var any1) when mOne == -1 && den != 1 => -(any1 / den),
             Mulf(var any1, Rational(var mOne, var den)) when mOne == -1 && den != 1 => -(any1 / den),
 
+            // Parity. Each of these holds on the whole complex plane, and the poles of the odd
+            // ones sit symmetrically about zero -- tan(-z) is undefined exactly where tan(z)
+            // is -- so the domain neither widens nor narrows and no condition is owed.
+            //
+            // What is matched is a product with a negative real coefficient, which is what
+            // both `-x` and `-2 * x` are: the first is a coefficient of -1, and -1 is exactly
+            // what the multiple-angle expansion skips, since that asks for |n| >= 2. So
+            // cos(-2 * x) folded while cos(-x) did not, sin folded neither, and
+            // sin(-x) + sin(x) did not reach zero.
+            // https://github.com/asc-community/AngouriMath/issues/929
+            //
+            // The inverse functions are deliberately absent. arcsin and arctan are odd and
+            // arccos is not, and this library's arccotan has range (-pi/2, pi/2] rather than
+            // the textbook (0, pi), so each of them wants measuring before it is written down.
+            Cosf(Mulf(Real { IsNegative: true } neg, var rest)) => new Cosf((-neg) * rest),
+            Secantf(Mulf(Real { IsNegative: true } neg, var rest)) => new Secantf((-neg) * rest),
+            Absf(Mulf(Real { IsNegative: true } neg, var rest)) => new Absf((-neg) * rest),
+
+            Sinf(Mulf(Real { IsNegative: true } neg, var rest)) => -new Sinf((-neg) * rest),
+            Tanf(Mulf(Real { IsNegative: true } neg, var rest)) => -new Tanf((-neg) * rest),
+            Cotanf(Mulf(Real { IsNegative: true } neg, var rest)) => -new Cotanf((-neg) * rest),
+            Cosecantf(Mulf(Real { IsNegative: true } neg, var rest)) => -new Cosecantf((-neg) * rest),
+            Signumf(Mulf(Real { IsNegative: true } neg, var rest)) => -new Signumf((-neg) * rest),
+
             _ => x
         };
     }

--- a/Sources/Tests/UnitTests/PatternsTest/ParityTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/ParityTest.cs
@@ -1,0 +1,96 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+using static AngouriMath.Entity;
+
+namespace AngouriMath.Tests.PatternsTest
+{
+    /// <summary>
+    /// The parity identities: cos, sec and abs are even, and sin, tan, cotan, cosec and sgn
+    /// are odd. Absent before, so an expression that cancels exactly did not — sin(-x) + sin(x)
+    /// came back as itself. https://github.com/asc-community/AngouriMath/issues/929
+    /// </summary>
+    /// <remarks>
+    /// What is asserted is the cancellation rather than the shape of a single function, and
+    /// deliberately. sin(-x) and -sin(x) rate exactly equal under the complexity criteria — 14
+    /// each — so which of them a lone sin(-x) simplifies to is a tie settled by generation
+    /// order, and pinning it would pin the tie-break rather than the identity. The cancellation
+    /// is what the identity is for and it does not depend on the tie.
+    /// </remarks>
+    [Trait("Area", "PatternsTest")]
+    public sealed class ParityTest
+    {
+        private static void AssertSimplifiesToZero(string expression)
+        {
+            var simplified = expression.ToEntity().Simplify();
+            // The odd reciprocal functions carry the condition they are defined under, which
+            // is right: tan(-x) + tan(x) is undefined at the poles, not zero there.
+            while (simplified is Providedf(var inner, _)) simplified = inner;
+            Assert.Equal(Number.Integer.Create(0), simplified);
+        }
+
+        [Theory]
+        [InlineData("cos(-x) - cos(x)")]
+        [InlineData("sec(-x) - sec(x)")]
+        [InlineData("abs(-x) - abs(x)")]
+        [InlineData("cos(-2 * x) - cos(2 * x)")]
+        [InlineData("abs(-2 * x) - abs(2 * x)")]
+        public void AnEvenFunctionDropsTheNegation(string expression) =>
+            AssertSimplifiesToZero(expression);
+
+        [Theory]
+        [InlineData("sin(-x) + sin(x)")]
+        [InlineData("tan(-x) + tan(x)")]
+        [InlineData("cotan(-x) + cotan(x)")]
+        [InlineData("cosec(-x) + cosec(x)")]
+        [InlineData("sgn(-x) + sgn(x)")]
+        [InlineData("sin(-2 * x) + sin(2 * x)")]
+        public void AnOddFunctionLiftsTheNegationOut(string expression) =>
+            AssertSimplifiesToZero(expression);
+
+        /// <summary>
+        /// A bare negation and a negative numeric coefficient are the same shape —
+        /// <c>Mulf</c> of a negative real — and both have to be reached. Before this, only a
+        /// coefficient of magnitude two or more was, and only for cosine, because what
+        /// happened to fold it was the multiple-angle expansion rather than parity.
+        /// </summary>
+        [Theory]
+        [InlineData("cos(-x)", "cos(x)")]
+        [InlineData("cos(-2 * x)", "cos(2 * x)")]
+        [InlineData("abs(-x)", "abs(x)")]
+        [InlineData("abs(-1/2 * x)", "abs(1/2 * x)")]
+        public void AnEvenFunctionReachesTheSameFormEitherWay(string written, string expected) =>
+            Assert.Equal(expected.ToEntity().Simplify(), written.ToEntity().Simplify());
+
+        /// <summary>
+        /// The identities are sound over the whole complex plane, so nothing here may acquire
+        /// a condition that the expression it came from did not have. `abs` and the entire
+        /// functions must come back unconditioned.
+        /// </summary>
+        [Theory]
+        [InlineData("cos(-x)")]
+        [InlineData("sin(-x)")]
+        [InlineData("abs(-x)")]
+        [InlineData("sgn(-x)")]
+        public void NoConditionIsAcquired(string expression) =>
+            Assert.False(expression.ToEntity().Simplify() is Providedf);
+
+        /// <summary>
+        /// A positive coefficient is left alone, so the rule cannot be cycling with whatever
+        /// would put the sign back.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(2 * x)")]
+        [InlineData("cos(2 * x)")]
+        [InlineData("abs(2 * x)")]
+        public void APositiveCoefficientIsUntouched(string expression) =>
+            Assert.Equal(expression.ToEntity(), expression.ToEntity().InnerSimplified);
+    }
+}


### PR DESCRIPTION
Closes #929.

`cos(-u) = cos(u)`, `sin(-u) = -sin(u)` and the rest of the family were absent, so an expression that cancels exactly did not.

```
"sin(-x) + sin(x)".Simplify()     was  sin(-x) + sin(x)     is  0
"cos(-x) - cos(x)".Simplify()     was  cos(-x) - cos(x)     is  0
```

Nothing false was being asserted, so this is coverage rather than a wrong answer put right — but an expression that is identically zero was left standing, and anything testing a residual against zero saw a non-zero residual where there was none.

## Why only `cos(-2 * x)` worked before

By accident. The multiple-angle expansion fires for a coefficient of magnitude two or more, and `-x` is a coefficient of `-1`, which it skips — so `cos(-2 * x)` folded while `cos(-x)` did not, and `sin(-2 * x)`, `tan(-2 * x)` and `abs(-2 * x)` did not either, cosine being the only function that expansion happens to handle this way.

A bare negation and a negative numeric coefficient are the **same shape** — a product with a negative real — and that is what is matched now.

## Soundness

Even: `cos`, `sec`, `abs`. Odd: `sin`, `tan`, `cotan`, `cosec`, `sgn`.

Each holds on the whole complex plane, and the poles of the odd ones sit symmetrically about zero — `tan(-z)` is undefined exactly where `tan(z)` is — so the domain neither widens nor narrows and **no condition is owed**. That has a test of its own rather than being asserted here.

A cancellation between reciprocal functions keeps the condition it already had: `tan(-x) + tan(x)` is `0 provided not cos(x) = 0`, which is right, since it is undefined at the poles rather than zero there.

The **inverse** functions are deliberately absent. `arcsin` and `arctan` are odd and `arccos` is not, and this library's `arccotan` has range `(-pi/2, pi/2]` rather than the textbook `(0, pi)`, so each wants measuring before anything is written down.

## One thing that did not move, and why the tests are shaped as they are

A lone `sin(-x)` still prints as `sin(-x)` rather than `-sin(x)`. That is a **tie**, not a failure: `rate::` gives both exactly **14**, and a tie goes to whichever candidate was generated first. The identity is applied — it is what makes the cancellation above work — but it does not win a comparison it was never going to win.

So the tests assert the cancellation, which is what the identity is for, rather than pinning the tie-break, which would pin the tie-break.

## How it was found

`canoncheck`, the canonical-form harness added for #746 tier 1 (see #928). `abs(-x)` vs `abs(x)`, `sin(-x)` vs `-sin(x)` and `cos(-x)` vs `cos(x)` are three of its listed agreement pairs and all three disagreed. Its `Simplify` agreement count goes **6 disagreements to 4** — the two remaining being `sin(-x)` (the tie above) and `x ^ 0`, which answers `1 provided not x = 0` and is correct.

## Measured

Suite 6960 passed / 0 failed (22 new); casbench 116/119 with 0 wrong, 0 error, 0 timeout; propcheck 1340 checks / 0 failures; rootcheck 596/596 clean; simpsweep 10463/10463 agree.

`BREAKING-CHANGES.md` carries the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
