### PR TITLE
Read the arms of a rule switch that lives inside a factory (#825)

### DIFF
--- a/Sources/Analyzers/RuleRegistryGenerator/RuleRegistryGenerator.cs
+++ b/Sources/Analyzers/RuleRegistryGenerator/RuleRegistryGenerator.cs
@@ -166,15 +166,33 @@ namespace AngouriMath.Generators
 
         private static string? Body(MethodDeclarationSyntax method, string indent)
         {
-            if (method.ExpressionBody?.Expression is not SwitchExpressionSyntax dispatch)
+            // Two shapes are read. A rule set written directly as a switch over its expression,
+            //     static Entity CommonRules(Entity x) => x switch { ... }
+            // and a *factory* for one, which is how a set parameterised by something that is not
+            // the expression is written,
+            //     static Func<Entity, Entity> SortRules(SortLevel level) => x => x switch { ... }
+            // The arms of a factory close over its parameters, so they cannot be a static field;
+            // they are emitted as a method taking the same parameters instead. Everything after
+            // this point is common to both, which is the point of unwrapping here.
+            var lambda = method.ExpressionBody?.Expression as SimpleLambdaExpressionSyntax;
+            if ((lambda?.Body ?? method.ExpressionBody?.Expression) is not SwitchExpressionSyntax dispatch)
                 return null;
             if (dispatch.GoverningExpression is not IdentifierNameSyntax governing)
                 return null;
-            if (method.ParameterList.Parameters.Count != 1)
-                return null;
-            var parameter = method.ParameterList.Parameters[0];
+            ParameterSyntax parameter;
+            if (lambda is null)
+            {
+                if (method.ParameterList.Parameters.Count != 1)
+                    return null;
+                parameter = method.ParameterList.Parameters[0];
+            }
+            else
+                parameter = lambda.Parameter;
             if (parameter.Identifier.Text != governing.Identifier.Text)
                 return null;
+            // A lambda parameter is written without its type, and the arms are copied into a
+            // context where nothing infers it, so it is named rather than echoed.
+            var parameterType = parameter.Type?.ToString() ?? "global::AngouriMath.Entity";
 
             var arms = dispatch.Arms.Where(arm => arm.Pattern is not DiscardPatternSyntax).ToList();
             var names = new Dictionary<string, int>(StringComparer.Ordinal);
@@ -184,9 +202,16 @@ namespace AngouriMath.Generators
             text.AppendLine($"{indent}/// The arms of <see cref=\"{method.Identifier.Text}\"/>, each one addressable on its own.");
             text.AppendLine($"{indent}/// Generated from the <c>switch</c> itself, so the two cannot disagree.");
             text.AppendLine($"{indent}/// </summary>");
-            text.AppendLine($"{indent}[global::AngouriMath.Core.ConstantField]");
-            text.AppendLine($"{indent}internal static readonly global::System.Collections.Generic.IReadOnlyList"
-                + $"<global::AngouriMath.Core.Transformations.RewriteRule> {method.Identifier.Text}Arms =");
+            if (lambda is null)
+            {
+                text.AppendLine($"{indent}[global::AngouriMath.Core.ConstantField]");
+                text.AppendLine($"{indent}internal static readonly global::System.Collections.Generic.IReadOnlyList"
+                    + $"<global::AngouriMath.Core.Transformations.RewriteRule> {method.Identifier.Text}Arms =");
+            }
+            else
+                text.AppendLine($"{indent}internal static global::System.Collections.Generic.IReadOnlyList"
+                    + $"<global::AngouriMath.Core.Transformations.RewriteRule> {method.Identifier.Text}Arms"
+                    + $"{method.ParameterList} =>");
             text.AppendLine($"{indent}    new global::AngouriMath.Core.Transformations.RewriteRule[]");
             text.AppendLine($"{indent}    {{");
 
@@ -217,8 +242,9 @@ namespace AngouriMath.Generators
                 text.AppendLine($"{indent}            replacementSource: {Literal(replacement)},");
                 text.AppendLine($"{indent}            growth: global::AngouriMath.Core.Transformations.RewriteRuleGrowth.{growth},");
                 text.AppendLine($"{indent}            sourceLine: {line},");
-                text.AppendLine($"{indent}            apply: static global::AngouriMath.Entity? "
-                    + $"({parameter.Type} {parameter.Identifier.Text}) => {parameter.Identifier.Text} switch");
+                // A factory's arm reads the factory's parameters, so its lambda cannot be static.
+                text.AppendLine($"{indent}            apply: {(lambda is null ? "static " : "")}global::AngouriMath.Entity? "
+                    + $"({parameterType} {parameter.Identifier.Text}) => {parameter.Identifier.Text} switch");
                 text.AppendLine($"{indent}            {{");
                 text.AppendLine($"{indent}                {arm.Pattern}{(arm.WhenClause is null ? "" : " " + arm.WhenClause)} => {arm.Expression},");
                 text.AppendLine($"{indent}                _ => null");

--- a/Sources/AngouriMath/Core/Transformations/RewriteRuleSet.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRuleSet.cs
@@ -51,9 +51,12 @@ namespace AngouriMath.Core.Transformations
         /// <remarks>
         /// <para>
         /// <b>Empty is not the same as "no rewrites".</b> A set whose rewrites are written as a
-        /// <c>switch</c> over the expression has every arm listed here; a set built some other
-        /// way — a sort, a polynomial division, a method with branches and locals — has none,
-        /// because there are no arms to generate from. <see cref="Name"/> and
+        /// <c>switch</c> over the expression has every arm listed here, whether the
+        /// <c>switch</c> is the rule method itself or sits inside a factory parameterised by
+        /// something else — the sorts are the latter, one <c>switch</c> read at three levels. A
+        /// set built without one — a polynomial division, a method with branches and locals, a
+        /// single <c>is</c> pattern that is one rule and has nothing to split — has none, because
+        /// there are no arms to generate from. <see cref="Name"/> and
         /// <see cref="ApplyOnce(Entity)"/> behave identically either way, so this is a statement
         /// about how finely the set can be reported on and not about what it does.
         /// </para>

--- a/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
@@ -50,7 +50,8 @@ namespace AngouriMath.Core.Transformations
             // Regrouping reads a quotient as a product with a negative power, which is the
             // same value wherever the divisor is not zero.
             Soundness.SoundUnderAssumptions,
-            Patterns.SortRules(TreeAnalyzer.SortLevel.HIGH_LEVEL));
+            Patterns.SortRules(TreeAnalyzer.SortLevel.HIGH_LEVEL),
+            Patterns.SortRulesArms(TreeAnalyzer.SortLevel.HIGH_LEVEL));
 
         /// <summary>
         /// <see cref="CanonicalOrder"/>, counting constants as well, so that terms differing
