### PR TITLE
Keep a node's codomain when a rewrite rebuilds it (#955)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -25,6 +25,25 @@ read first.
 | **Silent** | `"1/x".Integrate("x")`, and every antiderivative with a logarithm | `ln(abs(x)) + C` | `ln(x) + C` |
 | **Silent** | `CostModel.FewestDivisions.Cost(y ^ (1 * (-1)) * x)` | `0.007`, cheaper than `x / y` | `1.007` |
 | **Silent** | `Real.NaN > (Real)1`, and the other three operators | `true` | `false` |
+| **Silent** | a rewritten expression under `domain(...)` — including via `Substitute` | the constraint was dropped, so it answered | it refuses, as it did before the rewrite |
+
+### A rewritten node keeps its `Codomain`, so a domain constraint no longer disappears
+
+`Entity.Replace` rebuilds every node on the path to a change, and a rebuilt node started from its
+type's default codomain rather than the one the original carried. Any rewrite therefore dropped a
+`domain(...)` annotation — including `Substitute`, which is built on `Replace`.
+
+```csharp
+"domain(sqrt(x), ZZ)".ToEntity().Substitute("x", "4/9".ToEntity()).EvalNumerical()
+// was: 2/3     now: NaN        — 2/3 is not an integer, so the constraint refuses it
+```
+
+The old behaviour was **silent** and one-sided: constraints were only ever weakened, never
+strengthened, so a rewrite could make an undefined expression look defined but never the reverse.
+An expression that answered a value where it should have refused now refuses.
+
+Measured: the whole suite passes unchanged with the fix in, so nothing in the library depended on
+the annotation being lost. [#955](https://github.com/asc-community/AngouriMath/issues/955).
 
 ### `Real`'s comparison operators refuse `NaN` instead of ordering it
 

--- a/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.AbsSignum.Classes.cs
+++ b/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.AbsSignum.Classes.cs
@@ -20,7 +20,7 @@ namespace AngouriMath
             public Entity NodeChild => Argument;
 
             private Signumf New(Entity arg) =>
-                ReferenceEquals(Argument, arg) ? this : new(arg);
+                ReferenceEquals(Argument, arg) ? this : new(arg) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Argument.Replace(func)));
             /// <inheritdoc/>
@@ -36,7 +36,7 @@ namespace AngouriMath
             public Entity NodeChild => Argument;
 
             private Absf New(Entity arg) =>
-                ReferenceEquals(Argument, arg) ? this : new(arg);
+                ReferenceEquals(Argument, arg) ? this : new(arg) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Argument.Replace(func)));
             /// <inheritdoc/>

--- a/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.ArcTrigonometry.Classes.cs
+++ b/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.ArcTrigonometry.Classes.cs
@@ -20,7 +20,7 @@ namespace AngouriMath
             public Entity NodeChild => Argument;
 
             /// <summary>Reuse the cache by returning the same object if possible</summary>
-            private Arcsinf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument);
+            private Arcsinf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Argument.Replace(func)));
             /// <inheritdoc/>
@@ -36,7 +36,7 @@ namespace AngouriMath
             public Entity NodeChild => Argument;
 
             /// <summary>Reuse the cache by returning the same object if possible</summary>
-            private Arccosf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument);
+            private Arccosf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Argument.Replace(func)));
             /// <inheritdoc/>
@@ -52,7 +52,7 @@ namespace AngouriMath
             public Entity NodeChild => Argument;
 
             /// <summary>Reuse the cache by returning the same object if possible</summary>
-            private Arctanf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument);
+            private Arctanf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Argument.Replace(func)));
             /// <inheritdoc/>
@@ -68,7 +68,7 @@ namespace AngouriMath
             public Entity NodeChild => Argument;
 
             /// <summary>Reuse the cache by returning the same object if possible</summary>
-            Arccotanf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument);
+            Arccotanf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Argument.Replace(func)));
             /// <inheritdoc/>
@@ -84,7 +84,7 @@ namespace AngouriMath
             public Entity NodeChild => Argument;
 
             /// <summary>Reuse the cache by returning the same object if possible</summary>
