### PR TITLE
Drop the absolute value from an antiderivative unless the codomain is real (#946)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -1,4 +1,4 @@
-# Behavioural and breaking changes
+﻿# Behavioural and breaking changes
 
 AngouriMath puts mathematical correctness ahead of backward compatibility. An API that returns the
 wrong answer is not an asset to preserve, so when the two disagree the answer changes — see
@@ -22,6 +22,35 @@ read first.
 | Silent? | What | Was | Is |
 |---|---|---|---|
 | | `(Entity.Number)someBigInteger` | `FormatException: Illegal character found`, for almost every value | the number |
+| **Silent** | `"1/x".Integrate("x")`, and every antiderivative with a logarithm | `ln(abs(x)) + C` | `ln(x) + C` |
+
+### An antiderivative with a logarithm drops the absolute value unless the codomain is real
+
+`abs` is not holomorphic, so `ln(abs(f))` is an antiderivative of `f'/f` **on the real line and
+nowhere else** — differentiating it off the line does not return the integrand. The table produced
+it unconditionally, including under the default codomain, which is the complex plane. That is
+[#946](https://github.com/asc-community/AngouriMath/issues/946), and separating by codomain is the
+answer given on the issue.
+
+```csharp
+"1/x".Integrate("x")        // was: ln(abs(x)) + C        now: ln(x) + C
+"tan(x)".Integrate("x")     // was: -ln(abs(cos(x))) + C  now: -ln(cos(x)) + C
+```
+
+The previous answer is still available, and is now a statement about where you are working rather
+than the only thing on offer:
+
+```csharp
+using var _ = MathS.Settings.Codomain.Set(Domain.Real);
+"1/x".Integrate("x")        // ln(abs(x)) + C, as before
+```
+
+**Silent**: the call still succeeds and returns a different expression. If you were integrating on
+the reals and relying on the default, set the codomain and nothing changes.
+
+Eleven rules in the table introduced the absolute value themselves and all eleven now ask. The rule
+for `∫ ln(abs(ax + b)) dx` is deliberately **not** among them: there the absolute value comes from
+the integrand the caller wrote, not from the rule, so it is left where it is.
 
 ### A `BigInteger` converts to a `Number` instead of throwing
 

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -87,7 +87,7 @@ namespace AngouriMath.Functions.Algebra
             Entity.Powf(var @base, var power) =>
                 !power.ContainsNode(x) && @base == x ?
                     power == -1 ?
-                        MathS.Ln(MathS.Abs(@base)) :
+                        IntegralPatterns.AntiderivativeLog(@base) :
                         MathS.Pow(x, power + 1) / (power + 1) :
                     null,
 

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IntegralPatterns.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IntegralPatterns.cs
@@ -12,6 +12,35 @@ namespace AngouriMath.Functions.Algebra
     internal static class IntegralPatterns
     {
         /// <summary>
+        /// The logarithm an antiderivative of <c>f'/f</c> is written with: <c>ln(abs(f))</c> when
+        /// the codomain is the reals, <c>ln(f)</c> when it is the complex plane.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>ln(abs(f))</c> is an antiderivative of <c>f'/f</c> only on the real line. <c>abs</c>
+        /// is not holomorphic, so off the real line the textbook form is not an antiderivative of
+        /// anything -- differentiating it does not return the integrand. That is
+        /// https://github.com/asc-community/AngouriMath/issues/946, and separating by codomain is
+        /// the answer given there.
+        /// </para>
+        /// <para>
+        /// Under <see cref="AngouriMath.Core.Domain.Real"/> this returns exactly what the table
+        /// returned before, so a caller who has said they are working on the reals sees no change.
+        /// The default codomain is the complex plane, so the default answer does change --
+        /// recorded in <c>BREAKING-CHANGES.md</c>.
+        /// </para>
+        /// <para>
+        /// This is for an <c>abs</c> the rule <i>introduces</i>. Where the integrand already
+        /// carries one -- the rule for <c>ln(abs(ax + b))</c> below -- the <c>abs</c> in the
+        /// result is the caller's own and is left alone.
+        /// </para>
+        /// </remarks>
+        internal static Entity AntiderivativeLog(Entity arg)
+            => MathS.Settings.Codomain.Value is AngouriMath.Core.Domain.Real
+                ? MathS.Ln(MathS.Abs(arg))
+                : MathS.Ln(arg);
+
+        /// <summary>
         /// The argument through which each rule below reads its integrand's dependence on
         /// <paramref name="x"/>, or <see langword="null"/> for a shape none of them matches.
         /// </summary>
@@ -79,15 +108,15 @@ namespace AngouriMath.Functions.Algebra
 
             Entity.Cosecantf(var arg) when
                 TreeAnalyzer.TryGetPolyLinear(arg, x, out var a, out _) =>
-                    MathS.Ln(MathS.Abs(MathS.Tan(0.5 * arg))) / a,
+                    AntiderivativeLog(MathS.Tan(0.5 * arg)) / a,
 
             Entity.Tanf(var arg) when
                 TreeAnalyzer.TryGetPolyLinear(arg, x, out var a, out _) =>
-                    -MathS.Ln(MathS.Abs(MathS.Cos(arg))) / a,
+                    -AntiderivativeLog(MathS.Cos(arg)) / a,
 
             Entity.Cotanf(var arg) when
                TreeAnalyzer.TryGetPolyLinear(arg, x, out var a, out _) =>
-                    MathS.Ln(MathS.Abs(MathS.Sin(arg))) / a,
+                    AntiderivativeLog(MathS.Sin(arg)) / a,
 
             Entity.Logf(var @base, var arg) when
                 !@base.ContainsNode(x) && TreeAnalyzer.TryGetPolyLinear(arg, x, out var a, out var b) =>
@@ -128,11 +157,11 @@ namespace AngouriMath.Functions.Algebra
 
             Entity.Arctanf(var arg) when
                 TreeAnalyzer.TryGetPolyLinear(arg, x, out var a, out _) =>
-                    (arg * MathS.Arctan(arg) - MathS.Ln(MathS.Abs(1 + arg * arg)) / 2) / a,
+                    (arg * MathS.Arctan(arg) - AntiderivativeLog(1 + arg * arg) / 2) / a,
 
             Entity.Arccotanf(var arg) when
                 TreeAnalyzer.TryGetPolyLinear(arg, x, out var a, out _) =>
-                    (arg * MathS.Arccotan(arg) + MathS.Ln(MathS.Abs(1 + arg * arg)) / 2) / a,
+                    (arg * MathS.Arccotan(arg) + AntiderivativeLog(1 + arg * arg) / 2) / a,
 
             // ∫ B^(px + q) * sin(mx + n) dx and its cosine twin. Integrating by parts
             // twice returns the integral it started from, so the usual machinery cycles
@@ -201,7 +230,7 @@ namespace AngouriMath.Functions.Algebra
                 && TreeAnalyzer.TryGetPolyLinear(numerator, x, out var p, out var q)
                 && TreeAnalyzer.TryGetPolyLinear(denominator, x, out var b, out var c)
                 && b.Evaled is Entity.Number.Complex { IsZero: false }
-                    => p * x / b + (q - p * c / b) * MathS.Ln(MathS.Abs(denominator)) / b,
+                    => p * x / b + (q - p * c / b) * AntiderivativeLog(denominator) / b,
 
             // 1/cos(u)^2 and 1/sin(u)^2, which are written that way at least as often as
             // sec(u)^2 and csc(u)^2 and were not recognised in that form.
@@ -430,7 +459,7 @@ namespace AngouriMath.Functions.Algebra
 
             // a > 0
             var logarithmCase =
-                numerator * MathS.Ln(MathS.Abs(twoAxPlusB + 2 * MathS.Sqrt(a) * MathS.Sqrt(radicand))) / MathS.Sqrt(a);
+                numerator * AntiderivativeLog(twoAxPlusB + 2 * MathS.Sqrt(a) * MathS.Sqrt(radicand)) / MathS.Sqrt(a);
 
             // a = 0: sqrt(bx + c), which integrates as an ordinary power, and needs b ≠ 0 for
             // the same reason the rational case below does. Where the radicand has no x term
@@ -456,7 +485,7 @@ namespace AngouriMath.Functions.Algebra
         /// </summary>
         private static Entity IntegrateLinearOverQuadratic(
             Entity p, Entity q, Entity a, Entity b, Entity c, Entity denominator, Entity.Variable x)
-            => p / (2 * a) * MathS.Ln(MathS.Abs(denominator))
+            => p / (2 * a) * AntiderivativeLog(denominator)
                + IntegrateRationalQuadratic(q - p * b / (2 * a), a, b, c, x);
 
         private static Entity IntegrateRationalQuadratic(Entity numerator, Entity a, Entity b, Entity c, Entity.Variable x)
@@ -471,7 +500,7 @@ namespace AngouriMath.Functions.Algebra
             // NaN can propagate -- so k/(a x^2 + c) answered NaN while k/(2 x^2 + c) did not.
             var linearCase = TreeAnalyzer.IsZero(b)
                 ? numerator * x / c
-                : numerator * MathS.Ln(MathS.Abs(b * x + c)) / b;
+                : numerator * AntiderivativeLog(b * x + c) / b;
             
             // For true quadratics (a ≠ 0), discriminant Δ = 4ac - b^2 determines the form
             var discriminant = 4 * a * c - b * b;
@@ -490,7 +519,7 @@ namespace AngouriMath.Functions.Algebra
             // Case 3: Δ < 0 (two distinct real roots, use logarithm)
             // Result: (k/√(-Δ)) * ln|(2ax + b - √(-Δ))/(2ax + b + √(-Δ))|
             var sqrtNegDiscriminant = MathS.Sqrt(-discriminant);
-            var lnCase = numerator * MathS.Ln(MathS.Abs((twoAxPlusB - sqrtNegDiscriminant) / (twoAxPlusB + sqrtNegDiscriminant))) / sqrtNegDiscriminant;
+            var lnCase = numerator * AntiderivativeLog((twoAxPlusB - sqrtNegDiscriminant) / (twoAxPlusB + sqrtNegDiscriminant)) / sqrtNegDiscriminant;
             
             // Return as piecewise based on a and discriminant
             return MathS.Piecewise([

--- a/Sources/Tests/UnitTests/Calculus/IntegrationTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/IntegrationTest.cs
@@ -35,8 +35,48 @@ namespace AngouriMath.Tests.Calculus
         [InlineData("e^e^x", "integral(e ^ e ^ x, x)")] // don't recurse infinitely
         public void TestIndefinite(string initial, string expected)
         {
+            using var _ = MathS.Settings.Codomain.Set(AngouriMath.Core.Domain.Real);
             Assert.Equal(MathS.Boolean.True, initial.Integrate("x").EqualTo(expected).Simplify());
             Assert.Equal(expected, MathS.Integral(initial, "x").Simplify().Stringize());
+        }
+
+        /// <summary>
+        /// https://github.com/asc-community/AngouriMath/issues/946 -- <c>abs</c> is not
+        /// holomorphic, so <c>ln(abs(f))</c> is an antiderivative on the real line and nowhere
+        /// else. The default codomain is the complex plane, so the default answer is the plain
+        /// logarithm.
+        /// </summary>
+        [Theory]
+        [InlineData("1/x", "ln(x) + C")]
+        [InlineData("a / x", "a * ln(x) + C")]
+        [InlineData("tan(x)", "-ln(cos(x)) + C")]
+        [InlineData("cos(x) / sin(x)", "ln(sin(x)) + C")]
+        [InlineData("1 / (2*x + 5)", "ln(2 * x + 5) / 2 + C")]
+        [InlineData("arctan(x)", "x * arctan(x) - ln(1 + x ^ 2) / 2 + C")]
+        public void TheDefaultCodomainIntegratesWithoutAbs(string initial, string expected)
+        {
+            // Stated rather than assumed: the whole point of these rows is that they are what a
+            // caller who has set nothing gets.
+            Assert.Equal(AngouriMath.Core.Domain.Complex, MathS.Settings.Codomain.Value);
+            var result = initial.Integrate("x").InnerSimplified;
+            var expectedResult = expected.ToEntity().InnerSimplified;
+            Assert.Equal(MathS.Boolean.True, result.EqualTo(expectedResult).Simplify());
+        }
+
+        /// <summary>
+        /// And the real-line form is still reachable, which is the other half of #946: the
+        /// absolute value was not wrong, it was unconditional.
+        /// </summary>
+        [Theory]
+        [InlineData("1/x", "ln(abs(x)) + C")]
+        [InlineData("tan(x)", "-ln(abs(cos(x))) + C")]
+        [InlineData("cos(x) / sin(x)", "ln(abs(sin(x))) + C")]
+        public void TheRealCodomainKeepsTheAbsoluteValue(string initial, string expected)
+        {
+            using var _ = MathS.Settings.Codomain.Set(AngouriMath.Core.Domain.Real);
+            var result = initial.Integrate("x").InnerSimplified;
+            var expectedResult = expected.ToEntity().InnerSimplified;
+            Assert.Equal(MathS.Boolean.True, result.EqualTo(expectedResult).Simplify());
         }
         [Theory]
         [InlineData("2x * e ^ (x2)", "e ^ (x2) + C")]
@@ -56,6 +96,7 @@ namespace AngouriMath.Tests.Calculus
         [InlineData("cos(x) / sin(x)", "ln(abs(sin(x))) + C")]
         public void TestTrigonometricSubstitution(string initial, string expected)
         {
+            using var _ = MathS.Settings.Codomain.Set(AngouriMath.Core.Domain.Real);
             var result = initial.Integrate("x").InnerSimplified;
             var expectedResult = expected.ToEntity().InnerSimplified;
             Assert.Equal(MathS.Boolean.True, result.EqualTo(expectedResult).Simplify());
@@ -67,6 +108,7 @@ namespace AngouriMath.Tests.Calculus
         [InlineData("x / (1 + x2)", "1/2 * ln(abs(1 + x2)) + C")]
         public void TestRationalFunctionSubstitution(string initial, string expected)
         {
+            using var _ = MathS.Settings.Codomain.Set(AngouriMath.Core.Domain.Real);
             var result = initial.Integrate("x").InnerSimplified;
             var expectedResult = expected.ToEntity().InnerSimplified;
             Assert.Equal(MathS.Boolean.True, result.EqualTo(expectedResult).Simplify());
@@ -121,6 +163,7 @@ namespace AngouriMath.Tests.Calculus
         [InlineData("1 / (x * ln(x))", "ln(abs(ln(x))) + C")]
         public void TestLogarithmicSubstitution(string initial, string expected)
         {
+            using var _ = MathS.Settings.Codomain.Set(AngouriMath.Core.Domain.Real);
             var result = initial.Integrate("x").InnerSimplified;
             var expectedResult = expected.ToEntity().InnerSimplified;
             Assert.Equal(MathS.Boolean.True, result.EqualTo(expectedResult).Simplify());
@@ -131,6 +174,7 @@ namespace AngouriMath.Tests.Calculus
         [InlineData("sec(x) * tan(x)", "sec(x) + C")]
         public void TestAdvancedTrigSubstitution(string initial, string expected)
         {
+            using var _ = MathS.Settings.Codomain.Set(AngouriMath.Core.Domain.Real);
             var result = initial.Integrate("x").InnerSimplified;
             var expectedResult = expected.ToEntity().InnerSimplified;
             Assert.Equal(MathS.Boolean.True, result.EqualTo(expectedResult).Simplify());
@@ -236,6 +280,7 @@ namespace AngouriMath.Tests.Calculus
         [InlineData("1 / (3*x^2 + 5*x + 2)", "ln(abs(1 + -1/3 / (x + 1))) + C")] // factorable
         public void TestQuadraticDenominator(string initial, string expected)
         {
+            using var _ = MathS.Settings.Codomain.Set(AngouriMath.Core.Domain.Real);
             var result = initial.Integrate("x").InnerSimplified;
             var expectedResult = expected.ToEntity().InnerSimplified;
             Assert.Equal(MathS.Boolean.True, result.EqualTo(expectedResult).Simplify());
@@ -283,6 +328,7 @@ namespace AngouriMath.Tests.Calculus
         [InlineData("arccos(x)", "x * arccos(x) - sqrt(1 - x ^ 2) + C")]
         public void TestIntegrationByPartsNonPolynomial(string initial, string expected)
         {
+            using var _ = MathS.Settings.Codomain.Set(AngouriMath.Core.Domain.Real);
             var result = initial.Integrate("x").InnerSimplified;
             var expectedResult = expected.ToEntity().InnerSimplified;
             Assert.Equal(MathS.Boolean.True, result.EqualTo(expectedResult).Simplify());

--- a/Sources/Tests/UnitTests/Common/InnerSimplifyTest.cs
+++ b/Sources/Tests/UnitTests/Common/InnerSimplifyTest.cs
@@ -238,7 +238,7 @@ namespace AngouriMath.Tests.Common
 
         [Fact] public void PiecewiseIntegrate3NodeEvaled() =>
             "integral(piecewise(x provided a, 1/x), x)".ToEntity().Evaled
-            .ShouldBe("piecewise(x ^ 2 / 2 + C provided a, ln(abs(x)) + C)".ToEntity().Evaled);
+            .ShouldBe("piecewise(x ^ 2 / 2 + C provided a, ln(x) + C)".ToEntity().Evaled);
 
         [Fact] public void PiecewiseDerivative1NodeEvaled() =>
             "derivative(piecewise(x provided a, 1/x), x)".ToEntity().Evaled
@@ -272,7 +272,7 @@ namespace AngouriMath.Tests.Common
 
         [Fact] public void PiecewiseIntegrate3NodeInnerSimplified() =>
             "integral(piecewise(x provided a, 1/x), x)".ToEntity().InnerSimplified
-            .ShouldBe("piecewise(x ^ 2 / 2 + C provided a, ln(abs(x)) + C)");
+            .ShouldBe("piecewise(x ^ 2 / 2 + C provided a, ln(x) + C)");
 
         [Fact] public void PiecewiseDerivative1NodeInnerSimplified() =>
             "derivative(piecewise(x provided a, 1/x), x)".ToEntity().InnerSimplified


### PR DESCRIPTION
Closes #946.

`ln(abs(f))` is an antiderivative of `f'/f` **on the real line and nowhere else** — `abs` is not holomorphic, so differentiating it off the line does not return the integrand. The integral table produced it unconditionally, including under the default codomain, which is `Domain.Complex`. So the default answer to the simplest integral in the library was not an antiderivative of anything.

@Happypig375 answered the issue with *"Might need to separate by codomain"*, which is what this does.

```csharp
"1/x".Integrate("x")        // was: ln(abs(x)) + C        now: ln(x) + C
"tan(x)".Integrate("x")     // was: -ln(abs(cos(x))) + C  now: -ln(cos(x)) + C
```

The old answer is still available, and is now a statement about where you are working rather than the only thing on offer:

```csharp
using var _ = MathS.Settings.Codomain.Set(Domain.Real);
"1/x".Integrate("x")        // ln(abs(x)) + C, as before
```

The setting already had precedent — `Patterns.Power.cs` asks the same question the same way, and this uses the same form.

## Blast radius, measured rather than assumed

The issue reads as one rule. It is **twelve** sites, of which **eleven** change. All eleven introduce the absolute value themselves, and all now route through one helper:

| | |
|---|---|
| `∫ 1/x` (the issue's own case) | `IndefiniteIntegralSolver` |
| `∫ csc`, `∫ tan`, `∫ cot` | `IntegralPatterns` |
| `∫ arctan`, `∫ arccotan` | `IntegralPatterns` |
| linear/linear, constant/linear, linear/quadratic | `IntegralPatterns` |
| the radical and negative-discriminant cases | `IntegralPatterns` |

**The twelfth is deliberately left alone.** `∫ ln(abs(ax + b)) dx = ((ax+b)/a)(ln(abs(ax+b)) − 1)` keeps its absolute value, because there it comes from the integrand the caller wrote rather than from the rule. Changing it would alter an answer that is already correct on both domains. The applying script asserts that rule is still present, so the distinction cannot rot silently.

## Behaviour

**Under `Domain.Real` every one of the eleven returns exactly what it returned before**, so this is a no-op for a caller who has said where they are working. Only the default changes, and it changes from a non-antiderivative to an antiderivative.

Recorded in `BREAKING-CHANGES.md`, marked **Silent** — the call still succeeds and quietly returns a different expression, which is the class of change worth reading first.

## Evidence

- suite **7234 passed, 0 failed, 14 skipped**
- `casbench` **116/119, 0 wrong / 0 error / 0 timeout** — identical to its baseline. This is the harness that matters most here, because it verifies an antiderivative by **differentiating it back** rather than by comparing to stored text.
- probed on a build: `1/x → ln(x) + C`, `tan(x) → -ln(cos(x)) + C`, `1/(2x+5) → ln(2x+5)/2 + C`, `arctan(x) → x·arctan(x) − ln(1+x²)/2 + C`

Nineteen existing tests failed before the test changes, all from this one cause. They asserted the real-line forms, so they are now scoped to `Domain.Real` and **keep binding** rather than being edited to agree with the new output — the two `InnerSimplifyTest` cases are the exception, because they pinned the *default* and so their expected value is what changed. Two new theories cover the default and the real setting explicitly, so both branches of the separation are tested.

## What it does not do

- **Does not touch `Simplify` or evaluation** — only the integral table.
- **Does not revisit the piecewise decomposition** of the quadratic-denominator cases, whose branch conditions are real-ordering tests. Those branches now emit a plain logarithm under a complex codomain, which is an improvement on emitting a non-antiderivative, but whether that decomposition is the right shape off the real line is a separate question and not this PR's.
- **Does not change `Domain.Real` behaviour at all.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
