### PR TITLE
Two more rule sets say which arm fired (#825)

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/RewriteRuleSet.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRuleSet.cs
@@ -89,8 +89,17 @@ namespace AngouriMath.Core.Transformations
         /// The rule that fires at this node, or <see langword="null"/> where none does.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// At this node only, leaving its children alone — which is what an arm of the
         /// <c>switch</c> sees. Always null for a set with no <see cref="Rules"/>.
+        /// </para>
+        /// <para>
+        /// <b>Firing means changing the node.</b> An arm can match and then decline: the factorial
+        /// arms match any quotient of factorials and hand back what they were given where the two
+        /// offsets are a hundred apart, since writing that product out is not a simplification.
+        /// Naming such an arm here would report a rewrite that did not happen, so a rule that
+        /// returns the node it was given is not the rule that fired.
+        /// </para>
         /// </remarks>
         public RewriteRule? RuleFiringAt(Entity node)
         {
@@ -99,7 +108,7 @@ namespace AngouriMath.Core.Transformations
             // The array, and by index: this is walked once per recorded rewrite and the sets are
             // long -- CommonRules alone has 103 arms.
             for (var i = 0; i < Rules.Count; i++)
-                if (Rules[i].TryApply(node) is not null)
+                if (Rules[i].TryApply(node) is { } rewritten && rewritten != node)
                     return Rules[i];
             return null;
         }

--- a/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
@@ -378,7 +378,8 @@ namespace AngouriMath.Core.Transformations
             "Cancels a quotient of factorials into the product of the terms that do not cancel.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Patterns.ExpandFactorialDivisions);
+            Patterns.ExpandFactorialDivisions,
+            Patterns.ExpandFactorialDivisionsArms);
 
         /// <summary>
         /// Recognises a product of consecutive terms as a factorial.
@@ -388,7 +389,8 @@ namespace AngouriMath.Core.Transformations
             "Gathers a product of a factorial and its neighbouring terms back into one factorial.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Patterns.FactorizeFactorialMultiplications);