-            private Arcsecantf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument);
+            private Arcsecantf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Argument.Replace(func)));
             /// <inheritdoc/>
@@ -100,7 +100,7 @@ namespace AngouriMath
             public Entity NodeChild => Argument;
 
             /// <summary>Reuse the cache by returning the same object if possible</summary>
-            private Arccosecantf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument);
+            private Arccosecantf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Argument.Replace(func)));
             /// <inheritdoc/>

--- a/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Calculus.Classes.cs
+++ b/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Calculus.Classes.cs
@@ -22,7 +22,7 @@ namespace AngouriMath
             /// <summary>Reuse the cache by returning the same object if possible</summary>
             private Derivativef New(Entity expression, Entity var) =>
                 ReferenceEquals(Expression, expression) && ReferenceEquals(Var, var)
-                ? this : new(expression, var, Iterations);
+                ? this : new(expression, var, Iterations) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) =>
                 func(New(Expression.Replace(func), Var.Replace(func)));
@@ -40,7 +40,7 @@ namespace AngouriMath
                 ReferenceEquals(Expression, expression) && ReferenceEquals(Var, var)
                 && (range is null && Range is null || range is var (newFrom, newTo) && Range is var (oldFrom, oldTo)
                     && ReferenceEquals(newFrom, oldFrom) && ReferenceEquals(newTo, oldTo))
-                ? this : new(expression, var, range);
+                ? this : new(expression, var, range) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) =>
                 func(New(Expression.Replace(func), Var, Range is var (from, to) ? (from.Replace(func), to.Replace(func)) : null));
@@ -56,7 +56,7 @@ namespace AngouriMath
             /// <summary>Reuse the cache by returning the same object if possible</summary>
             private Limitf New(Entity expression, Entity var, Entity destination, ApproachFrom approachFrom) =>
                 ReferenceEquals(Expression, expression) && ReferenceEquals(Var, var) && ReferenceEquals(Destination, destination)
-                && ApproachFrom == approachFrom ? this : new(expression, var, destination, approachFrom);
+                && ApproachFrom == approachFrom ? this : new(expression, var, destination, approachFrom) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) =>
                 func(New(Expression.Replace(func), Var.Replace(func), Destination.Replace(func), ApproachFrom));

--- a/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Exponential.Classes.cs
+++ b/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Exponential.Classes.cs
@@ -18,7 +18,7 @@ namespace AngouriMath
         {
             /// <summary>Reuse the cache by returning the same object if possible</summary>
             private Powf New(Entity @base, Entity exponent) =>
-                ReferenceEquals(Base, @base) && ReferenceEquals(Exponent, exponent) ? this : new(@base, exponent);
+                ReferenceEquals(Base, @base) && ReferenceEquals(Exponent, exponent) ? this : new(@base, exponent) { Codomain = Codomain };
             internal override Priority Priority => Priority.Pow;
 
             /// <inheritdoc/>
@@ -40,7 +40,7 @@ namespace AngouriMath
         {
             /// <summary>Reuse the cache by returning the same object if possible</summary>
             private Logf New(Entity @base, Entity antilogarithm) =>
-                ReferenceEquals(Base, @base) && ReferenceEquals(Antilogarithm, antilogarithm) ? this : new(@base, antilogarithm);
+                ReferenceEquals(Base, @base) && ReferenceEquals(Antilogarithm, antilogarithm) ? this : new(@base, antilogarithm) { Codomain = Codomain };
 
             /// <inheritdoc/>
             public Entity NodeFirstChild => Base;

--- a/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Factorial.Classes.cs
+++ b/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Factorial.Classes.cs
@@ -17,7 +17,7 @@ namespace AngouriMath
         public sealed partial record Factorialf(Entity Argument) : Function, IUnaryNode
         {
             /// <summary>Reuse the cache by returning the same object if possible</summary>
-            private Factorialf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument);
+            private Factorialf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument) { Codomain = Codomain };
             // This is still a function for pattern replacement
             internal override Priority Priority => Priority.Factorial;
 

--- a/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Floors.Classes.cs
+++ b/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Floors.Classes.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) 2019-2026 Angouri.
 // AngouriMath is licensed under MIT.
 // Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
