### PR TITLE
Stop quoting a boundcheck figure that goes stale on its own

### DIFF
--- a/Sources/AngouriMath/Docs/Contributing/SimplificationContract.md
+++ b/Sources/AngouriMath/Docs/Contributing/SimplificationContract.md
@@ -290,7 +290,10 @@ Such a harness would have found all four rules of #884 immediately.
 
 **It exists.** `boundcheck`, in the analysis workspace beside this repository, is built exactly that
 way: it enumerates the unary function nodes by reflection, composes them pairwise, and tests the
-result at 25 points chosen to sit where some rule's assumption fails. 372 shapes, 966 comparisons. It
+result at 25 points chosen to sit where some rule's assumption fails — 372 shapes, of which only the
+ones some rule actually rewrites are worth comparing. The number of comparisons is deliberately not
+written down here: it falls every time a rule gains a guard, so a figure in prose is one that goes
+stale without anything failing. Ask the harness. It
 found [#887](https://github.com/asc-community/AngouriMath/issues/887) within minutes of existing —
 an error in the fix for #884, which is the most useful thing to record about it. It currently reports
 **no** disagreements; §11 is the last one it reported and how that was closed.


### PR DESCRIPTION
`SimplificationContract.md` §8 describes `boundcheck` and states "372 shapes, 966 comparisons".

Measured on `35e504a9`, the harness reports:

```
boundcheck: 372 shapes, 35 rewritten, 814 comparisons -- 0 disagreements, 0 did not finish
```

Three numbers now exist for one quantity — 966 in this document, 964 in the checked-in
`work/boundcheck.md`, 814 today — and none of them was wrong when it was written.

That is not a transcription slip, it is the wrong thing to write down. The comparison count is not a
property of the harness, which is what the paragraph is describing; it is the number of shapes some
rule actually *rewrites*. So it falls every time a rule gains a guard — which is precisely the work
this document exists to ask for. A figure that drops whenever the codebase improves, sitting in prose
where nothing checks it, will be wrong again by the next PR that guards a rule.

So the count is no longer stated. The shape count stays, because that follows from the node set and
the harness's own construction rather than from the current rule set, and the reader is pointed at
the harness for the rest.

**The zero is what §8 actually relies on, and it is still stated** — the paragraph's claim is that
`boundcheck` currently reports no disagreements, and it does.

### Why this came up

I was checking whether an old unmerged local branch still had anything in it. It did not — §11's
correction is already here, via #922. This figure was the only thing left, and it is the same class
of defect as the one recorded in this repository's own notes about generated reports: a number that
is *quoted* rather than *computed* goes stale silently, and regenerating cannot fix a hardcoded one.

Markdown only; no code, no test, no behaviour change.
