### PR TITLE
Let i be the loop variable when it is named as one (#976)

### DIFF
--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -6844,9 +6844,10 @@ namespace AngouriMath
         /// </summary>
         /// <param name="expr">The summand. It may mention <paramref name="var"/>.</param>
         /// <param name="var">
-        /// The index, which this <b>binds</b> — it is not a free variable of the result. It must be
-        /// a <see cref="Entity.Variable"/>: <c>i</c> is the imaginary unit here, not an index, so
-        /// <c>Sum("i", "i", 1, 10)</c> is left unevaluated rather than guessed at.
+        /// The index, which this <b>binds</b> — it is not a free variable of the result. Naming
+        /// <c>i</c> works: it is the imaginary unit everywhere else, but declaring it as the index
+        /// is taken as meaning it, throughout this operator and nowhere outside it. See
+        /// <see cref="Iterated"/>.
         /// </param>
         /// <param name="from">The first value of the index.</param>
         /// <param name="to">The last value of the index, inclusive.</param>
@@ -6875,7 +6876,7 @@ namespace AngouriMath
         /// </code>
         /// </example>
         public static Entity Sum(Entity expr, Entity var, Entity from, Entity to)
-            => new Summationf(expr, var, from, to);
+            => Iterated(static (e, v, f, t) => new Summationf(e, v, f, t), expr, var, from, to);
 
         /// <summary>
         /// A product of <paramref name="expr"/> as <paramref name="var"/> runs from
@@ -6902,7 +6903,43 @@ namespace AngouriMath
         /// </code>
         /// </example>
         public static Entity Product(Entity expr, Entity var, Entity from, Entity to)
-            => new Productf(expr, var, from, to);
+            => Iterated(static (e, v, f, t) => new Productf(e, v, f, t), expr, var, from, to);
+
+        /// <summary>
+        /// Reads <c>i</c> as the loop variable where it is named as one, through the summand and
+        /// the bounds as well as in the index position.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>i</c> is the imaginary unit, and that is decided in the lexer — <c>NUMBER: ... |</c>
+        /// <c>'i'</c> — so it never reaches the rule that makes variables and cannot be one
+        /// anywhere in the language. That left <c>sum(i, i, 1, 10)</c> quietly summing nothing:
+        /// the index was a number, so the operator had no variable to bind.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/976">#976</a>
+        /// </para>
+        /// <para>
+        /// Naming <c>i</c> as the index says something about the whole operator, so it is honoured
+        /// throughout it. Doing it in the index position alone would be worse than not doing it at
+        /// all: the index would become a variable while every <c>i</c> in the summand stayed the
+        /// imaginary unit, nothing would substitute, and <c>sum(i, i, 1, 10)</c> would answer
+        /// <c>10i</c> instead of 55 — a wrong answer in place of an unevaluated one.
+        /// </para>
+        /// <para>
+        /// Only inside the operator that declares it. <c>sum(i * k, k, 1, 3)</c> is <c>6i</c>, and
+        /// the <c>i</c> in <c>sum(i, i, 1, 3) + i</c> outside the sum is still the imaginary unit.
+        /// </para>
+        /// </remarks>
+        private static Entity Iterated(
+            Func<Entity, Entity, Entity, Entity, Entity> build,
+            Entity expr, Entity var, Entity from, Entity to)
+        {
+            if (var != i)
+                return build(expr, var, from, to);
+            var index = Entity.Variable.CreateVariableUnchecked("i");
+            Entity Rename(Entity subject) => subject.Replace(node => node == i ? index : node);
+            return build(Rename(expr), index, Rename(from), Rename(to));
+        }
+
 
         /// <summary>Some non-symbolic constants</summary>
         [SuppressMessage("Style", "IDE1006:Naming Styles",

--- a/Sources/Tests/UnitTests/Core/SummationProductTest.cs
+++ b/Sources/Tests/UnitTests/Core/SummationProductTest.cs
@@ -17,9 +17,11 @@ namespace AngouriMath.Tests.Core
     /// over a range. <a href="https://github.com/asc-community/AngouriMath/issues/248">#248</a>
     /// </summary>
     /// <remarks>
-    /// The index is written <c>k</c> throughout and never <c>i</c>, deliberately: <c>i</c> is the
-    /// imaginary unit, so <c>sum(i, i, 1, 10)</c> binds nothing and is left unevaluated. That is
-    /// pinned below rather than left as a trap.
+    /// The index is mostly written <c>k</c>, but <c>i</c> works too and the cases below say so.
+    /// <c>i</c> is the imaginary unit — decided in the lexer, so it cannot be a variable anywhere
+    /// in the language — and naming it as an index used to bind nothing and sum nothing. It is now
+    /// read as the declaration it plainly is, and only inside the operator that declares it.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/976">#976</a>
     /// </remarks>
     [Trait("Area", "Core")]
     public sealed class SummationProductTest
@@ -78,12 +80,33 @@ namespace AngouriMath.Tests.Core
                 "sum(k, k, 1, n)".ToEntity().Substitute("n", 3).Simplify().Evaled);
 
         /// <summary>
-        /// <c>i</c> is the imaginary unit, so it cannot be an index. The operator declines rather
-        /// than guessing, which is the honest answer and the one a caller can see.
+        /// <c>i</c> is the imaginary unit, and the lexer decides that — so naming it as the index
+        /// used to sum nothing. Naming it is now taken as the declaration it obviously is.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/976">#976</a>
         /// </summary>
+        [Theory]
+        [InlineData("sum(i, i, 1, 10)", "55")]
+        [InlineData("sum(i ^ 2, i, 1, 4)", "30")]
+        [InlineData("product(i, i, 1, 5)", "120")]
+        public void TheImaginaryUnitCanBeAnIndexWhenItIsDeclaredAsOne(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity().Evaled, expression.ToEntity().Simplify().Evaled);
+
+        /// <summary>
+        /// The other half, and the one that would make the change above a wrong answer if it
+        /// failed: <c>i</c> is reinterpreted only where it is the index. Anywhere else — inside
+        /// the same sum, or outside it — it is still the imaginary unit.
+        /// </summary>
+        [Theory]
+        [InlineData("sum(i * k, k, 1, 3)", "6i")]
+        [InlineData("sum(k + i, k, 1, 2)", "3 + 2i")]
+        [InlineData("sum(i, i, 1, 3) + i", "6 + i")]
+        public void ElsewhereItIsStillTheImaginaryUnit(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity().Evaled, expression.ToEntity().Simplify().Evaled);
+
+        /// <summary>A declared index with a symbolic bound is still carried, not guessed at.</summary>
         [Fact]
-        public void TheImaginaryUnitIsNotAnIndex() =>
-            Assert.IsType<Entity.Summationf>("sum(i, i, 1, 10)".ToEntity().Simplify());
+        public void ADeclaredImaginaryUnitIndexWithASymbolicBoundIsCarried() =>
+            Assert.IsType<Entity.Summationf>("sum(i, i, 1, n)".ToEntity().Simplify());
 
         /// <summary>
         /// Too many terms is left unexpanded: a thousand-term sum is a correct expansion and a


### PR DESCRIPTION
Addresses the first half of #976. The second half is answered in a comment below rather than implemented, with the references you asked me to check.

## `i` as the loop variable

`sum(i, i, 1, 10)` summed nothing. `i` is the imaginary unit, and that is decided in the **lexer** — `NUMBER: ... | 'i'` — so it never reaches the rule that makes variables and cannot be one anywhere in the language. The index arrived as a number, the operator had no variable to bind, and the whole expression stayed unevaluated. #966 documented that as a trap; you asked for it not to be one.

| | before | after |
|---|---|---|
| `sum(i, i, 1, 10)` | unevaluated | **55** |
| `product(i, i, 1, 5)` | unevaluated | **120** |
| `sum(i ^ 2, i, 1, 4)` | unevaluated | **30** |

Naming `i` as the index is a statement about the whole operator, so it is honoured through the summand and the bounds, not only in the index position. **Doing it there alone would have been worse than leaving it broken**: the index would become a variable while every `i` in the summand stayed the imaginary unit, nothing would substitute, and `sum(i, i, 1, 10)` would answer `10i` — a wrong answer replacing an unevaluated one.

And only inside the operator that declares it. These are unchanged, and they are what make the above a fix rather than a new defect:

```
sum(i * k, k, 1, 3)   ->  6i
sum(k + i, k, 1, 2)   ->  3 + 2i
sum(i, i, 1, 3) + i   ->  6 + i
i * i                 ->  -1
sqrt(-1)              ->  i
```

### Why this is in `MathS`, not the grammar

My first attempt was a grammar action. It fixed `"sum(i, i, 1, 10)".ToEntity()` and left `MathS.Sum("i", "i", 1, 10)` broken — one library with two answers, since the implicit string conversion is the only thing that goes through the parser. Putting it at the factory covers both paths, and leaves the parser **completely untouched**, so there is no regeneration and nothing for #965's grammar-drift check to catch.

### Tests

The class remark on `SummationProductTest` taught the trap and now records that it is gone. The test that pinned the old answer is replaced by cases for both halves — the index being read, *and* `i` still being the imaginary unit everywhere else.

Suite **7318 passed, 0 failed**, 14 skipped.
