### PR TITLE
Put the canonicalizers where a caller will look for them, and settle the -ize spelling (#746)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -35,6 +35,7 @@ read first.
 | **silent** | `"sin(-x) + sin(x)".Simplify()` | `sin(-x) + sin(x)` | `0` |
 | **silent** | `"cos(-x)".Simplify()` and `"abs(-x)".Simplify()` | unchanged | `cos(x)`, `abs(x)` |
 | **silent** | `"cos(0 ^ y)".InnerSimplified` | `-(-1) provided ...` | `1 provided ...` |
+| | `Transformation.Rationalisation` and `RewriteRules.RationaliseDenominator` | spelled `-ise`, alone on a surface that is otherwise `Factorize`, `Normalization` | spelled `-ize`; a build error rather than a wrong answer |
 
 ### `InnerSimplified` is idempotent again
 
@@ -312,6 +313,31 @@ The condition does not vanish: `ln(0) * 0` is `-oo * 0`, which is `NaN`, so `not
 From [#721](https://github.com/asc-community/AngouriMath/issues/721) and
 [#890](https://github.com/asc-community/AngouriMath/issues/890), in PR
 [#916](https://github.com/asc-community/AngouriMath/pull/916).
+
+### Three members spelled `-ise` are spelled `-ize`
+
+The rest of the surface is `Factorize`, `Latexize`, `Stringize`, `Normalization`, `Factorization`.
+Three members added in 2.1.0 were not, so the same operation had two spellings depending on which
+one a caller reached for:
+
+| Was | Is |
+|---|---|
+| `Transformation.Rationalisation` | `Transformation.Rationalization` |
+| `RewriteRules.RationaliseDenominator` | `RewriteRules.RationalizeDenominator` |
+| `Patterns.RationaliseDenominator` (internal) | `Patterns.RationalizeDenominator` |
+
+**This one breaks a build rather than an answer** — the compiler names the missing member, so there
+is nothing to discover at runtime. The rule set's `Name` comes from `nameof`, so a caller that
+matched on the string `"RationaliseDenominator"` gets `"RationalizeDenominator"` instead; that part
+*is* silent, and it is the only part that is.
+
+Documentation prose keeps British spelling throughout — `Factorize` has always sat beside the word
+"factorisation" and still does. The convention is about identifiers.
+
+Recorded here rather than left alone because a tag is public whether or not anyone has taken it. The
+two canonical-form members added in this release were renamed before they ever shipped, so they are
+not in the table.
+In PR [#940](https://github.com/asc-community/AngouriMath/pull/940).
 
 ---
 

--- a/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
@@ -179,12 +179,12 @@ namespace AngouriMath.Core.Transformations
         /// <summary>
         /// Clears a surd out of a two-term denominator.
         /// </summary>
-        public static RewriteRuleSet RationaliseDenominator { get; } = new(
-            nameof(RationaliseDenominator),
+        public static RewriteRuleSet RationalizeDenominator { get; } = new(
+            nameof(RationalizeDenominator),
             "Multiplies a quotient by the conjugate of its denominator to clear a surd from it.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Patterns.RationaliseDenominator);
+            Patterns.RationalizeDenominator);
 
         /// <summary>
         /// Brings a quotient of quotients down to a single one.
@@ -392,7 +392,7 @@ namespace AngouriMath.Core.Transformations
             Expansion,
             Factorization,
             PerfectSquare,
-            RationaliseDenominator,
+            RationalizeDenominator,
             CollapseMultipleFractions,
             CommonDenominator,
             CommonDenominatorCountingConstants,

--- a/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
+++ b/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
@@ -118,12 +118,12 @@ namespace AngouriMath.Core.Transformations
         /// Nothing runs this by default. See
         /// <c>Docs/Contributing/CanonicalForm.md</c> §5 and
         /// <a href="https://github.com/asc-community/AngouriMath/issues/934">#934</a>.
-        /// <see cref="Canonicalisation"/> is the companion that handles the commutative
+        /// <see cref="Canonicalization"/> is the companion that handles the commutative
         /// structure of expressions generally.
         /// </para>
         /// </remarks>
-        public static Transformation RationalCanonicalisation { get; }
-            = new RationalCanonicalisationTransformation();
+        public static Transformation RationalCanonicalization { get; }
+            = new RationalCanonicalizationTransformation();
 
         /// <summary>
         /// A canonical form for the commutative structure: two expressions differing only in
@@ -170,7 +170,7 @@ namespace AngouriMath.Core.Transformations
         /// tier 1.
         /// </para>
         /// </remarks>
-        public static Transformation Canonicalisation { get; }
+        public static Transformation Canonicalization { get; }
             = InnerSimplification
                 .Then(Rewriting(RewriteRules.CanonicalOrderExact))
                 .Then(InnerSimplification);
@@ -179,8 +179,8 @@ namespace AngouriMath.Core.Transformations
         /// Clears a surd out of a two-term denominator: <c>1 / (sqrt(3) + 5)</c> becomes
         /// <c>(sqrt(3) - 5) / (-22)</c>.
         /// </summary>
-        public static Transformation Rationalisation { get; }
-            = Rewriting(RewriteRules.RationaliseDenominator).Then(InnerSimplification);
+        public static Transformation Rationalization { get; }
+            = Rewriting(RewriteRules.RationalizeDenominator).Then(InnerSimplification);
 
         /// <summary>
         /// Replaces every occurrence of <paramref name="what"/> with
@@ -269,7 +269,7 @@ namespace AngouriMath.Core.Transformations
                     : cached[level - Lowest] ??= make(level);
         }
 
-        private sealed class RationalCanonicalisationTransformation : Transformation
+        private sealed class RationalCanonicalizationTransformation : Transformation
         {
             public override string Name => "rational-canonical-form";
 
@@ -278,7 +278,7 @@ namespace AngouriMath.Core.Transformations
             public override Soundness Soundness => Soundness.SoundUnderAssumptions;
 
             protected override Entity? ApplyCore(Entity input)
-                => RationalFunction.TryCanonicalise(input, out var canonical) ? canonical : null;
+                => RationalFunction.TryCanonicalize(input, out var canonical) ? canonical : null;
         }
 
         private sealed class InnerSimplificationTransformation : Transformation

--- a/Sources/AngouriMath/Docs/Contributing/CanonicalForm.md
+++ b/Sources/AngouriMath/Docs/Contributing/CanonicalForm.md
@@ -168,7 +168,7 @@ to give order independence on every pair tried.
 
 Both are met by composing what already exists in the right sequence — normalise, order, normalise —
 which §3 measures at 0 failures on both properties and which is
-`Transformation.Canonicalisation`. **Nesting comes with the ordering**, because the sort works over
+`Transformation.Canonicalization`. **Nesting comes with the ordering**, because the sort works over
 commutative *chains* rather than over one node, so it flattens as it sorts: `(x + y) + a` and
 `x + (y + a)` both reach `a + x + y`, as the same tree.
 
@@ -282,7 +282,7 @@ wrong by a test written in a hurry.
 
 ## 8. What is owed
 
-1. **Where the canonicaliser runs.** It exists — `Transformation.Canonicalisation`, built out of
+1. **Where the canonicaliser runs.** It exists — `Transformation.Canonicalization`, built out of
    parts that already existed, measured idempotent and order-independent, with no rule changed — and
    nothing calls it. Offering it changes nothing for anyone. Putting it inside `InnerSimplified`
    moves every commutative operand order in every printed answer at once, which is a release of its

--- a/Sources/AngouriMath/Docs/Contributing/Transformations.md
+++ b/Sources/AngouriMath/Docs/Contributing/Transformations.md
@@ -129,8 +129,8 @@ stands: it is parameterised by two variables, so it is a family of sets rather t
 A new transformation built from rules that already exist is one line:
 
 ```csharp
-public static Transformation Rationalisation { get; }
-    = Rewriting(RewriteRules.RationaliseDenominator).Then(InnerSimplification);
+public static Transformation Rationalization { get; }
+    = Rewriting(RewriteRules.RationalizeDenominator).Then(InnerSimplification);
 ```
 
 A new rule set is five, and registering it gets it enumeration, an identity, a soundness label, and

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/RationalFunction.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/RationalFunction.cs
@@ -68,7 +68,7 @@ namespace AngouriMath.Functions
         /// <see langword="false"/> where it is not a rational function over <c>Q</c> in its
         /// free variables, or where a bound is reached.
         /// </summary>
-        internal static bool TryCanonicalise(Entity expr, [NotNullWhen(true)] out Entity? canonical)
+        internal static bool TryCanonicalize(Entity expr, [NotNullWhen(true)] out Entity? canonical)
         {
             canonical = null;
             if (expr.Complexity > MaxComplexity)

--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Definition.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Definition.cs
@@ -474,6 +474,89 @@ namespace AngouriMath
         public Entity Simplify(int level = 2)
             => Transformation.SimplificationAtLevel(level).ApplyOrKeep(this);
 
+        /// <summary>
+        /// A canonical form for the commutative structure: two expressions differing only in
+        /// how their sums, products, conjunctions, disjunctions and set operations are
+        /// arranged or nested come out as the <b>identical tree</b>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is not <see cref="Simplify(int)"/> and is not trying to be. It makes an
+        /// expression <i>comparable</i>, not shorter, and it may well make it longer. What it
+        /// buys is that <c>a.Canonicalise() == b.Canonicalise()</c> is a real test of whether
+        /// the two are the same expression, where comparing simplified forms is not.
+        /// </para>
+        /// <para>
+        /// <b>Equal trees mean the expressions are equal; different trees mean nothing at
+        /// all.</b> There is no canonical form for the whole language — deciding whether an
+        /// expression is zero is undecidable once <c>pi</c>, the exponential, the trigonometric
+        /// functions and <c>abs</c> are in play — so this canonicalises the part that can be:
+        /// the arrangement of commutative operators. For rational functions over <c>Q</c>, where
+        /// a complete canonical form does exist, use
+        /// <see cref="CanonicaliseAsRationalFunction"/>.
+        /// <c>Docs/Contributing/CanonicalForm.md</c> states the boundary and how far off the
+        /// library is from it.
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// using AngouriMath;
+        /// using static System.Console;
+        ///
+        /// WriteLine("x + y".ToEntity().Canonicalise() == "y + x".ToEntity().Canonicalise());
+        /// WriteLine("(x + y) + a".ToEntity().Canonicalise() == "x + (y + a)".ToEntity().Canonicalise());
+        /// </code>
+        /// Prints
+        /// <code>
+        /// True
+        /// True
+        /// </code>
+        /// </example>
+        public Entity Canonicalise()
+            => Transformation.Canonicalisation.ApplyOrKeep(this);
+
+        /// <summary>
+        /// A canonical form for rational functions over <c>Q</c>, or <see langword="null"/>
+        /// where this is not one.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Two rational functions are equal <b>exactly when</b> this form is identical, so on
+        /// that sublanguage equality is decided by comparing nodes rather than by searching —
+        /// which is what <c>(a - b).Simplify()</c> against zero can never be.
+        /// </para>
+        /// <para>
+        /// <b>It answers only where it can, and says so by answering nothing.</b> Anything that
+        /// is not a rational function over <c>Q</c> in its free variables gets
+        /// <see langword="null"/>, because a form whose whole value is that equal trees mean
+        /// equal expressions must not hand back a normalisation that merely resembles one.
+        /// </para>
+        /// <para>
+        /// Cancelling a common factor widens the domain, so where one comes out the answer
+        /// carries the condition that it is nonzero: <c>x/x</c> is <c>1 provided not x = 0</c>
+        /// and not <c>1</c>, and <c>(x^2 - 1)/(x + 1)</c> is not the same function as
+        /// <c>x - 1</c>.
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// using AngouriMath;
+        /// using static System.Console;
+        ///
+        /// WriteLine("1/x + 1/y".ToEntity().CanonicaliseAsRationalFunction());
+        /// WriteLine("(x + y) / (x * y)".ToEntity().CanonicaliseAsRationalFunction());
+        /// WriteLine("sin(x) / x".ToEntity().CanonicaliseAsRationalFunction() is null);
+        /// </code>
+        /// Prints
+        /// <code>
+        /// (x + y) / (x * y)
+        /// (x + y) / (x * y)
+        /// True
+        /// </code>
+        /// </example>
+        public Entity? CanonicaliseAsRationalFunction()
+            => Transformation.RationalCanonicalisation.Apply(this).Output;
+
         /// <summary>Finds all alternative forms of an expression sorted by their complexity</summary>
         /// <example>
         /// <code>

--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Definition.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Definition.cs
@@ -483,7 +483,7 @@ namespace AngouriMath
         /// <para>
         /// This is not <see cref="Simplify(int)"/> and is not trying to be. It makes an
         /// expression <i>comparable</i>, not shorter, and it may well make it longer. What it
-        /// buys is that <c>a.Canonicalise() == b.Canonicalise()</c> is a real test of whether
+        /// buys is that <c>a.Canonicalize() == b.Canonicalize()</c> is a real test of whether
         /// the two are the same expression, where comparing simplified forms is not.
         /// </para>
         /// <para>
@@ -493,7 +493,7 @@ namespace AngouriMath
         /// functions and <c>abs</c> are in play — so this canonicalises the part that can be:
         /// the arrangement of commutative operators. For rational functions over <c>Q</c>, where
         /// a complete canonical form does exist, use
-        /// <see cref="CanonicaliseAsRationalFunction"/>.
+        /// <see cref="CanonicalizeAsRationalFunction"/>.
         /// <c>Docs/Contributing/CanonicalForm.md</c> states the boundary and how far off the
         /// library is from it.
         /// </para>
@@ -503,8 +503,8 @@ namespace AngouriMath
         /// using AngouriMath;
         /// using static System.Console;
         ///
-        /// WriteLine("x + y".ToEntity().Canonicalise() == "y + x".ToEntity().Canonicalise());
-        /// WriteLine("(x + y) + a".ToEntity().Canonicalise() == "x + (y + a)".ToEntity().Canonicalise());
+        /// WriteLine("x + y".ToEntity().Canonicalize() == "y + x".ToEntity().Canonicalize());
+        /// WriteLine("(x + y) + a".ToEntity().Canonicalize() == "x + (y + a)".ToEntity().Canonicalize());
         /// </code>
         /// Prints
         /// <code>
@@ -512,8 +512,8 @@ namespace AngouriMath
         /// True
         /// </code>
         /// </example>
-        public Entity Canonicalise()
-            => Transformation.Canonicalisation.ApplyOrKeep(this);
+        public Entity Canonicalize()
+            => Transformation.Canonicalization.ApplyOrKeep(this);
 
         /// <summary>
         /// A canonical form for rational functions over <c>Q</c>, or <see langword="null"/>
@@ -543,9 +543,9 @@ namespace AngouriMath
         /// using AngouriMath;
         /// using static System.Console;
         ///
-        /// WriteLine("1/x + 1/y".ToEntity().CanonicaliseAsRationalFunction());
-        /// WriteLine("(x + y) / (x * y)".ToEntity().CanonicaliseAsRationalFunction());
-        /// WriteLine("sin(x) / x".ToEntity().CanonicaliseAsRationalFunction() is null);
+        /// WriteLine("1/x + 1/y".ToEntity().CanonicalizeAsRationalFunction());
+        /// WriteLine("(x + y) / (x * y)".ToEntity().CanonicalizeAsRationalFunction());
+        /// WriteLine("sin(x) / x".ToEntity().CanonicalizeAsRationalFunction() is null);
         /// </code>
         /// Prints
         /// <code>
@@ -554,8 +554,8 @@ namespace AngouriMath
         /// True
         /// </code>
         /// </example>
-        public Entity? CanonicaliseAsRationalFunction()
-            => Transformation.RationalCanonicalisation.Apply(this).Output;
+        public Entity? CanonicalizeAsRationalFunction()
+            => Transformation.RationalCanonicalization.Apply(this).Output;
 
         /// <summary>Finds all alternative forms of an expression sorted by their complexity</summary>
         /// <example>

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Rational.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Rational.cs
@@ -115,7 +115,7 @@ namespace AngouriMath.Functions
                 : scaled / Integer.Create(ratio.Denominator);
         }
 
-        internal static Entity RationaliseDenominator(Entity expr)
+        internal static Entity RationalizeDenominator(Entity expr)
         {
             // k * (value / d) -> (k * value) / d, reduced, where the numerator carries a surd
             // this rule moved up out of a denominator. Without it a numeric coefficient never

--- a/Sources/AngouriMath/Functions/Simplification/Simplificator.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Simplificator.cs
@@ -121,7 +121,7 @@ namespace AngouriMath.Functions
                 // is an accident rather than a preference.
                 // https://github.com/asc-community/AngouriMath/issues/205
                 if (res.Nodes.Any(child => child is Divf))
-                    AddHistory(res = res.Rewrite(RewriteRules.RationaliseDenominator).InnerSimplified);
+                    AddHistory(res = res.Rewrite(RewriteRules.RationalizeDenominator).InnerSimplified);
 
                 res = res.Rewrite(RewriteRules.CanonicalOrderAt(sortLevel)).InnerSimplified;
                 if (res.Nodes.Any(child => child is Powf))

--- a/Sources/AngouriMath/Functions/TreeAnalyzer/LongDivision.cs
+++ b/Sources/AngouriMath/Functions/TreeAnalyzer/LongDivision.cs
@@ -69,7 +69,7 @@ namespace AngouriMath.Functions
         /// </remarks>
         private static EDecimal Canonical(EDecimal power) => power.Reduce(EContext.Unlimited);
 
-        private static Dictionary<EDecimal, Entity> Canonicalise(Dictionary<EDecimal, Entity> powers)
+        private static Dictionary<EDecimal, Entity> Canonicalize(Dictionary<EDecimal, Entity> powers)
         {
             var canonical = new Dictionary<EDecimal, Entity>();
             foreach (var pair in powers)
@@ -118,8 +118,8 @@ namespace AngouriMath.Functions
             // 1.5 + 0.5 comes out as 2.0 and misses the 2 already in the dictionary. Reduced
             // once, here, so that every key in play is in the one canonical form and the
             // lookups below mean what they say. https://github.com/asc-community/AngouriMath/issues/751
-            var powersOfP = Canonicalise(monoinfoP[polyvar]);
-            var powersOfQ = Canonicalise(monoinfoQ[polyvar]);
+            var powersOfP = Canonicalize(monoinfoP[polyvar]);
+            var powersOfQ = Canonicalize(monoinfoQ[polyvar]);
             var maxpowP = powersOfP.Keys.Max() ?? throw new AngouriBugException("No null expected");
             var maxpowQ = powersOfQ.Keys.Max() ?? throw new AngouriBugException("No null expected");
             var maxvalP = powersOfP[maxpowP];

--- a/Sources/Tests/DotnetBenchmark/TransformationLayer.cs
+++ b/Sources/Tests/DotnetBenchmark/TransformationLayer.cs
@@ -54,7 +54,7 @@ namespace DotnetBenchmark
         // The layer reached directly.
         [Benchmark] public void SimplificationTransformation() => Transformation.Simplification.Apply(simplifyInput);
         [Benchmark] public void Normalization() => Transformation.Normalization.Apply(unorderedInput);
-        [Benchmark] public void Rationalisation() => Transformation.Rationalisation.Apply(surdInput);
+        [Benchmark] public void Rationalization() => Transformation.Rationalization.Apply(surdInput);
         [Benchmark] public void Substitution() => Transformation.Substitution("x", 3).Apply(quotientInput);
 
         // A single rewrite pass, the unit everything above is built out of.

--- a/Sources/Tests/UnitTests/Common/PublicApi.txt
+++ b/Sources/Tests/UnitTests/Common/PublicApi.txt
@@ -2015,6 +2015,8 @@ AngouriMath.Entity.Arccotan() : AngouriMath.Entity
 AngouriMath.Entity.Arcsec() : AngouriMath.Entity
 AngouriMath.Entity.Arcsin() : AngouriMath.Entity
 AngouriMath.Entity.Arctan() : AngouriMath.Entity
+AngouriMath.Entity.Canonicalise() : AngouriMath.Entity
+AngouriMath.Entity.CanonicaliseAsRationalFunction() : AngouriMath.Entity
 AngouriMath.Entity.Ceil() : AngouriMath.Entity
 AngouriMath.Entity.Codomain { } : AngouriMath.Core.Domain
 AngouriMath.Entity.Compile(AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol, System.Type, System.Collections.Generic.IEnumerable<System.ValueTuple<System.Type,AngouriMath.Entity+Variable>>) : TDelegate

--- a/Sources/Tests/UnitTests/Common/PublicApi.txt
+++ b/Sources/Tests/UnitTests/Common/PublicApi.txt
@@ -138,7 +138,7 @@ AngouriMath.Core.Transformations.RewriteRules.PhiFunction { } : AngouriMath.Core
 AngouriMath.Core.Transformations.RewriteRules.PolynomialGcdCancellation { } : AngouriMath.Core.Transformations.RewriteRuleSet
 AngouriMath.Core.Transformations.RewriteRules.PolynomialLongDivision { } : AngouriMath.Core.Transformations.RewriteRuleSet
 AngouriMath.Core.Transformations.RewriteRules.Power { } : AngouriMath.Core.Transformations.RewriteRuleSet
-AngouriMath.Core.Transformations.RewriteRules.RationaliseDenominator { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.RewriteRules.RationalizeDenominator { } : AngouriMath.Core.Transformations.RewriteRuleSet
 AngouriMath.Core.Transformations.RewriteRules.SetOperator { } : AngouriMath.Core.Transformations.RewriteRuleSet
 AngouriMath.Core.Transformations.RewriteRules.Trigonometric { } : AngouriMath.Core.Transformations.RewriteRuleSet
 AngouriMath.Core.Transformations.RewriteStep.After { } : AngouriMath.Entity
@@ -154,7 +154,7 @@ AngouriMath.Core.Transformations.Soundness.value__ : System.Int32
 AngouriMath.Core.Transformations.Transformation.Apply(AngouriMath.Entity) : AngouriMath.Core.Transformations.TransformationResult
 AngouriMath.Core.Transformations.Transformation.ApplyCore(AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Core.Transformations.Transformation.ApplyOrKeep(AngouriMath.Entity) : AngouriMath.Entity
-AngouriMath.Core.Transformations.Transformation.Canonicalisation { } : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.Canonicalization { } : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Differentiation(AngouriMath.Entity+Variable) : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Expansion { } : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.ExpansionAtLevel(System.Int32) : AngouriMath.Core.Transformations.Transformation
@@ -165,8 +165,8 @@ AngouriMath.Core.Transformations.Transformation.Integration(AngouriMath.Entity+V
 AngouriMath.Core.Transformations.Transformation.LimitAt(AngouriMath.Entity+Variable, AngouriMath.Entity, AngouriMath.Core.ApproachFrom) : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Name { } : System.String
 AngouriMath.Core.Transformations.Transformation.Normalization { } : AngouriMath.Core.Transformations.Transformation
-AngouriMath.Core.Transformations.Transformation.RationalCanonicalisation { } : AngouriMath.Core.Transformations.Transformation
-AngouriMath.Core.Transformations.Transformation.Rationalisation { } : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.RationalCanonicalization { } : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.Rationalization { } : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Relation { } : AngouriMath.Core.Transformations.TransformationRelation
 AngouriMath.Core.Transformations.Transformation.Repeat(System.Int32) : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Rewriting(AngouriMath.Core.Transformations.RewriteRuleSet) : AngouriMath.Core.Transformations.Transformation
@@ -2015,8 +2015,8 @@ AngouriMath.Entity.Arccotan() : AngouriMath.Entity
 AngouriMath.Entity.Arcsec() : AngouriMath.Entity
 AngouriMath.Entity.Arcsin() : AngouriMath.Entity
 AngouriMath.Entity.Arctan() : AngouriMath.Entity
-AngouriMath.Entity.Canonicalise() : AngouriMath.Entity
-AngouriMath.Entity.CanonicaliseAsRationalFunction() : AngouriMath.Entity
+AngouriMath.Entity.Canonicalize() : AngouriMath.Entity
+AngouriMath.Entity.CanonicalizeAsRationalFunction() : AngouriMath.Entity
 AngouriMath.Entity.Ceil() : AngouriMath.Entity
 AngouriMath.Entity.Codomain { } : AngouriMath.Core.Domain
 AngouriMath.Entity.Compile(AngouriMath.Core.Compilation.IntoLinq.CompilationProtocol, System.Type, System.Collections.Generic.IEnumerable<System.ValueTuple<System.Type,AngouriMath.Entity+Variable>>) : TDelegate

--- a/Sources/Tests/UnitTests/Core/Transformations/CanonicaliseEntryPointTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/CanonicaliseEntryPointTest.cs
@@ -1,0 +1,99 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// The two canonicalisers reached from <see cref="Entity"/>, where a caller will look for
+    /// them, rather than only through the transformation layer.
+    /// https://github.com/asc-community/AngouriMath/issues/746
+    /// </summary>
+    [Trait("Area", "Core")]
+    public sealed class CanonicaliseEntryPointTest
+    {
+        /// <summary>
+        /// What the method is for: equality of the forms is a real test of equality of the
+        /// expressions, which comparing simplified forms is not.
+        /// </summary>
+        [Theory]
+        [InlineData("x + y", "y + x")]
+        [InlineData("x * y * a", "a * y * x")]
+        [InlineData("(x + y) + a", "x + (y + a)")]
+        [InlineData("1/2 - x", "-x + 1/2")]
+        public void CanonicaliseMakesTwoWritingsOneTree(string left, string right)
+            => Assert.Equal(left.ToEntity().Canonicalise(), right.ToEntity().Canonicalise());
+
+        [Theory]
+        [InlineData("x + y", "x * y")]
+        [InlineData("x - y", "y - x")]
+        public void AndDoesNotConflateWhatDiffers(string left, string right)
+            => Assert.NotEqual(left.ToEntity().Canonicalise(), right.ToEntity().Canonicalise());
+
+        /// <summary>It is a form, so applying it twice changes nothing.</summary>
+        [Theory]
+        [InlineData("1/2 - x")]
+        [InlineData("sin(x) + cos(x) + 1/3")]
+        [InlineData("(x + y) * (a - 1/2)")]
+        public void CanonicaliseIsAFixedPoint(string expression)
+        {
+            var once = expression.ToEntity().Canonicalise();
+            Assert.Equal(once, once.Canonicalise());
+        }
+
+        /// <summary>The rational form decides equality on the sublanguage where it can.</summary>
+        [Theory]
+        [InlineData("1/x + 1/y", "(x + y) / (x * y)")]
+        [InlineData("2 * x / (4 * y)", "x / (2 * y)")]
+        [InlineData("x / y + 1", "(x + y) / y")]
+        public void TheRationalFormDecidesEquality(string left, string right)
+        {
+            var one = left.ToEntity().CanonicaliseAsRationalFunction();
+            var two = right.ToEntity().CanonicaliseAsRationalFunction();
+            Assert.NotNull(one);
+            Assert.Equal(one, two);
+        }
+
+        /// <summary>
+        /// And answers nothing where it cannot, which is the boundary being in the signature
+        /// rather than in a comment.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x) / x")]
+        [InlineData("sqrt(x)")]
+        [InlineData("e ^ x")]
+        public void TheRationalFormRefusesWhatIsNotOne(string expression)
+            => Assert.Null(expression.ToEntity().CanonicaliseAsRationalFunction());
+
+        /// <summary>
+        /// A removable singularity is not removed: the quotient is undefined where the
+        /// polynomial is not, so they are not the same function and the form must not say
+        /// they are.
+        /// </summary>
+        [Fact]
+        public void ACancelledFactorKeepsItsCondition()
+        {
+            var cancelled = "x / x".ToEntity().CanonicaliseAsRationalFunction();
+            Assert.True(cancelled is Entity.Providedf);
+            Assert.NotEqual("1".ToEntity().CanonicaliseAsRationalFunction(), cancelled);
+        }
+
+        /// <summary>
+        /// Neither is applied by anything: asking to simplify must not start returning
+        /// canonicalised trees behind the caller's back.
+        /// </summary>
+        [Fact]
+        public void NothingRunsThemByDefault()
+        {
+            Assert.Equal("y + x".ToEntity(), "y + x".ToEntity().InnerSimplified);
+            Assert.Equal("1 / x + 1 / y".ToEntity(), "1/x + 1/y".ToEntity().Simplify());
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Core/Transformations/CanonicalizationTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/CanonicalizationTest.cs
@@ -13,7 +13,7 @@ using Xunit;
 namespace AngouriMath.Tests.Core.Transformations
 {
     /// <summary>
-    /// <see cref="Transformation.Canonicalisation"/>: a canonical form for the commutative
+    /// <see cref="Transformation.Canonicalization"/>: a canonical form for the commutative
     /// structure. Two expressions differing only in how their operands are arranged come out
     /// as the identical tree. https://github.com/asc-community/AngouriMath/issues/746
     /// </summary>
@@ -24,10 +24,10 @@ namespace AngouriMath.Tests.Core.Transformations
     /// most likely thing for a test in this area to get wrong.
     /// </remarks>
     [Trait("Area", "Core")]
-    public sealed class CanonicalisationTest
+    public sealed class CanonicalizationTest
     {
         private static Entity Canonical(string expression)
-            => Transformation.Canonicalisation.ApplyOrKeep(expression.ToEntity());
+            => Transformation.Canonicalization.ApplyOrKeep(expression.ToEntity());
 
         /// <summary>
         /// The property the form exists for: however the operands were written, the tree is
@@ -60,10 +60,10 @@ namespace AngouriMath.Tests.Core.Transformations
         [InlineData("x + 1 * 1 / 2")]
         [InlineData("(x + y) * (a - 1/2)")]
         [InlineData("sin(x) + cos(x) + 1/3")]
-        public void CanonicalisingTwiceIsCanonicalisingOnce(string expression)
+        public void CanonicalizingTwiceIsCanonicalizingOnce(string expression)
         {
             var once = Canonical(expression);
-            Assert.Equal(once, Transformation.Canonicalisation.ApplyOrKeep(once));
+            Assert.Equal(once, Transformation.Canonicalization.ApplyOrKeep(once));
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Core/Transformations/CanonicalizeEntryPointTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/CanonicalizeEntryPointTest.cs
@@ -17,7 +17,7 @@ namespace AngouriMath.Tests.Core.Transformations
     /// https://github.com/asc-community/AngouriMath/issues/746
     /// </summary>
     [Trait("Area", "Core")]
-    public sealed class CanonicaliseEntryPointTest
+    public sealed class CanonicalizeEntryPointTest
     {
         /// <summary>
         /// What the method is for: equality of the forms is a real test of equality of the
@@ -28,24 +28,24 @@ namespace AngouriMath.Tests.Core.Transformations
         [InlineData("x * y * a", "a * y * x")]
         [InlineData("(x + y) + a", "x + (y + a)")]
         [InlineData("1/2 - x", "-x + 1/2")]
-        public void CanonicaliseMakesTwoWritingsOneTree(string left, string right)
-            => Assert.Equal(left.ToEntity().Canonicalise(), right.ToEntity().Canonicalise());
+        public void CanonicalizeMakesTwoWritingsOneTree(string left, string right)
+            => Assert.Equal(left.ToEntity().Canonicalize(), right.ToEntity().Canonicalize());
 
         [Theory]
         [InlineData("x + y", "x * y")]
         [InlineData("x - y", "y - x")]
         public void AndDoesNotConflateWhatDiffers(string left, string right)
-            => Assert.NotEqual(left.ToEntity().Canonicalise(), right.ToEntity().Canonicalise());
+            => Assert.NotEqual(left.ToEntity().Canonicalize(), right.ToEntity().Canonicalize());
 
         /// <summary>It is a form, so applying it twice changes nothing.</summary>
         [Theory]
         [InlineData("1/2 - x")]
         [InlineData("sin(x) + cos(x) + 1/3")]
         [InlineData("(x + y) * (a - 1/2)")]
-        public void CanonicaliseIsAFixedPoint(string expression)
+        public void CanonicalizeIsAFixedPoint(string expression)
         {
-            var once = expression.ToEntity().Canonicalise();
-            Assert.Equal(once, once.Canonicalise());
+            var once = expression.ToEntity().Canonicalize();
+            Assert.Equal(once, once.Canonicalize());
         }
 
         /// <summary>The rational form decides equality on the sublanguage where it can.</summary>
@@ -55,8 +55,8 @@ namespace AngouriMath.Tests.Core.Transformations
         [InlineData("x / y + 1", "(x + y) / y")]
         public void TheRationalFormDecidesEquality(string left, string right)
         {
-            var one = left.ToEntity().CanonicaliseAsRationalFunction();
-            var two = right.ToEntity().CanonicaliseAsRationalFunction();
+            var one = left.ToEntity().CanonicalizeAsRationalFunction();
+            var two = right.ToEntity().CanonicalizeAsRationalFunction();
             Assert.NotNull(one);
             Assert.Equal(one, two);
         }
@@ -70,7 +70,7 @@ namespace AngouriMath.Tests.Core.Transformations
         [InlineData("sqrt(x)")]
         [InlineData("e ^ x")]
         public void TheRationalFormRefusesWhatIsNotOne(string expression)
-            => Assert.Null(expression.ToEntity().CanonicaliseAsRationalFunction());
+            => Assert.Null(expression.ToEntity().CanonicalizeAsRationalFunction());
 
         /// <summary>
         /// A removable singularity is not removed: the quotient is undefined where the
@@ -80,9 +80,9 @@ namespace AngouriMath.Tests.Core.Transformations
         [Fact]
         public void ACancelledFactorKeepsItsCondition()
         {
-            var cancelled = "x / x".ToEntity().CanonicaliseAsRationalFunction();
+            var cancelled = "x / x".ToEntity().CanonicalizeAsRationalFunction();
             Assert.True(cancelled is Entity.Providedf);
-            Assert.NotEqual("1".ToEntity().CanonicaliseAsRationalFunction(), cancelled);
+            Assert.NotEqual("1".ToEntity().CanonicalizeAsRationalFunction(), cancelled);
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Core/Transformations/RationalCanonicalFormTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RationalCanonicalFormTest.cs
@@ -13,7 +13,7 @@ using Xunit;
 namespace AngouriMath.Tests.Core.Transformations
 {
     /// <summary>
-    /// <see cref="Transformation.RationalCanonicalisation"/>: a canonical form for rational
+    /// <see cref="Transformation.RationalCanonicalization"/>: a canonical form for rational
     /// functions over Q, which is the part of the language where one is possible.
     /// https://github.com/asc-community/AngouriMath/issues/934
     /// </summary>
@@ -27,7 +27,7 @@ namespace AngouriMath.Tests.Core.Transformations
     {
         private static Entity? Canonical(string expression)
         {
-            var result = Transformation.RationalCanonicalisation.Apply(expression.ToEntity());
+            var result = Transformation.RationalCanonicalization.Apply(expression.ToEntity());
             return result.Succeeded ? result.Output : null;
         }
 
@@ -131,10 +131,10 @@ namespace AngouriMath.Tests.Core.Transformations
         [InlineData("2 * x / (4 * y)")]
         [InlineData("(x ^ 2 - 1) / (x + 1)")]
         [InlineData("x + 1")]
-        public void CanonicalisingTwiceIsCanonicalisingOnce(string expression)
+        public void CanonicalizingTwiceIsCanonicalizingOnce(string expression)
         {
             var once = Required(expression);
-            var twice = Transformation.RationalCanonicalisation.Apply(once);
+            var twice = Transformation.RationalCanonicalization.Apply(once);
             // A condition attached on the first pass is not itself a rational function, so the
             // second pass may decline; what must not happen is a different quotient.
             if (twice.Succeeded)

--- a/Sources/Tests/UnitTests/Core/Transformations/TransformationTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/TransformationTest.cs
@@ -206,7 +206,7 @@ namespace AngouriMath.Tests.Core.Transformations
             Assert.NotNull(Transformation.Expansion);
             Assert.NotNull(Transformation.Factorization);
             Assert.NotNull(Transformation.Normalization);
-            Assert.NotNull(Transformation.Rationalisation);
+            Assert.NotNull(Transformation.Rationalization);
             Assert.NotNull(Transformation.InnerSimplification);
         }
 
@@ -379,7 +379,7 @@ namespace AngouriMath.Tests.Core.Transformations
                          Transformation.Expansion,
                          Transformation.Factorization,
                          Transformation.Normalization,
-                         Transformation.Rationalisation,
+                         Transformation.Rationalization,
                          Transformation.InnerSimplification,
                      })
                 Assert.Equal(transformation.Apply(expr).Output, transformation.Apply(expr).Output);
@@ -395,7 +395,7 @@ namespace AngouriMath.Tests.Core.Transformations
                          Transformation.Expansion,
                          Transformation.Factorization,
                          Transformation.Normalization,
-                         Transformation.Rationalisation,
+                         Transformation.Rationalization,
                          Transformation.InnerSimplification,
                      })
             {
@@ -536,9 +536,9 @@ namespace AngouriMath.Tests.Core.Transformations
         }
 
         [Fact]
-        public void RationalisationClearsASurdOutOfADenominator()
+        public void RationalizationClearsASurdOutOfADenominator()
         {
-            var result = Transformation.Rationalisation.Apply(Parse("1 / (sqrt(3) + 5)"));
+            var result = Transformation.Rationalization.Apply(Parse("1 / (sqrt(3) + 5)"));
 
             Assert.True(result.Succeeded);
             Assert.DoesNotContain(

--- a/Sources/Tests/UnitTests/PatternsTest/RationalizeDenominatorTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/RationalizeDenominatorTest.cs
@@ -26,7 +26,7 @@ namespace AngouriMath.Tests.PatternsTest
     /// the binomial case rather than introducing one, which is the half of #205 that does
     /// not need a maintainer's ruling.
     /// </remarks>
-    public sealed class RationaliseDenominatorTest
+    public sealed class RationalizeDenominatorTest
     {
         private static bool IsSurd(Entity node)
             => node is Entity.Powf(_, Entity.Number.Rational and not Entity.Number.Integer);
@@ -99,7 +99,7 @@ namespace AngouriMath.Tests.PatternsTest
         /// through a different route and this rule does not fire on it at all.
         /// </summary>
         [Fact]
-        public void ASingleSurdDenominatorStillRationalises()
+        public void ASingleSurdDenominatorStillRationalizes()
             => Assert.Equal("sqrt(2) / 2".ToEntity().Simplify(), "1 / sqrt(2)".ToEntity().Simplify());
     }
 }


### PR DESCRIPTION
Both canonicalisers existed only as `Transformation` objects, reachable by someone who already knew the transformation layer existed. This puts them beside `Simplify`, `Expand` and `Factorize`.

```csharp
Entity Canonicalize()                     // the commutative structure
Entity? CanonicalizeAsRationalFunction()  // rational functions over Q, or null
```

## Wiring them into the pipeline turned out not to be a thing to do

`Simplify` **already** runs `CanonicalOrder` before its rules — that is what lets a binary rule find `sin(x)^2 + cos(x)^2` buried in a longer sum. And `Canonicalization` *is* `InnerSimplification` composed with the sort, so it cannot go inside `InnerSimplified` without containing itself.

What was missing was **reach, not application**.

## The rational one refuses, and says so by answering nothing

`null` where the expression is not a rational function over ℚ — the library's own way of saying "no answer", and it keeps the boundary in the signature. A form whose whole value is that equal trees mean equal expressions must not hand back a normalisation that merely resembles one.

Cancelling still carries its condition: `x/x` is `1 provided not x = 0`, and is *not* equal to the canonical form of `1`. There is a test saying exactly that.

## Nothing is applied by default

Pinned by a test: `InnerSimplified` still leaves `y + x` alone, and `Simplify` still leaves `1/x + 1/y` split. Turning either on by default moves every commutative operand order in every printed answer — a release's decision, not a method's.

## And the spelling is settled, in the direction the surface already went

The second commit renames five members so that one operation has one spelling:

| Was | Is | Shipped? |
|---|---|---|
| `Entity.Canonicalise` | `Canonicalize` | no |
| `Entity.CanonicaliseAsRationalFunction` | `CanonicalizeAsRationalFunction` | no |
| `Transformation.Canonicalisation` | `Canonicalization` | no |
| `Transformation.RationalCanonicalisation` | `RationalCanonicalization` | no |
| `Transformation.Rationalisation` | `Rationalization` | **v2.1.0** |
| `RewriteRules.RationaliseDenominator` | `RationalizeDenominator` | **v2.1.0** |

The rest of the surface is `Factorize`, `Latexize`, `Stringize`, `Normalization`, `Factorization`, so the odd ones out were the `-ise` five.

The last two are in the `v2.1.0` tag and so get a `BREAKING-CHANGES.md` entry. **It breaks a build rather than an answer** — the compiler names the missing member. The one silent part is the rule set's `Name`, which comes from `nameof`, so a caller matching the string `"RationaliseDenominator"` now sees `"RationalizeDenominator"`.

**Prose keeps British spelling.** `Factorize` has always sat beside the word "factorisation" and still does; the convention is about identifiers, not documentation. A private `LongDivision.Canonicalise` helper predating this work was renamed too, so a grep for the British spelling now returns only prose.

## Measured

Suite **7087 passed / 0 failed**, 17 of them new, run after the rename. `docsamples` against a build of the first commit: 84 samples, **0 compile errors, 0 output mismatches**, 57 outputs verified. Library, unit tests, benchmark project and the F# wrapper all build under `-c Release`; the two Windows-only sample projects fail on Linux exactly as they do on master. `PublicApi.txt` records every addition and rename, and the alphabetical ordering was re-checked because `s` and `z` do not sort alike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