@@ -26,7 +26,7 @@ namespace AngouriMath
             public Entity NodeChild => Argument;
 
             private Floorf New(Entity arg) =>
-                ReferenceEquals(Argument, arg) ? this : new(arg);
+                ReferenceEquals(Argument, arg) ? this : new(arg) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Argument.Replace(func)));
             /// <inheritdoc/>
@@ -46,7 +46,7 @@ namespace AngouriMath
             public Entity NodeChild => Argument;
 
             private Ceilf New(Entity arg) =>
-                ReferenceEquals(Argument, arg) ? this : new(arg);
+                ReferenceEquals(Argument, arg) ? this : new(arg) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Argument.Replace(func)));
             /// <inheritdoc/>

--- a/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Operators.Classes.cs
+++ b/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Operators.Classes.cs
@@ -30,7 +30,7 @@ namespace AngouriMath
 
             /// <summary>Reuse the cache by returning the same object if possible</summary>
             private Sumf New(Entity augend, Entity addend) =>
-                ReferenceEquals(Augend, augend) && ReferenceEquals(Addend, addend) ? this : new(augend, addend);
+                ReferenceEquals(Augend, augend) && ReferenceEquals(Addend, addend) ? this : new(augend, addend) { Codomain = Codomain };
             internal override Priority Priority => Priority.Sum;
 
             /// <inheritdoc/>
@@ -65,7 +65,7 @@ namespace AngouriMath
         {
             /// <summary>Reuse the cache by returning the same object if possible</summary>
             private Minusf New(Entity minuend, Entity subtrahend) =>
-                ReferenceEquals(Minuend, minuend) && ReferenceEquals(Subtrahend, subtrahend) ? this : new(minuend, subtrahend);
+                ReferenceEquals(Minuend, minuend) && ReferenceEquals(Subtrahend, subtrahend) ? this : new(minuend, subtrahend) { Codomain = Codomain };
             internal override Priority Priority => Priority.Minus;
 
             /// <inheritdoc/>
@@ -99,7 +99,7 @@ namespace AngouriMath
 
             /// <summary>Reuse the cache by returning the same object if possible</summary>
             private Mulf New(Entity multiplier, Entity multiplicand) =>
-                ReferenceEquals(Multiplier, multiplier) && ReferenceEquals(Multiplicand, multiplicand) ? this : new(multiplier, multiplicand);
+                ReferenceEquals(Multiplier, multiplier) && ReferenceEquals(Multiplicand, multiplicand) ? this : new(multiplier, multiplicand) { Codomain = Codomain };
             internal override Priority Priority => Priority.Mul;
 
             /// <inheritdoc/>
@@ -134,7 +134,7 @@ namespace AngouriMath
         {
             /// <summary>Reuse the cache by returning the same object if possible</summary>
             internal Divf New(Entity dividend, Entity divisor) =>
-                ReferenceEquals(Dividend, dividend) && ReferenceEquals(Divisor, divisor) ? this : new(dividend, divisor);
+                ReferenceEquals(Dividend, dividend) && ReferenceEquals(Divisor, divisor) ? this : new(dividend, divisor) { Codomain = Codomain };
             internal override Priority Priority => Priority.Div;
 
             /// <inheritdoc/>
@@ -159,7 +159,7 @@ namespace AngouriMath
         {
             /// <summary>Reuse the cache by returning the same object if possible</summary>
             internal Modf New(Entity dividend, Entity divisor) =>
-                ReferenceEquals(Dividend, dividend) && ReferenceEquals(Divisor, divisor) ? this : new(dividend, divisor);
+                ReferenceEquals(Dividend, dividend) && ReferenceEquals(Divisor, divisor) ? this : new(dividend, divisor) { Codomain = Codomain };
             internal override Priority Priority => Priority.Mul;
 
             /// <inheritdoc/>

--- a/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Rounding.Classes.cs
+++ b/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Rounding.Classes.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) 2019-2026 Angouri.
 // AngouriMath is licensed under MIT.
 // Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
@@ -26,7 +26,7 @@ namespace AngouriMath
             public Entity NodeChild => Argument;
 
             private Roundf New(Entity arg) =>
-                ReferenceEquals(Argument, arg) ? this : new(arg);
+                ReferenceEquals(Argument, arg) ? this : new(arg) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Argument.Replace(func)));
             /// <inheritdoc/>
