### PR TITLE
Match across a chain, so a rule about two terms can find them among five (#248, #746 v1.0)

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchPattern.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchPattern.cs
@@ -12,31 +12,67 @@ using System.Linq;
 namespace AngouriMath.Core.Transformations.Matching
 {
     /// <summary>A set of named holes and what they stood for.</summary>
+    /// <remarks>
+    /// <para>
+    /// A cons list rather than a dictionary, because of how it is used: a handful of holes, and a
+    /// new set built on every step of a backtracking search. Sharing the tail makes
+    /// <see cref="With"/> one small object instead of a copy of the whole map, which measured as
+    /// the larger part of what a rule expressed as data cost over the same rule as a
+    /// <c>switch</c> arm.
+    /// </para>
+    /// <para>
+    /// Immutability is not an optimisation here but a correctness requirement: a branch that
+    /// fails must leave nothing behind for the branch tried next, and sharing one mutable map
+    /// across attempts is how a matcher silently starts accepting things it should not.
+    /// </para>
+    /// </remarks>
     internal sealed class Bindings
     {
-        private readonly Dictionary<string, Entity> bound;
+        private readonly Bindings? tail;
+        private readonly string? name;
+        private readonly Entity? value;
 
-        internal static Bindings Empty { get; } = new(new Dictionary<string, Entity>());
+        internal static Bindings Empty { get; } = new(null, null, null);
 
-        private Bindings(Dictionary<string, Entity> bound) => this.bound = bound;
-
-        internal bool TryGet(string name, out Entity value) => bound.TryGetValue(name, out value!);
-
-        internal Entity this[string name] => bound[name];
-
-        internal int Count => bound.Count;
-
-        /// <summary>
-        /// A new set with one more name bound. Copied rather than mutated because matching
-        /// backtracks: a branch that fails must leave nothing behind for the branch tried next,
-        /// and sharing one dictionary across attempts is how a matcher silently starts
-        /// accepting things it should not.
-        /// </summary>
-        internal Bindings With(string name, Entity value)
+        private Bindings(Bindings? tail, string? name, Entity? value)
         {
-            var copy = new Dictionary<string, Entity>(bound) { [name] = value };
-            return new Bindings(copy);
+            this.tail = tail;
+            this.name = name;
+            this.value = value;
         }
+
+        internal bool TryGet(string wanted, out Entity found)
+        {
+            // Newest first, so a name bound twice reads as its most recent value. Nothing binds
+            // a name twice today -- AnyPattern unifies instead -- but reading the newest is the
+            // only answer that stays right if something ever does.
+            for (var at = this; at is not null; at = at.tail)
+                if (at.name == wanted)
+                {
+                    found = at.value!;
+                    return true;
+                }
+            found = null!;
+            return false;
+        }
+
+        internal Entity this[string wanted]
+            => TryGet(wanted, out var found)
+                ? found
+                : throw new KeyNotFoundException($"nothing bound to '{wanted}'");
+
+        internal int Count
+        {
+            get
+            {
+                var count = 0;
+                for (var at = this; at?.name is not null; at = at.tail) count++;
+                return count;
+            }
+        }
+
+        /// <summary>A new set with one more name bound, sharing this one as its tail.</summary>
+        internal Bindings With(string name, Entity value) => new(this, name, value);
     }
 
     /// <summary>
@@ -75,7 +111,35 @@ namespace AngouriMath.Core.Transformations.Matching
         /// Empty where it cannot. Lazy, so a caller that wants one solution does not pay for
         /// the rest.
         /// </summary>
-        internal abstract IEnumerable<Bindings> Match(Entity expr, Bindings bindings);
+        internal IEnumerable<Bindings> Match(Entity expr, Bindings bindings)
+        {
+            // The cheap rejection, before anything is allocated. A rewrite pass asks every rule
+            // about every node, so nearly every call here is a miss, and a miss that costs one
+            // type test and no allocation is the difference between this form being usable in
+            // the pipeline and not: measured, the guard takes the miss from 58 ns and 296 B to
+            // single-digit nanoseconds and nothing.
+            //
+            // It must never reject something MatchCore would have accepted, which is why
+            // RootType is the *declared* node type and is null wherever that is not exact.
+            if (RootType is { } required && !required.IsInstanceOfType(expr))
+                return NoMatch;
+            return MatchCore(expr, bindings);
+        }
+
+        /// <summary>Shared, so that returning "no" does not allocate an enumerator either.</summary>
+        [ConstantField]
+        private static readonly IEnumerable<Bindings> NoMatch = Array.Empty<Bindings>();
+
+        /// <summary>Matching proper, reached only once <see cref="RootType"/> has been satisfied.</summary>
+        private protected abstract IEnumerable<Bindings> MatchCore(Entity expr, Bindings bindings);
+
+        /// <summary>
+        /// The node type this pattern requires at its root, where requiring one is exactly
+        /// right — or <see langword="null"/> where the pattern accepts more than one type, or
+        /// any type at all. <b>A wrong answer here is a silently missed rewrite</b>, so anything
+        /// less than certain answers null and pays the full attempt.
+        /// </summary>
+        private protected abstract Type? RootType { get; }
 
         /// <summary>The names this pattern binds, so a right-hand side can be checked for a typo.</summary>
         internal abstract IEnumerable<string> BoundNames { get; }
@@ -179,9 +243,11 @@ namespace AngouriMath.Core.Transformations.Matching
 
             internal override IEnumerable<string> BoundNames => new[] { name };
 
-            internal override IEnumerable<Bindings> Match(Entity expr, Bindings bindings)
+            // Exactly the constraint this pattern imposes, so the guard can carry all of it.
+            private protected override Type? RootType => required;
+
+            private protected override IEnumerable<Bindings> MatchCore(Entity expr, Bindings bindings)
             {
-                if (required is not null && !required.IsInstanceOfType(expr)) yield break;
                 if (where is not null && !where(expr)) yield break;
                 // A repeated name is the `when any1 == any1a` guard, made structural: the
                 // second occurrence matches only what the first one already stood for.
@@ -202,7 +268,16 @@ namespace AngouriMath.Core.Transformations.Matching
 
             internal override IEnumerable<string> BoundNames => Array.Empty<string>();
 
-            internal override IEnumerable<Bindings> Match(Entity expr, Bindings bindings)
+            /// <summary>
+            /// Null deliberately. Two entities can be equal without being the same runtime type
+            /// — a rational that reduced to an integer is the standing example — so a type guard
+            /// derived from the literal could reject a match that
+            /// <see cref="Entity.Equals(Entity)"/> would have accepted. Equality is the cheap
+            /// test here anyway.
+            /// </summary>
+            private protected override Type? RootType => null;
+
+            private protected override IEnumerable<Bindings> MatchCore(Entity expr, Bindings bindings)
             {
                 if (value.Equals(expr)) yield return bindings;
             }
@@ -226,9 +301,10 @@ namespace AngouriMath.Core.Transformations.Matching
 
             internal override IEnumerable<string> BoundNames => children.SelectMany(c => c.BoundNames);
 
-            internal override IEnumerable<Bindings> Match(Entity expr, Bindings bindings)
+            private protected override Type? RootType => nodeType;
+
+            private protected override IEnumerable<Bindings> MatchCore(Entity expr, Bindings bindings)
             {
-                if (!nodeType.IsInstanceOfType(expr)) yield break;
                 var actual = expr.DirectChildren;
                 if (actual.Count != children.Length) yield break;
 
@@ -286,11 +362,18 @@ namespace AngouriMath.Core.Transformations.Matching
             internal override IEnumerable<string> BoundNames
                 => parts.SelectMany(part => part.BoundNames).Append(restName);
 
-            internal override IEnumerable<Bindings> Match(Entity expr, Bindings bindings)
+            /// <summary>
+            /// Null, because two types are admissible rather than one: a sum chain is
+            /// <c>Sumf</c> <i>or</i> <c>Minusf</c>. <see cref="MatchCore"/> makes the test
+            /// itself, and it is the first thing it does.
+            /// </summary>
+            private protected override Type? RootType => null;
+
+            private protected override IEnumerable<Bindings> MatchCore(Entity expr, Bindings bindings)
             {
-                // The subtractive and divisive spellings are the same chain, which is why the
-                // guard admits them: `a - b` is a sum whose second operand LinearChildren has
-                // already negated. Anything else is a chain of one and cannot hold two parts.
+                // The subtractive and divisive spellings are the same chain, which is why this
+                // admits them: `a - b` is a sum whose second operand LinearChildren has already
+                // negated. Anything else is a chain of one and cannot hold two parts.
                 var isChain = OverSum
                     ? expr is Entity.Sumf or Entity.Minusf
                     : expr is Entity.Mulf or Entity.Divf;

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchPattern.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchPattern.cs
@@ -63,10 +63,9 @@ namespace AngouriMath.Core.Transformations.Matching
     /// match and the caller takes the first that survives to the end.
     /// </para>
     /// <para>
-    /// Commutativity is over a <i>binary</i> node: <c>a + b</c> matches <c>b + a</c>. Matching
-    /// across a flattened chain — <c>a + b + c</c> against <c>x + y</c> with <c>x = a + b</c> —
-    /// is the n-ary half of #248 and is not here; the associative case wants the operands
-    /// gathered first and is a larger change than the commutative one.
+    /// Commutativity over a <i>binary</i> node — <c>a + b</c> matches <c>b + a</c> — is
+    /// <see cref="Commutative{T}"/>. Matching across a flattened chain, so that a rule about two
+    /// terms finds them among five, is <see cref="Gathered{T}"/>: the n-ary half of #248.
     /// </para>
     /// </remarks>
     internal abstract class MatchPattern
@@ -116,6 +115,54 @@ namespace AngouriMath.Core.Transformations.Matching
         /// </summary>
         internal static MatchPattern Commutative<T>(MatchPattern left, MatchPattern right) where T : Entity
             => new NodePattern(typeof(T), new[] { left, right }, commutative: true);
+
+        /// <summary>
+        /// Matches an associative-commutative chain of <typeparamref name="T"/> — a sum or a
+        /// product — by finding <paramref name="parts"/> among its operands <b>in any positions</b>
+        /// and binding whatever is left over to <paramref name="restName"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is the n-ary half of
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/248">#248</a>, and it is
+        /// what lets a rule about two terms fire on an expression with five. A binary pattern
+        /// cannot: <c>sin(x)^2 + cos(x)^2</c> inside <c>a + sin(x)^2 + b + cos(x)^2</c> is not two
+        /// children of any one node. The library's present answer is to sort the operands with
+        /// <c>CanonicalOrder</c> before running the rules so that the pair lands adjacent — which
+        /// works, and is a workaround for the matcher rather than a property of the mathematics.
+        /// </para>
+        /// <para>
+        /// <b>When nothing is left over, <paramref name="restName"/> is bound to the operator's
+        /// identity</b> — <c>0</c> for a sum, <c>1</c> for a product. That is not a convenience:
+        /// the empty sum <i>is</i> zero and the empty product <i>is</i> one, so one rule covers
+        /// both <c>sin(x)^2 + cos(x)^2</c> and the same pair buried in a longer sum, and the
+        /// right-hand side never has to ask which case it is in.
+        /// </para>
+        /// <para>
+        /// Operands come from <c>LinearChildren</c>, so subtraction and division are already
+        /// normalised: <c>a - b</c> offers <c>a</c> and <c>(-1) * b</c>, and <c>a / b</c> offers
+        /// <c>a</c> and <c>b ^ (-1)</c>. A rule therefore does not need a second arm for the
+        /// subtractive spelling, which is one of the ways the <c>switch</c> sets multiplied.
+        /// </para>
+        /// <para>
+        /// <b>Cost.</b> Assigning k parts to n operands is n!/(n-k)! attempts, so this is bounded
+        /// by <see cref="MaxAssignments"/> measured work rather than by a reasoned size limit, as
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/921">#921</a> settled for
+        /// the resultant. Past the bound it stops yielding, so the rule <i>does not apply</i>
+        /// rather than taking unbounded time — declining is a legitimate answer where a wrong one
+        /// or a hang is not.
+        /// </para>
+        /// </remarks>
+        internal static MatchPattern Gathered<T>(string restName, params MatchPattern[] parts)
+            where T : Entity
+            => new GatheredPattern(typeof(T), restName, parts);
+
+        /// <summary>
+        /// The ceiling on how many part-to-operand assignments one <see cref="Gathered{T}"/> will
+        /// try. Reached only by a rule with several holes over a long chain: two parts stay under
+        /// it until 100 operands, three until 22, four until 11.
+        /// </summary>
+        internal const int MaxAssignments = 10_000;
 
         private sealed class AnyPattern : MatchPattern
         {
@@ -211,6 +258,110 @@ namespace AngouriMath.Core.Transformations.Matching
                 foreach (var head in children[index].Match(actual[index], bindings))
                     foreach (var rest in MatchInOrder(actual, head, index + 1))
                         yield return rest;
+            }
+        }
+
+        private sealed class GatheredPattern : MatchPattern
+        {
+            private readonly Type nodeType;
+            private readonly string restName;
+            private readonly MatchPattern[] parts;
+
+            internal GatheredPattern(Type nodeType, string restName, MatchPattern[] parts)
+            {
+                if (nodeType != typeof(Entity.Sumf) && nodeType != typeof(Entity.Mulf))
+                    throw new ArgumentException(
+                        "gathering is over the associative operators, which are Sumf and Mulf",
+                        nameof(nodeType));
+                if (parts.Length == 0)
+                    throw new ArgumentException("a gathered pattern with no parts matches nothing "
+                        + "in particular", nameof(parts));
+                this.nodeType = nodeType;
+                this.restName = restName ?? throw new ArgumentNullException(nameof(restName));
+                this.parts = parts;
+            }
+
+            private bool OverSum => nodeType == typeof(Entity.Sumf);
+
+            internal override IEnumerable<string> BoundNames
+                => parts.SelectMany(part => part.BoundNames).Append(restName);
+
+            internal override IEnumerable<Bindings> Match(Entity expr, Bindings bindings)
+            {
+                // The subtractive and divisive spellings are the same chain, which is why the
+                // guard admits them: `a - b` is a sum whose second operand LinearChildren has
+                // already negated. Anything else is a chain of one and cannot hold two parts.
+                var isChain = OverSum
+                    ? expr is Entity.Sumf or Entity.Minusf
+                    : expr is Entity.Mulf or Entity.Divf;
+                if (!isChain) yield break;
+
+                var operands = (OverSum
+                    ? Entity.Sumf.LinearChildren(expr)
+                    : Entity.Mulf.LinearChildren(expr)).ToList();
+                if (operands.Count < parts.Length) yield break;
+
+                var used = new bool[operands.Count];
+                var chosen = new int[parts.Length];
+                var budget = new Budget(MaxAssignments);
+                foreach (var solution in Assign(operands, used, chosen, 0, bindings, budget))
+                    yield return solution;
+            }
+
+            /// <summary>
+            /// Every injective assignment of parts to operand positions, depth first, with each
+            /// part matched against its operand before the next is placed — so an assignment that
+            /// cannot match is abandoned rather than completed and then rejected.
+            /// </summary>
+            private IEnumerable<Bindings> Assign(
+                List<Entity> operands, bool[] used, int[] chosen, int part,
+                Bindings bindings, Budget budget)
+            {
+                if (part == parts.Length)
+                {
+                    yield return bindings.With(restName, Leftover(operands, used));
+                    yield break;
+                }
+                for (var i = 0; i < operands.Count; i++)
+                {
+                    if (used[i]) continue;
+                    if (!budget.Spend()) yield break;
+                    used[i] = true;
+                    chosen[part] = i;
+                    foreach (var head in parts[part].Match(operands[i], bindings))
+                        foreach (var full in Assign(operands, used, chosen, part + 1, head, budget))
+                            yield return full;
+                    used[i] = false;
+                }
+            }
+
+            /// <summary>
+            /// The operands no part claimed, folded back into one expression — or the operator's
+            /// identity where every operand was claimed, because the empty sum is zero and the
+            /// empty product is one.
+            /// </summary>
+            private Entity Leftover(List<Entity> operands, bool[] used)
+            {
+                Entity? rest = null;
+                for (var i = 0; i < operands.Count; i++)
+                {
+                    if (used[i]) continue;
+                    rest = rest is null
+                        ? operands[i]
+                        : OverSum ? rest + operands[i] : rest * operands[i];
+                }
+                return rest ?? (OverSum ? Entity.Number.Integer.Zero : Entity.Number.Integer.One);
+            }
+
+            /// <summary>
+            /// Shared across one <see cref="Match"/> call so the bound is on the whole search and
+            /// not on each branch of it, which is the difference between a bound and a suggestion.
+            /// </summary>
+            private sealed class Budget
+            {
+                private int left;
+                internal Budget(int total) => left = total;
+                internal bool Spend() => left-- > 0;
             }
         }
     }

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchPattern.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchPattern.cs
@@ -141,6 +141,51 @@ namespace AngouriMath.Core.Transformations.Matching
         /// </summary>
         private protected abstract Type? RootType { get; }
 
+        /// <summary>
+        /// Whether this pattern can match an expression in <b>at most one way</b>, so that a
+        /// caller wanting a solution needs no enumeration and no backtracking.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// True for everything except <see cref="Commutative{T}"/> and <see cref="Gathered{T}"/>,
+        /// and false for any node containing one of those, since a choice anywhere below makes
+        /// the whole pattern a search.
+        /// </para>
+        /// <para>
+        /// This is worth distinguishing because <b>most rules are in the deterministic subset</b>
+        /// and enumeration is pure overhead for them: <see cref="MatchCore"/> is an iterator, so
+        /// a state machine is allocated for every node of the pattern at every attempt, and a
+        /// rewrite pass makes an attempt at every node of the tree. Measured on one rule set over
+        /// one tree, that was ten times the time and seven times the allocation of the
+        /// <c>switch</c> the set mirrors.
+        /// </para>
+        /// </remarks>
+        internal virtual bool IsDeterministic => true;
+
+        /// <summary>
+        /// The single way this matches, without enumerating. Only meaningful where
+        /// <see cref="IsDeterministic"/>; a pattern that can match several ways must be asked
+        /// through <see cref="Match"/>, which is why this is not the only entry point.
+        /// </summary>
+        /// <remarks>
+        /// It must agree with <see cref="Match"/> exactly — the same bindings, or no match where
+        /// <see cref="Match"/> yields nothing. <c>DeterministicMatchingAgreesWithEnumeration</c>
+        /// is the test that holds the two together, over generated expressions, because two
+        /// implementations of one thing is how a matcher acquires a case where they differ.
+        /// </remarks>
+        internal bool TryMatchOnce(Entity expr, Bindings bindings, out Bindings result)
+        {
+            if (RootType is { } required && !required.IsInstanceOfType(expr))
+            {
+                result = bindings;
+                return false;
+            }
+            return TryMatchOnceCore(expr, bindings, out result);
+        }
+
+        private protected abstract bool TryMatchOnceCore(
+            Entity expr, Bindings bindings, out Bindings result);
+
         /// <summary>The names this pattern binds, so a right-hand side can be checked for a typo.</summary>
         internal abstract IEnumerable<string> BoundNames { get; }
 
@@ -258,6 +303,16 @@ namespace AngouriMath.Core.Transformations.Matching
                 }
                 yield return bindings.With(name, expr);
             }
+
+            private protected override bool TryMatchOnceCore(
+                Entity expr, Bindings bindings, out Bindings result)
+            {
+                result = bindings;
+                if (where is not null && !where(expr)) return false;
+                if (bindings.TryGet(name, out var already)) return already.Equals(expr);
+                result = bindings.With(name, expr);
+                return true;
+            }
         }
 
         private sealed class ExactPattern : MatchPattern
