### PR TITLE
Read a PR's own thread before merging it (#976)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,6 +352,11 @@ Then:
    [BREAKING-CHANGES.md](BREAKING-CHANGES.md) — including when the old answer was wrong. A test you
    had to change is the usual sign that you owe an entry.
 6. Open a PR. State what was wrong, why the fix is right, and what you measured.
+7. **Read the PR's own thread before it merges**, and answer what is on it. Comments arrive after
+   the checks go green, so a PR that was clear when it was opened need not still be; and a review
+   merged over does not go away — it comes back as an issue somebody else had to file. Both places
+   count, and the API shows them separately: `gh pr view <n> --comments` for the thread, and
+   `gh api repos/{owner}/{repo}/pulls/<n>/comments` for comments left on the diff.
 
 `TreatWarningsAsErrors` is on and there are custom analyzers; a static field needs
 `[ConstantField]`, `[ThreadStatic]` or `[ConcurrentField]`.


### PR DESCRIPTION
#976 ends with "Update your instructions to read PR comments before merging." This is that.

The working-practice list in `AGENTS.md` ran from *branch first* to *open a PR* and stopped there,
which leaves the interval between the last green check and the merge unaccounted for — and that is
exactly where a review comment lands. On #966 a comment was left 28 minutes before the merge and
went unread; it came back as #976, which is a reviewer having to file an issue for a review they
had already given.

The new step 7 says the thread is read and answered before the merge, and names both places a
comment can be — the conversation and the diff are separate endpoints, and reading only the first
looks exactly like having read the thread.

No code, one file.