@@ -53,7 +53,7 @@ namespace AngouriMath
             public Entity NodeSecondChild => Right;
 
             private Minf New(Entity left, Entity right) =>
-                ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right);
+                ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Left.Replace(func), Right.Replace(func)));
             /// <inheritdoc/>
@@ -73,7 +73,7 @@ namespace AngouriMath
             public Entity NodeSecondChild => Right;
 
             private Maxf New(Entity left, Entity right) =>
-                ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right);
+                ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Left.Replace(func), Right.Replace(func)));
             /// <inheritdoc/>
@@ -99,7 +99,7 @@ namespace AngouriMath
             public Entity NodeSecondChild => Right;
 
             private Gcdf New(Entity left, Entity right) =>
-                ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right);
+                ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Left.Replace(func), Right.Replace(func)));
             /// <inheritdoc/>

--- a/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Trigonometry.Classes.cs
+++ b/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Trigonometry.Classes.cs
@@ -20,7 +20,7 @@ namespace AngouriMath
             public Entity NodeChild => Argument;
 
             /// <summary>Reuse the cache by returning the same object if possible</summary>
-            private Sinf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument);
+            private Sinf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Argument.Replace(func)));
             /// <inheritdoc/>
@@ -36,7 +36,7 @@ namespace AngouriMath
             public Entity NodeChild => Argument;
 
             /// <summary>Reuse the cache by returning the same object if possible</summary>
-            private Cosf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument);
+            private Cosf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Argument.Replace(func)));
             /// <inheritdoc/>
@@ -52,7 +52,7 @@ namespace AngouriMath
             public Entity NodeChild => Argument;
 
             /// <summary>Reuse the cache by returning the same object if possible</summary>
-            private Tanf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument);
+            private Tanf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Argument.Replace(func)));
             /// <inheritdoc/>
@@ -68,7 +68,7 @@ namespace AngouriMath
             public Entity NodeChild => Argument;
 
             /// <summary>Reuse the cache by returning the same object if possible</summary>
-            private Cotanf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument);
+            private Cotanf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Argument.Replace(func)));
             /// <inheritdoc/>
@@ -84,7 +84,7 @@ namespace AngouriMath
             public Entity NodeChild => Argument;
 
             /// <summary>Reuse the cache by returning the same object if possible</summary>
-            private Secantf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument);
+            private Secantf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Argument.Replace(func)));
             /// <inheritdoc/>
@@ -100,7 +100,7 @@ namespace AngouriMath
             public Entity NodeChild => Argument;
 
             /// <summary>Reuse the cache by returning the same object if possible</summary>
-            private Cosecantf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument);
+            private Cosecantf New(Entity argument) => ReferenceEquals(Argument, argument) ? this : new(argument) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Argument.Replace(func)));
             /// <inheritdoc/>

--- a/Sources/AngouriMath/Core/Entity/Discrete/Entity.Discrete.Classes.cs
+++ b/Sources/AngouriMath/Core/Entity/Discrete/Entity.Discrete.Classes.cs
@@ -98,7 +98,7 @@ namespace AngouriMath
             public Entity NodeChild => Argument;
 
             private Notf New(Entity negated) =>
-                ReferenceEquals(Argument, negated) ? this : new(negated);
+                ReferenceEquals(Argument, negated) ? this : new(negated) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Argument.Replace(func)));
             /// <inheritdoc/>