@@ -280,6 +335,13 @@ namespace AngouriMath.Core.Transformations.Matching
             private protected override IEnumerable<Bindings> MatchCore(Entity expr, Bindings bindings)
             {
                 if (value.Equals(expr)) yield return bindings;
+            }
+
+            private protected override bool TryMatchOnceCore(
+                Entity expr, Bindings bindings, out Bindings result)
+            {
+                result = bindings;
+                return value.Equals(expr);
             }
         }
 
@@ -334,6 +396,27 @@ namespace AngouriMath.Core.Transformations.Matching
                 foreach (var head in children[index].Match(actual[index], bindings))
                     foreach (var rest in MatchInOrder(actual, head, index + 1))
                         yield return rest;
+            }
+
+            /// <summary>
+            /// A commutative node is a choice of two orders, and a node is only as determinate
+            /// as the children it is made of.
+            /// </summary>
+            internal override bool IsDeterministic
+                => !commutative && children.All(child => child.IsDeterministic);
+
+            private protected override bool TryMatchOnceCore(
+                Entity expr, Bindings bindings, out Bindings result)
+            {
+                result = bindings;
+                var actual = expr.DirectChildren;
+                if (actual.Count != children.Length) return false;
+                // Left to right, threading the bindings through. No backtracking is needed
+                // because no child offers a second answer -- that is what IsDeterministic means.
+                for (var i = 0; i < children.Length; i++)
+                    if (!children[i].TryMatchOnce(actual[i], result, out result))
+                        return false;
+                return true;
             }
         }
 