@@ -61,7 +62,8 @@ namespace AngouriMath.Core.Transformations
             "Sorts and groups commutative operands, distinguishing terms by their constants too.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Patterns.SortRules(TreeAnalyzer.SortLevel.MIDDLE_LEVEL));
+            Patterns.SortRules(TreeAnalyzer.SortLevel.MIDDLE_LEVEL),
+            Patterns.SortRulesArms(TreeAnalyzer.SortLevel.MIDDLE_LEVEL));
 
         /// <summary>
         /// <see cref="CanonicalOrder"/> over the whole subtree, so that only structurally
@@ -72,7 +74,8 @@ namespace AngouriMath.Core.Transformations
             "Sorts and groups commutative operands by the whole subtree.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Patterns.SortRules(TreeAnalyzer.SortLevel.LOW_LEVEL));
+            Patterns.SortRules(TreeAnalyzer.SortLevel.LOW_LEVEL),
+            Patterns.SortRulesArms(TreeAnalyzer.SortLevel.LOW_LEVEL));
 
         /// <summary>
         /// Turns a negative power into a quotient: <c>a * b ^ (-1)</c> becomes <c>a / b</c>.

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.cs
@@ -27,6 +27,7 @@ namespace AngouriMath.Functions
         }
 
         /// <summary>Actual sorting with <see cref="Entity.SortHash(TreeAnalyzer.SortLevel)"/></summary>
+        [AddressableRules]
         internal static Func<Entity, Entity> SortRules(TreeAnalyzer.SortLevel level) => x => x switch
         {
             Sumf or Minusf =>

--- a/Sources/Tests/UnitTests/Core/Transformations/AddressableRulesTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/AddressableRulesTest.cs
@@ -57,6 +57,12 @@ namespace AngouriMath.Tests.Core.Transformations
             yield return (RewriteRules.InequalityEquality, Patterns.InequalityEqualityRules);
             yield return (RewriteRules.SetOperator, Patterns.SetOperatorRules);
             yield return (RewriteRules.PhiFunction, Patterns.PhiFunctionRules);
+            // The factory shape: one switch, three sets, differing only in the sort level it is
+            // closed over. Each is replayed against the switch built at its own level, so a rule
+            // generated at one level and applied at another would show up here.
+            yield return (RewriteRules.CanonicalOrder, Patterns.SortRules(TreeAnalyzer.SortLevel.HIGH_LEVEL));
+            yield return (RewriteRules.CanonicalOrderCountingConstants, Patterns.SortRules(TreeAnalyzer.SortLevel.MIDDLE_LEVEL));
+            yield return (RewriteRules.CanonicalOrderExact, Patterns.SortRules(TreeAnalyzer.SortLevel.LOW_LEVEL));
         }
 
         public static IEnumerable<object[]> AddressableSets()
@@ -252,11 +258,12 @@ namespace AngouriMath.Tests.Core.Transformations
             var without = RewriteRules.All.Where(set => set.Rules.Count == 0)
                 .Select(set => set.Name).OrderBy(name => name, StringComparer.Ordinal).ToList();
 