+            Patterns.FactorizeFactorialMultiplications,
+            Patterns.FactorizeFactorialMultiplicationsArms);
 
         /// <summary>
         /// Rules about Euler's totient function.

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Factorial.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Factorial.cs
@@ -11,54 +11,65 @@ namespace AngouriMath.Functions
 {
     internal static partial class Patterns
     {
-        /// <summary>(x + a)! / (x + b)! -> (x+b+1)*(x+b+2)*...*(x+a)</summary>
-        internal static Entity ExpandFactorialDivisions(Entity expr)
+        /// <summary>
+        /// The terms that survive a quotient of factorials, or <paramref name="whole"/> where none
+        /// do — the two offsets are not a fixed distance apart, or they are far enough apart that
+        /// writing the product out is not a simplification.
+        /// </summary>
+        /// <remarks>
+        /// A static method rather than the local function it was, so that the <c>switch</c> below
+        /// is the whole of the method and its arms can be read as data. See
+        /// <see cref="Core.Transformations.RewriteRuleSet.Rules"/> and
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/825">#825</a>.
+        /// </remarks>
+        private static Entity CancelFactorials(Entity whole, Entity x, Entity x2, Number num, Number den)
         {
-            Entity ExpandFactorialDivisions(Entity x, Entity x2, Number num, Number den)
-            {
-                static Entity Add(Entity a, Number b) =>
-                    b is Integer(0) ? a : a + b;
-                if (x == x2
-                    && num - den is Integer { EInteger: var diff }
-                    && !diff.IsZero && diff.Abs() < 20) // We don't want to expand (x+100)!/x!
-                    if (diff > 0) // e.g. (x+3)!/x! = (x+1)(x+2)(x+3)
-                    {
-                        var expr = Add(x, den + 1);
-                        for (var i = 2; i <= diff; i++)
-                            expr *= Add(x, den + i);
-                        return expr;
-                    }
-                    else // e.g. x!/(x+3)! = 1/(x+1)/(x+2)/(x+3)
-                    {
-                        diff = -diff;
-                        var expr = 1 / Add(x, num + 1);
-                        for (var i = 2; i <= diff; i++)
-                            expr /= Add(x, num + i);
-                        return expr;
-                    }
-                return expr;
-            }
-            return expr switch
+            static Entity Add(Entity a, Number b) =>
+                b is Integer(0) ? a : a + b;
+            if (x == x2
+                && num - den is Integer { EInteger: var diff }
+                && !diff.IsZero && diff.Abs() < 20) // We don't want to expand (x+100)!/x!
+                if (diff > 0) // e.g. (x+3)!/x! = (x+1)(x+2)(x+3)
+                {
+                    var expr = Add(x, den + 1);
+                    for (var i = 2; i <= diff; i++)
+                        expr *= Add(x, den + i);
+                    return expr;
+                }
+                else // e.g. x!/(x+3)! = 1/(x+1)/(x+2)/(x+3)
+                {
+                    diff = -diff;
+                    var expr = 1 / Add(x, num + 1);
+                    for (var i = 2; i <= diff; i++)
+                        expr /= Add(x, num + i);
+                    return expr;
+                }
+            return whole;
+        }
+
+        /// <summary>(x + a)! / (x + b)! -> (x+b+1)*(x+b+2)*...*(x+a)</summary>
+        [AddressableRules]
+        internal static Entity ExpandFactorialDivisions(Entity expr)
+            => expr switch
             {
                 Divf(Factorialf(Sumf(var any1, Number const1)), Factorialf(Sumf(var any1a, Number const2)))
-                    => ExpandFactorialDivisions(any1, any1a, const1, const2),
+                    => CancelFactorials(expr, any1, any1a, const1, const2),
                 Divf(Factorialf(Sumf(var any1, Number const1)), Factorialf(Sumf(Number const2, var any1a)))
-                    => ExpandFactorialDivisions(any1, any1a, const1, const2),
+                    => CancelFactorials(expr, any1, any1a, const1, const2),
                 Divf(Factorialf(Sumf(Number const1, var any1)), Factorialf(Sumf(var any1a, Number const2)))
-                    => ExpandFactorialDivisions(any1, any1a, const1, const2),
+                    => CancelFactorials(expr, any1, any1a, const1, const2),
                 Divf(Factorialf(Sumf(Number const1, var any1)), Factorialf(Sumf(Number const2, var any1a)))
-                    => ExpandFactorialDivisions(any1, any1a, const1, const2),
+                    => CancelFactorials(expr, any1, any1a, const1, const2),
                 Divf(Factorialf(var any1), Factorialf(Sumf(var any1a, Number const2)))
-                    => ExpandFactorialDivisions(any1, any1a, 0, const2),
+                    => CancelFactorials(expr, any1, any1a, 0, const2),
                 Divf(Factorialf(var any1), Factorialf(Sumf(Number const2, var any1a)))
-                    => ExpandFactorialDivisions(any1, any1a, 0, const2),
+                    => CancelFactorials(expr, any1, any1a, 0, const2),
                 Divf(Factorialf(Sumf(var any1, Number const1)), Factorialf(var any1a))
-                    => ExpandFactorialDivisions(any1, any1a, const1, 0),
+                    => CancelFactorials(expr, any1, any1a, const1, 0),
                 Divf(Factorialf(Sumf(Number const1, var any1)), Factorialf(var any1a))
-                    => ExpandFactorialDivisions(any1, any1a, const1, 0),
+                    => CancelFactorials(expr, any1, any1a, const1, 0),
                 _ => expr
             };
-        }
 
         // https://en.wikipedia.org/wiki/Reflection_formula
         // (z-1)! (-z)! -> Γ(z) Γ(1 - z) = π/sin(π z), z ∉ ℤ // actually, when z ∈ ℤ, both sides include division by zero, so we can still replace
@@ -69,30 +80,35 @@ namespace AngouriMath.Functions
         // (z-1)! (z-1/2)! -> Γ(z) Γ(z + 1/2) = 2^(1 - 2 z) sqrt(π) Γ(2 z) -> 2^(1 - 2 z) sqrt(π) (2 z - 1)!
         // is also another possible simplification
         /// <summary>(x-1)! x -> x!, x! (x+1) -> (x+1)!, etc. <!--as well as z! (-z-1)! -> -π/sin(π z)--></summary>
+        [AddressableRules]
         internal static Entity FactorizeFactorialMultiplications(Entity expr)
-        {
-            Entity FactorizeFactorialMultiplications(Entity x, Entity x2, Number factConst, Number @const) =>
-                x == x2 && factConst + 1 == @const ? new Factorialf(x + @const) : expr;
-            return expr switch
+            => expr switch
             {
                 Mulf(Factorialf(Sumf(var any1, Number const1)), Sumf(var any1a, Number const2)) =>
-                    FactorizeFactorialMultiplications(any1, any1a, const1, const2),
+                    GatherFactorial(expr, any1, any1a, const1, const2),
                 Mulf(Factorialf(Sumf(Number const1, var any1)), Sumf(var any1a, Number const2)) =>
-                    FactorizeFactorialMultiplications(any1, any1a, const1, const2),
+                    GatherFactorial(expr, any1, any1a, const1, const2),
                 Mulf(Factorialf(Sumf(var any1, Number const1)), Sumf(Number const2, var any1a)) =>
-                    FactorizeFactorialMultiplications(any1, any1a, const1, const2),
+                    GatherFactorial(expr, any1, any1a, const1, const2),
                 Mulf(Factorialf(Sumf(Number const1, var any1)), Sumf(Number const2, var any1a)) =>
-                    FactorizeFactorialMultiplications(any1, any1a, const1, const2),
+                    GatherFactorial(expr, any1, any1a, const1, const2),
                 Mulf(Factorialf(var any1), Sumf(var any1a, Number const2)) =>
-                    FactorizeFactorialMultiplications(any1, any1a, 0, const2),
+                    GatherFactorial(expr, any1, any1a, 0, const2),
                 Mulf(Factorialf(var any1), Sumf(Number const2, var any1a)) =>
-                    FactorizeFactorialMultiplications(any1, any1a, 0, const2),
+                    GatherFactorial(expr, any1, any1a, 0, const2),
                 Mulf(Factorialf(Sumf(var any1, Number const1)), var any1a) =>
-                    FactorizeFactorialMultiplications(any1, any1a, const1, 0),
+                    GatherFactorial(expr, any1, any1a, const1, 0),
                 Mulf(Factorialf(Sumf(Number const1, var any1)), var any1a) =>
-                    FactorizeFactorialMultiplications(any1, any1a, const1, 0),
+                    GatherFactorial(expr, any1, any1a, const1, 0),
                 _ => expr
             };
-        }
+
+        /// <summary>
+        /// The factorial one term further on, where the term multiplying it is the next one — and
+        /// <paramref name="whole"/> where it is not. A static method for the same reason
+        /// <see cref="CancelFactorials"/> is one.
+        /// </summary>
+        private static Entity GatherFactorial(Entity whole, Entity x, Entity x2, Number factConst, Number @const) =>
+            x == x2 && factConst + 1 == @const ? new Factorialf(x + @const) : whole;
     }
 }

