### PR TITLE
Do not differentiate over something that cannot vary (#964)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -36,7 +36,9 @@ read first.
 | **Silent** | `integral(i, i)` | `-1/2 + C` | `i ^ 2 / 2 + C` |
 | | `lambda(i, i + 1)` | `InvalidArgumentParseException` | the lambda |
 | **Silent** | `derivative(x ^ 3, 3)`, and any derivative or integral over a number | `ln(x) * x ^ 3` | the unevaluated `derivative(x ^ 3, 3)` |
-| **Silent** | `derivative(x ^ 2, sin(x))`, over a subexpression that does not occur | `0` | the unevaluated derivative |
+| **Silent** | `derivative(x ^ 2, x + 1)`, over a subexpression that does not occur | `0` | `2 * x`, by change of variables |
+| **Silent** | `derivative(x * (x + 1), x + 1)`, where the rename left a variable behind | `x` | `1 + 2 * x` |
+| **Silent** | `derivative(x ^ 2, x * y)`, over several variables at once | `0` | the unevaluated derivative |
 | **Silent** | `derivative(x ^ 2 + y ^ 2, [x, y])` | `0` | `[2 * x, 2 * y]`, the gradient |
 | **Silent** | `integral(x, [x, y]T)` | `[[C + x ^ 2, C + x * y]]` | `[[x ^ 2 / 2 + C, x * y + C]]` |
 | **Silent** | `derivative(e ^ 2, e)`, over a named constant | `0` | `2 * e` |
@@ -259,20 +261,43 @@ bound `e` still means `2.718…`, since the bound name and the constant are one 
 Differentiating with respect to a *subexpression* is a feature
 ([#230](https://github.com/asc-community/AngouriMath/issues/230)): the subexpression is given a
 name and the derivative is taken over the name, so `derivative((x + 1) ^ 2, x + 1)` is `2 * (x + 1)`.
-It has two premises — the subexpression has to be able to vary, and it has to occur — and neither
-was checked. Both are now.
+The rename has two premises that were not checked. The subexpression has to be able to **vary** —
+a number in that position was renamed and differentiated over, which answers a question with no
+meaning:
 
 ```csharp
-"derivative(x ^ 3, 3)".ToEntity().Simplify()      // was: ln(x) * x ^ 3   now: unevaluated
-"integral(x ^ 2, 2)".ToEntity().Simplify()        // was: x ^ 2 / ln(x) + C   now: unevaluated
-"derivative(x ^ 2, sin(x))".ToEntity().Simplify() // was: 0               now: unevaluated
-"derivative(x ^ 2, x + 1)".ToEntity().Simplify()  // was: 0               now: unevaluated
+"derivative(x ^ 3, 3)".ToEntity().Simplify()   // was: ln(x) * x ^ 3       now: unevaluated
+"integral(x ^ 2, 2)".ToEntity().Simplify()     // was: x ^ 2 / ln(x) + C   now: unevaluated
 ```
 
-A number renamed and differentiated over gives an answer to a question with no meaning; a
-subexpression that does not occur gives `0`, which asserts independence rather than reporting that
-there was nothing to rename. Both are now the unevaluated node, which is the library's way of
-saying it could not settle the question.
+And the rename has to be **exact**, which means nothing of the subexpression's own variables may be
+left behind. Where something is, the leftovers were read as independent of the name they came from:
+
+```csharp
+"derivative(x * (x + 1), x + 1)".ToEntity().Simplify()  // was: x   now: 1 + 2 * x
+```
+
+`x` is what you get by renaming `x + 1` to `z` and reading the other `x` as a constant. With
+`z = x + 1` the expression is `(z - 1) * z`, whose derivative is `2z - 1`, which is `2x + 1`.
+
+**Where the rename is not exact, this is a change of variables — and a change of variables needs no
+occurrence at all.** `d f / d g` is `(df/dx) / (dg/dx)`, which is the substitution without having to
+invert `g`:
+
+```csharp
+"derivative(x ^ 2, x + 1)".ToEntity().Simplify()   // was: 0   now: 2 * x
+"derivative(x ^ 2, 2 * x)".ToEntity().Simplify()   // was: 0   now: x
+"derivative(x ^ 2, sin(x))".ToEntity().Simplify()  // was: 0   now: 2 * x / cos(x)
+"integral(x ^ 2, x + 1)".ToEntity().Simplify()     // was: 0   now: x ^ 3 / 3 + C
+```
+
+What still has no answer is a subexpression of **several** variables that the rename cannot take
+exactly: `d(x + y)/d(x * y)` is `1/y` through `x` and `1/x` through `y`, so there is nothing to
+answer without a direction. Those are the unevaluated node — the library's way of saying it could
+not settle the question — rather than `0`.
+
+A definite integral over a subexpression is unchanged: its range is stated in the new variable, and
+converting it needs `g` inverted, which is a separate question.
 
 **A vector in that position is now the gradient.** The elementwise broadcast every binder already
 has was unreachable, because the rename matched first and answered `0`:

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -35,6 +35,11 @@ read first.
 | **Silent** | `limit(i, i, 0)` | unevaluated | `0` |
 | **Silent** | `integral(i, i)` | `-1/2 + C` | `i ^ 2 / 2 + C` |
 | | `lambda(i, i + 1)` | `InvalidArgumentParseException` | the lambda |
+| **Silent** | `derivative(x ^ 3, 3)`, and any derivative or integral over a number | `ln(x) * x ^ 3` | the unevaluated `derivative(x ^ 3, 3)` |
+| **Silent** | `derivative(x ^ 2, sin(x))`, over a subexpression that does not occur | `0` | the unevaluated derivative |
+| **Silent** | `derivative(x ^ 2 + y ^ 2, [x, y])` | `0` | `[2 * x, 2 * y]`, the gradient |
+| **Silent** | `integral(x, [x, y]T)` | `[[C + x ^ 2, C + x * y]]` | `[[x ^ 2 / 2 + C, x * y + C]]` |
+| **Silent** | `derivative(e ^ 2, e)`, over a named constant | `0` | `2 * e` |
 
 ### A rewritten node keeps its `Codomain`, so a domain constraint no longer disappears
 
@@ -249,6 +254,47 @@ bound `e` still means `2.718…`, since the bound name and the constant are one 
 [#984](https://github.com/asc-community/AngouriMath/issues/984) has the measurements.
 
 [#976](https://github.com/asc-community/AngouriMath/issues/976).
+### A derivative or an integral over something that is not a variable
+
+Differentiating with respect to a *subexpression* is a feature
+([#230](https://github.com/asc-community/AngouriMath/issues/230)): the subexpression is given a
+name and the derivative is taken over the name, so `derivative((x + 1) ^ 2, x + 1)` is `2 * (x + 1)`.
+It has two premises — the subexpression has to be able to vary, and it has to occur — and neither
+was checked. Both are now.
+
+```csharp
+"derivative(x ^ 3, 3)".ToEntity().Simplify()      // was: ln(x) * x ^ 3   now: unevaluated
+"integral(x ^ 2, 2)".ToEntity().Simplify()        // was: x ^ 2 / ln(x) + C   now: unevaluated
+"derivative(x ^ 2, sin(x))".ToEntity().Simplify() // was: 0               now: unevaluated
+"derivative(x ^ 2, x + 1)".ToEntity().Simplify()  // was: 0               now: unevaluated
+```
+
+A number renamed and differentiated over gives an answer to a question with no meaning; a
+subexpression that does not occur gives `0`, which asserts independence rather than reporting that
+there was nothing to rename. Both are now the unevaluated node, which is the library's way of
+saying it could not settle the question.
+
+**A vector in that position is now the gradient.** The elementwise broadcast every binder already
+has was unreachable, because the rename matched first and answered `0`:
+
+```csharp
+"derivative(x ^ 2 + y ^ 2, [x, y])".ToEntity().Simplify()   // was: 0   now: [2 * x, 2 * y]
+"integral(x, [x, y]T)".ToEntity().Simplify()
+// was: [[C + x ^ 2, C + x * y]]      the first component is not the integral of x
+// now: [[x ^ 2 / 2 + C, x * y + C]]
+```
+
+This is componentwise and no more than that: `derivative([x * y, x + y], [x, y])` pairs index with
+index and is `[y, 1]`, the diagonal of the Jacobian rather than the Jacobian. What shape a full
+Jacobian or Hessian should take is a convention this does not choose.
+
+**A named constant can be differentiated over.** `derivative(e ^ 2, e)` was `0` — `e` is a variable
+carrying a value, the value arrived in the variable position, and a number there took the rename
+path. It is `2 * e`, and `derivative(pi ^ 2, pi)` is `2 * pi`. Two of the four defects recorded in
+[#984](https://github.com/asc-community/AngouriMath/issues/984) go with it; the set builder and
+`limit(e, e, 0).Evaled` remain.
+
+[#964](https://github.com/asc-community/AngouriMath/issues/964).
 
 ---
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -44,6 +44,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [Tests/UnitTests/Core/CostModelTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[Tests/UnitTests/Calculus/BoundNameTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [Tests/UnitTests/Core/BinderShadowingTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 

--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
@@ -13,6 +13,36 @@ namespace AngouriMath
 {
     partial record Entity
     {
+        /// <summary>
+        /// The derivative of <paramref name="expr"/> with respect to <paramref name="over"/>,
+        /// taken <paramref name="times"/> times, by changing variables rather than by renaming.
+        /// </summary>
+        /// <remarks>
+        /// Differentiating with respect to something that is a function of one variable is
+        /// <c>(df/dx) / (dg/dx)</c> — the chain rule read backwards, which is the change of
+        /// variables <c>z = g(x)</c> without having to invert <c>g</c>. It needs no occurrence of
+        /// <paramref name="over"/> in <paramref name="expr"/>: <c>d(x ^ 2)/d(x + 1)</c> is
+        /// <c>2x</c>. <see langword="null"/> where the question has no answer this way — a
+        /// <paramref name="over"/> that does not vary in <c>x</c>, or a derivative the library
+        /// cannot take.
+        /// </remarks>
+        private static Entity? ChangeOfVariable(Entity expr, Entity over, int times)
+        {
+            var x = over.Vars[0];
+            var dOver = over.Differentiate(x).InnerSimplified;
+            if (dOver is Derivativef || dOver == 0)
+                return null;
+            var result = expr;
+            for (var taken = 0; taken < times; taken++)
+            {
+                var dResult = result.Differentiate(x);
+                if (dResult is Derivativef)
+                    return null;
+                result = (dResult / dOver).InnerSimplified;
+            }
+            return result;
+        }
+
         public partial record Derivativef
         {
             // The derivative operator is always defined symbolically, even though
@@ -30,25 +60,35 @@ namespace AngouriMath
                         (var expr, Variable var, int asInt) => null,
                         (Application, _, _) => null,
                         // Differentiating with respect to a subexpression rather than a variable
-                        // -- https://github.com/asc-community/AngouriMath/issues/230 -- works by
-                        // giving that subexpression a name and differentiating over the name. It
-                        // therefore has two premises, and both have to hold or the answer is a
-                        // confident number about a question nobody asked.
-                        //
-                        // The subexpression has to be something that can *vary*: with a number
-                        // there, `derivative(x ^ 3, 3)` renamed the exponent and answered
-                        // `ln(x) * x ^ 3`. And it has to actually occur, or the rename changes
-                        // nothing and the derivative of an expression that does not contain it
-                        // comes back 0 -- which is how `derivative(x ^ 2 + y ^ 2, [x, y])`, a
-                        // gradient, was 0. Declining here lets the matrix broadcast above reach
-                        // it instead, one component at a time.
+                        // -- https://github.com/asc-community/AngouriMath/issues/230. The
+                        // subexpression has to be something that can *vary*: with a number there,
+                        // `derivative(x ^ 3, 3)` renamed the exponent and answered
+                        // `ln(x) * x ^ 3`, which is the derivative of a question nobody asked.
                         // https://github.com/asc-community/AngouriMath/issues/964
+                        //
+                        // Where the whole expression can be written in terms of the subexpression,
+                        // naming it and differentiating over the name is exact: sin(x) ^ 3 is
+                        // z ^ 3, and d(z ^ 3)/dz is 3z ^ 2 wherever z is. That is this arm, and
+                        // the guard is that nothing of the subexpression's own variables is left
+                        // over -- without it, `derivative(x * (x + 1), x + 1)` renamed one factor,
+                        // read the other as independent of the name, and answered `x` where the
+                        // change of variables gives 2x + 1.
                         (var expr, Entity otherExpr, int asInt)
-                            when otherExpr.Vars.Count > 0 && expr.ContainsNode(otherExpr)
+                            when otherExpr.Vars.Count > 0
                             && Variable.CreateTemp(otherExpr.Vars) is var tempVar
                             && expr.Substitute(otherExpr, tempVar) is var tempSubstituted
+                            && !otherExpr.Vars.Any(tempSubstituted.ContainsNode)
                             && tempSubstituted.Differentiate(tempVar, asInt) is var res and not Derivativef
                             => res.Substitute(tempVar, otherExpr).InnerSimplified(isExact),
+                        // Otherwise it is a change of variables and not a rename, and the
+                        // subexpression does not need to occur at all: with z = x + 1, x ^ 2 is
+                        // (z - 1) ^ 2 and its derivative is 2(z - 1) = 2x. df/dg is
+                        // (df/dx) / (dg/dx), which is that without having to invert g.
+                        // https://github.com/asc-community/AngouriMath/pull/990
+                        (var expr, Entity otherExpr, int asInt)
+                            when otherExpr.Vars.Count is 1
+                            && ChangeOfVariable(expr, otherExpr, asInt) is { } res
+                            => res.InnerSimplified(isExact),
                         _ => null
                     },
                     (@this, a, b, _) => ((Derivativef)@this).New(a, b), isExact);
@@ -61,25 +101,55 @@ namespace AngouriMath
             private protected override Entity IntrinsicCondition => Boolean.True;
 
             private static Entity? ConditionallySimplified(Entity e, bool isExact) => e is Integralf ? null : e.InnerSimplified(isExact);
+
+            /// <summary>
+            /// The antiderivative of <paramref name="expr"/> with respect to
+            /// <paramref name="over"/>, by changing variables rather than by renaming.
+            /// </summary>
+            /// <remarks>
+            /// With <c>z = g(x)</c>, the integral of <c>f</c> over <c>z</c> is the integral of
+            /// <c>f (dg/dx)</c> over <c>x</c>, which needs no occurrence of
+            /// <paramref name="over"/> in <paramref name="expr"/> and no inverse of <c>g</c>.
+            /// <see langword="null"/> where there is no answer this way.
+            /// </remarks>
+            private static Entity? ChangeOfVariable(Entity expr, Entity over)
+            {
+                var x = over.Vars[0];
+                var dOver = over.Differentiate(x).InnerSimplified;
+                if (dOver is Derivativef || dOver == 0)
+                    return null;
+                return (expr * dOver).Integrate(x) is var res and not Integralf ? res : null;
+            }
             /// <inheritdoc/>
             protected override Entity InnerSimplify(bool isExact) =>
                 ExpandOnTwoAndTArguments(Expression, Var, Range,
                     (a, b, c) => (a, b, c) switch
                     {
                         (var expr, Variable var, var (from, to)) => ConditionallySimplified(expr.Integrate(var, from, to), isExact),
-                        // Both premises of the rename, as in Derivativef above.
+                        // The rename, under the same guard as in Derivativef above: exact only
+                        // where nothing of the subexpression's own variables is left over.
                         // https://github.com/asc-community/AngouriMath/issues/964
                         (var expr, var otherExpr, var (from, to))
-                            when otherExpr.Vars.Count > 0 && expr.ContainsNode(otherExpr)
+                            when otherExpr.Vars.Count > 0
                             && Variable.CreateTemp(otherExpr.Vars) is var tempVar
                             && expr.Substitute(otherExpr, tempVar) is var tempSubstituted
+                            && !otherExpr.Vars.Any(tempSubstituted.ContainsNode)
                             && tempSubstituted.Integrate(tempVar, from, to) is var res => ConditionallySimplified(res.Substitute(tempVar, otherExpr), isExact),
                         (var expr, Variable var, null) => ConditionallySimplified(expr.Integrate(var), isExact),
                         (var expr, var otherExpr, null)
-                            when otherExpr.Vars.Count > 0 && expr.ContainsNode(otherExpr)
+                            when otherExpr.Vars.Count > 0
                             && Variable.CreateTemp(otherExpr.Vars) is var tempVar
                             && expr.Substitute(otherExpr, tempVar) is var tempSubstituted
+                            && !otherExpr.Vars.Any(tempSubstituted.ContainsNode)
                             && tempSubstituted.Integrate(tempVar) is var res => ConditionallySimplified(res.Substitute(tempVar, otherExpr), isExact),
+                        // Otherwise a change of variables, as the derivative does: with z = g(x),
+                        // the integral over z is the integral of f (dg/dx) over x. Indefinite
+                        // only -- a range is stated in z, and converting it needs g inverted,
+                        // which is a separate question.
+                        // https://github.com/asc-community/AngouriMath/pull/990
+                        (var expr, var otherExpr, null)
+                            when otherExpr.Vars.Count is 1
+                            && ChangeOfVariable(expr, otherExpr) is { } res => ConditionallySimplified(res, isExact),
                         _ => null
                     },
                     (@this, a, b, c) => ((Integralf)@this).New(a, b, c), isExact);

--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
@@ -29,8 +29,23 @@ namespace AngouriMath
                             => res.InnerSimplified(isExact),
                         (var expr, Variable var, int asInt) => null,
                         (Application, _, _) => null,
+                        // Differentiating with respect to a subexpression rather than a variable
+                        // -- https://github.com/asc-community/AngouriMath/issues/230 -- works by
+                        // giving that subexpression a name and differentiating over the name. It
+                        // therefore has two premises, and both have to hold or the answer is a
+                        // confident number about a question nobody asked.
+                        //
+                        // The subexpression has to be something that can *vary*: with a number
+                        // there, `derivative(x ^ 3, 3)` renamed the exponent and answered
+                        // `ln(x) * x ^ 3`. And it has to actually occur, or the rename changes
+                        // nothing and the derivative of an expression that does not contain it
+                        // comes back 0 -- which is how `derivative(x ^ 2 + y ^ 2, [x, y])`, a
+                        // gradient, was 0. Declining here lets the matrix broadcast above reach
+                        // it instead, one component at a time.
+                        // https://github.com/asc-community/AngouriMath/issues/964
                         (var expr, Entity otherExpr, int asInt)
-                            when Variable.CreateTemp(otherExpr.Vars) is var tempVar
+                            when otherExpr.Vars.Count > 0 && expr.ContainsNode(otherExpr)
+                            && Variable.CreateTemp(otherExpr.Vars) is var tempVar
                             && expr.Substitute(otherExpr, tempVar) is var tempSubstituted
                             && tempSubstituted.Differentiate(tempVar, asInt) is var res and not Derivativef
                             => res.Substitute(tempVar, otherExpr).InnerSimplified(isExact),
@@ -52,13 +67,17 @@ namespace AngouriMath
                     (a, b, c) => (a, b, c) switch
                     {
                         (var expr, Variable var, var (from, to)) => ConditionallySimplified(expr.Integrate(var, from, to), isExact),
+                        // Both premises of the rename, as in Derivativef above.
+                        // https://github.com/asc-community/AngouriMath/issues/964
                         (var expr, var otherExpr, var (from, to))
-                            when Variable.CreateTemp(otherExpr.Vars) is var tempVar
+                            when otherExpr.Vars.Count > 0 && expr.ContainsNode(otherExpr)
+                            && Variable.CreateTemp(otherExpr.Vars) is var tempVar
                             && expr.Substitute(otherExpr, tempVar) is var tempSubstituted
                             && tempSubstituted.Integrate(tempVar, from, to) is var res => ConditionallySimplified(res.Substitute(tempVar, otherExpr), isExact),
                         (var expr, Variable var, null) => ConditionallySimplified(expr.Integrate(var), isExact),
                         (var expr, var otherExpr, null)
-                            when Variable.CreateTemp(otherExpr.Vars) is var tempVar
+                            when otherExpr.Vars.Count > 0 && expr.ContainsNode(otherExpr)
+                            && Variable.CreateTemp(otherExpr.Vars) is var tempVar
                             && expr.Substitute(otherExpr, tempVar) is var tempSubstituted
                             && tempSubstituted.Integrate(tempVar) is var res => ConditionallySimplified(res.Substitute(tempVar, otherExpr), isExact),
                         _ => null

--- a/Sources/Tests/UnitTests/Calculus/BoundNameTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/BoundNameTest.cs
@@ -17,10 +17,13 @@ namespace AngouriMath.Tests.Calculus
     /// </summary>
     /// <remarks>
     /// Differentiating with respect to a <i>subexpression</i> is a real feature
-    /// (<a href="https://github.com/asc-community/AngouriMath/issues/230">#230</a>): the
-    /// subexpression is given a name and the derivative is taken over the name. It has two
-    /// premises — the subexpression must be able to vary, and it must occur — and neither was
-    /// checked, so the answers below were produced for questions that have none.
+    /// (<a href="https://github.com/asc-community/AngouriMath/issues/230">#230</a>). It was done
+    /// by giving the subexpression a name and differentiating over the name, which has two
+    /// premises that were not checked: the subexpression must be able to <i>vary</i>, and the
+    /// rename must be <i>exact</i> — nothing of the subexpression's own variables may be left
+    /// over, or the leftovers are read as independent of the name they came from.
+    /// Where the rename is not exact this is a change of variables, and a change of variables
+    /// needs no occurrence at all.
     /// </remarks>
     [Trait("Area", "Calculus")]
     public sealed class BoundNameTest
@@ -41,15 +44,48 @@ namespace AngouriMath.Tests.Calculus
             AssertDeclined(expression);
 
         /// <summary>
-        /// A subexpression that does not occur cannot be renamed, so there is nothing to
-        /// differentiate over — and answering <c>0</c> asserts that the expression does not
-        /// depend on it, which is a different and unchecked claim.
+        /// A subexpression that does not occur is a <b>change of variables</b> and not a rename,
+        /// and it has an answer. With <c>z = x + 1</c>, <c>x ^ 2</c> is <c>(z - 1) ^ 2</c>, whose
+        /// derivative is <c>2(z - 1) = 2x</c> — which is <c>(df/dx) / (dg/dx)</c> without having
+        /// to invert <c>g</c>. Answering <c>0</c> asserted independence; declining said there was
+        /// no answer; there is one.
+        /// </summary>
+        /// <remarks>
+        /// Named by @Happypig375 in review on
+        /// <a href="https://github.com/asc-community/AngouriMath/pull/990">#990</a>.
+        /// </remarks>
+        [Theory]
+        [InlineData("derivative(x ^ 2, x + 1)", "2 * x")]
+        [InlineData("derivative(x ^ 2, x + 1, 2)", "2")]
+        [InlineData("derivative(x ^ 2, 2 * x)", "x")]
+        [InlineData("derivative(x ^ 2, sin(x))", "2 * x / cos(x)")]
+        [InlineData("integral(x ^ 2, x + 1)", "x ^ 3 / 3 + C")]
+        public void ASubexpressionThatDoesNotOccurIsAChangeOfVariables(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity().Simplify(), expression.ToEntity().Simplify());
+
+        /// <summary>
+        /// And a rename that leaves the subexpression's own variables behind is not exact, so it
+        /// is a change of variables too. <c>derivative(x * (x + 1), x + 1)</c> renamed one factor
+        /// and read the other as independent of the name, answering <c>x</c>; with
+        /// <c>z = x + 1</c> the expression is <c>(z - 1) z</c>, whose derivative is
+        /// <c>2z - 1 = 2x + 1</c>.
         /// </summary>
         [Theory]
-        [InlineData("derivative(x ^ 2, sin(x))")]
-        [InlineData("derivative(x ^ 2, x + 1)")]
-        [InlineData("integral(x ^ 2, sin(x))")]
-        public void ASubexpressionThatDoesNotOccurIsDeclined(string expression) =>
+        [InlineData("derivative(x * (x + 1), x + 1)", "1 + 2 * x")]
+        [InlineData("integral(x * (x + 1), x + 1)", "x ^ 3 / 3 + x ^ 2 / 2 + C")]
+        public void ARenameThatLeavesTheVariableBehindIsNotExact(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity().Simplify(), expression.ToEntity().Simplify());
+
+        /// <summary>
+        /// What still has no answer: a subexpression of more than one variable that the rename
+        /// cannot take exactly. <c>d(x + y)/d(x * y)</c> is <c>1/y</c> through <c>x</c> and
+        /// <c>1/x</c> through <c>y</c>, so there is nothing to answer without a direction.
+        /// </summary>
+        [Theory]
+        [InlineData("derivative(x ^ 2, x * y)")]
+        [InlineData("derivative(x + y, x * y)")]
+        [InlineData("integral(x ^ 2, x * y)")]
+        public void ASubexpressionOfSeveralVariablesIsStillDeclined(string expression) =>
             AssertDeclined(expression);
 
         /// <summary>
@@ -70,6 +106,9 @@ namespace AngouriMath.Tests.Calculus
         [Theory]
         [InlineData("derivative((x + 1) ^ 2, x + 1)", "2 * (1 + x)")]
         [InlineData("derivative(sin(x) ^ 2, sin(x))", "2 * sin(x)")]
+        [InlineData("derivative(sin(x) ^ 3, sin(x))", "3 * sin(x) ^ 2")]
+        [InlineData("derivative((x * y) ^ 2, x * y)", "2 * x * y")]
+        [InlineData("integral((x + 1) ^ 2, x + 1)", "(x + 1) ^ 3 / 3 + C")]
         public void DifferentiatingOverASubexpressionThatOccursStillWorks(string expression, string expected) =>
             Assert.Equal(expected.ToEntity().Simplify(), expression.ToEntity().Simplify());
 

--- a/Sources/Tests/UnitTests/Calculus/BoundNameTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/BoundNameTest.cs
@@ -1,0 +1,127 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// What a derivative or an integral does when the thing it is taken over is not a variable.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/964">#964</a>
+    /// </summary>
+    /// <remarks>
+    /// Differentiating with respect to a <i>subexpression</i> is a real feature
+    /// (<a href="https://github.com/asc-community/AngouriMath/issues/230">#230</a>): the
+    /// subexpression is given a name and the derivative is taken over the name. It has two
+    /// premises — the subexpression must be able to vary, and it must occur — and neither was
+    /// checked, so the answers below were produced for questions that have none.
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class BoundNameTest
+    {
+        /// <summary>
+        /// A number cannot be differentiated or integrated over. <c>derivative(x ^ 3, 3)</c>
+        /// renamed the exponent and answered <c>ln(x) * x ^ 3</c>, which is the derivative of a
+        /// question nobody asked.
+        /// </summary>
+        [Theory]
+        [InlineData("derivative(x ^ 3, 3)")]
+        [InlineData("derivative(x ^ 2, 2)")]
+        [InlineData("integral(x ^ 2, 2)")]
+        [InlineData("derivative(x ^ 2, 0)")]
+        public void ANumberIsNotSomethingToDifferentiateOver(string expression) =>
+            // The node, not the printed form: a declined derivative is still normalised, so
+            // `x + 1` comes back as `1 + x` and comparing strings would fail on the tidying.
+            AssertDeclined(expression);
+
+        /// <summary>
+        /// A subexpression that does not occur cannot be renamed, so there is nothing to
+        /// differentiate over — and answering <c>0</c> asserts that the expression does not
+        /// depend on it, which is a different and unchecked claim.
+        /// </summary>
+        [Theory]
+        [InlineData("derivative(x ^ 2, sin(x))")]
+        [InlineData("derivative(x ^ 2, x + 1)")]
+        [InlineData("integral(x ^ 2, sin(x))")]
+        public void ASubexpressionThatDoesNotOccurIsDeclined(string expression) =>
+            AssertDeclined(expression);
+
+        /// <summary>
+        /// Declined means the node survives simplification — "I could not settle this" — rather
+        /// than becoming a number.
+        /// </summary>
+        private static void AssertDeclined(string expression)
+        {
+            var simplified = expression.ToEntity().Simplify();
+            Assert.True(simplified is Entity.Derivativef or Entity.Integralf,
+                $"{expression} answered {simplified.Stringize()} instead of declining");
+        }
+
+        /// <summary>
+        /// The feature the two checks above are protecting, which still works.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/230">#230</a>
+        /// </summary>
+        [Theory]
+        [InlineData("derivative((x + 1) ^ 2, x + 1)", "2 * (1 + x)")]
+        [InlineData("derivative(sin(x) ^ 2, sin(x))", "2 * sin(x)")]
+        public void DifferentiatingOverASubexpressionThatOccursStillWorks(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity().Simplify(), expression.ToEntity().Simplify());
+
+        /// <summary>
+        /// A vector in the variable position is the gradient, and it comes from the elementwise
+        /// broadcast that every binder already had — it was unreachable because the rename
+        /// matched first and answered <c>0</c>.
+        /// </summary>
+        [Theory]
+        [InlineData("derivative(x ^ 2 + y ^ 2, [x, y])", "[2 * x, 2 * y]")]
+        [InlineData("derivative(x + y, [x, y])", "[1, 1]")]
+        [InlineData("derivative(x ^ 2, [x, y, z])", "[2 * x, 0, 0]")]
+        [InlineData("derivative(x ^ 2 + y ^ 2, [x, y]T)", "[[2 * x, 2 * y]]")]
+        public void AVectorInTheVariablePositionIsTheGradient(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity(), expression.ToEntity().Simplify());
+
+        /// <summary>
+        /// The same for an integral: one antiderivative per component, each of them correct.
+        /// <c>integral(x, [x, y]T)</c> was <c>[[C + x ^ 2, C + x * y]]</c> — the first component
+        /// is not the integral of <c>x</c>.
+        /// </summary>
+        [Theory]
+        [InlineData("integral(x, [x, y])", "[x ^ 2 / 2 + C, x * y + C]")]
+        [InlineData("integral(x ^ 2 + y ^ 2, [x, y])", "[x ^ 3 / 3 + y ^ 2 * x + C, y ^ 3 / 3 + x ^ 2 * y + C]")]
+        public void AVectorInTheVariablePositionIntegratesComponentwise(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity().Simplify(), expression.ToEntity().Simplify());
+
+        /// <summary>
+        /// What the componentwise reading is <b>not</b>, stated so that it is not mistaken for
+        /// more than it is: a vector differentiated over a vector pairs component with component,
+        /// which is the diagonal of the Jacobian and not the Jacobian. The shape a full Jacobian
+        /// or Hessian should take is a convention this does not choose.
+        /// </summary>
+        [Fact]
+        public void ComponentwiseIsNotAJacobian()
+        {
+            // [x * y, x + y] over [x, y] pairs index with index: d(xy)/dx and d(x+y)/dy.
+            Assert.Equal("[y, 1]".ToEntity(), "derivative([x * y, x + y], [x, y])".ToEntity().Simplify());
+            // and the second derivative is the diagonal of the Hessian, not the Hessian
+            Assert.Equal("[2 * y ^ 3, 6 * x ^ 2 * y]".ToEntity(),
+                "derivative(derivative(x ^ 2 * y ^ 3, [x, y]), [x, y])".ToEntity().Simplify());
+        }
+
+        /// <summary>Ordinary differentiation is untouched, which is most of what this could break.</summary>
+        [Theory]
+        [InlineData("derivative(x ^ 2, x)", "2 * x")]
+        [InlineData("derivative(x * y, x)", "y")]
+        [InlineData("derivative(y, x)", "0")]
+        [InlineData("derivative([x, x ^ 2], x)", "[1, 2 * x]")]
+        [InlineData("integral(x ^ 2, x)", "x ^ 3 / 3 + C")]
+        [InlineData("derivative(apply(f, x), y)", "0")]
+        public void OrdinaryDifferentiationIsUnaffected(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity().Simplify(), expression.ToEntity().Simplify());
+    }
+}

--- a/Sources/Tests/UnitTests/Core/BinderShadowingTest.cs
+++ b/Sources/Tests/UnitTests/Core/BinderShadowingTest.cs
@@ -142,18 +142,28 @@ namespace AngouriMath.Tests.Core
         /// <remarks>
         /// A bound <c>e</c> keeps the constant's value, because the bound name and the constant
         /// are the same object: <c>Variable.ConstantList</c> is keyed by name, so a variable
-        /// called <c>e</c> is <c>2.718…</c> wherever it is read, binder or no binder. Nothing
-        /// short of a representation that tells a bound name from a constant one fixes these,
+        /// called <c>e</c> is <c>2.718…</c> wherever something reads its value. Nothing
+        /// short of a representation that tells a bound name from a constant one fixes it,
         /// which is why this change is about the one constant that is not a variable — for
         /// <c>i</c> the bound name and the unit are distinguishable, and that is the whole reason
         /// the fix above is possible at all.
         /// <a href="https://github.com/asc-community/AngouriMath/issues/984">#984</a>
         /// </remarks>
         [Theory]
-        [InlineData("derivative(e ^ 2, e)", "0")]              // 2 * e
-        [InlineData("derivative(pi ^ 2, pi)", "0")]            // 2 * pi
         [InlineData("{ e : e > 0 }", "{ e : True }")]          // { e : e > 0 }
         public void ABoundNamedConstantStillCarriesItsValue(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity(), expression.ToEntity().Simplify());
+
+        /// <summary>
+        /// Differentiating over a bound named constant works, and it is worth its own test
+        /// because it did not: it answered <c>0</c> until the bound name stopped being read as
+        /// the number the constant evaluates to.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/964">#964</a>
+        /// </summary>
+        [Theory]
+        [InlineData("derivative(e ^ 2, e)", "2 * e")]
+        [InlineData("derivative(pi ^ 2, pi)", "2 * pi")]
+        public void ABoundNamedConstantCanBeDifferentiatedOver(string expression, string expected) =>
             Assert.Equal(expected.ToEntity(), expression.ToEntity().Simplify());
 
         /// <summary>The same, on the path that shows it most plainly.</summary>


### PR DESCRIPTION
Part of #964, and it answers half of what @Happypig375 asked there — *"we may need derivative representation on higher dimensions over vectors and matrixes"*. Most of that representation was already present and unreachable.

## What was wrong

Differentiating with respect to a **subexpression** is a feature (#230): the subexpression is given a name and the derivative is taken over the name, so `derivative((x + 1) ^ 2, x + 1)` is `2 * (x + 1)`. It has two premises — the subexpression must be able to *vary*, and it must *occur*. Neither was checked.

| | was | is |
|---|---|---|
| `derivative(x ^ 3, 3)` | `ln(x) * x ^ 3` | unevaluated |
| `integral(x ^ 2, 2)` | `x ^ 2 / ln(x) + C` | unevaluated |
| `derivative(x ^ 2, sin(x))` | `0` | unevaluated |
| `derivative(x ^ 2, x + 1)` | `0` | unevaluated |

The first two rename **a number**: the `3` in `x ^ 3` became the variable of differentiation and the exponential rule fired. The other two rename something **absent** — the rename changes nothing, and the derivative of an expression not containing the name is `0`, which asserts independence instead of reporting that there was nothing to rename.

Both premises are now conditions on the arm, and where they fail the node stays unevaluated — *"I could not settle this"* rather than an answer to a question with no meaning.

## The gradient falls out, with no new code

The elementwise broadcast every binder already has was unreachable, because the rename matched first:

| | was | is |
|---|---|---|
| `derivative(x ^ 2 + y ^ 2, [x, y])` | `0` | `[2 * x, 2 * y]` |
| `derivative(x ^ 2, [x, y, z])` | `0` | `[2 * x, 0, 0]` |
| `integral(x, [x, y]T)` | `[[C + x ^ 2, C + x * y]]` | `[[x ^ 2 / 2 + C, x * y + C]]` |

The integral's first component was not the integral of `x` — it was `x` times the integrand, because it integrated over a name that did not occur.

**Componentwise and no more, and the test says so** rather than leaving it to be discovered: `derivative([x * y, x + y], [x, y])` pairs index with index and gives `[y, 1]`, the *diagonal* of the Jacobian; a repeated vector derivative gives the diagonal of the Hessian. What shape a full Jacobian or Hessian should take is a convention I have not chosen here — that is the part of your question this does not answer, and it is worth settling deliberately.

## A named constant can be differentiated over

`derivative(e ^ 2, e)` was `0` and is `2 * e`; `derivative(pi ^ 2, pi)` is `2 * pi`. `e` is a variable carrying a value, the value arrived in the variable position, and a number there took the rename path. Two of the four defects I recorded in #984 go with it — the set builder and `limit(e, e, 0).Evaled` remain, and the tests that pinned all four now pin the two that are left.

## What this does not do

It is not #241 and not an ODE solver. It does not add a total-derivative representation — I have a separate measurement about that for #964's thread, since the answer turned out to be that the library already has one and my original report misread it.

## Measured

- Suite **7385 passed, 0 failed**, 14 skipped — 22 new tests.
- Corpus **116/119**, 0 wrong, 0 error, 0 timeout — unchanged.
- Public surface unchanged.
- `BREAKING-CHANGES.md` records all five changed answers.

One flake to mention because I hit it three times today and it is not this change: `OneSidedLimitTest.ADifferenceOfReciprocalLogarithms` gives itself a 60-second wall clock for work that takes ~8s, and it fails when the machine is loaded. Measured the same way on both sides — master `8016 / 7345 ms`, this branch `8127 / 7814 ms` — so the budget, not the branch. Happy to raise it separately.
