### PR TITLE
Offer a canonical form for the commutative structure (#746)

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
+++ b/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
@@ -89,6 +89,56 @@ namespace AngouriMath.Core.Transformations
             = Rewriting(RewriteRules.CanonicalOrder).Then(InnerSimplification);
 
         /// <summary>
+        /// A canonical form for the commutative structure: two expressions differing only in
+        /// how their sums, products, conjunctions, disjunctions and set operations are
+        /// arranged or nested come out as the identical tree.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Normalise, order, normalise</b>, and the first of those is what makes it work.
+        /// The order's key depends on a node's class and the normalisation changes classes:
+        /// in <c>1/2 - x</c> the constant reaches an unprepared sort as <c>1 * 2 ^ (-1)</c>,
+        /// a product, and is ordered against <c>-x</c> as one, but folds to the number
+        /// <c>1/2</c> immediately afterwards — so the next pass orders it the other way and
+        /// the two alternate. Sorting a tree that has already settled sorts what the tree is
+        /// actually going to be.
+        /// </para>
+        /// <para>
+        /// Measured over 834 generated expressions and 2738 ordered pairs by
+        /// <c>work/canoncheck</c>: <b>idempotent, and independent of the order the operands
+        /// were written in</b>, where ordering without the leading normalisation fails 21 of
+        /// the first and <see cref="InnerSimplification"/> alone fails 2024 of the second.
+        /// </para>
+        /// <para>
+        /// <b>What it is not.</b> It is not a canonical form for the language — no such thing
+        /// exists, since zero-equivalence is undecidable here — and it is not a
+        /// simplification, since it makes an expression comparable rather than shorter.
+        /// Equal trees mean the expressions are equal; different trees mean nothing at all.
+        /// <c>Docs/Contributing/CanonicalForm.md</c> states the boundary and what is still owed.
+        /// </para>
+        /// <para>
+        /// <b>Nesting goes with order.</b> The sort works over commutative chains rather than
+        /// over one node, so it flattens as it sorts: <c>(x + y) + a</c> and <c>x + (y + a)</c>
+        /// both reach <c>a + x + y</c>, and reach it as the same tree. That is worth saying
+        /// because <see cref="InnerSimplification"/> alone leaves those two as different trees
+        /// which <i>print identically</i> — associativity being normalised on the way out
+        /// rather than in the expression — so a comparison of printed forms cannot tell the
+        /// two situations apart.
+        /// </para>
+        /// <para>
+        /// Nothing in the library runs this: it is offered, not applied. Putting it inside
+        /// <see cref="InnerSimplification"/> would move every commutative operand order in
+        /// every printed answer at once, which is a decision for a release rather than for a
+        /// transformation. <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a>
+        /// tier 1.
+        /// </para>
+        /// </remarks>
+        public static Transformation Canonicalisation { get; }
+            = InnerSimplification
+                .Then(Rewriting(RewriteRules.CanonicalOrderExact))
+                .Then(InnerSimplification);
+
+        /// <summary>
         /// Clears a surd out of a two-term denominator: <c>1 / (sqrt(3) + 5)</c> becomes
         /// <c>(sqrt(3) - 5) / (-22)</c>.
         /// </summary>

--- a/Sources/Tests/UnitTests/Common/PublicApi.txt
+++ b/Sources/Tests/UnitTests/Common/PublicApi.txt
@@ -154,6 +154,7 @@ AngouriMath.Core.Transformations.Soundness.value__ : System.Int32
 AngouriMath.Core.Transformations.Transformation.Apply(AngouriMath.Entity) : AngouriMath.Core.Transformations.TransformationResult
 AngouriMath.Core.Transformations.Transformation.ApplyCore(AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Core.Transformations.Transformation.ApplyOrKeep(AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.Core.Transformations.Transformation.Canonicalisation { } : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Differentiation(AngouriMath.Entity+Variable) : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Expansion { } : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.ExpansionAtLevel(System.Int32) : AngouriMath.Core.Transformations.Transformation

--- a/Sources/Tests/UnitTests/Core/Transformations/CanonicalisationTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/CanonicalisationTest.cs
@@ -1,0 +1,124 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Core.Transformations;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// <see cref="Transformation.Canonicalisation"/>: a canonical form for the commutative
+    /// structure. Two expressions differing only in how their operands are arranged come out
+    /// as the identical tree. https://github.com/asc-community/AngouriMath/issues/746
+    /// </summary>
+    /// <remarks>
+    /// Everything here compares **entities**. Comparing printed forms would pass whatever the
+    /// transformation did, since the printer already reorders and reassociates on its way out —
+    /// `(x + y) + a` and `x + (y + a)` print alike and are different trees, which is the single
+    /// most likely thing for a test in this area to get wrong.
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class CanonicalisationTest
+    {
+        private static Entity Canonical(string expression)
+            => Transformation.Canonicalisation.ApplyOrKeep(expression.ToEntity());
+
+        /// <summary>
+        /// The property the form exists for: however the operands were written, the tree is
+        /// the same one.
+        /// </summary>
+        [Theory]
+        [InlineData("x + y", "y + x")]
+        [InlineData("x * y", "y * x")]
+        [InlineData("x + y + a", "a + y + x")]
+        [InlineData("x * y * a", "a * y * x")]
+        [InlineData("1/2 - x", "-x + 1/2")]
+        [InlineData("x + sqrt(a)", "sqrt(a) + x")]
+        [InlineData("x * sin(y)", "sin(y) * x")]
+        [InlineData("x and y", "y and x")]
+        [InlineData("x or y", "y or x")]
+        public void OperandOrderDoesNotSurvive(string left, string right)
+            => Assert.Equal(Canonical(left), Canonical(right));
+
+        /// <summary>
+        /// Canonicalising a canonical form leaves it alone. Ordering *without* the leading
+        /// normalisation does not have this property: the sort's key depends on a node's class
+        /// and the normalisation changes classes, so `1/2 - x` alternates for ever.
+        /// </summary>
+        [Theory]
+        [InlineData("1/2 - x")]
+        [InlineData("0 ^ x")]
+        [InlineData("x + y")]
+        [InlineData("x * y * a")]
+        [InlineData("sqrt(1/2) + x")]
+        [InlineData("x + 1 * 1 / 2")]
+        [InlineData("(x + y) * (a - 1/2)")]
+        [InlineData("sin(x) + cos(x) + 1/3")]
+        public void CanonicalisingTwiceIsCanonicalisingOnce(string expression)
+        {
+            var once = Canonical(expression);
+            Assert.Equal(once, Transformation.Canonicalisation.ApplyOrKeep(once));
+        }
+
+        /// <summary>
+        /// It is a form, not a simplification: the value is unchanged, which is checked the way
+        /// this repository checks an identity — subtract and simplify to zero.
+        /// </summary>
+        [Theory]
+        [InlineData("1/2 - x")]
+        [InlineData("x + y + a")]
+        [InlineData("x * y * a")]
+        [InlineData("(x + y) * (a - 1/2)")]
+        [InlineData("sin(x) + cos(x) + 1/3")]
+        public void TheValueIsUnchanged(string expression)
+        {
+            var difference = (expression.ToEntity() - Canonical(expression)).Simplify();
+            while (difference is Entity.Providedf(var inner, _)) difference = inner;
+            Assert.Equal(Entity.Number.Integer.Create(0), difference);
+        }
+
+        /// <summary>
+        /// Nesting goes as well as order: the sort works over commutative *chains*, so it
+        /// flattens as it sorts. `(x + y) + a` and `x + (y + a)` both reach `a + x + y`, and
+        /// they reach it as the same tree rather than merely printing alike — which is the
+        /// distinction that matters, since `InnerSimplified` alone leaves them as two trees
+        /// that print identically.
+        /// </summary>
+        [Theory]
+        [InlineData("(x + y) + a", "x + (y + a)")]
+        [InlineData("(x * y) * a", "x * (y * a)")]
+        [InlineData("((x + y) + a) + b", "x + (y + (a + b))")]
+        [InlineData("(x + y) + a", "a + (y + x)")]
+        public void AssociativityGoesToo(string left, string right)
+            => Assert.Equal(Canonical(left), Canonical(right));
+
+        /// <summary>
+        /// And the pair that motivated all of this, stated as the two facts side by side: the
+        /// normalisation alone leaves two trees that print the same, and the canonicalisation
+        /// makes them one tree.
+        /// </summary>
+        [Fact]
+        public void TheTwoTreesThatPrintAlikeBecomeOne()
+        {
+            var left = "(x + y) + a".ToEntity();
+            var right = "x + (y + a)".ToEntity();
+            Assert.Equal(left.InnerSimplified.Stringize(), right.InnerSimplified.Stringize());
+            Assert.NotEqual(left.InnerSimplified, right.InnerSimplified);
+            Assert.Equal(Canonical("(x + y) + a"), Canonical("x + (y + a)"));
+        }
+
+        /// <summary>
+        /// And it is not applied by anything: asking for a simplification must not start
+        /// returning canonicalised trees behind the caller's back.
+        /// </summary>
+        [Fact]
+        public void NothingRunsItByDefault()
+            => Assert.Equal("y + x".ToEntity().InnerSimplified, "y + x".ToEntity());
+    }
+}


### PR DESCRIPTION
#746 tier 1 asks for "a specified canonicaliser". This is one, and it is a composition of parts that **all already existed** — `Transformation.Canonicalisation` is `InnerSimplification`, then the `CanonicalOrderExact` rule set, then `InnerSimplification` again. No rule is changed and nothing new is computed.

## The leading normalisation is the part that matters

The sort's key depends on a node's **class**, and the normalisation **changes** classes. In `1/2 - x` the constant reaches an unprepared sort as `1 * 2 ^ (-1)` — a *product* — and is ordered against `-x` as one, then folds to the number `1/2` immediately afterwards, so the next pass orders it the other way and the two alternate for ever:

```
1 / 2 - x    sorted  ->  -x + 1 * 2 ^ (-1)   normalised  ->  -x + 1/2
-x + 1/2     sorted  ->  1/2 + -x                            ...and back
```

Sorting a tree that has already settled sorts what the tree is actually going to be. `x + (-1/2)`, whose constant is already a number, was stable throughout — the control that makes this the explanation rather than a guess.

## Measured

Over 834 generated expressions and 2738 ordered pairs, by the analysis workspace's `canoncheck`:

| | idempotence | order independence |
|---|--:|--:|
| `InnerSimplified` | 0 of 834 | 2024 of 2738 |
| order, then normalise | 21 of 834 | 0 of 2738 |
| **this** | **0 of 834** | **0 of 2738** |

## Nesting goes with order, which I did not expect

The sort works over commutative *chains* rather than over one node, so it flattens as it sorts. `(x + y) + a` and `x + (y + a)` both reach `a + x + y` **and reach it as the same tree** — where `InnerSimplified` alone leaves them as two different trees that *print identically*, associativity being normalised on the way out rather than in the expression.

A test states both halves side by side, because a comparison of printed forms cannot tell those two situations apart. Every test here compares entities, for that reason. (I had written the opposite as a test asserting non-equality; it failed, which is how this was found.)

## What it does not claim

Not a canonical form for the language — zero-equivalence is undecidable here — and not a simplification: it makes an expression comparable, not shorter. **Equal trees mean the expressions are equal; different trees mean nothing at all.** `Docs/Contributing/CanonicalForm.md` (#928) states the boundary.

**Nothing runs it**: it is offered, not applied, and a test pins that. Putting it inside `InnerSimplified` would move every commutative operand order in every printed answer at once — a decision for a release rather than for a transformation.

## Scope

No `BREAKING-CHANGES.md` entry: no input gives a different answer. The new public property is recorded in `PublicApi.txt`, which is what caught the omission.

Suite 6988 passed / 0 failed, of which 28 are new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)