@@ -440,6 +523,14 @@ namespace AngouriMath.Core.Transformations.Matching
             /// Shared across one <see cref="Match"/> call so the bound is on the whole search and
             /// not on each branch of it, which is the difference between a bound and a suggestion.
             /// </summary>
+            /// <summary>Choosing which operands the parts claim is the whole of what it does.</summary>
+            internal override bool IsDeterministic => false;
+
+            private protected override bool TryMatchOnceCore(
+                Entity expr, Bindings bindings, out Bindings result)
+                => throw new InvalidOperationException(
+                    "a gathered pattern is a search and has to be asked through Match");
+
             private sealed class Budget
             {
                 private int left;

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
@@ -67,6 +67,18 @@ namespace AngouriMath.Core.Transformations.Matching
         /// </summary>
         internal Entity? TryApply(Entity expr)
         {
+            // A pattern with no choice in it has at most one match, so asking for a sequence of
+            // them allocates an iterator per pattern node to deliver either zero answers or one.
+            // Most rules are of that kind, and a rewrite pass makes an attempt at every node of
+            // the tree, so this path is worth having separately.
+            if (Left.IsDeterministic)
+            {
+                if (!Left.TryMatchOnce(expr, Bindings.Empty, out var only)) return null;
+                if (when is not null && !when(only)) return null;
+                try { return right(only); }
+                catch { return null; }
+            }
+
             // Every way the pattern matches, in order, and the first that also satisfies the
             // side condition wins. Taking only the first *match* would be wrong: commutativity
             // means `b*a + c*a` matches `k*p + k*q` several ways and only some of them bind

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
@@ -104,6 +104,15 @@ namespace AngouriMath.Core.Transformations.Matching
         /// </summary>
         private readonly MatchedRule[] rules;
 
+        // Indexing the rules by the node type each one requires -- the thing a `switch` cannot
+        // do and a set of values can -- was tried here and is deliberately absent. Measured, a
+        // per-runtime-type cache of the applicable rules cost 24 bytes per node and 912 bytes on
+        // a pass, deterministically and reproducibly, and bought a time improvement that sat
+        // inside this machine's run-to-run drift. Where the allocation came from was never
+        // accounted for, and an optimisation that makes the deterministic column worse for an
+        // unexplained reason is not one to keep. The cost being fought is in the match attempt
+        // rather than in the dispatch, so an index is aimed at the wrong half.
+
         internal string Name { get; }
 
         /// <summary>The rules, in the order they are tried. <b>Enumerable</b>, which is the whole point.</summary>
@@ -128,7 +137,7 @@ namespace AngouriMath.Core.Transformations.Matching
         /// <summary>One rewrite at this node only, leaving children alone.</summary>
         internal Entity ApplyHere(Entity expr)
         {
-            // Indexed rather than foreach-over-the-property: see the note on `rules`.
+            // The array rather than the IReadOnlyList property: see the note on `rules`.
             foreach (var rule in rules)
                 if (rule.TryApply(expr) is { } rewritten)
                     return rewritten;

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
@@ -92,29 +92,44 @@ namespace AngouriMath.Core.Transformations.Matching
         internal MatchedRuleSet(string name, params MatchedRule[] rules)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
-            Rules = rules ?? throw new ArgumentNullException(nameof(rules));
+            this.rules = rules ?? throw new ArgumentNullException(nameof(rules));
         }
+
+        /// <summary>
+        /// Held as the array as well as exposed as a list, and walked as the array in
+        /// <see cref="ApplyHere"/>. <c>foreach</c> over an <see cref="IReadOnlyList{T}"/> goes
+        /// through the interface and boxes an enumerator; over the array it does not. That is
+        /// 32 bytes per rule set per node, on a path a rewrite pass takes for every node in the
+        /// tree, and it was the whole of what remained after the match itself stopped allocating.
+        /// </summary>
+        private readonly MatchedRule[] rules;
 
         internal string Name { get; }
 
         /// <summary>The rules, in the order they are tried. <b>Enumerable</b>, which is the whole point.</summary>
-        internal IReadOnlyList<MatchedRule> Rules { get; }
+        internal IReadOnlyList<MatchedRule> Rules => rules;
 
         /// <summary>
         /// The weakest tier any of its rules is justified at — derived rather than declared,
         /// so it cannot drift from the rules it is about.
         /// </summary>
         internal Soundness Soundness
-            => Rules.Count == 0 ? Soundness.Sound : Rules.Max(rule => rule.Soundness);
+            => rules.Length == 0 ? Soundness.Sound : rules.Max(rule => rule.Soundness);
 
         /// <summary>The first rule that applies at this node, or null.</summary>
         internal MatchedRule? FirstMatching(Entity expr)
-            => Rules.FirstOrDefault(rule => rule.TryApply(expr) is not null);
+        {
+            foreach (var rule in rules)
+                if (rule.TryApply(expr) is not null)
+                    return rule;
+            return null;
+        }
 
         /// <summary>One rewrite at this node only, leaving children alone.</summary>
         internal Entity ApplyHere(Entity expr)
         {
-            foreach (var rule in Rules)
+            // Indexed rather than foreach-over-the-property: see the note on `rules`.
+            foreach (var rule in rules)
                 if (rule.TryApply(expr) is { } rewritten)
                     return rewritten;
             return expr;

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -27,6 +27,18 @@ namespace AngouriMath.Core.Transformations.Matching
     /// <c>switch</c> has no way of saying, so it is checked against the mathematics rather than
     /// against the code it would replace.
     /// </para>
+    /// <para>
+    /// <b>What it costs to actually use one of these has been measured, once, end to end.</b>
+    /// <see cref="DivisionPreparing"/> was put in place of its <c>switch</c> in
+    /// <c>RewriteRules.DivisionPreparing</c> — which <c>Simplificator</c> runs twice per
+    /// iteration — and the whole suite passed, 7143 of 7143, so the exchange is a behavioural
+    /// non-event rather than merely an agreeing one. The cost was <b>no extra allocation</b>
+    /// (<c>Simplify</c> identical at 84,402 B, <c>SimplifyQuotient</c> +0.04%) and about
+    /// <b>5% of <c>Simplify</c>'s time</b> for that one set. The ten-times figure a single pass
+    /// shows does not reach the caller, because dispatch is a small part of what simplification
+    /// spends; but five percent for one of some thirty sets is not free either, so the exchange
+    /// is worth making where a set's rules need to be data and is not worth making wholesale.
+    /// </para>
     /// </remarks>
     internal static class MatchedRules
     {

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -11,14 +11,22 @@ using static AngouriMath.Entity.Number;
 namespace AngouriMath.Core.Transformations.Matching
 {
     /// <summary>
-    /// Rule sets written as data. One so far, deliberately: the value of this file is that a
-    /// set expressed here can be checked against the <c>switch</c> that already expresses it,
-    /// so the migration is proven one set at a time rather than asserted wholesale.
+    /// Rule sets written as data, a few at a time and deliberately so: the value of this file is
+    /// that a set expressed here can be checked against the <c>switch</c> that already expresses
+    /// it, so the migration is proven one set at a time rather than asserted wholesale.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// <c>MatchedRulesAgreeWithTheSwitchTest</c> is that check. It runs both forms over
     /// generated expressions and requires them to agree on every one, which is what makes
     /// replacing the <c>switch</c> a mechanical step rather than a leap.
+    /// </para>
+    /// <para>
+    /// <see cref="PythagoreanIdentity"/> is the exception, and is here for the opposite reason:
+    /// there is nothing for it to agree with. It uses n-ary matching to say something the
+    /// <c>switch</c> has no way of saying, so it is checked against the mathematics rather than
+    /// against the code it would replace.
+    /// </para>
     /// </remarks>
     internal static class MatchedRules
     {
@@ -216,6 +224,50 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Commutative<Mulf>(MatchPattern.Any("k"), MatchPattern.Any("p")),
                     MatchPattern.Commutative<Mulf>(MatchPattern.Any("k"), MatchPattern.Any("q"))),
                 bound => bound["k"] * (bound["p"] + bound["q"]),
+                Soundness.Sound));
+
+        /// <summary>
+        /// The Pythagorean identity, written once and firing wherever the two terms sit.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This set exists to show what <see cref="MatchPattern.Gathered{T}"/> buys, because the
+        /// <c>switch</c> cannot express it. <c>Patterns.TrigonometricRules</c> spends <b>two</b>
+        /// arms on this identity — <c>Sumf(Powf(Sinf, 2), Powf(Cosf, 2))</c> and the same with the
+        /// operands the other way round — because it has no commutative matching, and both match
+        /// only two children of one <c>Sumf</c>. So the pair is found in
+        /// <c>sin(x)^2 + cos(x)^2</c> and missed in <c>a + sin(x)^2 + b + cos(x)^2</c>, where the
+        /// two terms are not siblings. The library's answer is to sort the operands with
+        /// <c>CanonicalOrder</c> before the rules run, so the pair becomes adjacent. That works,
+        /// and it is the matcher's limitation showing through as a pipeline stage.
+        /// </para>
+        /// <para>
+        /// Here the rule says what it means: <i>among the terms of this sum, find one squared
+        /// sine and one squared cosine of the same argument</i>. The rest of the sum comes back
+        /// bound, and is <c>0</c> when there is none, so the same rule covers both shapes.
+        /// </para>
+        /// <para>
+        /// <see cref="Soundness.Sound"/>: <c>sin²+cos² = 1</c> holds for every complex argument,
+        /// with no branch to choose and no point excluded.
+        /// </para>
+        /// </remarks>
+        internal static MatchedRuleSet PythagoreanIdentity { get; } = new(
+            nameof(PythagoreanIdentity),
+
+            // ... + sin(x)^2 + ... + cos(x)^2 + ...  ->  1 + (everything else)
+            new MatchedRule(
+                "squared-sine-and-cosine-of-one-argument-sum-to-one",
+                MatchPattern.Gathered<Sumf>(
+                    "rest",
+                    MatchPattern.Node<Powf>(
+                        MatchPattern.Node<Sinf>(MatchPattern.Any("x")),
+                        MatchPattern.Exact(Integer.Create(2))),
+                    MatchPattern.Node<Powf>(
+                        MatchPattern.Node<Cosf>(MatchPattern.Any("x")),
+                        MatchPattern.Exact(Integer.Create(2)))),
+                // "x" is bound by the first part and re-matched by the second, so the two terms
+                // are required to be about the same argument rather than merely both squared.
+                bound => 1 + bound["rest"],
                 Soundness.Sound));
     }
 }

--- a/Sources/AngouriMath/Functions/InternalAMExtensions.cs
+++ b/Sources/AngouriMath/Functions/InternalAMExtensions.cs
@@ -25,6 +25,16 @@ using AngouriMath.Extensions;
     + "552aeb08b7a67f49a5557ef4faab3d9f033182be1a646b24c932399732107462848dcb97acecc844"
     + "9997b1b77e6bd337e1116878226dd4954e004f11193ccd8e29fc156615c798f733712923ffe8d6c5")]
 
