### PR TITLE
Stop packing a library nobody publishes (#542)

### DIFF
--- a/Sources/Terminal/AngouriMath.Terminal.Lib/AngouriMath.Terminal.Lib.fsproj
+++ b/Sources/Terminal/AngouriMath.Terminal.Lib/AngouriMath.Terminal.Lib.fsproj
@@ -12,6 +12,18 @@
     <Compile Include="PreRunCode.fs" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <!--
+    Never published: angourimath.terminal.lib is a 404 on nuget.org, while the tool that uses it,
+    angourimath.terminal, is published. It packed anyway, and packing raised NU5104, which says a
+    stable release should not have a prerelease dependency, about Microsoft.DotNet.Interactive.FSharp,
+    which has 107 versions on nuget and has never shipped a stable one. So the warning was about a
+    package nobody releases, naming a dependency that cannot become stable.
+    https://github.com/asc-community/AngouriMath/issues/542
+    -->
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="FSharp.SystemTextJson" Version="0.17.4" />
     <PackageReference Include="Microsoft.DotNet.Interactive.FSharp" Version="1.0.0-beta.25323.1" />


### PR DESCRIPTION
Addresses #542.

`AngouriMath.Terminal.Lib` packed on every build, and packing raised **NU5104** — *a stable release should not have a prerelease dependency* — naming `Microsoft.DotNet.Interactive.FSharp`.

Both halves of that warning are about something that cannot happen:

- **The library is never released.** `angourimath.terminal.lib` is a **404** on nuget.org. The tool that consumes it, `angourimath.terminal`, *is* published and packs fine.
- **The dependency cannot become stable.** `Microsoft.DotNet.Interactive.FSharp` has **107 versions** on nuget and has never shipped one without a prerelease suffix, so no upgrade clears it.

So this is `IsPackable=false`, not a `NoWarn`. The warning goes because its premise is false, not because it was silenced — which matters, since a suppressed warning looks identical to a fixed one.

## What is left, and why I did not "fix" it

The rest of #542 is **NU1608**, six of them on the published tool:

```
NU1608: FSharp.Compiler.Service 43.9.300 requires FSharp.Core (= 9.0.300)
        but version FSharp.Core 10.1.302 was resolved.
```

That is an upstream constraint, not something this repo chose. **Pinning `FSharp.Core` to 9.0.300 was measured and does not work**: NU1608 stays and two NU1504 appear, because the SDK already references `FSharp.Core` implicitly. Upgrading the package that brings the compiler service in is already recorded on this issue as failing with 452 build errors.

I have deliberately **not** suppressed it. A version-constraint violation is a real risk to hide — the tests pass today, but that is evidence about today — and choosing to accept it is a maintainer's call rather than a warning to paper over.

## Evidence

- `Terminal.Lib` packs **0 NU5104** (was 1)
- the tool still produces `AngouriMath.Terminal.2.2.0.nupkg`
- F# wrapper tests **130 passed**, terminal tests **7 passed**

## What it does not do

- Does not change what is published, or how the tool is packaged.
- Does not touch `AngouriMath.Interactive`, which packs clean already.
- Does not silence NU1608.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