@@ -120,7 +120,7 @@ namespace AngouriMath
             public Entity NodeSecondChild => Right;
 
             private Andf New(Entity left, Entity right) =>
-                ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right);
+                ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func)
                 => func(New(Left.Replace(func), Right.Replace(func)));
@@ -142,7 +142,7 @@ namespace AngouriMath
             public Entity NodeSecondChild => Right;
 
             private Orf New(Entity left, Entity right) =>
-                ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right);
+                ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func)
                 => func(New(Left.Replace(func), Right.Replace(func)));
@@ -164,7 +164,7 @@ namespace AngouriMath
             public Entity NodeSecondChild => Right;
 
             private Xorf New(Entity left, Entity right) =>
-                ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right);
+                ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func)
                 => func(New(Left.Replace(func), Right.Replace(func)));
@@ -186,7 +186,7 @@ namespace AngouriMath
             public Entity NodeSecondChild => Conclusion;
 
             private Impliesf New(Entity assumption, Entity conclusion) =>
-                ReferenceEquals(Assumption, assumption) && ReferenceEquals(Conclusion, conclusion) ? this : new(assumption, conclusion);
+                ReferenceEquals(Assumption, assumption) && ReferenceEquals(Conclusion, conclusion) ? this : new(assumption, conclusion) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func)
                 => func(New(Assumption.Replace(func), Conclusion.Replace(func)));
@@ -238,7 +238,7 @@ namespace AngouriMath
             public Entity NodeSecondChild => Right;
 
             internal Greaterf New(Entity left, Entity right)
-                => ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right);
+                => ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func)
                 => func(New(Left.Replace(func), Right.Replace(func)));
@@ -264,7 +264,7 @@ namespace AngouriMath
             public Entity NodeSecondChild => Right;
 
             internal GreaterOrEqualf New(Entity left, Entity right)
-                => ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right);
+                => ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func)
                 => func(New(Left.Replace(func), Right.Replace(func)));
@@ -290,7 +290,7 @@ namespace AngouriMath
             public Entity NodeSecondChild => Right;
 
             internal Lessf New(Entity left, Entity right)
-                => ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right);
+                => ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func)
                 => func(New(Left.Replace(func), Right.Replace(func)));
@@ -316,7 +316,7 @@ namespace AngouriMath
             public Entity NodeSecondChild => Right;
 
             internal LessOrEqualf New(Entity left, Entity right)
-                => ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right);
+                => ReferenceEquals(Left, left) && ReferenceEquals(Right, right) ? this : new(left, right) { Codomain = Codomain };
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func)
                 => func(New(Left.Replace(func), Right.Replace(func)));
@@ -343,7 +343,7 @@ namespace AngouriMath
                 public Entity NodeSecondChild => SupSet;
 
                 internal Inf New(Entity element, Entity supSet)
-                    => ReferenceEquals(Element, element) && ReferenceEquals(SupSet, supSet) ? this : new(element, supSet);
+                    => ReferenceEquals(Element, element) && ReferenceEquals(SupSet, supSet) ? this : new(element, supSet) { Codomain = Codomain };
                 /// <inheritdoc/>
                 public override Entity Replace(Func<Entity, Entity> func)
                     => func(New(Element.Replace(func), SupSet.Replace(func)));
@@ -363,7 +363,7 @@ namespace AngouriMath
             public Entity NodeChild => Argument;
 
             internal Phif New(Entity argument)
-                   => ReferenceEquals(argument, Argument) ? this : new(argument);
+                   => ReferenceEquals(argument, Argument) ? this : new(argument) { Codomain = Codomain };
 
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func) => func(New(Argument.Replace(func)));

--- a/Sources/AngouriMath/Core/Entity/Omni/Entity.Matrix.cs
+++ b/Sources/AngouriMath/Core/Entity/Omni/Entity.Matrix.cs
@@ -57,7 +57,7 @@ namespace AngouriMath
             Matrix New(GenTensor innerMatrix) =>
                 innerMatrix.Iterate().All(tup => ReferenceEquals(InnerMatrix.GetValueNoCheck(tup.Index), tup.Value))
                 ? this
