### PR TITLE
Let a binder bind `i`, in every binder there is (#976)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -28,6 +28,13 @@ read first.
 | **Silent** | a rewritten expression under `domain(...)` — including via `Substitute` | the constraint was dropped, so it answered | it refuses, as it did before the rewrite |
 | **Silent** | `"x!".Differentiate("x")`, and anything containing it | `NaN` | the unevaluated `derivative(x!, x)` |
 | **Silent** | `"7/2".ToEntity()` and any quotient of two integer literals | a `Divf` | the `Rational` it denotes |
+| **Silent** | `sum(i, i, 1, 10)`, and every binder given `i` as the name it binds | the imaginary unit in the name position, so nothing was bound | `i` is the bound name, and `55` |
+| **Silent** | `sum(2i, i, 1, 3)` | `6i` | `12` |
+| **Silent** | `derivative(i ^ 2, i)` | `0` | `2 * i` |
+| **Silent** | `{ i : i > 0 }` | `NaN` | the set it describes |
+| **Silent** | `limit(i, i, 0)` | unevaluated | `0` |
+| **Silent** | `integral(i, i)` | `-1/2 + C` | `i ^ 2 / 2 + C` |
+| | `lambda(i, i + 1)` | `InvalidArgumentParseException` | the lambda |
 
 ### A rewritten node keeps its `Codomain`, so a domain constraint no longer disappears
 
@@ -202,6 +209,46 @@ work.
 Found while documenting the members a `#pragma warning disable CS1591` was covering — the two
 conversions sit in different files and had to be read side by side to look wrong.
 [#585](https://github.com/asc-community/AngouriMath/issues/585).
+
+### A binder given `i` as the name it binds reads it as that name
+
+`i` is the imaginary unit, and the lexer decides it — `NUMBER: ... | 'i'` — so it never reaches the
+rule that makes variables and could not be a bound name anywhere in the language. Every binder
+handed one therefore did something other than bind: a sum bound nothing and stayed unevaluated, a
+set builder answered `NaN`, a lambda threw. Naming `i` is now read as the declaration it plainly
+is, throughout that binder and nowhere else.
+
+```csharp
+"sum(i, i, 1, 10)".ToEntity().Simplify()      // was: unevaluated       now: 55
+"sum(2i, i, 1, 3)".ToEntity().Simplify()      // was: 6i                now: 12
+"integral(i, i)".ToEntity().Simplify()        // was: -1/2 + C          now: i ^ 2 / 2 + C
+"limit(i, i, 0)".ToEntity().Simplify()        // was: unevaluated       now: 0
+"derivative(i ^ 2, i)".ToEntity().Simplify()  // was: 0                 now: 2 * i
+"{ i : i > 0 }".ToEntity().Simplify()         // was: NaN               now: { i : i > 0 }
+"lambda(i, i + 1)".ToEntity()                 // was: threw             now: the lambda
+```
+
+`2i` is one token, so a written coefficient on the bound name arrives as a single number with
+nothing in it to rename; under a binder that names `i` it is read as the product it would be with
+any other name, which is what turns `6i` into `12` above.
+
+**Only inside the binder that declares it**, which is what makes this a fix and not a new defect:
+
+```csharp
+"sum(i * k, k, 1, 3)".ToEntity().Simplify()          // 6i, unchanged
+"sum(i, i, 1, 3) + i".ToEntity().Simplify()          // 6 + i, unchanged
+"sum(sqrt(-1) * i, i, 1, 10)".ToEntity().Simplify()  // 55i — the sum's index, times the unit
+```
+
+The last is what SymPy answers for `Sum(sqrt(-1) * i, (i, 1, 10))`, which resolves the same
+collision by naming the constant `I` and refusing to bind it.
+
+`e` and `pi` are unaffected and needed nothing here: they are variables that carry a value, so a
+binder has always taken those names. They are also not fully fixed by anything in this entry — a
+bound `e` still means `2.718…`, since the bound name and the constant are one object.
+[#984](https://github.com/asc-community/AngouriMath/issues/984) has the measurements.
+
+[#976](https://github.com/asc-community/AngouriMath/issues/976).
 
 ---
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -38,7 +38,13 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [AngouriMath/Core/CostModel.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[AngouriMath/Core/Binding.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [Tests/UnitTests/Core/CostModelTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Core/BinderShadowingTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
 [Tests/UnitTests/Common/ListArgumentOverloadTest.cs]

--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -6846,8 +6846,8 @@ namespace AngouriMath
         /// <param name="var">
         /// The index, which this <b>binds</b> — it is not a free variable of the result. Naming
         /// <c>i</c> works: it is the imaginary unit everywhere else, but declaring it as the index
-        /// is taken as meaning it, throughout this operator and nowhere outside it. See
-        /// <see cref="Iterated"/>.
+        /// is taken as meaning it, throughout this operator and nowhere outside it — and the
+        /// same holds of every other binder in the language. See <see cref="Core.Binding"/>.
         /// </param>
         /// <param name="from">The first value of the index.</param>
         /// <param name="to">The last value of the index, inclusive.</param>
@@ -6876,7 +6876,7 @@ namespace AngouriMath
         /// </code>
         /// </example>
         public static Entity Sum(Entity expr, Entity var, Entity from, Entity to)
-            => Iterated(static (e, v, f, t) => new Summationf(e, v, f, t), expr, var, from, to);
+            => new Summationf(expr, var, from, to);
 
         /// <summary>
         /// A product of <paramref name="expr"/> as <paramref name="var"/> runs from
@@ -6903,43 +6903,7 @@ namespace AngouriMath
         /// </code>
         /// </example>
         public static Entity Product(Entity expr, Entity var, Entity from, Entity to)
-            => Iterated(static (e, v, f, t) => new Productf(e, v, f, t), expr, var, from, to);
-
-        /// <summary>
-        /// Reads <c>i</c> as the loop variable where it is named as one, through the summand and
-        /// the bounds as well as in the index position.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// <c>i</c> is the imaginary unit, and that is decided in the lexer — <c>NUMBER: ... |</c>
-        /// <c>'i'</c> — so it never reaches the rule that makes variables and cannot be one
-        /// anywhere in the language. That left <c>sum(i, i, 1, 10)</c> quietly summing nothing:
-        /// the index was a number, so the operator had no variable to bind.
-        /// <a href="https://github.com/asc-community/AngouriMath/issues/976">#976</a>
-        /// </para>
-        /// <para>
-        /// Naming <c>i</c> as the index says something about the whole operator, so it is honoured
-        /// throughout it. Doing it in the index position alone would be worse than not doing it at
-        /// all: the index would become a variable while every <c>i</c> in the summand stayed the
-        /// imaginary unit, nothing would substitute, and <c>sum(i, i, 1, 10)</c> would answer
-        /// <c>10i</c> instead of 55 — a wrong answer in place of an unevaluated one.
-        /// </para>
-        /// <para>
-        /// Only inside the operator that declares it. <c>sum(i * k, k, 1, 3)</c> is <c>6i</c>, and
-        /// the <c>i</c> in <c>sum(i, i, 1, 3) + i</c> outside the sum is still the imaginary unit.
-        /// </para>
-        /// </remarks>
-        private static Entity Iterated(
-            Func<Entity, Entity, Entity, Entity, Entity> build,
-            Entity expr, Entity var, Entity from, Entity to)
-        {
-            if (var != i)
-                return build(expr, var, from, to);
-            var index = Entity.Variable.CreateVariableUnchecked("i");
-            Entity Rename(Entity subject) => subject.Replace(node => node == i ? index : node);
-            return build(Rename(expr), index, Rename(from), Rename(to));
-        }
-
+            => new Productf(expr, var, from, to);
 
         /// <summary>Some non-symbolic constants</summary>
         [SuppressMessage("Style", "IDE1006:Naming Styles",

--- a/Sources/AngouriMath/Core/Antlr/AngouriMath.g
+++ b/Sources/AngouriMath/Core/Antlr/AngouriMath.g
@@ -461,8 +461,13 @@ atom returns[Entity value]
             var body = $args.list.Last();
             foreach (var x in ((IEnumerable<Entity>)$args.list).Reverse().Skip(1))
             {
-                if (x is not Variable v) throw new InvalidArgumentParseException($"Lambda is expected to have valid parameters, {x} encountered instead");
-                body = body.LambdaOver(v);
+                /* Lambda's parameter is typed Variable, so unlike every other binder it cannot
+                   be handed the imaginary unit and read it there. i is what a lambda over an
+                   index is called, so it is read here instead.
+                   https://github.com/asc-community/AngouriMath/issues/976 */
+                var bound = AngouriMath.Core.Binding.Of(x);
+                if (bound.Name is not Variable v) throw new InvalidArgumentParseException($"Lambda is expected to have valid parameters, {x} encountered instead");
+                body = bound.In(body).LambdaOver(v);
             }
             $value = body;
         }

--- a/Sources/AngouriMath/Core/Antlr/AngouriMathParser.cs
+++ b/Sources/AngouriMath/Core/Antlr/AngouriMathParser.cs
@@ -3290,8 +3290,13 @@ internal partial class AngouriMathParser : Parser {
 				            var body = _localctx.args.list.Last();
 				            foreach (var x in ((IEnumerable<Entity>)_localctx.args.list).Reverse().Skip(1))
 				            {
-				                if (x is not Variable v) throw new InvalidArgumentParseException($"Lambda is expected to have valid parameters, {x} encountered instead");
-				                body = body.LambdaOver(v);
+				                /* Lambda's parameter is typed Variable, so unlike every other binder it cannot
+				                   be handed the imaginary unit and read it there. i is what a lambda over an
+				                   index is called, so it is read here instead.
+				                   https://github.com/asc-community/AngouriMath/issues/976 */
+				                var bound = AngouriMath.Core.Binding.Of(x);
+				                if (bound.Name is not Variable v) throw new InvalidArgumentParseException($"Lambda is expected to have valid parameters, {x} encountered instead");
+				                body = bound.In(body).LambdaOver(v);
 				            }
 				            _localctx.value =  body;
 				        

--- a/Sources/AngouriMath/Core/Binding.cs
+++ b/Sources/AngouriMath/Core/Binding.cs
@@ -1,0 +1,97 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+namespace AngouriMath.Core
+{
+    using static Entity;
+    using static Entity.Number;
+
+    /// <summary>
+    /// The name a binder is handed, and what that name means inside it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// There is one name in the language a binder cannot otherwise bind. <c>i</c> is the
+    /// imaginary unit and that is decided in the lexer — <c>NUMBER: ... | 'i'</c> — so it never
+    /// reaches the rule that makes variables and cannot be one anywhere. <c>e</c> and <c>pi</c>
+    /// are the other way round: they are <see cref="Variable"/>s that carry a value, so a binder
+    /// takes the name without trouble — and cannot then stop it meaning the constant, since a
+    /// bound <c>e</c> and the constant <c>e</c> are one object. That is why this is about the one
+    /// named constant that is not a variable.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/976">#976</a>,
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/984">#984</a>
+    /// </para>
+    /// <para>
+    /// Naming <c>i</c> as the bound name says something about the whole binder, so it is
+    /// honoured throughout it — through the summand and the bounds, not only in the name
+    /// position. Doing it in the name position alone would be worse than not doing it at all:
+    /// the index would become a variable while every <c>i</c> beside it stayed the imaginary
+    /// unit, nothing would substitute, and <c>sum(i, i, 1, 10)</c> would answer <c>10i</c>
+    /// instead of 55 — a wrong answer in place of an unevaluated one.
+    /// </para>
+    /// <para>
+    /// Only inside the binder that declares it. <c>sum(i * k, k, 1, 3)</c> is <c>6i</c>, and the
+    /// <c>i</c> outside the sum in <c>sum(i, i, 1, 3) + i</c> is still the imaginary unit.
+    /// </para>
+    /// <para>
+    /// This is a <see langword="struct"/> holding two fields and it is the whole cost of the
+    /// feature where nothing is shadowed: <see cref="Of(Entity)"/> is one equality test and
+    /// <see cref="In(Entity)"/> hands the expression straight back without walking it.
+    /// </para>
+    /// </remarks>
+    internal readonly struct Binding
+    {
+        /// <summary>
+        /// What <c>i</c> becomes where it is bound. Unchecked, because the checked factory
+        /// parses and the parser reads <c>i</c> as the imaginary unit — the very thing that
+        /// makes this type necessary.
+        /// </summary>
+        [ConstantField]
+        private static readonly Variable index = Variable.CreateVariableUnchecked("i");
+
+        private readonly Entity given;
+        private readonly bool shadowed;
+
+        private Binding(Entity given, bool shadowed) => (this.given, this.shadowed) = (given, shadowed);
+
+        /// <summary>Reads a bound name as the binder was given it.</summary>
+        /// <param name="name">Whatever arrived in the name position.</param>
+        /// <remarks>
+        /// Every binder node runs this on the way in, so it is written to cost nothing in the
+        /// case that is nearly all of them: a bound name is a <see cref="Variable"/>, the type
+        /// test fails, and the equality is never reached. Measured at 2.2ns as an equality and
+        /// 0.5ns this way, against about 10ns to construct the node it guards.
+        /// </remarks>
+        internal static Binding Of(Entity name) => new(name, name is Complex && name == MathS.i);
+
+        /// <summary>The name to bind: what was given, unless that was the imaginary unit.</summary>
+        internal Entity Name => shadowed ? index : given;
+
+        /// <summary>
+        /// An expression that is inside this binder, with the bound name meaning what it means
+        /// here. Identity unless something is shadowed.
+        /// </summary>
+        internal Entity In(Entity scope) => shadowed ? scope.Replace(Rename) : scope;
+
+        /// <remarks>
+        /// <c>2i</c> is one token — the lexer's <c>NUMBER</c> ends <c>'i'?</c> — so a written
+        /// <c>2i</c> arrives as a single number and not as a product with anything to rename.
+        /// Under a binder that names <c>i</c> it is nevertheless the writer's <c>2</c> beside
+        /// the writer's <c>i</c>, and <c>2e</c> is a product there, so this reads it as one:
+        /// <c>sum(2i, i, 1, 3)</c> is 12 rather than <c>6i</c>.
+        /// </remarks>
+        private static Entity Rename(Entity node)
+        {
+            // Real derives from Complex, so the second test is the one that says "and it has an
+            // imaginary part". NaN and the infinities are Reals and so are left alone.
+            if (node is not Complex complex || node is Real)
+                return node;
+            Entity scaled = complex.ImaginaryPart == Integer.One ? index : complex.ImaginaryPart * index;
+            return complex.RealPart.IsZero ? scaled : complex.RealPart + scaled;
+        }
+    }
+}

--- a/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Calculus.Classes.cs
+++ b/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Calculus.Classes.cs
@@ -6,6 +6,7 @@
 //
 
 using System;
+using AngouriMath.Core;
 
 namespace AngouriMath
 {
@@ -35,6 +36,11 @@ namespace AngouriMath
         /// </summary>
         public sealed partial record Integralf(Entity Expression, Entity Var, (Entity from, Entity to)? Range) : CalculusOperator(Expression, Var)
         {
+            /// <summary>The interval integrated over, or <see langword="null"/> for an indefinite integral.</summary>
+            public (Entity from, Entity to)? Range { get; init; } = Range is var (from, to)
+                ? (Binding.Of(Var).In(from), Binding.Of(Var).In(to))
+                : Range;
+
             /// <summary>Reuse the cache by returning the same object if possible</summary>
             private Integralf New(Entity expression, Entity var, (Entity from, Entity to)? range) =>
                 ReferenceEquals(Expression, expression) && ReferenceEquals(Var, var)
@@ -70,6 +76,12 @@ namespace AngouriMath
         /// </remarks>
         public sealed partial record Summationf(Entity Expression, Entity Var, Entity From, Entity To) : CalculusOperator(Expression, Var)
         {
+            /// <summary>The first value of the index.</summary>
+            public Entity From { get; init; } = Binding.Of(Var).In(From);
+
+            /// <summary>The last value of the index, inclusive.</summary>
+            public Entity To { get; init; } = Binding.Of(Var).In(To);
+
             /// <summary>Reuse the cache by returning the same object if possible</summary>
             private Summationf New(Entity expression, Entity var, Entity from, Entity to) =>
                 ReferenceEquals(Expression, expression) && ReferenceEquals(Var, var)
@@ -89,6 +101,12 @@ namespace AngouriMath
         /// <remarks><a href="https://github.com/asc-community/AngouriMath/issues/248">#248</a></remarks>
         public sealed partial record Productf(Entity Expression, Entity Var, Entity From, Entity To) : CalculusOperator(Expression, Var)
         {
+            /// <summary>The first value of the index.</summary>
+            public Entity From { get; init; } = Binding.Of(Var).In(From);
+
+            /// <summary>The last value of the index, inclusive.</summary>
+            public Entity To { get; init; } = Binding.Of(Var).In(To);
+
             /// <summary>Reuse the cache by returning the same object if possible</summary>
             private Productf New(Entity expression, Entity var, Entity from, Entity to) =>
                 ReferenceEquals(Expression, expression) && ReferenceEquals(Var, var)
@@ -106,6 +124,9 @@ namespace AngouriMath
         /// </summary>
         public sealed partial record Limitf(Entity Expression, Entity Var, Entity Destination, ApproachFrom ApproachFrom) : CalculusOperator(Expression, Var)
         {
+            /// <summary>What the variable approaches.</summary>
+            public Entity Destination { get; init; } = Binding.Of(Var).In(Destination);
+
             /// <summary>Reuse the cache by returning the same object if possible</summary>
             private Limitf New(Entity expression, Entity var, Entity destination, ApproachFrom approachFrom) =>
                 ReferenceEquals(Expression, expression) && ReferenceEquals(Var, var) && ReferenceEquals(Destination, destination)

--- a/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Definition.cs
+++ b/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Definition.cs
@@ -5,6 +5,8 @@
 // Website: https://am.angouri.org.
 //
 
+using AngouriMath.Core;
+
 namespace AngouriMath
 {
     partial record Entity
@@ -36,8 +38,18 @@ namespace AngouriMath
         /// <summary>
         /// Describes any calculus operator
         /// </summary>
+        /// <remarks>
+        /// Every one of these <b>binds</b> <see cref="Var"/>, so this is where a bound name is
+        /// read — see <see cref="Core.Binding"/> for the one name in the language that needs
+        /// reading rather than taking as it arrives.
+        /// </remarks>
         public abstract partial record CalculusOperator(Entity Expression, Entity Var) : Function
         {
+            /// <summary>The name this operator binds.</summary>
+            public Entity Var { get; init; } = Binding.Of(Var).Name;
+
+            /// <summary>The expression the operator is applied to, which may mention <see cref="Var"/>.</summary>
+            public Entity Expression { get; init; } = Binding.Of(Var).In(Expression);
         }
 
         /// <summary>

--- a/Sources/AngouriMath/Core/Entity/Omni/Entity.Omni.Classes.cs
+++ b/Sources/AngouriMath/Core/Entity/Omni/Entity.Omni.Classes.cs
@@ -6,6 +6,7 @@
 //
 
 using System;
+using AngouriMath.Core;
 using System.Collections;
 using AngouriMath.Core.HashCode;
 using AngouriMath.Core.Exceptions;
@@ -431,6 +432,12 @@ namespace AngouriMath
             /// </example>
             public sealed partial record ConditionalSet(Entity Var, Entity Predicate) : Set, IEquatable<ConditionalSet?>
             {
+                /// <summary>The name this set builder binds. See <see cref="Core.Binding"/>.</summary>
+                public Entity Var { get; init; } = Binding.Of(Var).Name;
+
+                /// <summary>What holds of <see cref="Var"/> exactly for the members of this set.</summary>
+                public Entity Predicate { get; init; } = Binding.Of(Var).In(Predicate);
+
                 /// <inheritdoc/>
                 public override Entity Replace(Func<Entity, Entity> func)
                     => func(New(Var, Predicate.Replace(func)));

--- a/Sources/Tests/UnitTests/Core/BinderShadowingTest.cs
+++ b/Sources/Tests/UnitTests/Core/BinderShadowingTest.cs
@@ -1,0 +1,170 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Core
+{
+    /// <summary>
+    /// A binder handed <c>i</c> as the name it binds reads it as that name, and every binder in
+    /// the language does it the same way.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/976">#976</a>
+    /// </summary>
+    /// <remarks>
+    /// <c>e</c> and <c>pi</c> need none of this and are here to say why: they are
+    /// <see cref="Entity.Variable"/>s that carry a value, so a binder shadows them by
+    /// construction. <c>i</c> is a number — the lexer decides it, <c>NUMBER: ... | 'i'</c> — so
+    /// without this it is the one name in the language that no binder can bind.
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class BinderShadowingTest
+    {
+        /// <summary>
+        /// Every binder, given the same expression written over <c>i</c> and over an ordinary
+        /// name, answers the same thing.
+        /// </summary>
+        [Theory]
+        [InlineData("sum({0}, {0}, 1, 10)")]
+        [InlineData("product({0}, {0}, 1, 5)")]
+        [InlineData("integral({0}, {0})")]
+        [InlineData("integral({0}, {0}, 0, 1)")]
+        [InlineData("integral({0} ^ 2 + 1, {0}, 0, 2)")]
+        [InlineData("limit({0}, {0}, 0)")]
+        [InlineData("limit(sin({0}) / {0}, {0}, 0)")]
+        [InlineData("derivative({0} ^ 2, {0})")]
+        [InlineData("apply(lambda({0}, {0} + 1), 3)")]
+        public void ABinderOverIAnswersWhatTheSameBinderOverKAnswers(string shape)
+        {
+            var overK = string.Format(shape, "k").ToEntity().Simplify();
+            var overI = string.Format(shape, "i").ToEntity().Simplify();
+            // Renamed rather than compared as they stand: the two answers are the same
+            // expression written over different names wherever the name survives into it.
+            Assert.Equal(overK, overI.Substitute(Entity.Variable.CreateVariableUnchecked("i"), "k"));
+        }
+
+        /// <summary>
+        /// <c>2i</c> is one token — the lexer's <c>NUMBER</c> ends <c>'i'?</c> — so it arrives as a
+        /// single number with nothing in it to rename. Under a binder that names <c>i</c> it is
+        /// the writer's <c>2</c> beside the writer's <c>i</c>, and <c>2k</c> there is a product.
+        /// </summary>
+        [Theory]
+        [InlineData("sum(2i, i, 1, 3)", "12")]
+        [InlineData("product(2i, i, 1, 3)", "48")]
+        [InlineData("sum(3 + 2i, i, 1, 3)", "21")]
+        [InlineData("integral(2i, i, 0, 1)", "1")]
+        public void AWrittenCoefficientOnTheBoundNameIsAProduct(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity().Evaled, expression.ToEntity().Simplify().Evaled);
+
+        /// <summary>
+        /// The half that makes the above a fix rather than a new defect: <c>i</c> is read as a
+        /// name only inside the binder that declares it.
+        /// </summary>
+        /// <remarks>
+        /// The last case is the one Happypig375 asked about on
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/979">#979</a>, and it is
+        /// what SymPy answers for <c>Sum(sqrt(-1) * i, (i, 1, 10))</c>.
+        /// </remarks>
+        [Theory]
+        [InlineData("sum(i * k, k, 1, 3)", "6i")]
+        [InlineData("integral(i * k, k, 0, 2)", "2i")]
+        [InlineData("limit(i * k, k, 2)", "2i")]
+        [InlineData("sum(i, i, 1, 3) + i", "6 + i")]
+        [InlineData("sum(sqrt(-1) * i, i, 1, 10)", "55i")]
+        public void ElsewhereItIsStillTheImaginaryUnit(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity().Evaled, expression.ToEntity().Simplify().Evaled);
+
+        /// <summary>A set builder binds its name too, and used to answer <c>NaN</c> over this one.</summary>
+        [Fact]
+        public void ASetBuilderOverIIsTheSetItDescribes()
+        {
+            var set = (Entity.Set)"{ i : i > 0 }".ToEntity();
+            Assert.True(set.Contains(5));
+            Assert.False(set.Contains(-5));
+        }
+
+        /// <summary>
+        /// A lambda's parameter is typed <see cref="Entity.Variable"/>, so it is the one binder
+        /// that cannot be handed the imaginary unit at all — it threw rather than answering.
+        /// </summary>
+        [Fact]
+        public void ALambdaOverIBindsIt()
+        {
+            var lambda = Assert.IsType<Entity.Lambda>("lambda(i, i + 1)".ToEntity());
+            Assert.IsType<Entity.Variable>(lambda.Parameter);
+            Assert.Equal(4, "apply(lambda(i, i + 1), 3)".ToEntity().Simplify().EvalNumerical());
+        }
+
+        /// <summary>
+        /// Read at the node and not at the way in, so the constructor gets it as well as
+        /// <see cref="MathS.Sum(Entity, Entity, Entity, Entity)"/> and the parser.
+        /// </summary>
+        [Fact]
+        public void TheNodeItselfReadsTheName()
+        {
+            Assert.Equal(55, new Entity.Summationf(MathS.i, MathS.i, 1, 10).Simplify().EvalNumerical());
+            Assert.Equal(120, new Entity.Productf(MathS.i, MathS.i, 1, 5).Simplify().EvalNumerical());
+            Assert.Equal(55, MathS.Sum(MathS.i, MathS.i, 1, 10).Simplify().EvalNumerical());
+        }
+
+        /// <summary>
+        /// One reading for the whole binder, not one per position: the bounds are inside it too.
+        /// </summary>
+        [Fact]
+        public void TheWholeBinderReadsTheNameTheSameWay()
+        {
+            var sum = Assert.IsType<Entity.Summationf>(MathS.Sum(MathS.i, MathS.i, 1, MathS.i));
+            Assert.IsType<Entity.Variable>(sum.Var);
+            Assert.Equal(sum.Var, sum.Expression);
+            Assert.Equal(sum.Var, sum.To);
+        }
+
+        /// <summary>
+        /// Nothing was added for <c>e</c> and <c>pi</c> because a binder already shadows them:
+        /// they are variables that carry a value, so the name in the index position binds, and
+        /// these have always worked.
+        /// </summary>
+        [Theory]
+        [InlineData("sum(e, e, 1, 3)", "6")]
+        [InlineData("product(pi, pi, 1, 4)", "24")]
+        [InlineData("integral(e, e, 0, 1)", "1/2")]
+        public void ANamedConstantThatIsAVariableNeededNothing(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity(), expression.ToEntity().Simplify());
+
+        /// <summary>
+        /// And where they do <i>not</i> work, which is recorded here rather than believed away.
+        /// </summary>
+        /// <remarks>
+        /// A bound <c>e</c> keeps the constant's value, because the bound name and the constant
+        /// are the same object: <c>Variable.ConstantList</c> is keyed by name, so a variable
+        /// called <c>e</c> is <c>2.718…</c> wherever it is read, binder or no binder. Nothing
+        /// short of a representation that tells a bound name from a constant one fixes these,
+        /// which is why this change is about the one constant that is not a variable — for
+        /// <c>i</c> the bound name and the unit are distinguishable, and that is the whole reason
+        /// the fix above is possible at all.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/984">#984</a>
+        /// </remarks>
+        [Theory]
+        [InlineData("derivative(e ^ 2, e)", "0")]              // 2 * e
+        [InlineData("derivative(pi ^ 2, pi)", "0")]            // 2 * pi
+        [InlineData("{ e : e > 0 }", "{ e : True }")]          // { e : e > 0 }
+        public void ABoundNamedConstantStillCarriesItsValue(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity(), expression.ToEntity().Simplify());
+
+        /// <summary>The same, on the path that shows it most plainly.</summary>
+        [Fact]
+        public void ABoundNamedConstantEvaluatesToTheConstant()
+        {
+            // Simplify gets this right -- it is 0 -- and Evaled does not, which is the shape of
+            // the defect: the bound name is only a constant once something reads its value.
+            Assert.Equal("limit(e, e, 0)".ToEntity().Simplify(), (Entity)0);
+            Assert.Equal(MathS.DecimalConst.e, "limit(e, e, 0)".ToEntity().Evaled.EvalNumerical().RealPart.EDecimal);
+        }
+
+    }
+}


### PR DESCRIPTION
Closes #976. **Replaces #979**, which I am closing unmerged — it patched the `MathS` entry points, and after your "(2) would probably be most mathematically close to how we denote in math" that is the wrong place. This is (2).

## What was wrong

`i` is the imaginary unit and the lexer decides it — `NUMBER: ... | 'i'` — so it never reaches the rule that makes variables and cannot be a bound name **anywhere** in the language. Every binder handed one did something other than bind:

| written | was | is |
|---|---|---|
| `sum(i, i, 1, 10)` | unevaluated | `55` |
| `sum(2i, i, 1, 3)` | `6i` | `12` |
| `integral(i, i)` | `-1/2 + C` | `i ^ 2 / 2 + C` |
| `limit(i, i, 0)` | unevaluated | `0` |
| `derivative(i ^ 2, i)` | `0` | `2 * i` |
| `{ i : i > 0 }` | `NaN` | `{ i : i > 0 }` |
| `lambda(i, i + 1)` | `InvalidArgumentParseException` | the lambda |

`integral(i, i)` is the one that shows it was never merely missing: `-1/2 + C` is the symbol read as the *variable* in one place and as the *constant* in another, in one answer.

## Where it is done

One type, `Core/Binding.cs`, holding the decision; the **nodes** ask it, not the ways in. `CalculusOperator` covers the five calculus operators and `ConditionalSet` the set builder, so the parser, `MathS.Sum` and `new Summationf(...)` all get the same reading and none of them has to remember to.

A lambda's parameter is typed `Variable`, so it is the one binder that cannot be handed the unit at all — no node can read what it cannot hold. That one is read in the grammar, and the parser is regenerated from the pinned `antlr-4.13.1-complete.jar`; the generated diff is exactly the nine lines of the changed action.

`2i` is one token, so a written coefficient on the bound name arrives as a single number with nothing in it to rename. Under a binder that names `i` it is the writer's `2` beside the writer's `i` — `2k` there is a product — and that is what turns `6i` into `12`.

## Your four questions

**`sum(sqrt(-1) * i, i, 1, 10)`** → **`55i`**. The sum's index, times the imaginary unit. That is what SymPy gives, and it works here because `sqrt(-1)` is `Powf(-1, 1/2)` at parse time and not a complex literal, so it is not a written `i` and is not renamed.

**How SymPy resolves it** — measured, 1.14: it names the constant `I`, so lowercase `i` is free, and it *refuses* to bind the constant (`Sum(I, (I, 1, 10))` is a `ValueError`, `Lambda(I, I + 1)` a `BadSignatureError`). It buys consistency by giving up the notation — nobody writes `∑_I`.

**`integral(i, i)`** → `i ^ 2 / 2 + C`, which is what `integral(k, k)` gives with the name changed. Under this reading there is nothing special left about it.

**Should `i` become a `Variable`?** I built it to find out: three lines and a regenerated lexer. It works, and it costs **53 tests** — 42 LaTeX juxtaposition, 5 SymPy export, the rest round-trips — all about how `i` is *written*. This PR costs **0**. It is a real option for a major version and its price is now measured rather than guessed; I did not want to spend it here.

## A correction, and a new issue

I told you on #979 that "`e` and `pi` need nothing — they already work, everywhere". **That was measured on too few paths and it is wrong.**

```
derivative(e ^ 2, e)    0          should be 2 * e
derivative(pi ^ 2, pi)  0          should be 2 * pi
{ e : e > 0 }           { e : True }
limit(e, e, 0).Evaled   2.71828…   .Simplify() gets it right, and gives 0
```

`Variable.ConstantList` is keyed by name, so a variable called `e` is `2.718…` wherever it is read — a bound `e` and the constant `e` are **the same object**, and nothing downstream can tell them apart. That is the opposite of `i`'s problem and it is why `i` was fixable at all: a `Variable` named `i` *is* distinct from `Complex.ImaginaryOne`. Filed with the measurements as #984; the tests here pin the four wrong answers so nobody re-derives them.

Two unrelated export defects turned up while checking that the new forms round-trip, both reproducing on `master` with ordinary names: #985.

## Measured

- Suite **7353 passed, 0 failed**, 14 skipped — 29 new tests.
- Corpus **116/119**, 0 wrong, 0 error, 0 timeout — unchanged.
- Public surface unchanged; `PublicApi.txt` needed no edit.
- Cost: one type test on the way into a binder node, which fails for the `Variable` nearly every bound name is. Node construction over three runs each — master `7.66 / 8.02 / 8.10 ns`, this branch `7.84 / 7.85 / 8.25 ns`. That is the same number.
- Round trips, LaTeX and SymPy export all check out, and LaTeX even distinguishes them: `\sum_{i=1}^{3}2 i` for the index against `\mathrm{i}` for the unit.
- `BREAKING-CHANGES.md` records all seven changed answers, including #981's, which was never recorded.
