### PR TITLE
Name the release 2.2.0, and say what the pinned AssemblyVersion does not cover (#746)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -15,7 +15,7 @@ read first.
 
 ---
 
-## Unreleased — since 2.1.0
+## 2.2.0 — since 2.1.0
 
 ### At a glance
 
@@ -326,10 +326,17 @@ one a caller reached for:
 | `RewriteRules.RationaliseDenominator` | `RewriteRules.RationalizeDenominator` |
 | `Patterns.RationaliseDenominator` (internal) | `Patterns.RationalizeDenominator` |
 
-**This one breaks a build rather than an answer** — the compiler names the missing member, so there
-is nothing to discover at runtime. The rule set's `Name` comes from `nameof`, so a caller that
-matched on the string `"RationaliseDenominator"` gets `"RationalizeDenominator"` instead; that part
-*is* silent, and it is the only part that is.
+**If you recompile, this breaks a build rather than an answer** — the compiler names the missing
+member. Two ways it can reach you later than that:
+
+- `AssemblyVersion` is pinned at `2.0.0.0` for the whole of 2.x precisely so that a consumer can
+  drop a new DLL in without a binding redirect. Do that without recompiling, and a call to
+  `Transformation.Rationalisation` throws `MissingMethodException` when it is *reached*, not when
+  the assembly loads. That is the one path on which this behaves like a silent change.
+- The rule set's `Name` comes from `nameof`, so a caller matching on the string
+  `"RationaliseDenominator"` now sees `"RationalizeDenominator"` and simply stops matching.
+
+Recompiling against 2.2.0 turns both into compile errors, except the string.
 
 Documentation prose keeps British spelling throughout — `Factorize` has always sat beside the word
 "factorisation" and still does. The convention is about identifiers.

--- a/Sources/Package.Build.props
+++ b/Sources/Package.Build.props
@@ -17,17 +17,21 @@
     release tag, so what ships is named by the tag; this is what a local build and the
     assembly metadata carry.
     -->
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
 
     <!--
     Pinned to the major for the whole of 2.x, and deliberately not tracking Version.
     The assembly is strong-named (see AngouriMath.csproj), and for a signed assembly
     every AssemblyVersion change breaks binding on consumers that do not add a redirect.
-    Holding it at 2.0.0.0 makes every 2.x release a drop-in replacement. FileVersion
+    Holding it at 2.0.0.0 lets a 2.x assembly load in place of another without one.
+
+    That is binding, not compatibility: a member removed or renamed within 2.x still
+    throws MissingMethodException when a consumer compiled against the older assembly
+    reaches it. 2.2.0 renames two, both recorded in BREAKING-CHANGES.md. FileVersion
     carries the release for anyone reading the file properties.
     -->
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.1.0.0</FileVersion>
+    <FileVersion>2.2.0.0</FileVersion>
 
     <Authors>WhiteBlackGoose and contributors</Authors>
     <Company>Angouri</Company>


### PR DESCRIPTION
The last checklist item before 2.2.0 can be tagged. `Version` and `FileVersion` move to 2.2.0, and `BREAKING-CHANGES.md`'s `Unreleased` section becomes `2.2.0 — since 2.1.0`.

## And a correction to the comment on the pin

`AssemblyVersion` stays `2.0.0.0`, as it has for the whole of 2.x. The comment explaining why said that holding it there "makes every 2.x release a drop-in replacement".

**That is true of binding and not of compatibility**, and this release is exactly where the difference shows. 2.2.0 renames two members that shipped in 2.1.0, so a consumer that swaps the assembly *without recompiling* still binds — and then throws `MissingMethodException` when the call is reached.

I had written the `BREAKING-CHANGES` entry claiming the rename "breaks a build rather than an answer … there is nothing to discover at runtime". The pinned `AssemblyVersion` is what makes that wrong, and it is wrong in the direction that matters, so both the comment and the entry now say which of the two the pin guarantees.

## The number

Checked against [#746](https://github.com/asc-community/AngouriMath/issues/746) rather than picked: **2.2.0 advances tier 1 and completes none of it**. The polynomial layer is done, canonical form is specified and implemented in both halves, and expression metadata is retired as having no consumer; pattern-matching-as-data is begun but internal, and the per-commit corpus is not wired into CI. Nothing of tier 2 ships. The note recording that is [on the issue](https://github.com/asc-community/AngouriMath/issues/746#issuecomment-5295827063).

Strict semver would read a rename of a shipped member as a major. This project has not: 2.1.0 shipped a dozen changed answers under a minor, on the stated principle that correctness outranks compatibility. A rename is a weaker break than a changed answer, so 2.2.0 is consistent rather than an exception — stated explicitly here rather than left as an inference.

## Measured, on a build of the merge commit rather than on a branch

| | |
|---|---|
| suite | **7117 passed / 0 failed**, 14 skipped |
| `casbench` | 116/119 solved, **0 wrong, 0 error, 0 timeout** — identical to the committed baseline |
| `canoncheck` | canonical form: **0/834 idempotence, 0/2738 order** failures; every column matches the committed baseline exactly |
| `rulecheck` | 30 sets, 1365 applications, **0 that never settle, 0 value changes** |

`crashcheck` and `docsamples` are running against the same build; I will post their results here rather than tag without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
