### PR TITLE
Take the sign back the right way when both operands are negative (#936)

### DIFF
--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Common.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Common.cs
@@ -22,11 +22,20 @@ namespace AngouriMath.Functions
 
         internal static Entity NumericNeatRules(Entity x) => x switch
         {
-            Sumf(Real { IsNegative: true } left, Real { IsNegative: true } right) => -(left + right),
+            // (-a) + (-b) is -(a + b), and the operands are already negative here, so what is
+            // added is their magnitudes. Written as -(left + right) this negated a sum that was
+            // negative already and answered `2` for `-1 + -1` -- invisible through Simplify,
+            // where evaluation folds a pair of numerals before this is ever consulted, and
+            // plainly wrong through RewriteRules.NumericNeat, which is public.
+            // https://github.com/asc-community/AngouriMath/issues/936
+            Sumf(Real { IsNegative: true } left, Real { IsNegative: true } right)
+                => -((-left) + (Entity)(-right)),
             Sumf(var any1, Real { IsNegative: true } right) => any1 - -right,
             Sumf(Real { IsNegative: true } left, var any1) => any1 - -left,
 
-            Minusf(Real { IsNegative: true } left, Real { IsNegative: true } right) => -left + -right,
+            // (-a) - (-b) is b - a, not a + b.
+            Minusf(Real { IsNegative: true } left, Real { IsNegative: true } right)
+                => (-right) - (Entity)(-left),
             Minusf(var any1, Real { IsNegative: true } right) => any1 + -right,
             Minusf(Real { IsNegative: true } left, var any1) => -(any1 + -left),
 

--- a/Sources/Tests/UnitTests/Core/Transformations/NumericNeatSignTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/NumericNeatSignTest.cs
@@ -1,0 +1,78 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Core.Transformations;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// <see cref="RewriteRules.NumericNeat"/> inverted the sign where both operands of a sum
+    /// or a difference were negative numerals: `-1 + -1` came back as `2`.
+    /// https://github.com/asc-community/AngouriMath/issues/936
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The value is asserted rather than the shape, because the shape is the rule's business
+    /// — it exists to write `-1 + -1` as `-(1 + 1)` — and the value is the part that was wrong.
+    /// </para>
+    /// <para>
+    /// It has to be asserted against the <b>rule set applied alone</b>. Through `Simplify` the
+    /// defect was invisible: the rule only ever fires on numerals, and on numerals evaluation
+    /// has already produced the right answer before this is consulted, so every corpus in
+    /// `work/` passed throughout. A rule that only fires where something else covers for it can
+    /// be arbitrarily wrong and never show, until a caller applies it on its own — which the
+    /// transformation layer now lets them do.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class NumericNeatSignTest
+    {
+        private static Entity Rewritten(string expression)
+            => RewriteRules.NumericNeat.ApplyOnce(expression.ToEntity());
+
+        [Theory]
+        [InlineData("-1 + -1", -2)]
+        [InlineData("-2 + -3", -5)]
+        [InlineData("-1/2 + -3/2", -2)]
+        [InlineData("-1 - (-1)", 0)]
+        [InlineData("-3 - (-1)", -2)]
+        [InlineData("-1 - (-3)", 2)]
+        public void TheValueSurvivesTheRewrite(string expression, int expected)
+        {
+            var value = Rewritten(expression).EvalNumerical();
+            Assert.Equal(expected, value.RealPart.EDecimal.ToDouble(), 9);
+            Assert.Equal(0, value.ImaginaryPart.EDecimal.ToDouble(), 9);
+        }
+
+        /// <summary>
+        /// The branches beside the two that were wrong, so that a later correction cannot fix
+        /// one sign by breaking another. Each is a mixed-sign case and each was already right.
+        /// </summary>
+        [Theory]
+        [InlineData("x + -1", "x - 1")]
+        [InlineData("-1 + x", "x - 1")]
+        [InlineData("x - (-1)", "x + 1")]
+        [InlineData("-1 - x", "-(x + 1)")]
+        public void TheMixedSignBranchesAreUnchanged(string expression, string expected)
+            => Assert.Equal(expected.ToEntity(), Rewritten(expression));
+
+        /// <summary>
+        /// And the whole pipeline still answers what it always did — which is the point about
+        /// why this hid for so long, stated as a test rather than as a remark.
+        /// </summary>
+        [Theory]
+        [InlineData("-1 + -1", -2)]
+        [InlineData("-2 + -3", -5)]
+        [InlineData("-1 - (-1)", 0)]
+        public void SimplifyWasNeverAffected(string expression, int expected)
+            => Assert.Equal(
+                Entity.Number.Integer.Create(expected), expression.ToEntity().Simplify());
+    }
+}


### PR DESCRIPTION
Closes #936. **A wrong answer through public API.**

```
RewriteRules.NumericNeat.ApplyOnce("-1 + -1")     was  2   is  -(1 + 1)
RewriteRules.NumericNeat.ApplyOnce("-2 + -3")     was  5   is  -(2 + 3)
RewriteRules.NumericNeat.ApplyOnce("-1 - (-1)")   was  2   is   1 - 1
```

`RewriteRules` and `RewriteRuleSet.ApplyOnce` are both public, and `Transformation.Rewriting(RewriteRules.NumericNeat)` is the documented way to run a single rule set.

## The arithmetic

`(-a) + (-b)` is `-(a + b)`, and the operands are **already negative** where the rule matches, so what is added is their magnitudes. Written `-(left + right)` it negated a sum that was negative already. And `(-a) - (-b)` is `b - a`, not `a + b`.

Every neighbouring branch is right — the four mixed-sign sum and difference cases, and the both-negative product and quotient — so this is two lines rather than a design problem. There is a test on the neighbours so a later correction cannot fix one sign by breaking another.

## Why nothing caught it, which is the part worth keeping

`Simplify` and `Evaled` were **correct throughout**: the rule only ever fires on numerals, and on numerals evaluation has already produced the answer before this is consulted. Every harness in `work/` exercises `Simplify`, so none of them could see it — the corpora were green on both sides.

**A rule that only fires where something else covers for it can be arbitrarily wrong and never show**, until a caller applies it alone — which the transformation layer now lets them do. The test therefore asserts the rule set applied *on its own*, and asserts the **value** rather than the shape, since writing `-1 + -1` as `-(1 + 1)` is what the rule is for.

## How it was found

`rulecheck`, a new harness for #746 tier 2, which asks for confluence and termination *"checked by tooling rather than asserted by authors"*. Every `RewriteRuleSet` declares a `TransformationRelation` and a `Soundness` and nothing had ever checked either. It applies each set to generated expressions and, for a set declaring `Equivalence`, compares the value at sample points **on and off the real line**.

These were two of its findings on the first run. The other eight are non-termination — `NumericNeat` on `--x` produces `-1 * 1 * 1 * 1 * ...` without settling — and want their own issue.

## Measured

Suite 7024 passed / 0 failed, 13 new; casbench 116/119 with 0 wrong, 0 error, 0 timeout; simpsweep 10463/10463 agree; propcheck 1340/0.

No `BREAKING-CHANGES.md` entry for `Simplify`, whose answers do not move; the rule set's own output does, and the issue records that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)