--- a/Sources/Tests/UnitTests/Core/Transformations/AddressableRulesTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/AddressableRulesTest.cs
@@ -267,10 +267,10 @@ namespace AngouriMath.Tests.Core.Transformations
         /// than a claim that it is "mostly" done.
         /// </summary>
         /// <remarks>
-        /// The sets that are not are the ones whose rewrites are not a <c>switch</c> over the
-        /// expression — a sort, a polynomial division, a method with branches and locals. Each is
-        /// named here so that making one addressable is a change to this list rather than a
-        /// silent improvement nobody records.
+        /// A set that is not addressable is one whose rewrites are not a <c>switch</c> over the
+        /// expression. Each is named here rather than counted, so that making one addressable is a
+        /// change to this list rather than a silent improvement nobody records — and so that a
+        /// claim about <i>why</i> a set is on it can be checked against the set.
         /// </remarks>
         [Fact]
         public void TheRegistryIsAddressableAsFarAsItSaysItIs()
@@ -279,19 +279,43 @@ namespace AngouriMath.Tests.Core.Transformations
             var without = RewriteRules.All.Where(set => set.Rules.Count == 0)
                 .Select(set => set.Name).OrderBy(name => name, StringComparer.Ordinal).ToList();
 
-            // All three are a method with a statement body, branches and locals, and no arms to
-            // read. That is the only reason left: every shape the generator can read is now read,
-            // and PerfectSquare -- held out of this list on cost rather than shape until #974 --
-            // has joined them.
-            Assert.Equal(new[]
-            {
-                "ExpandFactorialDivisions",
-                "FactorizeFactorialMultiplications",
-                "RationalizeDenominator",
-            }, without);
+            // One left, and it is the only reason left: a rewrite written as a procedure --
+            // branches, locals, a conjugate computed and oriented -- with no arms to read. The two
+            // factorial sets were on this list until it turned out they were not that shape at
+            // all: each was a switch that a statement body and a local function had put out of
+            // reach, and lifting the local function out was the whole of it.
+            Assert.Equal(new[] { "RationalizeDenominator" }, without);
 