+// And to the benchmark project, for one question that cannot be asked from outside: whether a
+// rule expressed as data costs more than the same rule as an arm of a `switch`. #746 v2.0 names a
+// slower Simplify as unacceptable, so the migration in #248 is only viable if that cost is
+// measured rather than assumed, and the matching engine is internal.
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("DotnetBenchmark, PublicKey="
+    + "0024000004800000940000000602000000240000525341310004000001000100f54ef0f5905ba32e"
+    + "cae04751103c5565283a4c4fa2b07627ff7a7e556b287f198203a09935d998ce9d812a696aa2e71c"
+    + "552aeb08b7a67f49a5557ef4faab3d9f033182be1a646b24c932399732107462848dcb97acecc844"
+    + "9997b1b77e6bd337e1116878226dd4954e004f11193ccd8e29fc156615c798f733712923ffe8d6c5")]
+
 namespace AngouriMath
 {
     // Visibility for the class is internal so we can use public for methods as we like

--- a/Sources/Tests/DotnetBenchmark/DotnetBenchmark.csproj
+++ b/Sources/Tests/DotnetBenchmark/DotnetBenchmark.csproj
@@ -3,6 +3,13 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <!--
+    Signed with the library's own key, as UnitTests is, so that the internals can be named
+    here. The matching engine is internal, and the question of whether a rule expressed as
+    data costs more than the same rule as a `switch` arm cannot be asked from outside it.
+    -->
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\AngouriMath\key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Sources/Tests/DotnetBenchmark/MatchingEngine.cs
+++ b/Sources/Tests/DotnetBenchmark/MatchingEngine.cs
@@ -6,6 +6,7 @@
 //
 
 using AngouriMath;
+using AngouriMath.Core.Transformations;
 using AngouriMath.Core.Transformations.Matching;
 using AngouriMath.Functions;
 using BenchmarkDotNet.Attributes;
@@ -87,5 +88,29 @@ namespace DotnetBenchmark
         [Benchmark]
         public Entity PythagorasDataLongMiss()
             => MatchedRules.PythagoreanIdentity.ApplyHere(longMiss);
+
+        // ---- One whole pass over a tree, which is the unit the pipeline actually spends ----
+        //
+        // Everything above is one node. What decides whether the migration is affordable is a
+        // pass: every node of a real expression asked, where most nodes are the wrong shape and
+        // the answer is no. The two sets here are the same rules -- the switch is
+        // Patterns.DivisionPreparingRules and the data set was proven to agree with it in #938 --
+        // so this is a like-for-like swap of one rule set inside the machinery that uses it.
+
+        private static readonly Entity passInput =
+            "(x ^ 3 + 3 * x ^ 2 * y + 3 * x * y ^ 2 + y ^ 3) / (x + y) + a * (1 / b) + sin(x) / 2";
+
+        private static readonly RewriteRuleSet divisionAsData = new(
+            "DivisionPreparingAsData",
+            "The same rules as RewriteRules.DivisionPreparing, expressed as data.",
+            TransformationRelation.Equivalence,
+            Soundness.SoundUnderAssumptions,
+            MatchedRules.DivisionPreparing.ApplyHere);
+
+        [Benchmark]
+        public Entity PassSwitch() => RewriteRules.DivisionPreparing.ApplyOnce(passInput);
+
+        [Benchmark]
+        public Entity PassData() => divisionAsData.ApplyOnce(passInput);
     }
 }

