### PR TITLE
Fail CI when the committed parser no longer matches its grammar (#898)

### DIFF
--- a/.github/workflows/GrammarUpToDate.yml
+++ b/.github/workflows/GrammarUpToDate.yml
@@ -1,0 +1,69 @@
+name: 'Grammar Up To Date'
+
+# The parser under Sources/AngouriMath/Core/Antlr is generated from AngouriMath.g and committed,
+# and nothing regenerates it at build time. That is a deliberate trade -- generating on every build
+# would put a Java runtime between a contributor and `dotnet build` -- but it leaves one hazard:
+# a grammar edit whose regeneration was forgotten produces a parser that no longer matches its own
+# grammar, and nothing notices until someone wonders why their rule does not fire.
+#
+# So this regenerates and fails if the tree moves. It is the same guarantee the rule registry gets
+# from being generated at compile time (#825), bought here for one CI job rather than for every
+# build on every machine.
+#
+# Measured before writing this: a full regeneration on 4b2c104b reproduced the committed files
+# byte for byte, so the check starts from a clean baseline rather than from a diff nobody can fix.
+# https://github.com/asc-community/AngouriMath/issues/898
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "Sources/AngouriMath/Core/Antlr/**"
+      - "Sources/Utils/Utils/AntlrPostProcessor.cs"
+      - ".github/workflows/GrammarUpToDate.yml"
+  pull_request:
+    branches:
+      - '*'
+    paths:
+      - "Sources/AngouriMath/Core/Antlr/**"
+      - "Sources/Utils/Utils/AntlrPostProcessor.cs"
+      - ".github/workflows/GrammarUpToDate.yml"
+
+jobs:
+  Regenerate:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    # The jar is vendored next to the grammar, so the version is pinned by the repository rather
+    # than by whatever the runner happens to have.
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+
+    - name: Setup .NET 10
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '10.x'
+        dotnet-quality: 'preview'
+
+    # The same two commands Sources/Utils/antlr_rerun.bat runs, without its interactive pause.
+    - name: 'Regenerate the parser from the grammar'
+      run: java -jar ./antlr-4.13.1-complete.jar -package AngouriMath.Core.Antlr ./AngouriMath.g
+      working-directory: Sources/AngouriMath/Core/Antlr
+
+    - name: 'Make the generated classes internal again'
+      run: dotnet run --project Utils -c Release AntlrPostProcessorReplacePublicWithInternal
+      working-directory: Sources/Utils
+
+    - name: 'Fail if the committed parser is not what the grammar generates'
+      run: |
+        if ! git diff --exit-code -- Sources/AngouriMath/Core/Antlr/; then
+          echo "::error::The committed parser does not match AngouriMath.g."
+          echo "::error::Run Sources/Utils/antlr_rerun.bat and commit the result."
+          exit 1
+        fi


### PR DESCRIPTION
Addresses part of #898 — and the measurement behind it corrects what I wrote on that issue earlier.

## What I found before writing anything

I claimed on #898 that regeneration was "a manual, risky step". **The first half is true and the second is not.** A full regeneration on `4b2c104b` — the vendored `antlr-4.13.1-complete.jar`, then `AntlrPostProcessorReplacePublicWithInternal` — reproduces **every committed file byte for byte**. The jar is pinned in the repository, the two commands are scripted in `antlr_rerun.bat`, and the only external requirement is a Java runtime.

So the pipeline is sound. The hazard is narrower than I said: **forgetting to run it.** A grammar edit without regeneration leaves a parser that does not match its own grammar, and nothing notices until a rule mysteriously never fires.

## What this does

Regenerates in CI and fails if the tree moves. That is the same guarantee the rule registry gets from being generated at compile time (#825), bought for one job rather than for every build on every machine.

**It is deliberately not build-time generation**, which was my own earlier suggestion on the issue. That would put a Java runtime between a contributor and `dotnet build`, and it addresses a problem the measurement says does not exist — the tool works fine, people just forget to run it.

## Verified both ways

A check that cannot fail is worse than no check, so:

| | |
|---|---|
| clean tree | **passes** |
| grammar edited (a new lexer token) without regenerating | **fails** — 7 files, 443 lines of difference |

Path-filtered to the grammar, the generated folder and the post-processor, so it costs nothing on changes that cannot affect it.

## What it leaves open

The actual question on #898 — ANTLR versus Yoakke — is untouched, and this does not argue either way. What it does is remove one of the reasons grammar changes feel risky, which matters because **four open issues are queued behind grammar work**: #225 (quantifiers), #248 (Σ, Π) and #495's syntax half all need a variable binder, and #286 needs implicit multiplication disabled in call position.

If the parser is eventually replaced, this check is deleted along with the generated files it guards, and nothing is lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
