### PR TITLE
Do not look for a real root where there cannot be one (#975)

### DIFF
--- a/Sources/AngouriMath/Core/Entity/Continuous/Number/Operators.cs
+++ b/Sources/AngouriMath/Core/Entity/Continuous/Number/Operators.cs
@@ -239,6 +239,37 @@ namespace AngouriMath
                 return res;
             }
 
+            /// <summary>
+            /// Whether <see cref="FindGoodRoot"/> can return anything at all for this base and
+            /// root power, asked before it runs so that its cost is only paid where its answer
+            /// can be used.
+            /// </summary>
+            /// <remarks>
+            /// <para>
+            /// It answers with a <see cref="Real"/>, and a negative real has no real root of even
+            /// order — for real <c>x</c> and even <c>q</c>, <c>x ^ q</c> is never negative — so
+            /// every even root of it lies off the real line and the search is a certain miss.
+            /// </para>
+            /// <para>
+            /// It is not a cheap miss. The search computes all <c>q</c> roots to the full decimal
+            /// precision and attempts a rational conversion of each part of each, which is 7.5 ms
+            /// of the 12.6 ms that evaluating <c>sqrt(-pi)</c> used to cost. What makes that reach
+            /// a caller is that <c>Simplify</c> asks for the value of the same expression dozens of
+            /// times over — each rewrite hands it a freshly built node, whose cached value is not
+            /// the previous node's — so <c>Simplify("sqrt(-pi)")</c> spent 556 ms returning its
+            /// argument unchanged, and spends 232 ms now.
+            /// <a href="https://github.com/asc-community/AngouriMath/issues/975">#975</a>
+            /// </para>
+            /// <para>
+            /// A non-real base is left to the search rather than excluded here. A complex number
+            /// has no real root either, but a real one whose imaginary part is a rounding artefact
+            /// arrives as <see cref="Complex"/>, and this is a performance guard rather than the
+            /// place to decide what such a number is.
+            /// </para>
+            /// </remarks>
+            private static bool CanHaveARealRoot(Complex @base, EInteger rootPower) =>
+                @base is not Real { IsNegative: true } || !rootPower.IsEven;
+
             internal static Real? FindGoodRoot(Complex @base, Integer power)
             {
                 Real? positive = null, real = null;
@@ -378,7 +409,8 @@ namespace AngouriMath
                 if (@base.IsFinite && power is Integer { EInteger: var pow })
                     return BinaryIntPow(@base, pow);
 
-                if (@base.IsFinite && power is Rational r && r.ERational.Denominator.Abs() < 10 // there should be a minimal threshold to avoid long searches 
+                if (@base.IsFinite && power is Rational r && r.ERational.Denominator.Abs() < 10 // there should be a minimal threshold to avoid long searches
+                    && CanHaveARealRoot(@base, r.ERational.Denominator.Abs())
                     && FindGoodRoot(@base, r.ERational.Denominator) is { } goodRoot)
                     return Pow(goodRoot, r.ERational.Numerator);
 

--- a/Sources/Tests/UnitTests/Core/Numeric.cs
+++ b/Sources/Tests/UnitTests/Core/Numeric.cs
@@ -56,6 +56,41 @@ namespace AngouriMath.Tests.Core
             Complex c = a + b;
             Assert.Equal(Complex.Create(3, 1), c);
         }
+        /// <summary>
+        /// A root of a negative real. Evaluating one used to search for a real root first, which
+        /// for an even order cannot exist — every even root of a negative real is off the real
+        /// line — and the search is not a cheap miss, so
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/975">#975</a> skips it
+        /// there. These pin what the skipping must not cost: the exact answers on the even side,
+        /// and the real root the search is still there to find on the odd side.
+        /// </summary>
+        [Theory]
+        // Even order: the real-root search is skipped, and the exact value has to survive the
+        // general complex formula it falls through to.
+        [InlineData("sqrt(-4)", "2i")]
+        [InlineData("(-4) ^ (3/2)", "-8i")]
+        [InlineData("(-1) ^ (1/2)", "i")]
+        // Odd order: a real root exists, so the search still runs and still answers exactly.
+        [InlineData("(-8) ^ (1/3)", "-2")]
+        [InlineData("(-27) ^ (2/3)", "9")]
+        // And the positive side, which the guard does not touch.
+        [InlineData("4 ^ (1/2)", "2")]
+        [InlineData("16 ^ (1/4)", "2")]
+        [InlineData("1 ^ (1/4)", "1")]
+        public void ARootOfANegativeRealKeepsItsExactValue(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity().Evaled, expression.ToEntity().Evaled);
+
+        /// <summary>
+        /// And where it is not exact it is still the imaginary multiple of the positive root, to
+        /// the last digit of the precision context — which is the identity the skipped search was
+        /// never contributing to. #975
+        /// </summary>
+        [Theory]
+        [InlineData("sqrt(-2)", "i * sqrt(2)")]
+        [InlineData("sqrt(-pi)", "i * sqrt(pi)")]
+        public void AnEvenRootOfANegativeRealIsTheImaginaryOne(string negative, string imaginary) =>
+            Assert.Equal(imaginary.ToEntity().Evaled, negative.ToEntity().Evaled);
+
         [Fact]
         public void TestRationalDowncasting()
         {


### PR DESCRIPTION
Half of #975. `Simplify` of a root of a negative irrational took **556 ms** and returned its argument
unchanged; it now takes **232 ms**, with every answer identical. The other half is measured and named
on the issue rather than guessed at here.

## What the time was

`Number.Pow` asks `FindGoodRoot` for a real root before it does anything else. For a **negative real
base and an even root order there is no real root** — for real `x` and even `q`, `x ^ q` is never
negative — so the search is a certain miss, and not a cheap one: it computes all `q` roots to the
full decimal precision and attempts a rational conversion on each part of each. That is 7.5 ms of the
12.6 ms that evaluating `sqrt(-pi)` cost.

What makes 12.6 ms reach a caller as half a second is that **`Simplify` asks for the value of the
same expression dozens of times**: each rewrite hands it a freshly built node, and the cached value
belongs to the node it was computed on, not to the shape.

So the guard is one line, and asks a question that is decidable without computing anything.

## Measured

Both arms in one process, interleaved, medians of seven — timings from separate runs on this machine
are not comparable, which is why it is not two runs.

| `Simplify` | before | after | |
|---|--:|--:|--:|
| `sqrt(-pi)` | 555.7 ms | 231.9 ms | **2.40×** |
| `sqrt(-sqrt(2))` | 542.7 ms | 229.9 ms | **2.36×** |
| `sqrt(-sqrt(3))` | 550.3 ms | 234.2 ms | **2.35×** |
| `sqrt(-2)` | 2.75 ms | 1.10 ms | **2.50×** |
| `a + b - sqrt(2)` | 77.9 ms | 44.5 ms | **1.75×** |
| `(-sqrt(2)) ^ (1/3)` | 411.2 ms | 411.1 ms | 1.00× |
| `(-8) ^ (1/3)` | 1.97 ms | 1.96 ms | 1.00× |
| `sqrt(pi)`, `sqrt(sqrt(2))` | — | — | 1.00× |

`a + b - sqrt(2)` is #972's expression, and it is on the list because `CollapseToPerfectSquare` takes
the square root of each term: one of them is `-sqrt(2)`, so it constructs exactly the shape above.
#974 stopped it constructing them so often; this makes them cheaper.

The odd order is deliberately untouched — a real root exists there, the search finds it, and
`(-8) ^ (1/3)` is `-2` because of it.

## No answer changes, and the exact ones are what to check

| | |
|---|---|
| `sqrt(-4)` | `2i` |
| `(-4) ^ (3/2)` | `-8i` |
| `(-1) ^ (1/2)` | `i` |
| `(-8) ^ (1/3)` | `-2` |
| `(-27) ^ (2/3)` | `9` |
| `4 ^ (1/2)`, `16 ^ (1/4)`, `1 ^ (1/4)` | `2`, `2`, `1` |

All of these are the same before and after, and they are now pinned in `Core/Numeric.cs` — the exact
values on the even side, which have to survive the general complex formula the guard falls through
to, and the real root on the odd side, which is what the search is still there for. Also pinned:
`sqrt(-pi)` equals `i * sqrt(pi)` to the last digit of the precision context, which is the identity
the skipped search was never contributing to.

## Evidence

- suite **7322 passed, 0 failed**
- `casbench` **116/119**, 0 wrong, 0 error, 0 timeout
- `boundcheck` 372 shapes, 814 comparisons, **0 disagreements** — the harness for exactly this, since
  a root of a negative number is a branch cut
- `simpsweep` **10463/10463** agree; `rootcheck` **596/596** clean; `propcheck` 1340 checks, 0 failures
- no `BREAKING-CHANGES.md` entry: no answer changes, which the A/B above checked by comparing
  `Stringize` of `Evaled` and of `Simplify` on both arms rather than by reasoning about it