-                : new Matrix(innerMatrix);
+                : new Matrix(innerMatrix) { Codomain = Codomain };
             internal override Priority Priority => Priority.Leaf;
             internal Matrix Elementwise(Func<Entity, Entity> operation) =>
                 New(GenTensor.CreateTensor(InnerMatrix.Shape, indices => operation(InnerMatrix.GetValueNoCheck(indices))));

--- a/Sources/AngouriMath/Core/Entity/Omni/Entity.Omni.Classes.cs
+++ b/Sources/AngouriMath/Core/Entity/Omni/Entity.Omni.Classes.cs
@@ -247,12 +247,12 @@ namespace AngouriMath
                 internal Interval New(Entity left, Entity right)
                     => ReferenceEquals(Left, left) 
                     && ReferenceEquals(Right, right)
-                    ? this : new Interval(left, LeftClosed, right, RightClosed);
+                    ? this : new Interval(left, LeftClosed, right, RightClosed) { Codomain = Codomain };
 
                 internal Interval New(Entity left, bool leftClosed, Entity right, bool rightClosed)
                     => ReferenceEquals(Left, left) && ReferenceEquals(Right, right)
                     && LeftClosed == leftClosed && RightClosed == rightClosed
-                    ? this : new Interval(left, leftClosed, right, rightClosed);
+                    ? this : new Interval(left, leftClosed, right, rightClosed) { Codomain = Codomain };
 
                 /// <inheritdoc/>
                 public override Entity Replace(Func<Entity, Entity> func)
@@ -463,7 +463,7 @@ namespace AngouriMath
 
                 internal Entity New(Entity var, Entity predicate)
                     => ReferenceEquals(Var, var) && ReferenceEquals(Predicate, predicate) ?
-                    this : new ConditionalSet(var, predicate);
+                    this : new ConditionalSet(var, predicate) { Codomain = Codomain };
 
                 internal override Priority Priority => Priority.Leaf;
 

--- a/Sources/AngouriMath/Core/Entity/Omni/Entity.Piecewise.cs
+++ b/Sources/AngouriMath/Core/Entity/Omni/Entity.Piecewise.cs
@@ -26,7 +26,7 @@ namespace AngouriMath
             
             internal Providedf New(Entity expression, Entity predicate)
                 => ReferenceEquals(expression, Expression) && ReferenceEquals(predicate, Predicate) ? this :
-                new Providedf(expression, predicate);
+                new Providedf(expression, predicate) { Codomain = Codomain };
 
             /// <inheritdoc/>
             public override Entity Replace(Func<Entity, Entity> func)
@@ -63,7 +63,7 @@ namespace AngouriMath
             protected override Entity[] InitDirectChildren() => Cases.Select(c => (c.Expression, c.Predicate)).ConcatTuples().ToArray();
 
             private Piecewise New(IEnumerable<Providedf> newCases)
-                => (Cases, newCases).SequencesAreEqualReferences() ? this : new Piecewise(newCases);
+                => (Cases, newCases).SequencesAreEqualReferences() ? this : new Piecewise(newCases) { Codomain = Codomain };
 
             /// <summary>
             /// Creates an instance of Piecewise

--- a/Sources/Tests/UnitTests/Core/Domains.cs
+++ b/Sources/Tests/UnitTests/Core/Domains.cs
@@ -6,6 +6,7 @@
 //
 
 using AngouriMath;
+using AngouriMath.Core;
 using AngouriMath.Extensions;
 using Xunit;
 
@@ -25,6 +26,42 @@ namespace AngouriMath.Tests.Core
         [InlineData("domain(1 / 2, ZZ)")]
         public void CheckNaN(string expr)
             => Assert.Equal(MathS.NaN, expr.EvalNumerical());
