### PR TITLE
A canonical form for rational functions over Q (#934)

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -39,7 +39,7 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [Tests/UnitTests/Core/KnownLimitsAreNotBugsTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
-[AngouriMath/Functions/Algebra/Polynomials/{IntegerPolynomial,PrimeFieldPolynomial,PrimeFieldFactorization,SquareFreeDecomposition,PolynomialFactorization,PolynomialResultant,RationalPolynomial,PartialFractions}.cs]
+[AngouriMath/Functions/Algebra/Polynomials/{IntegerPolynomial,PrimeFieldPolynomial,PrimeFieldFactorization,SquareFreeDecomposition,PolynomialFactorization,PolynomialResultant,RationalPolynomial,PartialFractions,RationalFunction}.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
 [Tests/UnitTests/Algebra/Polynomials/*.cs]

--- a/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
+++ b/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
@@ -89,6 +89,43 @@ namespace AngouriMath.Core.Transformations
             = Rewriting(RewriteRules.CanonicalOrder).Then(InnerSimplification);
 
         /// <summary>
+        /// A canonical form for <b>rational functions over <c>Q</c></b>: two expressions
+        /// denoting the same quotient of polynomials become the identical tree, so equality on
+        /// that sublanguage is decided by comparing nodes rather than by searching.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>It answers only where it can.</b> There is no canonical form for the whole
+        /// language — zero-equivalence is undecidable once <c>pi</c>, the exponential, the
+        /// trigonometric functions and <c>abs</c> are in play (Richardson, 1968) — so anything
+        /// that is not a rational function over <c>Q</c> in its free variables gets no answer
+        /// at all. That refusal is the point: a form whose value is that equal trees mean equal
+        /// expressions must not quietly hand back a normalisation that merely resembles one.
+        /// </para>
+        /// <para>
+        /// The expression is gathered into a single quotient — which is the part nothing else
+        /// in the library does, and without which <c>1/x + 1/y</c> and <c>(x + y)/(x*y)</c>
+        /// could never meet — then reduced by the multivariate greatest common divisor and
+        /// scaled so the denominator is monic in the lexicographic monomial order.
+        /// </para>
+        /// <para>
+        /// <b>Cancelling carries its condition.</b> <c>x/x</c> is not <c>1</c>, so where a
+        /// factor of positive degree comes out the answer says the factor is nonzero, as the
+        /// rest of the library already does. Gathering over a common denominator widens
+        /// nothing by itself: a sum is defined exactly where its terms are.
+        /// </para>
+        /// <para>
+        /// Nothing runs this by default. See
+        /// <c>Docs/Contributing/CanonicalForm.md</c> §5 and
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/934">#934</a>.
+        /// <c>Transformation.Canonicalisation</c> is the companion that handles the commutative
+        /// structure of expressions generally.
+        /// </para>
+        /// </remarks>
+        public static Transformation RationalCanonicalisation { get; }
+            = new RationalCanonicalisationTransformation();
+
+        /// <summary>
         /// Clears a surd out of a two-term denominator: <c>1 / (sqrt(3) + 5)</c> becomes
         /// <c>(sqrt(3) - 5) / (-22)</c>.
         /// </summary>
@@ -180,6 +217,18 @@ namespace AngouriMath.Core.Transformations
                 => level < Lowest || level > Highest
                     ? make(level)
                     : cached[level - Lowest] ??= make(level);
+        }
+
+        private sealed class RationalCanonicalisationTransformation : Transformation
+        {
+            public override string Name => "rational-canonical-form";
+
+            public override TransformationRelation Relation => TransformationRelation.Equivalence;
+
+            public override Soundness Soundness => Soundness.SoundUnderAssumptions;
+
+            protected override Entity? ApplyCore(Entity input)
+                => RationalFunction.TryCanonicalise(input, out var canonical) ? canonical : null;
         }
 
         private sealed class InnerSimplificationTransformation : Transformation

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/RationalFunction.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/RationalFunction.cs
@@ -1,0 +1,263 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using PeterO.Numbers;
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// A canonical form for rational functions over <c>Q</c>: two expressions denoting the
+    /// same quotient of polynomials become the identical tree, so that deciding whether they
+    /// are equal is a structural comparison rather than a search.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the part of the language where a canonical form is <i>possible</i>. There is
+    /// none for the whole of it — zero-equivalence is undecidable once <c>pi</c>, the
+    /// exponential, the trigonometric functions and <c>abs</c> are in play (Richardson, 1968)
+    /// — so the boundary is in the signature: a refusal means "not a rational function over
+    /// <c>Q</c>, and no canonical form is claimed", never a normalisation that resembles one.
+    /// <c>Docs/Contributing/CanonicalForm.md</c> is the specification.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/934">#934</a>.
+    /// </para>
+    /// <para>
+    /// Four steps, and only the first is new. The expression is gathered into a single
+    /// quotient — nothing else in the library does that, and without it <c>1/x + 1/y</c> and
+    /// <c>(x + y)/(x*y)</c> could never meet. Then the numerator and denominator are divided
+    /// by their multivariate greatest common divisor, which
+    /// <see cref="PolynomialGcd"/> computes and verifies. Then both are scaled so that the
+    /// denominator's leading coefficient is one, which is what makes <c>2x/(4y)</c> and
+    /// <c>x/(2y)</c> the same tree. Coefficients are in lowest terms throughout.
+    /// </para>
+    /// <para>
+    /// <b>The domain is preserved rather than assumed away.</b> Cancelling a common factor
+    /// widens the domain — <c>x/x</c> is not <c>1</c> — so where a factor of positive degree
+    /// is cancelled the answer carries the condition that it is nonzero, which is what the
+    /// library already does elsewhere and what keeps "equal trees means equal expressions"
+    /// true rather than nearly true. Gathering over a common denominator does not widen
+    /// anything: a sum is defined exactly where its terms are, and the product of the
+    /// denominators vanishes exactly where one of them does.
+    /// </para>
+    /// </remarks>
+    internal static class RationalFunction
+    {
+        /// <summary>
+        /// A quotient larger than this is left alone. On node count, and a refusal rather
+        /// than an approximation.
+        /// </summary>
+        private const int MaxComplexity = 256;
+
+        /// <summary>
+        /// Raising to a power is where a gathered quotient explodes, so the exponent is
+        /// bounded before <see cref="MultivariatePolynomial.Power"/> is asked; that has its
+        /// own bound on the number of terms, which catches the rest.
+        /// </summary>
+        private const int MaxExponent = 32;
+
+        /// <summary>
+        /// <paramref name="expr"/> as a canonical quotient of polynomials over <c>Q</c>, or
+        /// <see langword="false"/> where it is not a rational function over <c>Q</c> in its
+        /// free variables, or where a bound is reached.
+        /// </summary>
+        internal static bool TryCanonicalise(Entity expr, [NotNullWhen(true)] out Entity? canonical)
+        {
+            canonical = null;
+            if (expr.Complexity > MaxComplexity)
+                return false;
+
+            var variables = expr.Vars
+                .OrderBy(variable => variable.Name, StringComparer.Ordinal)
+                .ToArray();
+            if (variables.Length > MultivariatePolynomial.MaxVariables)
+                return false;
+            var indices = new Dictionary<Variable, int>(variables.Length);
+            for (var i = 0; i < variables.Length; i++)
+                indices[variables[i]] = i;
+            var variableCount = variables.Length;
+
+            if (!TryGather(expr, indices, variableCount, out var numerator, out var denominator))
+                return false;
+            // A vanishing denominator is not a rational function, and a vanishing numerator
+            // is zero however it was written.
+            if (denominator.IsZero)
+                return false;
+            if (numerator.IsZero)
+            {
+                canonical = Integer.Create(0);
+                return true;
+            }
+
+            var order = new int[variableCount];
+            for (var i = 0; i < order.Length; i++)
+                order[i] = i;
+
+            var cancelled = MultivariatePolynomial.One(variableCount);
+            if (variableCount > 0
+                && PolynomialGcd.Gcd(numerator, denominator, order, 0) is { } divisor
+                && !divisor.IsConstant)
+            {
+                if (numerator.DivideExact(divisor) is not { } reducedTop
+                    || denominator.DivideExact(divisor) is not { } reducedBottom)
+                    return false;
+                // Multiplied back independently of the division that produced them, as
+                // PolynomialGcd does for the same reason: an incomplete cancellation is a
+                // tolerable answer and a wrong one is not.
+                if (reducedTop.Multiply(divisor) is not { } checkedTop || !checkedTop.SameAs(numerator)
+                    || reducedBottom.Multiply(divisor) is not { } checkedBottom
+                    || !checkedBottom.SameAs(denominator))
+                    return false;
+                numerator = reducedTop;
+                denominator = reducedBottom;
+                cancelled = divisor;
+            }
+
+            // Scaled so the denominator leads with one, under the same lexicographic monomial
+            // order the Gröbner solver uses. Without this, 2x/(4y) and x/(2y) are different
+            // trees for one function: their greatest common divisor is fixed only up to a
+            // unit, and nothing obliges the machinery to take the 2 out.
+            var leading = denominator.LeadingCoefficient(MonomialOrder.Lexicographic);
+            if (leading.IsZero)
+                return false;
+            if (leading.CompareTo(ERational.One) != 0)
+            {
+                var inverse = ERational.One.Divide(leading).ToLowestTerms();
+                numerator = numerator.ScaleBy(inverse);
+                denominator = denominator.ScaleBy(inverse);
+            }
+
+            // The denominator is now monic, so a constant one is exactly 1 and is dropped.
+            var quotient = denominator.IsConstant
+                ? numerator.ToEntity(variables)
+                : numerator.ToEntity(variables) / denominator.ToEntity(variables);
+
+            canonical = cancelled.IsConstant
+                ? quotient
+                : new Providedf(quotient, !cancelled.ToEntity(variables).EqualTo(0));
+            return true;
+        }
+
+        /// <summary>
+        /// <paramref name="expr"/> as a single quotient of polynomials, gathering a sum of
+        /// quotients over a common denominator. The denominator is never zero and never
+        /// simplified away; it is <c>1</c> for a polynomial.
+        /// </summary>
+        /// <remarks>
+        /// The common denominator is the product rather than the least common multiple. Both
+        /// are correct and the product is cheaper to build; what it costs is a larger
+        /// intermediate, which the greatest common divisor then removes — so the answer is the
+        /// same and only the work in between differs.
+        /// </remarks>
+        private static bool TryGather(
+            Entity expr, IReadOnlyDictionary<Variable, int> indices, int variableCount,
+            [NotNullWhen(true)] out MultivariatePolynomial? numerator,
+            [NotNullWhen(true)] out MultivariatePolynomial? denominator)
+        {
+            numerator = denominator = null;
+
+            // A polynomial is its own numerator, and this is the common case, so it is tried
+            // before the expression is taken apart.
+            if (MultivariatePolynomial.TryParse(expr, indices) is { } whole)
+            {
+                numerator = whole;
+                denominator = MultivariatePolynomial.One(variableCount);
+                return true;
+            }
+
+            switch (expr)
+            {
+                case Sumf(var left, var right):
+                    return TryCombine(left, right, subtract: false, indices, variableCount,
+                        out numerator, out denominator);
+
+                case Minusf(var left, var right):
+                    return TryCombine(left, right, subtract: true, indices, variableCount,
+                        out numerator, out denominator);
+
+                case Mulf(var left, var right):
+                {
+                    if (!TryGather(left, indices, variableCount, out var leftTop, out var leftBottom)
+                        || !TryGather(right, indices, variableCount, out var rightTop, out var rightBottom))
+                        return false;
+                    if (leftTop.Multiply(rightTop) is not { } top
+                        || leftBottom.Multiply(rightBottom) is not { } bottom)
+                        return false;
+                    numerator = top;
+                    denominator = bottom;
+                    return true;
+                }
+
+                case Divf(var left, var right):
+                {
+                    if (!TryGather(left, indices, variableCount, out var leftTop, out var leftBottom)
+                        || !TryGather(right, indices, variableCount, out var rightTop, out var rightBottom))
+                        return false;
+                    // Dividing by a quotient that is identically zero is not a rational
+                    // function, and inverting it here would quietly produce one.
+                    if (rightTop.IsZero)
+                        return false;
+                    if (leftTop.Multiply(rightBottom) is not { } top
+                        || leftBottom.Multiply(rightTop) is not { } bottom)
+                        return false;
+                    numerator = top;
+                    denominator = bottom;
+                    return true;
+                }
+
+                case Powf(var @base, Integer power):
+                {
+                    var exponent = power.EInteger;
+                    if (exponent.Abs().CompareTo(EInteger.FromInt32(MaxExponent)) > 0)
+                        return false;
+                    if (!TryGather(@base, indices, variableCount, out var baseTop, out var baseBottom))
+                        return false;
+                    var magnitude = exponent.Abs().ToInt32Checked();
+                    var negative = exponent.Sign < 0;
+                    if (negative && baseTop.IsZero)
+                        return false;
+                    var top = negative ? baseBottom : baseTop;
+                    var bottom = negative ? baseTop : baseBottom;
+                    if (top.Power(magnitude) is not { } raisedTop
+                        || bottom.Power(magnitude) is not { } raisedBottom)
+                        return false;
+                    numerator = raisedTop;
+                    denominator = raisedBottom;
+                    return true;
+                }
+
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// A sum or a difference of two quotients, over the product of their denominators.
+        /// </summary>
+        private static bool TryCombine(
+            Entity left, Entity right, bool subtract,
+            IReadOnlyDictionary<Variable, int> indices, int variableCount,
+            [NotNullWhen(true)] out MultivariatePolynomial? numerator,
+            [NotNullWhen(true)] out MultivariatePolynomial? denominator)
+        {
+            numerator = denominator = null;
+            if (!TryGather(left, indices, variableCount, out var leftTop, out var leftBottom)
+                || !TryGather(right, indices, variableCount, out var rightTop, out var rightBottom))
+                return false;
+            if (leftTop.Multiply(rightBottom) is not { } crossLeft
+                || rightTop.Multiply(leftBottom) is not { } crossRight
+                || leftBottom.Multiply(rightBottom) is not { } bottom)
+                return false;
+            numerator = subtract ? crossLeft.Subtract(crossRight) : crossLeft.Add(crossRight);
+            denominator = bottom;
+            return true;
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Common/PublicApi.txt
+++ b/Sources/Tests/UnitTests/Common/PublicApi.txt
@@ -164,6 +164,7 @@ AngouriMath.Core.Transformations.Transformation.Integration(AngouriMath.Entity+V
 AngouriMath.Core.Transformations.Transformation.LimitAt(AngouriMath.Entity+Variable, AngouriMath.Entity, AngouriMath.Core.ApproachFrom) : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Name { } : System.String
 AngouriMath.Core.Transformations.Transformation.Normalization { } : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.RationalCanonicalisation { } : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Rationalisation { } : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Relation { } : AngouriMath.Core.Transformations.TransformationRelation
 AngouriMath.Core.Transformations.Transformation.Repeat(System.Int32) : AngouriMath.Core.Transformations.Transformation

--- a/Sources/Tests/UnitTests/Core/Transformations/RationalCanonicalFormTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RationalCanonicalFormTest.cs
@@ -1,0 +1,167 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Core.Transformations;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// <see cref="Transformation.RationalCanonicalisation"/>: a canonical form for rational
+    /// functions over Q, which is the part of the language where one is possible.
+    /// https://github.com/asc-community/AngouriMath/issues/934
+    /// </summary>
+    /// <remarks>
+    /// The property being asserted is that equality becomes a structural comparison — two
+    /// writings of one rational function reach the identical tree. Everything here compares
+    /// entities; comparing printed forms would test the printer.
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class RationalCanonicalFormTest
+    {
+        private static Entity? Canonical(string expression)
+        {
+            var result = Transformation.RationalCanonicalisation.Apply(expression.ToEntity());
+            return result.Succeeded ? result.Output : null;
+        }
+
+        private static Entity Required(string expression)
+        {
+            var canonical = Canonical(expression);
+            Assert.True(canonical is not null, $"'{expression}' was refused");
+            return canonical!;
+        }
+
+        /// <summary>
+        /// The point of the whole thing: however it was written, one rational function has one
+        /// form. The first pair is the one nothing else in the library could bring together,
+        /// since no other route puts a sum of quotients over a common denominator.
+        /// </summary>
+        [Theory]
+        [InlineData("1/x + 1/y", "(x + y) / (x * y)")]
+        [InlineData("1/x - 1/y", "(y - x) / (x * y)")]
+        [InlineData("1/x + 1/y", "(y + x) / (y * x)")]
+        [InlineData("2 * x / (4 * y)", "x / (2 * y)")]
+        [InlineData("(x + 1) / (x + 2)", "(2 * x + 2) / (2 * x + 4)")]
+        [InlineData("x / y + 1", "(x + y) / y")]
+        [InlineData("1 / (1 / x)", "x")]
+        [InlineData("x ^ (-2)", "1 / x ^ 2")]
+        [InlineData("(a + b) / (a * b)", "1/b + 1/a")]
+        public void OneFunctionHasOneForm(string left, string right)
+            => Assert.Equal(Required(left), Required(right));
+
+        /// <summary>
+        /// Two rational functions that are <i>not</i> equal must not collide, or the form
+        /// decides equality wrongly, which is worse than not deciding it.
+        /// </summary>
+        [Theory]
+        [InlineData("1/x + 1/y", "1/x - 1/y")]
+        [InlineData("x / y", "y / x")]
+        [InlineData("(x + 1) / (x + 2)", "(x + 2) / (x + 1)")]
+        [InlineData("x / (2 * y)", "x / (3 * y)")]
+        public void DifferentFunctionsDoNotCollide(string left, string right)
+            => Assert.NotEqual(Required(left), Required(right));
+
+        /// <summary>
+        /// The case where "the same function" is a trap. `(x^2 - 1)/(x + 1)` is undefined at
+        /// `x = -1` and `x - 1` is not, so they are *not* the same function and the form must
+        /// not equate them — even though every textbook writes the cancellation. This is the
+        /// assertion that makes "equal trees means equal expressions" true rather than nearly
+        /// true, and it is the reason cancelling carries a condition.
+        /// </summary>
+        [Theory]
+        [InlineData("(x ^ 2 - 1) / (x + 1)", "x - 1")]
+        [InlineData("x / x", "1")]
+        [InlineData("(x * y) / x", "y")]
+        public void ARemovableSingularityIsNotRemoved(string quotient, string polynomial)
+            => Assert.NotEqual(Required(quotient), Required(polynomial));
+
+        /// <summary>
+        /// Cancelling widens the domain, so the cancelled factor's non-vanishing is stated.
+        /// `x/x` is the whole reason this cannot be skipped: it is 1 everywhere it is defined
+        /// and undefined at zero, and a form that answered a bare `1` would be claiming the
+        /// two are the same function.
+        /// </summary>
+        [Theory]
+        [InlineData("x / x")]
+        [InlineData("(x ^ 2 - 1) / (x - 1)")]
+        [InlineData("(x * y) / (x * z)")]
+        public void ACancelledFactorKeepsItsCondition(string expression)
+            => Assert.True(Required(expression) is Entity.Providedf,
+                $"'{expression}' cancelled a factor and dropped the condition");
+
+        /// <summary>
+        /// And where nothing is cancelled, no condition is invented — gathering over a common
+        /// denominator does not widen anything, since a sum is defined exactly where its terms
+        /// are.
+        /// </summary>
+        [Theory]
+        [InlineData("1/x + 1/y")]
+        [InlineData("(x + 1) / (x + 2)")]
+        [InlineData("x + 1")]
+        [InlineData("x / y")]
+        public void NothingCancelledMeansNoCondition(string expression)
+            => Assert.False(Required(expression) is Entity.Providedf,
+                $"'{expression}' acquired a condition it did not need");
+
+        /// <summary>
+        /// The boundary, and it is in the signature rather than in a comment: anything that is
+        /// not a rational function over Q gets no answer. A form whose value is that equal
+        /// trees mean equal expressions must not hand back a normalisation that resembles one.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x) / x")]
+        [InlineData("x ^ y")]
+        [InlineData("sqrt(x)")]
+        [InlineData("e ^ x")]
+        [InlineData("ln(x) / (x + 1)")]
+        [InlineData("x ^ (1/2) / y")]
+        public void WhatIsNotARationalFunctionIsRefused(string expression)
+            => Assert.Null(Canonical(expression));
+
+        /// <summary>A form is a fixed point of itself.</summary>
+        [Theory]
+        [InlineData("1/x + 1/y")]
+        [InlineData("2 * x / (4 * y)")]
+        [InlineData("(x ^ 2 - 1) / (x + 1)")]
+        [InlineData("x + 1")]
+        public void CanonicalisingTwiceIsCanonicalisingOnce(string expression)
+        {
+            var once = Required(expression);
+            var twice = Transformation.RationalCanonicalisation.Apply(once);
+            // A condition attached on the first pass is not itself a rational function, so the
+            // second pass may decline; what must not happen is a different quotient.
+            if (twice.Succeeded)
+                Assert.Equal(once, twice.Output);
+        }
+
+        /// <summary>
+        /// It is a form and not a rewrite of the value: the difference simplifies to zero,
+        /// which is how this repository checks an identity.
+        /// </summary>
+        [Theory]
+        [InlineData("1/x + 1/y")]
+        [InlineData("x / y + 1")]
+        [InlineData("(x + 1) / (x + 2)")]
+        [InlineData("2 * x / (4 * y)")]
+        public void TheValueIsUnchanged(string expression)
+        {
+            Entity canonical = Required(expression);
+            while (canonical is Entity.Providedf(var inner, _)) canonical = inner;
+            var difference = (expression.ToEntity() - canonical).Simplify();
+            while (difference is Entity.Providedf(var inner, _)) difference = inner;
+            Assert.Equal(Entity.Number.Integer.Create(0), difference);
+        }
+
+        /// <summary>Nothing applies it behind the caller's back.</summary>
+        [Fact]
+        public void NothingRunsItByDefault()
+            => Assert.Equal("1/x + 1/y".ToEntity(), "1/x + 1/y".ToEntity().Simplify());
+    }
+}


### PR DESCRIPTION
Closes #934.

The part of the language where a canonical form **is** possible. There is none for the whole of it — zero-equivalence is undecidable once `pi`, the exponential, the trigonometric functions and `abs` are in play (Richardson 1968) — so the boundary is in the signature: anything that is not a rational function over ℚ gets no answer at all, never a normalisation that resembles one.

```
1/x + 1/y             ->  (x + y) / (x * y)
(x + y)/(x * y)       ->  (x + y) / (x * y)      the same tree, which nothing could do before
2 * x / (4 * y)       ->  1/2 * x / y
x / (2 * y)           ->  1/2 * x / y
(x^2 - 1) / (x - 1)   ->  x + 1 provided not x - 1 = 0
sin(x) / x            ->  refused
```

Two rational functions are equal **exactly when this form is identical**, so equality on that sublanguage is decided by comparing nodes rather than by searching — which is what a canonical form is for, and what `(a - b).Simplify()` against zero can never be.

## What was actually missing

Four steps, and only the first is new. **Nothing in the library put an expression over a common denominator** — measured through `Simplify`, `InnerSimplified` and `Factorize` alike, and `Simplify` actively prefers the split form — so `1/x + 1/y` and `(x+y)/(x*y)` could not be brought together by any existing route.

Gathering is a structural recursion over sums, differences, products, quotients and whole powers, taking the **product** of denominators rather than their least common multiple: both are correct, the product is cheaper to build, and the GCD removes the difference immediately afterwards.

The other three steps are existing parts. `PolynomialGcd.Gcd` reduces the quotient and verifies its own division by multiplying back. `MultivariatePolynomial.LeadingCoefficient`, from the Gröbner half of the class, gives the lexicographic leading coefficient to scale by, so the denominator comes out **monic** — without that, `2x/(4y)` and `x/(2y)` stay different trees for one function, since a greatest common divisor is fixed only up to a unit.

## The assertion the whole form rests on

**Cancelling carries its condition.** `(x^2 - 1)/(x + 1)` is undefined at `x = -1` and `x - 1` is not, so they are *not* the same function and the form must not equate them, however universally that cancellation is written. There is a test saying exactly that, beside one saying `x/x` is not `1`.

(I wrote the opposite first — `(x^2-1)/(x+1)` equals `x-1` as a same-function case — and it failed. The form was right and the test was wrong.)

Gathering over a common denominator widens nothing by itself, since a sum is defined exactly where its terms are, so no condition is invented where nothing was cancelled. That has a test too.

## Scope

Offered and not applied: nothing in the library runs it, and a test pins that. No `BREAKING-CHANGES.md` entry — no input gives a different answer. The new public property is in `PublicApi.txt`.

Suite 6998 passed / 0 failed, of which 38 are new; F# 130/130; casbench 116/119 with 0 wrong, 0 error, 0 timeout; propcheck 1340/0; rootcheck 596/596; simpsweep 10463/10463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)