--- a/Sources/Tests/DotnetBenchmark/MatchingEngine.cs
+++ b/Sources/Tests/DotnetBenchmark/MatchingEngine.cs
@@ -1,0 +1,91 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Core.Transformations.Matching;
+using AngouriMath.Functions;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Exporters.Csv;
+
+namespace DotnetBenchmark
+{
+    /// <summary>
+    /// A rewrite rule as an arm of a <c>switch</c> against the same rule as data, on the same
+    /// input, one node at a time.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This measures the thing that decides whether
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/248">#248</a> can actually
+    /// happen. <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> v2.0
+    /// says a slower <c>Simplify</c> for the common case is unacceptable and that the fast path
+    /// must survive as a path. A <c>switch</c> arm is a type test and a few field reads; a
+    /// pattern is an object walk that allocates a <c>Bindings</c> per hole and enumerates with
+    /// iterators. It would be surprising if they cost the same, and the question is whether the
+    /// difference is a factor to engineer around or a factor that ends the design.
+    /// </para>
+    /// <para>
+    /// <b>The miss is the case that matters.</b> A rewrite pass asks every rule about every node,
+    /// so nearly every question asked of a rule set is answered "no". A form that is quick to
+    /// accept and slow to decline would be slower in practice than these numbers suggest if only
+    /// the hits were measured, which is why each set is measured on a node it rewrites and on one
+    /// it does not.
+    /// </para>
+    /// <para>
+    /// Read the allocation column first, as with <see cref="TransformationLayer"/>: it is
+    /// deterministic where the timings on an ordinary machine move ten percent between runs.
+    /// </para>
+    /// </remarks>
+    [ArtifactsPath(@"./benchmark_results.csv")]
+    [CsvExporter(CsvSeparator.Semicolon)]
+    [MemoryDiagnoser]
+    public class MatchingEngine
+    {
+        // A node the DivisionPreparing set rewrites -- a * (1 / b) -- and one it does not.
+        private static readonly Entity divisionHit = "a * (1 / b)";
+        private static readonly Entity divisionMiss = "a + b";
+
+        // The Pythagorean identity as the switch sees it: two terms of one sum.
+        private static readonly Entity pythagorasAdjacent = "sin(x) ^ 2 + cos(x) ^ 2";
+
+        // And buried, where the switch cannot see it at all and Gathered can. There is no
+        // switch counterpart to compare against here -- that is the point of the rule -- so
+        // this measures what the new capability costs, not a like-for-like difference.
+        private static readonly Entity pythagorasBuried = "a + sin(x) ^ 2 + b + cos(x) ^ 2 + c";
+
+        // A long sum with nothing to find: the shape that would make an n-ary matcher expensive
+        // if it were going to be, since every operand is tried in every position.
+        private static readonly Entity longMiss = "aa + ab + ac + ad + ae + af + ag + ah";
+
+        [Benchmark(Baseline = true)]
+        public Entity DivisionSwitchHit() => Patterns.DivisionPreparingRules(divisionHit);
+
+        [Benchmark]
+        public Entity DivisionDataHit() => MatchedRules.DivisionPreparing.ApplyHere(divisionHit);
+
+        [Benchmark]
+        public Entity DivisionSwitchMiss() => Patterns.DivisionPreparingRules(divisionMiss);
+
+        [Benchmark]
+        public Entity DivisionDataMiss() => MatchedRules.DivisionPreparing.ApplyHere(divisionMiss);
+
+        [Benchmark]
+        public Entity PythagorasSwitchAdjacent() => Patterns.TrigonometricRules(pythagorasAdjacent);
+
+        [Benchmark]
+        public Entity PythagorasDataAdjacent()
+            => MatchedRules.PythagoreanIdentity.ApplyHere(pythagorasAdjacent);
+
+        [Benchmark]
+        public Entity PythagorasDataBuried()
+            => MatchedRules.PythagoreanIdentity.ApplyHere(pythagorasBuried);
+
+        [Benchmark]
+        public Entity PythagorasDataLongMiss()
+            => MatchedRules.PythagoreanIdentity.ApplyHere(longMiss);
+    }
+}

