### PR TITLE
Keep the benchmark's numbers after the job that produced them (#500)

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -1,4 +1,4 @@
-name: 'Kernel Benchmark'
+﻿name: 'Kernel Benchmark'
 
 # The path filters below used to read "./Sources/AngouriMath/AngouriMath", which is not a
 # path in this tree: the kernel is Sources/AngouriMath/ and its project file is
@@ -54,4 +54,24 @@ jobs:
       run: |
         cd Sources/Tests/DotnetBenchmark
         dotnet run -c Release RAMUsageTest
+
+    # The numbers used to exist only in this job's log, which expires -- so there was no way to
+    # see whether a figure had moved without re-running an old commit by hand. Retaining them is
+    # step 1 of https://github.com/asc-community/AngouriMath/issues/500, and the only step that
+    # can be taken from inside this repository: the two destinations that issue names,
+    # AngouriMathLab/performance-reports and AngouriMathLab/performance-reports-tools, do not
+    # exist.
+    #
+    # if: always() because a benchmark that fell over part way still produced numbers for the
+    # cases that ran, and those are the interesting ones when something has just broken.
+    - name: 'Retain the results'
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: benchmark-results-${{ github.sha }}
+        path: |
+          Sources/Tests/DotnetBenchmark/benchmark_results.csv/**
+          Sources/Tests/DotnetBenchmark/BenchmarkDotNet.Artifacts/**
+        if-no-files-found: warn
+        retention-days: 90
         

--- a/Sources/Tests/DotnetBenchmark/RAMUsageTest.cs
+++ b/Sources/Tests/DotnetBenchmark/RAMUsageTest.cs
@@ -10,6 +10,7 @@ using AngouriMath.Extensions;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using HonkSharp.Fluency;
+using BenchmarkDotNet.Exporters.Csv;
 using HonkSharp.Functional;
 using System;
 using static AngouriMath.Entity;
@@ -17,6 +18,11 @@ using static AngouriMath.Entity.Number;
 
 namespace DotnetBenchmark
 {
+    // Exports a CSV like CommonFunctionsInterVersion does. Without it this benchmark wrote its
+    // numbers to the console only, so the RAM half of every CI run was gone the moment the job
+    // finished. https://github.com/asc-community/AngouriMath/issues/500
+    [ArtifactsPath(@"./benchmark_results.csv")]
+    [CsvExporter(CsvSeparator.Semicolon)]
     [MemoryDiagnoser]
     public class RAMUsageTest
     {


### PR DESCRIPTION
Step 1 of #500, and the only step that can be taken from inside this repository.

The Kernel Benchmark workflow ran a CPU benchmark and a RAM benchmark and then **threw both away**. The numbers existed only in the job log, which expires — so there was no way to see whether a figure had moved without checking out an old commit and re-running it by hand.

Two changes:

- **`RAMUsageTest` now exports a CSV.** It carried `[MemoryDiagnoser]` but no exporter, so unlike `CommonFunctionsInterVersion` it wrote to the console only. Half of every run was unrecoverable by construction.
- **The workflow uploads both benchmarks' artifacts**, with `if: always()` — a run that fell over part way still produced numbers for the cases that completed, and those are the interesting ones when something has just broken.

## Verified by running it, not by reading the attribute

`BenchmarkDotNet`'s `ArtifactsPath` names a **directory**, not a file, despite `[ArtifactsPath("./benchmark_results.csv")]` reading like a filename. Running the benchmark confirms where the output actually lands:

```
benchmark_results.csv/results/DotnetBenchmark.RAMUsageTest-report.csv
benchmark_results.csv/results/DotnetBenchmark.RAMUsageTest-report-github.md
benchmark_results.csv/results/DotnetBenchmark.RAMUsageTest-report.html
```

which is what the upload glob matches. Worth checking rather than assuming: a path that matches nothing uploads nothing and the job still goes green, which looks exactly like success. `if-no-files-found: warn` is there for the same reason.

The directory is already in `.gitignore`, so nothing generated is committable.

## What this does not do, and why

The issue's plan pushes `result.csv` to **`AngouriMathLab/performance-reports`** and builds diagrams in **`AngouriMathLab/performance-reports-tools`**, then publishes to the site. **Neither repository exists** — I checked both. So the remaining steps need either those repositories created, or a different destination decided, and that is a call rather than an implementation.

What this gets you meanwhile: 90 days of downloadable, comparable CSVs per commit, which is enough to answer "did this PR move the number" without re-running anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