-            Assert.Equal(27, withRules.Count);
-            Assert.Equal(389, withRules.Sum(set => set.Rules.Count));
+            Assert.Equal(29, withRules.Count);
+            Assert.Equal(405, withRules.Sum(set => set.Rules.Count));
+        }
+
+        /// <summary>
+        /// The two factorial sets, whose arms match a shape and then decide — and whose deciding
+        /// is what makes "which rule fired" a question with a wrong answer available.
+        /// </summary>
+        [Fact]
+        public void AnArmThatMatchesAndDeclinesIsNotTheRuleThatFired()
+        {
+            var set = RewriteRules.ExpandFactorialDivisions;
+            var declined = "(x + 100)! / x!".ToEntity();
+
+            // An arm matches -- the shape is a quotient of factorials over the same variable --
+            // and hands back what it was given, because a hundred terms written out is not a
+            // simplification. So the set as a whole changes nothing.
+            var matched = set.Rules.Where(rule => rule.TryApply(declined) is not null).ToList();
+            Assert.NotEmpty(matched);
+            Assert.All(matched, rule => Assert.Equal(declined, rule.TryApply(declined)));
+            Assert.Equal(declined, set.ApplyOnce(declined));
+            // So no rule fired here, and saying one did would be reporting a rewrite that did not
+            // happen.
+            Assert.Null(set.RuleFiringAt(declined));
+
+            // and the same set, on an input where an arm does fire, names it
+            var fires = "(x + 2)! / x!".ToEntity();
+            var rule = Assert.IsType<RewriteRule>(set.RuleFiringAt(fires));
+            Assert.Equal(set.ApplyOnce(fires), rule.TryApply(fires));
+            Assert.NotEqual(fires, set.ApplyOnce(fires));
         }
 
         [Fact]


### PR DESCRIPTION
Answers the follow-up I offered on #825 — and the answer is 29 of 30, not 30 of 30, for a reason worth stating.

## Two of the three were not the shape the list said they were

The test that pins the not-addressable list described all three as *"a method with a statement body, branches and locals"*. I wrote that from the sets I had opened. Two of the three are nothing of the kind:

```csharp
internal static Entity ExpandFactorialDivisions(Entity expr)
{
    Entity ExpandFactorialDivisions(Entity x, Entity x2, Number num, Number den) { ... }
    return expr switch { ...eight arms... };
}
```

A switch of eight arms, held out of reach by a statement body and a local function — the generator reads an expression-bodied method. Lifting the local function to a private static method is the whole change; the switch becomes what the method *is*, the attribute goes on, and the arms are read.

**27 of 30 sets, 389 rules → 29 of 30, 405.**

The sixteen new rules are the eight ways a quotient of factorials and the eight ways a product of them can be written with the constant on either side, each now named on its own:

```
ExpandFactorialDivisions[6]  Divf(Factorialf(Sumf(var any1, Number const1)), Factorialf(var any1a))
FactorizeFactorialMultiplications[4]  Mulf(Factorialf(var any1), Sumf(var any1a, Number const2))
```

## The third one is that shape, and I left it

`RationalizeDenominator` is a procedure: it computes `a * a - b * b`, requires it to be a nonzero rational, orients the conjugate so the denominator comes out positive, and cancels a rational numerator against the divisor. It *could* be forced into one `x is pattern && guard ? replacement : x` with a guard long enough to carry all of that — and the rule would be harder to read than it is now, to make a count round up. Left alone; the test that names the list now says why rather than asserting a shape.

## An attribution question these arms make answerable

An arm here matches a shape and then **decides**. `(x + 100)! / x!` matches — it is a quotient of factorials over one variable — and the arm hands back what it was given, because writing a hundred terms out is not a simplification.

`RuleFiringAt` reported that arm as the rule that fired, because it asked only whether the arm returned *anything*. Firing means changing the node, so it now asks that:

```csharp
if (Rules[i].TryApply(node) is { } rewritten && rewritten != node)
```

Without this, the first public consumer of the registry to ask "which rule did this?" over a factorial expression gets the name of a rewrite that did not happen. The recording path was never wrong — it only asks after the node has already changed — so this is the direct API being brought up to what the recording already assumed.

## Measured

- Suite **7325 passed, 0 failed**, 14 skipped.
- Corpus **116/119**, 0 wrong, 0 error, 0 timeout — unchanged.
- Public surface unchanged.
- Registry enumerated on a build rather than read off the diff: `29 of 30 sets addressable, 405 rules`, `no arms: RationalizeDenominator`.