--- a/Sources/Tests/DotnetBenchmark/Program.cs
+++ b/Sources/Tests/DotnetBenchmark/Program.cs
@@ -82,6 +82,10 @@ namespace DotnetBenchmark
                         // Allocated as well as Mean: the regressions this one exists to catch
                         // show up in allocation and are invisible in the timings.
                         "TransformationLayer" => GetReportByBenchmark(typeof(TransformationLayer), "Mean", "Error", "StdDev", "Allocated"),
+                        // Ratio as well: this one exists to compare two forms of the same rule,
+                        // and the absolute nanoseconds matter far less than the factor between
+                        // them. See MatchingEngine for what the factor decides.
+                        "MatchingEngine" => GetReportByBenchmark(typeof(MatchingEngine), "Mean", "Error", "StdDev", "Ratio", "Allocated"),
                         "CompiledFuncTest" => GetReportByBenchmark(typeof(CompiledFuncTest), "Mean", "Error", "StdDev"),
                         "NumbersBenchmark" => GetReportByBenchmark(typeof(NumbersBenchmark), "Mean", "Error", "StdDev"),
                         _ => throw new($"Unexpected benchmark {arg}")

--- a/Sources/Tests/UnitTests/Core/Transformations/DeterministicMatchingTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/DeterministicMatchingTest.cs
@@ -1,0 +1,123 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Core.Transformations.Matching;
+using AngouriMath.Extensions;
+using Xunit;
+using static AngouriMath.Entity;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// The single-shot matcher against the enumerating one, on every rule in the registry and
+    /// every expression to hand.
+    /// </summary>
+    /// <remarks>
+    /// There are now two implementations of matching: <c>Match</c>, which yields every way a
+    /// pattern fits, and <c>TryMatchOnce</c>, which skips the iterators for patterns that can
+    /// only fit one way. The second exists because the first allocated a state machine per
+    /// pattern node per attempt, which a rewrite pass pays at every node of the tree. Two
+    /// implementations of one thing is how a matcher acquires a case where they differ, so this
+    /// holds them together rather than trusting that they agree.
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class DeterministicMatchingTest
+    {
+        private static IEnumerable<MatchedRuleSet> AllSets => new[]
+        {
+            MatchedRules.DivisionPreparing,
+            MatchedRules.CollapseMultipleFractions,
+            MatchedRules.PowerOfPower,
+            MatchedRules.SharedFactor,
+            MatchedRules.PythagoreanIdentity,
+        };
+
+        /// <summary>
+        /// Shapes chosen to hit the rules and to miss them, including the node types they are
+        /// about, so that the agreement below is over both answers rather than only over "no".
+        /// </summary>
+        private static readonly string[] Corpus =
+        {
+            "a * (1 / b)", "2 / x * y", "(2 * a) / b", "(2 / a) * b",
+            "1 / (1 / x)", "x / y / z", "(x / y) / (z / w)", "1 / x + 1 / y",
+            "(x ^ 2) ^ 3", "(x ^ a) ^ b", "x ^ 2", "2 ^ x",
+            "a * x + a * y", "x * a + y * a", "a + b", "a - b",
+            "sin(x) ^ 2 + cos(x) ^ 2", "a + sin(x) ^ 2 + cos(x) ^ 2",
+            "sin(x)", "x", "17", "1/2", "x + y + z", "x * y * z",
+            "sqrt(x)", "e ^ x", "log(2, x)", "x ^ 0", "0 ^ x", "-x",
+        };
+
+        /// <summary>
+        /// Where a pattern says it can only fit one way, the two matchers must agree on whether
+        /// it fits, and on what it bound when it did.
+        /// </summary>
+        [Fact]
+        public void DeterministicMatchingAgreesWithEnumeration()
+        {
+            var checkedPairs = 0;
+            foreach (var rule in AllSets.SelectMany(set => set.Rules))
+            {
+                if (!rule.Left.IsDeterministic) continue;
+                foreach (var text in Corpus)
+                {
+                    var expr = text.ToEntity();
+                    var enumerated = rule.Left.Match(expr, Bindings.Empty).ToList();
+                    var single = rule.Left.TryMatchOnce(expr, Bindings.Empty, out var once);
+
+                    Assert.True(enumerated.Count <= 1,
+                        $"{rule.Name} calls itself deterministic but matched '{text}' "
+                        + $"{enumerated.Count} ways");
+                    Assert.True(single == (enumerated.Count == 1),
+                        $"{rule.Name} disagreed on whether it matches '{text}'");
+
+                    if (single)
+                        foreach (var name in rule.Left.BoundNames.Distinct())
+                        {
+                            Assert.True(once.TryGet(name, out var fast));
+                            Assert.True(enumerated[0].TryGet(name, out var slow));
+                            Assert.Equal(slow, fast);
+                        }
+                    checkedPairs++;
+                }
+            }
+            // A test that silently checked nothing would pass just as loudly.
+            Assert.True(checkedPairs > 100, $"only {checkedPairs} pattern/expression pairs checked");
+        }
+
+        // That the sets still *rewrite* the same thing end to end is not restated here:
+        // MatchedRulesAgreeWithTheSwitchTest already runs both the data sets and the `switch`
+        // they mirror over generated expressions and requires them to agree, and it now goes
+        // through the fast path to do it. A second copy of that check, with the right-hand
+        // sides reached from a test, would mean opening them up for no gain in coverage.
+
+        /// <summary>
+        /// The classification itself: a pattern with a choice in it must not claim otherwise,
+        /// and a node inherits the indeterminacy of anything below it.
+        /// </summary>
+        [Fact]
+        public void AChoiceAnywhereMakesThePatternASearch()
+        {
+            Assert.True(MatchPattern.Any("x").IsDeterministic);
+            Assert.True(MatchPattern.Node<Powf>(
+                MatchPattern.Any("x"), MatchPattern.Any("y")).IsDeterministic);
+
+            var commutative = MatchPattern.Commutative<Sumf>(
+                MatchPattern.Any("x"), MatchPattern.Any("y"));
+            Assert.False(commutative.IsDeterministic);
+
+            // ...and buried one level down, which is the case a per-node flag would get wrong.
+            Assert.False(MatchPattern.Node<Powf>(commutative, MatchPattern.Any("n"))
+                .IsDeterministic);
+
+            Assert.False(MatchPattern.Gathered<Sumf>("rest", MatchPattern.Any("x"),
+                MatchPattern.Any("y")).IsDeterministic);
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Core/Transformations/GatheredMatchingTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/GatheredMatchingTest.cs
@@ -1,0 +1,206 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Core.Transformations.Matching;
+using AngouriMath.Extensions;
+using Xunit;
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// The n-ary half of <a href="https://github.com/asc-community/AngouriMath/issues/248">#248</a>:
+    /// a rule about two terms finding them among many.
+    /// </summary>
+    [Trait("Area", "Core")]
+    public sealed class GatheredMatchingTest
+    {
+        private static MatchPattern SquaredSine(string arg) =>
+            MatchPattern.Node<Powf>(
+                MatchPattern.Node<Sinf>(MatchPattern.Any(arg)),
+                MatchPattern.Exact(Integer.Create(2)));
+
+        private static MatchPattern SquaredCosine(string arg) =>
+            MatchPattern.Node<Powf>(
+                MatchPattern.Node<Cosf>(MatchPattern.Any(arg)),
+                MatchPattern.Exact(Integer.Create(2)));
+
+        private static MatchPattern Pythagoras =>
+            MatchPattern.Gathered<Sumf>("rest", SquaredSine("x"), SquaredCosine("x"));
+
+        /// <summary>
+        /// The point of the whole exercise: the pair is found wherever it sits, including split
+        /// apart by terms that have nothing to do with it.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x)^2 + cos(x)^2")]
+        [InlineData("a + sin(x)^2 + cos(x)^2")]
+        [InlineData("sin(x)^2 + a + cos(x)^2")]
+        [InlineData("sin(x)^2 + a + b + cos(x)^2")]
+        [InlineData("a + sin(x)^2 + b + cos(x)^2 + c")]
+        [InlineData("cos(x)^2 + sin(x)^2")]
+        [InlineData("a + cos(x)^2 + b + sin(x)^2")]
+        public void ThePairIsFoundWhereverItSits(string expression)
+            => Assert.True(Pythagoras.Matches(expression.ToEntity()));
+
+        /// <summary>And is not found where it is not there.</summary>
+        [Theory]
+        [InlineData("sin(x)^2 + sin(x)^2")]
+        [InlineData("a + b + c")]
+        [InlineData("sin(x)^2")]
+        [InlineData("sin(x)^2 * cos(x)^2")]
+        public void AndNotWhereItIsNot(string expression)
+            => Assert.False(Pythagoras.Matches(expression.ToEntity()));
+
+        /// <summary>
+        /// A repeated hole unifies across operands, so the two terms must be about the same
+        /// argument. Without this the rule would rewrite <c>sin(x)^2 + cos(y)^2</c> to 1.
+        /// </summary>
+        [Fact]
+        public void TheTwoTermsMustShareAnArgument()
+        {
+            Assert.True(Pythagoras.Matches("sin(x)^2 + cos(x)^2 + q".ToEntity()));
+            Assert.False(Pythagoras.Matches("sin(x)^2 + cos(y)^2 + q".ToEntity()));
+        }
+
+        /// <summary>
+        /// The leftover is the operator's identity when every operand was claimed — the empty sum
+        /// is zero — so a right-hand side never has to ask which case it is in.
+        /// </summary>
+        [Fact]
+        public void AnExhaustedSumLeavesZeroBehind()
+        {
+            var solution = First("sin(x)^2 + cos(x)^2");
+            Assert.NotNull(solution);
+            Assert.Equal(Integer.Create(0), solution!["rest"]);
+        }
+
+        [Theory]
+        [InlineData("sin(x)^2 + cos(x)^2 + a", "a")]
+        [InlineData("a + sin(x)^2 + cos(x)^2", "a")]
+        public void AndTheRestOfTheSumOtherwise(string expression, string expected)
+            => Assert.Equal(expected.ToEntity(), First(expression)!["rest"]);
+
+        /// <summary>
+        /// Operands come from <c>LinearChildren</c>, which has already turned subtraction into a
+        /// negated term — so a rule needs no second arm for the subtractive spelling.
+        /// </summary>
+        [Fact]
+        public void SubtractionIsTheSameChain()
+        {
+            // The chain is { sin(x)^2, cos(x)^2, (-1) * a }, so the pair is still there...
+            Assert.True(Pythagoras.Matches("sin(x)^2 + cos(x)^2 - a".ToEntity()));
+            Assert.Equal((-1 * MathS.Var("a")).InnerSimplified,
+                First("sin(x)^2 + cos(x)^2 - a")!["rest"].InnerSimplified);
+
+            // ...and a *subtracted* square is a different term, which the rule must not claim:
+            // a - sin(x)^2 + cos(x)^2 offers (-1) * sin(x)^2, not sin(x)^2.
+            Assert.False(Pythagoras.Matches("a - sin(x)^2 + cos(x)^2".ToEntity()));
+        }
+
+        /// <summary>Gathering works over a product too, where the identity left behind is one.</summary>
+        [Fact]
+        public void OverAProductTheIdentityIsOne()
+        {
+            var pattern = MatchPattern.Gathered<Mulf>(
+                "rest", MatchPattern.Any<Variable>("p"), MatchPattern.Any<Variable>("q"));
+            var solution = pattern.Match("a * b".ToEntity(), Bindings.Empty).First();
+            Assert.Equal(Integer.Create(1), solution["rest"]);
+        }
+
+        /// <summary>
+        /// A sum of distinct variables. The names are letters only on purpose: <c>v0</c> parses
+        /// as <c>v ^ 0</c>, since a digit after an identifier is exponentiation in this grammar,
+        /// so a generated name with a digit in it is not a variable at all.
+        /// </summary>
+        private static Entity Chain(int terms)
+            => string.Join(" + ", Enumerable.Range(0, terms)
+                .Select(i => $"{(char)('a' + i / 26)}{(char)('a' + i % 26)}")).ToEntity();
+
+        private static MatchPattern FreeHoles(int count)
+            => MatchPattern.Gathered<Sumf>("rest",
+                Enumerable.Range(0, count)
+                    .Select(i => MatchPattern.Any<Variable>($"h{i}")).ToArray());
+
+        /// <summary>
+        /// Every assignment of holes to operands is enumerated, which is what backtracking needs
+        /// and what a matcher returning one answer cannot give.
+        /// </summary>
+        [Fact]
+        public void EveryAssignmentIsEnumerated()
+        {
+            // Three distinct holes over eight terms: 8 * 7 * 6 ordered assignments.
+            var solutions = FreeHoles(3).Match(Chain(8), Bindings.Empty).Count();
+            Assert.Equal(8 * 7 * 6, solutions);
+        }
+
+        /// <summary>
+        /// And the search is <b>bounded</b>, not exhaustive. Five holes over twenty terms is
+        /// 20*19*18*17*16 = 1,860,480 assignments; the ceiling stops it long before that.
+        /// </summary>
+        /// <remarks>
+        /// Observed as a count rather than as a duration, because a timing assertion is flaky in
+        /// CI and this one is exact: past the ceiling the enumeration simply stops yielding.
+        /// </remarks>
+        [Fact]
+        public void TheSearchIsBoundedRatherThanExhaustive()
+        {
+            var solutions = FreeHoles(5).Match(Chain(20), Bindings.Empty).Count();
+            Assert.InRange(solutions, 1, MatchPattern.MaxAssignments);
+            Assert.True(solutions < 20 * 19 * 18 * 17 * 16);
+        }
+
+        /// <summary>
+        /// A chain that cannot match declines rather than running away — the bound is on the
+        /// whole search, so no branch of it can spend forever. Declining is a legitimate answer:
+        /// the rule does not apply, and nothing wrong is returned.
+        /// </summary>
+        [Fact]
+        public void APathologicalChainDeclines()
+        {
+            // Four holes that match anything, and a fifth that matches nothing, over forty
+            // terms. Every one of the 40*39*38*37 prefixes is built and then fails on the last
+            // hole, so this is the case where the bound is what makes it return.
+            var parts = Enumerable.Range(0, 4)
+                .Select(i => MatchPattern.Any<Variable>($"h{i}"))
+                .Append(SquaredSine("never"))
+                .ToArray();
+            Assert.False(MatchPattern.Gathered<Sumf>("rest", parts).Matches(Chain(40)));
+        }
+
+        /// <summary>The rule set built on it, end to end.</summary>
+        [Theory]
+        [InlineData("sin(x)^2 + cos(x)^2", "1")]
+        [InlineData("a + sin(x)^2 + cos(x)^2", "1 + a")]
+        [InlineData("sin(x)^2 + a + cos(x)^2", "1 + a")]
+        public void TheRuleSetRewritesIt(string expression, string expected)
+        {
+            var rewritten = MatchedRules.PythagoreanIdentity.ApplyHere(expression.ToEntity());
+            Assert.Equal(expected.ToEntity().InnerSimplified, rewritten.InnerSimplified);
+        }
+
+        /// <summary>
+        /// The claim that motivates <c>Gathered</c>, checked rather than asserted: the binary
+        /// pattern that the <c>switch</c> form corresponds to finds the pair only when the two
+        /// terms are siblings.
+        /// </summary>
+        [Fact]
+        public void TheBinaryPatternIsTheOneThatCannotDoThis()
+        {
+            var binary = MatchPattern.Commutative<Sumf>(SquaredSine("x"), SquaredCosine("x"));
+            Assert.True(binary.Matches("sin(x)^2 + cos(x)^2".ToEntity()));
+            Assert.False(binary.Matches("a + sin(x)^2 + cos(x)^2".ToEntity()));
+            Assert.True(Pythagoras.Matches("a + sin(x)^2 + cos(x)^2".ToEntity()));
+        }
+
+        private static Bindings? First(string expression)
+            => Pythagoras.Match(expression.ToEntity(), Bindings.Empty).FirstOrDefault();
+    }
+}


### PR DESCRIPTION
[#746](https://github.com/asc-community/AngouriMath/issues/746) v1.0 asks for pattern matching "with commutative **and n-ary** matching handled by the engine". #938 built the commutative half and said plainly that the n-ary half was missing: `a + b + c` could not match `x + y`. This is that half, and it is the last piece of #248's matching engine.

```csharp
MatchPattern.Gathered<Sumf>("rest", squaredSine, squaredCosine)
```

Flattens the chain with the `LinearChildren` the library already has, finds the parts among the operands **in any positions**, and binds the leftovers to `rest`.

## The empty sum is zero

Where nothing is left over, `rest` is bound to the operator's **identity** — `0` for a sum, `1` for a product. Not a convenience: the empty sum *is* zero and the empty product *is* one. So one rule covers both `sin(x)^2 + cos(x)^2` and the same pair buried in a longer sum, and no right-hand side has to ask which case it is in.

Because the operands come from `LinearChildren`, the subtractive and divisive spellings arrive normalised — `a - b` offers `a` and `(-1) * b`. A rule needs no second arm for them, which is one of the ways the `switch` sets multiplied.

## What it buys, stated against the code rather than in the abstract

`Patterns.TrigonometricRules` spends **two arms** on the Pythagorean identity:

```csharp
Sumf(Powf(Sinf(var any1), Integer(2)), Powf(Cosf(var any1a), Integer(2))) when any1 == any1a => 1,
Sumf(Powf(Cosf(var any1), Integer(2)), Powf(Sinf(var any1a), Integer(2))) when any1 == any1a => 1,
```

Two, because there is no commutative matching. And both match only two children of **one** `Sumf`, so the pair is found in `sin(x)^2 + cos(x)^2` and missed in `a + sin(x)^2 + b + cos(x)^2`.

The library's answer is to sort the operands with `CanonicalOrder` before the rules run, so the pair lands adjacent. That works — and it is **the matcher's limitation showing through as a pipeline stage**. One `Gathered` rule replaces both arms and handles the buried case, and `MatchedRules.PythagoreanIdentity` is that rule.

It is the first set in that file with no `switch` to be checked against, because the `switch` cannot express it. It is checked against the mathematics instead.

## Bounded, because this is where the explosion lives

Assigning k parts to n operands is n!/(n−k)! attempts. #746 warns that combinatorial explosion is the whole difficulty of the rewrite graph, so the search is bounded by **measured work** rather than by a reasoned size limit — the same choice #921 settled on for the resultant. Past the ceiling the enumeration stops yielding, so the rule *does not apply* rather than taking unbounded time. Declining is a legitimate answer where a hang is not. Two parts stay under the bound until 100 operands.

## Measured

Suite **7141 passed / 0 failed**, 24 of them new.

The bound is checked by **counting solutions, not by timing a run** — a timing assertion is flaky in CI, and this one is exact: three holes over eight terms enumerates exactly 8·7·6 = 336, and five holes over twenty stops well short of 1,860,480.

Worth recording, because the first version of that test was worthless: it used a pattern that failed at the first hole, so the search died at depth 1 having spent 60 of its 10,000 budget. It passed, and proved nothing. The replacement builds prefixes that all match and fail only at the last hole, which is the case the bound is actually for.

Nothing runs the new rule set, so **no answer changes** — no `BREAKING-CHANGES.md` entry. Everything here is internal; `PublicApi.txt` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
