### PR TITLE
Keep the expression when the sort did not move it (#975)

### DIFF
--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.cs
@@ -13,7 +13,7 @@ namespace AngouriMath.Functions
 {
     internal static partial class Patterns
     {
-        private static Entity SortAndGroup(IEnumerable<Entity> children, TreeAnalyzer.SortLevel level, Func<Entity, Entity, Entity> ctor)
+        private static Entity SortAndGroup(Entity original, IEnumerable<Entity> children, TreeAnalyzer.SortLevel level, Func<Entity, Entity, Entity> ctor)
         {
             var groups = new Dictionary<string, List<Entity>>();
             foreach (var child in children)
@@ -23,7 +23,13 @@ namespace AngouriMath.Functions
                     groups[hash] = new();
                 groups[hash].Add(child);
             }
-            return groups.OrderBy(pair => pair.Key).Select(pair => pair.Value.Aggregate(ctor)).Aggregate(ctor);
+            var sorted = groups.OrderBy(pair => pair.Key).Select(pair => pair.Value.Aggregate(ctor)).Aggregate(ctor);
+            // Hand the original back where the sort changed nothing. Aggregate builds a fresh
+            // node whether or not the order moved, and an Entity memoises InnerSimplified, Evaled
+            // and its complexity on the instance -- so rebuilding an already-ordered chain threw
+            // all of that away and made the next pass re-derive it from cold.
+            // https://github.com/asc-community/AngouriMath/issues/975
+            return sorted == original ? original : sorted;
         }
 
         /// <summary>Actual sorting with <see cref="Entity.SortHash(TreeAnalyzer.SortLevel)"/></summary>
@@ -31,19 +37,19 @@ namespace AngouriMath.Functions
         internal static Func<Entity, Entity> SortRules(TreeAnalyzer.SortLevel level) => x => x switch
         {
             Sumf or Minusf =>
-                SortAndGroup(Sumf.LinearChildren(x), level, (a, b) => a + b),
+                SortAndGroup(x, Sumf.LinearChildren(x), level, (a, b) => a + b),
             Mulf or Divf =>
-                SortAndGroup(Mulf.LinearChildren(x), level, (a, b) => a * b),
+                SortAndGroup(x, Mulf.LinearChildren(x), level, (a, b) => a * b),
             Andf =>
-                SortAndGroup(Andf.LinearChildren(x), level, (a, b) => a & b),
+                SortAndGroup(x, Andf.LinearChildren(x), level, (a, b) => a & b),
             Orf =>
-                SortAndGroup(Orf.LinearChildren(x), level, (a, b) => a | b),
+                SortAndGroup(x, Orf.LinearChildren(x), level, (a, b) => a | b),
             Unionf =>
-                SortAndGroup(Unionf.LinearChildren(x), level, (a, b) => a.Unite(b)),
+                SortAndGroup(x, Unionf.LinearChildren(x), level, (a, b) => a.Unite(b)),
             Intersectionf =>
-                SortAndGroup(Intersectionf.LinearChildren(x), level, (a, b) => a.Intersect(b)),
+                SortAndGroup(x, Intersectionf.LinearChildren(x), level, (a, b) => a.Intersect(b)),
             Xorf => 
-                SortAndGroup(Xorf.LinearChildren(x), level, (a, b) => a ^ b),
+                SortAndGroup(x, Xorf.LinearChildren(x), level, (a, b) => a ^ b),
             _ => x,
         };
         [AddressableRules]


### PR DESCRIPTION
Closes #975.

`Simplify("sqrt(-pi)")` took over half a second and returned its argument. **516 ms of the 554 went on 89 `AddHistory` calls, every one handed the same unchanged `sqrt(-pi)`**, each costing about 6 ms.

An `Entity` memoises `InnerSimplified`, `Evaled` and its complexity **on the instance**, so those 89 calls ought to have been one and 88 cache hits. They were not, because `SortAndGroup` aggregates a commutative chain into a fresh node whether or not the order changed. `sqrt(-pi)` has the product `(-1) * pi` for a base, so every pass rebuilt an equal-but-new tree and threw the memo away — and the next pass re-derived it from cold, which is expensive because `InnerSimplified` on a power with a **negative** base is precision-bound:

| `InnerSimplified`, fresh instance | precision 10 | precision 100 |
|---|--:|--:|
| `sqrt(pi)` | 0.14 ms | 0.28 ms |
| `sqrt(-pi)` | 2.4 ms | **10.9 ms** |

So the sort now hands the original back where the result is the same expression.

## Measured

Best of 7, a fresh instance each time:

| | master | this |
|---|--:|--:|
| **`sqrt(-pi)`** | **556.4 ms** | **8.0 ms** |
| **`sqrt(-sqrt(2))`** | **546.2 ms** | **13.6 ms** |
| `sqrt(-2)` | 12.0 ms | 12.0 ms |
| `sqrt(-3)` | 11.7 ms | 11.8 ms |
| `y - pi - sqrt(2)` | 86.0 ms | 94.2 ms |
| `a / (b / c)` | 1.1 ms | 1.1 ms |
| `x^(-1)/(y/z)` | 1.7 ms | 1.7 ms |
| `(x^3 + 3x²y + 3xy² + y³) / (x + y)` | 3.0 ms | 2.5 ms |

Nothing else moves. The cost added is one structural equality per sorted chain, against a rebuild it replaces.

Suite **7312 passed, 0 failed**, 14 skipped — the same count as `master`, since this adds no tests and changes no answer.

## Two measurements on the way here were wrong

Both for the same underlying reason, and both are why the table above is best-of-seven on a fresh instance. Recording them because each is easy to repeat:

- **Timing a method on one `Entity` in a loop measures the memo** after the first iteration. That told me `InnerSimplified` cost 0.0002 ms and was therefore not the problem. It costs 10 ms.
- **Timing one `Simplify` call measures the JIT.** That told me this change regressed `a / (b / c)` fourfold and `y - pi - sqrt(2)` from 86 ms to 300 ms. It moves neither.

The best of those was `sqrt(-2)`, which appeared to regress from 2.7 ms to 12 ms. `sqrt(-2)` is 12 ms on `master` too — it only measured 2.7 because the 556 ms `sqrt(-pi)` ahead of it in the same process had warmed everything up. **Fixing the slow case removed the warm-up the fast case had been living off**, and the fast case then looked like a regression.
