### PR TITLE
Ask the cheap question first in the perfect-square rule (#972)

### DIFF
--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.ExpandFactorize.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.ExpandFactorize.cs
@@ -137,13 +137,29 @@ namespace AngouriMath.Functions
             var terms = Sumf.LinearChildren(expr).ToList();
             if (terms.Count != 3)
                 return null;
+            // A collapse has to survive AgreesNumerically, which needs a Complex at every sample
+            // point. So a sum with free variables that does not evaluate to one -- a set inside a
+            // radical, say -- can never fire this rule, and asking symbolically first only pays
+            // for the refusal. Not a special case for sets: it is the same necessary condition
+            // the rule already ends on, asked before the cost instead of after it.
+            if (!EvaluableAtSamplePoints(expr))
+                return null;
 
             for (var cross = 0; cross < 3; cross++)
             {
                 var w = terms[cross];
                 var p = new Powf(terms[(cross + 1) % 3], Rational.Create(1, 2));
                 var q = new Powf(terms[(cross + 2) % 3], Rational.Create(1, 2));
-                var product = (2 * p * q).Simplify();
+                // Reject at sample points before paying for the symbolic test, which is the
+                // whole cost of this rule. A term of the sum may be negative -- `-sqrt(2)` in
+                // `a + b - sqrt(2)` -- and taking its square root builds `sqrt(-sqrt(2))`, a
+                // nested radical over a negative number, which Simplify is very slow on. Twelve
+                // of those per entry is eight seconds to answer "no".
+                // https://github.com/asc-community/AngouriMath/issues/972
+                var crossTerm = 2 * p * q;
+                if (DiffersNumerically(crossTerm, w) && DiffersNumerically(crossTerm, -w))
+                    continue;
+                var product = crossTerm.Simplify();
                 var candidate =
                     (product - w).Simplify() == 0 ? new Powf((p + q).Simplify(), 2) :
                     (product + w).Simplify() == 0 ? new Powf((p - q).Simplify(), 2) :
@@ -164,6 +180,60 @@ namespace AngouriMath.Functions
         /// <see cref="PerfectSquareSamplePoints"/> with each free variable offset from the
         /// last so that two of them never take the same value.
         /// </summary>
+        /// <summary>
+        /// Whether the sum evaluates to a number at the sample points at all, which
+        /// <see cref="AgreesNumerically"/> requires of any collapse this proposes.
+        /// </summary>
+        /// <remarks>
+        /// A sum with no free variables is exempt, because <see cref="AgreesNumerically"/>
+        /// exempts it too — it returns true without evaluating anything, so a rule that fires
+        /// on a constant sum must not be stopped here.
+        /// </remarks>
+        private static bool EvaluableAtSamplePoints(Entity expr)
+        {
+            var variables = expr.Vars.ToList();
+            if (variables.Count == 0)
+                return true;
+            Entity at = expr;
+            for (var v = 0; v < variables.Count; v++)
+                at = at.Substitute(variables[v], Real.Create(PerfectSquareSamplePoints[v % PerfectSquareSamplePoints.Length]));
+            return at.Evaled is Complex;
+        }
+
+        /// <summary>
+        /// Whether two expressions are <i>demonstrably</i> different at
+        /// <see cref="PerfectSquareSamplePoints"/>, used to drop a cross term before the
+        /// symbolic test costs anything.
+        /// </summary>
+        /// <remarks>
+        /// The asymmetry with <see cref="AgreesNumerically"/> is deliberate and is what makes
+        /// this safe to put in front of the symbolic test: that one answers "may I keep this",
+        /// so it refuses whatever it cannot evaluate; this one answers "may I drop this", so it
+        /// refuses to drop whatever it cannot evaluate. A point it cannot reach is not evidence
+        /// of difference, and a rule may not decline on evidence it does not have.
+        /// </remarks>
+        private static bool DiffersNumerically(Entity left, Entity right)
+        {
+            var variables = (left + right).Vars.ToList();
+            for (var i = 0; i < PerfectSquareSamplePoints.Length; i++)
+            {
+                Entity a = left, b = right;
+                for (var v = 0; v < variables.Count; v++)
+                {
+                    var point = PerfectSquareSamplePoints[(i + v) % PerfectSquareSamplePoints.Length];
+                    a = a.Substitute(variables[v], Real.Create(point));
+                    b = b.Substitute(variables[v], Real.Create(point));
+                }
+                if (a.Evaled is not Complex left1 || b.Evaled is not Complex right1)
+                    return false;
+                var difference = (left1 - right1).Abs();
+                if (difference is Real real && real.EDecimal.Abs()
+                        .CompareTo(EDecimal.FromString("1e-12")) > 0)
+                    return true;
+            }
+            return false;
+        }
+
         private static bool AgreesNumerically(Entity original, Entity candidate)
         {
             var variables = original.Vars.ToList();

--- a/Sources/Tests/UnitTests/PatternsTest/CollapsePerfectSquareTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/CollapsePerfectSquareTest.cs
@@ -78,6 +78,35 @@ namespace AngouriMath.Tests.PatternsTest
             => AssertSameValue(expr, expr.ToEntity().Factorize());
 
         /// <summary>
+        /// A sum the rule cannot evaluate at its sample points is left alone, and cheaply:
+        /// the numeric check it ends on needs a number at every point, so asking the
+        /// symbolic question first only pays for the refusal.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/972">#972</a>
+        /// </summary>
+        /// <remarks>
+        /// Asserted on the root rather than on every node: a collapse of the whole sum lands
+        /// there, while <c>FactorizeRules</c> may leave a square somewhere inside for reasons
+        /// that have nothing to do with this rule.
+        /// </remarks>
+        [Fact]
+        public void ASumItCannotEvaluateIsLeftAlone()
+            => Assert.False("x - pi - sqrt({ 1, 2 })".ToEntity().Factorize()
+                is Entity.Powf(_, Entity.Number.Integer(2)));
+
+        /// <summary>
+        /// The rule builds <c>sqrt</c> of each term to test the cross term, so a negative
+        /// term makes it ask about a nested radical over a negative number — which is what
+        /// took eight seconds to answer "no". It still answers "no".
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/972">#972</a>
+        /// </summary>
+        [Theory]
+        [InlineData("x + 1 - sqrt(2)")]
+        [InlineData("x - pi - sqrt(2)")]
+        [InlineData("x + 1 - 2 ^ (1/3)")]
+        public void ASumWithANegativeRadicalTermIsLeftAlone(string expr)
+            => AssertSameValue(expr, expr.ToEntity().Factorize());
+
+        /// <summary>
         /// <c>sqrt(u)^2</c> is <c>u</c> for every complex <c>u</c>, but <c>sqrt(u^2)</c> is
         /// not <c>u</c> -- it is <c>u</c> only where <c>u</c> is non-negative. So a
         /// polynomial trinomial must not be collapsed through this route, which would be


### PR DESCRIPTION
Closes #972.

`Simplify("a + b - sqrt(2)")` took **eight seconds** to return its argument unchanged. All of it was one rule.

`Simplify` offers `Factorize` as a candidate; `Factorize`'s first pass is `PerfectSquare`; and `CollapseToPerfectSquare` decides whether a cross term matches by calling `Simplify` — up to twelve times per entry, on products it builds from the terms. One term of `a + b - sqrt(2)` **is** `-sqrt(2)`, and the rule takes the square root of each term, so it manufactures `sqrt(-sqrt(2))`: a nested radical over a negative number, which is the shape `Simplify` is worst at.

| ingredient | `Simplify` |
|---|--:|
| `-a + sqrt(2) * sqrt(b) * 2` — positive radicand | 21 ms |
| `-a + sqrt(-2) * sqrt(b) * 2` — negative, not nested | 87 ms |
| `-a + sqrt(sqrt(2)) * sqrt(b) * 2` — nested, positive | 113 ms |
| `-a + sqrt(-sqrt(2)) * sqrt(b) * 2` — **nested and negative** | **1 495 ms** |

## The change

The rule already had a cheap necessary condition — `AgreesNumerically` samples four points and vetoes a symbolic match. It just asked it **last**. This puts a screen in front of the symbolic work, derived from that same check:

- **`DiffersNumerically`** rejects a cross term only where the sample points *demonstrate* a difference. The asymmetry with `AgreesNumerically` is the point, and is what makes it safe to run first: that one answers "may I keep this", so it refuses whatever it cannot evaluate; this one answers "may I drop this", so it refuses to **drop** whatever it cannot evaluate. A point it cannot reach is not evidence of difference, and a rule may not decline on evidence it does not have.
- **`EvaluableAtSamplePoints`** declines a sum that has free variables and does not evaluate to a number at those points — since `AgreesNumerically` will demand exactly that of any collapse. It is strictly weaker than that check, which needs *all four* assignments to evaluate, including this one. A sum with no free variables is exempt, because `AgreesNumerically` exempts it too.

Nothing about the identity, the sampling, or the symbolic confirmation changes. **The rule fires on exactly what it fired on before.**

## Measured

Idle machine, release, on `fb905193` versus this branch:

| expression | before | after |
|---|--:|--:|
| `y - pi - sqrt(2)` | 15 272 ms | **454 ms** |
| `1 - pi - sqrt(2)` | 13 823 ms | **143 ms** |
| `a + b - 2 ^ (1/3)` | 10 148 ms | **236 ms** |
| `a + b - sqrt(2)` | 8 432 ms | **260 ms** |
| `a + b - sqrt(3)` | ~8 100 ms | **95 ms** |
| `x - y - sqrt(2)` | 7 893 ms | **129 ms** |

And the collapses this rule exists for still happen:

```
1 + sqrt(2 * x) + x / 2        ->  (sqrt(x / 2) + 1) ^ 2
x + 2 * sqrt(x) * sqrt(y) + y  ->  (sqrt(x) + sqrt(y)) ^ 2
4 + 4 * sqrt(x) + x            ->  (2 + sqrt(x)) ^ 2
2 + 2 * sqrt(2) + 1            ->  3 + 2 * sqrt(2)
```

- Suite **7312 passed, 0 failed**, 14 skipped — four more than master, which are the new tests.
- `boundcheck`: **372 shapes, 35 rewritten, 814 comparisons, 0 disagreements** — identical to master. Re-run after *each* gate, since this rule exists because of a branch-cut error (#752) and the second gate touches exactly the set-valued expressions that harness exercises.

## What this does not fix

Applying `RewriteRules.PerfectSquare` across a generated 39 398-node corpus is **74 s**, down from 147 s but still against 57 ms for `RewriteRules.Common`. The residue is expressions that *do* evaluate at the sample points and are simply slow to simplify — the second, independent cost recorded on #972, which is not about this rule. So this does not yet make `PerfectSquare` cheap enough to join the addressable registry, and I would rather say so than let the headline numbers imply it.

## Tests

Three added to `CollapsePerfectSquareTest`, alongside the existing ones which all still pass:

- `ASumWithANegativeRadicalTermIsLeftAlone` — the shapes that took eight seconds still answer "no", and still have their value.
- `ASumItCannotEvaluateIsLeftAlone` — the new gate, asserted on the root rather than every node, because `FactorizeRules` may leave a square inside for reasons unrelated to this rule.