+            // The three CanonicalOrder sets are not here: their rules are written as a switch
+            // inside a factory parameterised by the sort level, which the generator now reads.
+            // What is left is genuinely armless -- a polynomial division, a method with branches
+            // and locals, a single `is` pattern that is one rule and has nothing to split.
             Assert.Equal(new[]
             {
-                "CanonicalOrder",
-                "CanonicalOrderCountingConstants",
-                "CanonicalOrderExact",
                 "CollapseMultipleFractions",
                 "CommonDenominator",
                 "CommonDenominatorCountingConstants",
@@ -270,8 +277,8 @@ namespace AngouriMath.Tests.Core.Transformations
                 "RationalizeDenominator",
             }, without);
 
-            Assert.Equal(16, withRules.Count);
-            Assert.Equal(347, withRules.Sum(set => set.Rules.Count));
+            Assert.Equal(19, withRules.Count);
+            Assert.Equal(368, withRules.Sum(set => set.Rules.Count));
         }
 
         [Fact]
@@ -344,12 +351,16 @@ namespace AngouriMath.Tests.Core.Transformations
         [Fact]
         public void ASetWithNoAddressableRulesStillRecordsItsStep()
         {
+            // Stated rather than assumed: if this set ever becomes addressable the test would
+            // otherwise keep passing while testing nothing at all.
+            Assert.Empty(RewriteRules.InvertNegativePowers.Rules);
+
             using var recording = RewriteRecording.Start();
-            RewriteRules.CanonicalOrderExact.ApplyOnce("y + x".ToEntity());
+            RewriteRules.InvertNegativePowers.ApplyOnce("x ^ (-2)".ToEntity());
             recording.Dispose();
 
             var step = Assert.Single(recording.Steps);
-            Assert.Equal(RewriteRules.CanonicalOrderExact, step.RuleSet);
+            Assert.Equal(RewriteRules.InvertNegativePowers, step.RuleSet);
             Assert.Null(step.Rule);
         }
     }


### PR DESCRIPTION
Fourteen of the thirty rewrite rule sets had no addressable rules. **Three of those fourteen had arms all along** — the canonical-order sets, whose rules are one `switch` over the node type, seven arms, each dispatching to `SortAndGroup`.

What stopped the generator reading them was the shape *around* the switch, not anything about the rules:

```csharp
static Entity CommonRules(Entity x)                 => x switch { ... }      // read
static Func<Entity, Entity> SortRules(SortLevel l)  => x => x switch { ... } // not read
```

A set parameterised by something that is not the expression is written as a factory. So there is a lambda in the way, and the arms close over the factory's parameter. That is the whole change:

- the switch is found one level down, through the lambda, and the governing identifier is checked against the **lambda's** parameter rather than the method's;
- the arms **cannot be a `static readonly` field**, because they capture the parameter — they are emitted as a method taking the factory's own parameter list, and the `apply` lambda loses its `static`.

A lambda parameter carries no type and the arms are copied into a context that infers nothing, so the parameter type is named rather than echoed.

|  | before | after |
|---|---|---|
| addressable sets | 16 | **19** |
| addressable rules | 347 | **368** |
| armless sets | 14 | **11** |

### What this does not do

`SortRules` is still the method the simplifier calls and still the thing a human edits. The arms are still copied as syntax, so a rule still cannot say something its arm does not. `ApplyOnce` calls the same `Func` it called before — this adds reporting granularity and changes no answer.

It also does not chase the remaining eleven, and they are armless for a reason rather than for want of a generator: a polynomial long division, a GCD cancellation, methods with branches and locals, and three single `is` patterns that are **one rule each and have nothing to split**. `RewriteRuleSet.Rules` offered "a sort" as an example of the first kind — that was the wrong example, and the doc now says so.

### The new tests bind

The three sets join the replay test, each against the switch built **at its own level**. That per-level pairing is not decoration — it is the mistake this shape newly makes possible, so I tried to make it:

```
Patterns.SortRulesArms(SortLevel.HIGH_LEVEL)   // while the switch stays at LOW_LEVEL

  Failed AddressableRulesTest.EveryArmIsTheArmItWasGeneratedFrom(setName: "CanonicalOrderExact")
  Failed: 1, Passed: 25
```

Reverted, of course; 26/26 pass on the branch.

`ASetWithNoAddressableRulesStillRecordsItsStep` used `CanonicalOrderExact` as its armless example, which it no longer is. It now uses `InvertNegativePowers` and asserts up front that the set really has no rules — otherwise the test would keep passing while testing nothing the day that set becomes addressable too.

### Measured

- Suite **7301 passed, 0 failed**, 14 skipped.
- `canoncheck` on this branch is **identical to master, line for line**: `InnerSimplified` idempotence 0/834 and order 2024/2738; `CanonicalOrderExact` 18/834 and 0/2738; `Normalise+Order` 0 and 0; `Simplify` 0/120 and 8/72. I measured master myself rather than reading the checked-in report, which says 21 for the second of those — it is stale against master independently of this PR.

No `BREAKING-CHANGES.md` entry: `RewriteRuleSet.Rules` does not exist in 2.2.0, so there is nothing here to break against.
