### PR TITLE
Give F# a way to solve a system of equations (#562)

### DIFF
--- a/Sources/Tests/FSharpWrapperUnitTests/FSharpWrapperUnitTests.fsproj
+++ b/Sources/Tests/FSharpWrapperUnitTests/FSharpWrapperUnitTests.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="CompilationTest.fs" />
     <Compile Include="Functions.Matrices.fs" />
     <Compile Include="Functions.Order.fs" />
+    <Compile Include="Functions.Systems.fs" />
     <Compile Include="Common.fs" />
     <Compile Include="Functions.Discrete.fs" />
     <Compile Include="Functions.Continuous.fs" />

--- a/Sources/Tests/FSharpWrapperUnitTests/Functions.Systems.fs
+++ b/Sources/Tests/FSharpWrapperUnitTests/Functions.Systems.fs
@@ -1,0 +1,38 @@
+module AngouriMath.FSharp.Tests.Systems
+
+open AngouriMath.FSharp.Core
+open AngouriMath.FSharp.Functions
+open Xunit
+
+// https://github.com/asc-community/AngouriMath/issues/562. Version 2 of the two shapes proposed
+// there: the variables first and the equations second, which is how `solutions x expr` already
+// reads, rather than a separate EquationSystem type the caller has to know about. `equationSystem`
+// is still exposed for anyone who wants to build one and pass it around.
+
+[<Fact>]
+let ``A linear system is solved over its variables`` () =
+    match solveSystem ["x"; "y"] ["x + y - 3"; "x - y - 1"] with
+    | Some solutions ->
+        Assert.Equal(1, solutions.RowCount)
+        Assert.Equal(parsed "2", solutions.[0, 0])   // columns follow the order of vars
+        Assert.Equal(parsed "1", solutions.[0, 1])
+    | None -> failwith "the system has a solution and should not have answered None"
+
+[<Fact>]
+let ``An equality may be written out rather than moved to one side`` () =
+    let asEquality = solveSystem ["x"; "y"] ["x + y = 3"; "x - y = 1"]
+    let asExpression = solveSystem ["x"; "y"] ["x + y - 3"; "x - y - 1"]
+    Assert.Equal(asExpression.IsSome, asEquality.IsSome)
+    Assert.Equal(asExpression.Value.[0, 0], asEquality.Value.[0, 0])
+    Assert.Equal(asExpression.Value.[0, 1], asEquality.Value.[0, 1])
+
+/// An inconsistent system has no solution, and None is that rather than an empty matrix.
+[<Fact>]
+let ``An inconsistent system answers None`` () =
+    Assert.True((solveSystem ["x"; "y"] ["x + y - 1"; "x + y - 2"]).IsNone)
+
+[<Fact>]
+let ``A system can be built and passed around`` () =
+    let system = equationSystem ["x + y - 3"; "x - y - 1"]
+    Assert.NotNull(system)
+    Assert.True((system.Solve(symbol "x", symbol "y")) <> null)

--- a/Sources/Wrappers/AngouriMath.FSharp/Functions.fs
+++ b/Sources/Wrappers/AngouriMath.FSharp/Functions.fs
@@ -250,3 +250,26 @@ let solutions x expr =
     match parsed expr with
     | :? Entity.Statement as statement -> statement.Solve(symbol x).InnerSimplified :?> Entity.Set
     | func -> (equality func 0).Solve(symbol x).InnerSimplified :?> Entity.Set
+
+/// Returns a system of equations, built from a list of equalities or expressions.
+/// An expression that is not an equality is read as being equal to zero, exactly as
+/// `solutions` reads a single one.
+let equationSystem (equations : 'T list) =
+    MathS.Equations(equations |> List.map (fun eq ->
+        match parsed eq with
+        // EquationSystem reads each entry as being equal to zero, so an equality written out
+        // is moved to one side rather than handed over as a node -- passing the node makes the
+        // solver try to invert an equality, which it cannot do.
+        | :? Entity.Equalsf as equation -> equation.Left - equation.Right
+        | func -> func))
+
+/// Solves a system of equations over the given variables.
+///
+/// Each row of the resulting matrix is one solution and its columns follow the order of
+/// `vars`, so `solveSystem ["x"; "y"] ["x + y - 3"; "x - y - 1"]` answers `[[2, 1]]`:
+/// one solution, with x = 2 and y = 1. Returns None where none was found, rather than an
+/// empty matrix, since "no solution" and "the solver gave up" are the same answer here and
+/// neither is a matrix.
+let solveSystem (vars : 'T list) (equations : 'U list) =
+    (equationSystem equations).Solve(vars |> List.map symbol |> Array.ofList)
+    |> Option.ofObj


### PR DESCRIPTION
Addresses #562.

> You can be the one to pick up this redesign; keeping open until a redesign arrives.

Here it is. The wrapper had `solutions x expr` for one equation and **nothing for a system**, so the only route was dropping into the C# API.

```fsharp
solveSystem ["x"; "y"] ["x + y - 3"; "x - y - 1"]   // [[2, 1]]
```

## Which of the two shapes, and why

The issue offered:

```fsharp
// Version 1
val system : list 'a -> EquationSystem
val solveSystem : EquationSystem -> Matrix

// Version 2
val solveSystem : list Variable -> list 'a -> Matrix
```

**Version 2**, because it reads like the `solutions x expr` already in the wrapper — subject first, then the thing — and because Version 1 makes a caller learn an `EquationSystem` type before they can solve anything. `equationSystem` is exposed as well, so Version 1's *use* (build one, pass it around) is available without Version 1 being the only door.

## Two decisions the tests pin

**An entry may be written either way.** `x + y = 3` and `x + y - 3` mean the same system. An equality is moved to one side rather than passed on as a node — and that is not cosmetic: handing an `Equalsf` to `EquationSystem` makes the solver try to invert an equality and throw `NotSufficientlySupportedException`. That is what my first version did, and the tests caught it.

**No solution answers `None`.** `EquationSystem.Solve` returns a null `Matrix`, and in F# a null is worth turning into an option at the boundary. "There is no solution" and "the solver gave up" arrive the same way here, and neither is a matrix.

## Evidence

- F# wrapper tests **134 passed, 0 failed** (130 existing + 4 new)
- the tests cover: a solved linear system with columns following the order of `vars`, the two spellings agreeing, an inconsistent system answering `None`, and building a system to pass around
- purely additive — no existing function changes, so no `BREAKING-CHANGES.md` entry

## Not included

The issue is one of three `[WIP]` F#/plotting redesigns (#575, #558) marked by their author in 2022 and never advanced. This does **not** speak to those — it takes the one concrete API the thread actually specified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