+
+        /// <summary>
+        /// A rewritten node keeps the codomain the original carried.
+        /// https://github.com/asc-community/AngouriMath/issues/955 -- `Replace` rebuilds every
+        /// node on the path to a change, and the rebuilt node used to start from its type's
+        /// default, so a domain constraint silently disappeared and the expression began
+        /// answering where it had refused.
+        /// </summary>
+        [Fact]
+        public void ARewrittenNodeKeepsItsCodomain()
+        {
+            var original = "domain(sqrt(x), ZZ)".ToEntity();
+            Assert.Equal(Domain.Integer, original.Codomain);
+
+            var rewritten = original.Replace(node =>
+                node is Entity.Variable { Name: "x" } ? "y".ToEntity() : node);
+            Assert.Equal(Domain.Integer, rewritten.Codomain);
+        }
+
+        /// <summary>
+        /// The same through `Substitute`, which is what a caller actually reaches for and is
+        /// built on `Replace`. sqrt(4/9) is 2/3, which is not an integer, so this must refuse.
+        /// </summary>
+        [Fact]
+        public void SubstitutingIntoADomainKeepsTheConstraint()
+            => Assert.Equal(MathS.NaN,
+                "domain(sqrt(x), ZZ)".ToEntity().Substitute("x", "4/9".ToEntity()).EvalNumerical());
+
+        /// <summary>And a constraint deeper than one level survives too.</summary>
+        [Fact]
+        public void ANestedRewriteKeepsTheCodomain()
+        {
+            var rewritten = "domain(sin(x) + 1, ZZ)".ToEntity()
+                .Replace(node => node is Entity.Variable { Name: "x" } ? "y".ToEntity() : node);
+            Assert.Equal(Domain.Integer, rewritten.Codomain);
+        }
 
         [Theory]
         [InlineData("domain(sqrt(4), RR)")]


### PR DESCRIPTION
Closes #955.

`Entity.Replace` rebuilds every node on the path to a change, and each rebuild goes through a `New(...)` helper whose `new(...)` starts from the type's **default** codomain rather than the one the original carried. So any rewrite dropped a `domain(...)` annotation — `Substitute` included, since that is built on `Replace`:

```csharp
"domain(sqrt(x), ZZ)".ToEntity().Substitute("x", "4/9".ToEntity()).EvalNumerical()
// was: 2/3     now: NaN
```

2/3 is not an integer, and the constraint existed to refuse it.

The old behaviour was **silent** and **one-sided**: constraints were only ever weakened, never strengthened, so a rewrite could make an undefined expression look defined but never the reverse. That is the direction that gets acted on rather than noticed.

## The fix

47 rebuild sites, all the same shape:

- 41 target-typed `ReferenceEquals(...) ? this : new(...)` across the continuous and discrete node classes
- 6 written with an explicit type — `Providedf`, `Piecewise`, two `Interval` overloads, `ConditionalSet`, `Matrix`

Each now carries the original's codomain. I audited for leftovers rather than trusting the sweep: there is no remaining `? this : new(` without it.

## The blast radius, which was the open question on the issue

**Zero.** The full suite passes **7263, 0 failed** with the fix in — unchanged from master. Nothing in the library depended on the annotation being lost, which is what made me willing to take the broad option rather than the narrower "only preserve a non-default codomain" one.

Three tests pin the behaviour and **all three fail without the source change** (verified by stashing only `Sources/AngouriMath/`):

- through `Replace` directly
- through `Substitute`, which is what a caller actually reaches for
- one level deeper, so a nested rebuild is covered too

Recorded in `BREAKING-CHANGES.md` as **Silent**: an expression that answered a value where it should have refused now refuses.

## How it was found, and what it unblocks

Implementing #873 — parsing a quotient of two integer literals as a `Rational` — by rewriting the parsed tree. `domain(1/2, ZZ)` stopped answering `NaN`, and it turned out not to be a parser bug at all. #873 is blocked behind this rather than able to work around it, since any post-parse rewrite has the same hole; it becomes straightforward once this lands.

## What it does not do

- Does not change how a codomain is *chosen* for a freshly built node — only that a rewrite preserves what was there.
- Does not touch `WithCodomain`, `Codomain`'s declaration, or domain checking itself.
- Does not address #873, which follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
