### PR TITLE
A name a binder declares is a variable, including pi and e (#984)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -35,6 +35,15 @@ read first.
 | **Silent** | `limit(i, i, 0)` | unevaluated | `0` |
 | **Silent** | `integral(i, i)` | `-1/2 + C` | `i ^ 2 / 2 + C` |
 | | `lambda(i, i + 1)` | `InvalidArgumentParseException` | the lambda |
+| **Silent** | `derivative(e ^ 2, e)`, `derivative(pi ^ 2, pi)` | `0` | `2 * e`, `2 * pi` |
+| **Silent** | `{ e : e > 0 }` | `{ e : True }` | the set it describes |
+| **Silent** | `limit(e, e, 0).Evaled` | `2.718…` | `0` |
+| **Silent** | `integral(e, e, 0, 1).Evaled` | `3.694…` | `1/2` |
+| **Silent** | `integral(arccos(0), pi, 0, 1)` | `1/4` | `pi / 2` |
+| **Silent** | `sum(ln(x), e, 1, 2)`, and any binder over `e` around a logarithm | `log(1, x) + log(2, x)` | `2 * ln(x)` |
+| **Silent** | `ln(x).Substitute("e", 3)` | `log(3, x)` | `ln(x)` |
+| **Silent** | `"sum(pi, pi, 1, 3)".ToEntity().Vars` | empty — the index was read as a constant | `pi` |
+| | `MathS.pi.GetType()` | `Entity.Variable` | `Entity.Constant`, which derives from it |
 
 ### A rewritten node keeps its `Codomain`, so a domain constraint no longer disappears
 
@@ -243,12 +252,75 @@ any other name, which is what turns `6i` into `12` above.
 The last is what SymPy answers for `Sum(sqrt(-1) * i, (i, 1, 10))`, which resolves the same
 collision by naming the constant `I` and refusing to bind it.
 
-`e` and `pi` are unaffected and needed nothing here: they are variables that carry a value, so a
-binder has always taken those names. They are also not fully fixed by anything in this entry — a
-bound `e` still means `2.718…`, since the bound name and the constant are one object.
-[#984](https://github.com/asc-community/AngouriMath/issues/984) has the measurements.
+`e` and `pi` needed nothing here, being variables that carried a value — and were not fixed by it
+either, for the same reason. The entry below does that.
 
 [#976](https://github.com/asc-community/AngouriMath/issues/976).
+
+### A name a binder declares is a variable, including `pi` and `e`
+
+A mathematical constant used to be a `Variable` whose *name* was looked up in a table, so a `pi` a
+binder declared and the constant `pi` were one object and nothing downstream could tell them apart.
+It is now `Entity.Constant`, a node — so a binder holds a variable while the rest of the language
+holds the constant, and every binder-based operation reads the same thing.
+
+```csharp
+"derivative(e ^ 2, e)".ToEntity().Simplify()   // was: 0             now: 2 * e
+"derivative(pi ^ 2, pi)".ToEntity().Simplify() // was: 0             now: 2 * pi
+"{ e : e > 0 }".ToEntity().Simplify()          // was: { e : True }  now: { e : e > 0 }
+"limit(e, e, 0)".ToEntity().Evaled             // was: 2.718…        now: 0
+"integral(e, e, 0, 1)".ToEntity().Evaled       // was: 3.694…        now: 1/2
+```
+
+A constant that simplification **produces** inside a binder over its name is no longer caught by it,
+which was a wrong answer of a different kind — `arccos(0)` is `pi / 2`, and integrating it over a
+name spelled `pi` integrated that:
+
+```csharp
+"integral(arccos(0), pi, 0, 1)".ToEntity().Simplify()  // was: 1/4   now: pi / 2
+"integral(arccos(0), q, 0, 1)".ToEntity().Simplify()   // pi / 2, unchanged — the same answer now
+```
+
+`ln` and `exp` are written over Euler's number in their own definitions — `Ln(a)` is `Logf(e, a)`,
+and `exp(x)` is `e ^ x` — and that occurrence is the value rather than a mention of the name, so no
+binder reaches it and neither does a substitution for the name:
+
+```csharp
+"sum(ln(x), e, 1, 2)".ToEntity().Simplify()   // was: log(1, x) + log(2, x)   now: 2 * ln(x)
+"sum(exp(x), e, 1, 2)".ToEntity().Simplify()  // was: 1 + 2 ^ x               now: 2 * e ^ x
+"sum(ln(e), e, 1, 1)".ToEntity().Simplify()   // was: NaN, being log(1, 1)    now: 0
+MathS.Ln("x").Substitute("e", 3)              // was: log(3, x)               now: ln(x)
+```
+
+Where the writer does name `e`, it still binds, which is the same rule read the other way:
+
+```csharp
+"sum(log(e, x), e, 1, 2)".ToEntity().Simplify()  // log(1, x) + log(2, x)
+"sum(e ^ x, e, 1, 2)".ToEntity().Simplify()      // 1 + 2 ^ x
+```
+
+**Two consequences to read for.** A bound name now counts as a variable, so `Vars` reports it:
+
+```csharp
+"sum(pi, pi, 1, 3)".ToEntity().Vars   // was: empty      now: pi
+"pi * x".ToEntity().Vars              // x, unchanged — a free constant is still not a variable
+```
+
+And `MathS.pi` and `MathS.e` are `Entity.Constant` rather than `Entity.Variable`. They are still
+*typed* `Variable` and `Constant` derives from it, so no signature changed and nothing that compiles
+today stops compiling; but `MathS.Var("pi")` is a constant, and a `pi` a binder declares is no
+longer equal to it. Substituting for the constant is unchanged where it was already right — a
+binder's own name was out of reach before as well — and no longer reaches into a logarithm:
+
+```csharp
+"pi + x".ToEntity().Substitute(MathS.pi, 3)             // 3 + x, unchanged
+"sum(pi, pi, 1, 3)".ToEntity().Substitute(MathS.pi, 3)  // unchanged before and after
+```
+
+Free `pi` and `e` are otherwise untouched: `sin(pi)` is `0`, `ln(e)` is `1`, `arccos(0)` is `pi / 2`,
+and their numeric values are what they were.
+
+[#984](https://github.com/asc-community/AngouriMath/issues/984).
 
 ---
 

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -30,16 +30,17 @@ read first.
 | **Silent** | `"7/2".ToEntity()` and any quotient of two integer literals | a `Divf` | the `Rational` it denotes |
 | **Silent** | `sum(i, i, 1, 10)`, and every binder given `i` as the name it binds | the imaginary unit in the name position, so nothing was bound | `i` is the bound name, and `55` |
 | **Silent** | `sum(2i, i, 1, 3)` | `6i` | `12` |
-| **Silent** | `derivative(i ^ 2, i)` | `0` | `2 * i` |
+| **Silent** | `derivative(i ^ 2, i)` | `0` | `2 * i_1` |
 | **Silent** | `{ i : i > 0 }` | `NaN` | the set it describes |
 | **Silent** | `limit(i, i, 0)` | unevaluated | `0` |
-| **Silent** | `integral(i, i)` | `-1/2 + C` | `i ^ 2 / 2 + C` |
+| **Silent** | `integral(i, i)` | `-1/2 + C` | `i_1 ^ 2 / 2 + C` |
 | | `lambda(i, i + 1)` | `InvalidArgumentParseException` | the lambda |
-| **Silent** | `derivative(e ^ 2, e)`, `derivative(pi ^ 2, pi)` | `0` | `2 * e`, `2 * pi` |
+| **Silent** | `derivative(e ^ 2, e)`, `derivative(pi ^ 2, pi)` | `0` | `2 * e_1`, `2 * pi_1` |
 | **Silent** | `{ e : e > 0 }` | `{ e : True }` | the set it describes |
 | **Silent** | `limit(e, e, 0).Evaled` | `2.718…` | `0` |
 | **Silent** | `integral(e, e, 0, 1).Evaled` | `3.694…` | `1/2` |
 | **Silent** | `integral(arccos(0), pi, 0, 1)` | `1/4` | `pi / 2` |
+| **Silent** | `derivative(arccos(0) * pi, pi)` | `0` | `pi / 2` |
 | **Silent** | `sum(ln(x), e, 1, 2)`, and any binder over `e` around a logarithm | `log(1, x) + log(2, x)` | `2 * ln(x)` |
 | **Silent** | `ln(x).Substitute("e", 3)` | `log(3, x)` | `ln(x)` |
 | **Silent** | `"sum(pi, pi, 1, 3)".ToEntity().Vars` | empty — the index was read as a constant | `pi` |
@@ -230,9 +231,9 @@ is, throughout that binder and nowhere else.
 ```csharp
 "sum(i, i, 1, 10)".ToEntity().Simplify()      // was: unevaluated       now: 55
 "sum(2i, i, 1, 3)".ToEntity().Simplify()      // was: 6i                now: 12
-"integral(i, i)".ToEntity().Simplify()        // was: -1/2 + C          now: i ^ 2 / 2 + C
+"integral(i, i)".ToEntity().Simplify()        // was: -1/2 + C          now: i_1 ^ 2 / 2 + C
 "limit(i, i, 0)".ToEntity().Simplify()        // was: unevaluated       now: 0
-"derivative(i ^ 2, i)".ToEntity().Simplify()  // was: 0                 now: 2 * i
+"derivative(i ^ 2, i)".ToEntity().Simplify()  // was: 0                 now: 2 * i_1
 "{ i : i > 0 }".ToEntity().Simplify()         // was: NaN               now: { i : i > 0 }
 "lambda(i, i + 1)".ToEntity()                 // was: threw             now: the lambda
 ```
@@ -265,11 +266,29 @@ It is now `Entity.Constant`, a node — so a binder holds a variable while the r
 holds the constant, and every binder-based operation reads the same thing.
 
 ```csharp
-"derivative(e ^ 2, e)".ToEntity().Simplify()   // was: 0             now: 2 * e
-"derivative(pi ^ 2, pi)".ToEntity().Simplify() // was: 0             now: 2 * pi
+"derivative(e ^ 2, e)".ToEntity().Simplify()   // was: 0             now: 2 * e_1
+"derivative(pi ^ 2, pi)".ToEntity().Simplify() // was: 0             now: 2 * pi_1
 "{ e : e > 0 }".ToEntity().Simplify()          // was: { e : True }  now: { e : e > 0 }
 "limit(e, e, 0)".ToEntity().Evaled             // was: 2.718…        now: 0
 "integral(e, e, 0, 1)".ToEntity().Evaled       // was: 3.694…        now: 1/2
+```
+
+**`pi_1`, not `pi`.** Most binders consume the name they declare — a sum over `pi` answers a number,
+a set builder keeps it inside itself — and those print as they were written and read back as
+themselves. A derivative and an indefinite integral *return* it, and a variable called `pi` is one
+the parser cannot produce, so `2 * pi` would read back as twice the constant. Renaming a bound
+variable is free, so it is renamed to a name that can be written. **This applies to `i` as well**,
+and changes the two answers the entry above introduced: `derivative(i ^ 2, i)` is `2 * i_1` and
+`integral(i, i)` is `i_1 ^ 2 / 2 + C`. Every binder over `pi`, `e` or `i` now answers something that
+parses back to itself; an ordinary name is never renamed.
+
+Differentiation compares the node rather than its name, so a constant that simplification
+**produces** inside a binder over that name is no longer differentiated as though it were the index:
+
+```csharp
+"derivative(arccos(0) * pi, pi)".ToEntity().Simplify()  // was: 0                     now: pi / 2
+"derivative(arccos(0) * q, q)".ToEntity().Simplify()    // pi / 2, unchanged — the same answer now
+"derivative(ln(x) * e, e)".ToEntity().Simplify()        // was: 0 provided not x = 0  now: ln(x) provided not x = 0
 ```
 
 A constant that simplification **produces** inside a binder over its name is no longer caught by it,

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -42,7 +42,6 @@ read first.
 | **Silent** | `integral(arccos(0), pi, 0, 1)` | `1/4` | `pi / 2` |
 | **Silent** | `derivative(arccos(0) * pi, pi)` | `0` | `pi / 2` |
 | **Silent** | `sum(ln(x), e, 1, 2)`, and any binder over `e` around a logarithm | `log(1, x) + log(2, x)` | `2 * ln(x)` |
-| **Silent** | `ln(x).Substitute("e", 3)` | `log(3, x)` | `ln(x)` |
 | **Silent** | `"sum(pi, pi, 1, 3)".ToEntity().Vars` | empty — the index was read as a constant | `pi` |
 | | `MathS.pi.GetType()` | `Entity.Variable` | `Entity.Constant`, which derives from it |
 
@@ -302,14 +301,18 @@ name spelled `pi` integrated that:
 
 `ln` and `exp` are written over Euler's number in their own definitions — `Ln(a)` is `Logf(e, a)`,
 and `exp(x)` is `e ^ x` — and that occurrence is the value rather than a mention of the name, so no
-binder reaches it and neither does a substitution for the name:
+binder reaches it:
 
 ```csharp
 "sum(ln(x), e, 1, 2)".ToEntity().Simplify()   // was: log(1, x) + log(2, x)   now: 2 * ln(x)
 "sum(exp(x), e, 1, 2)".ToEntity().Simplify()  // was: 1 + 2 ^ x               now: 2 * e ^ x
 "sum(ln(e), e, 1, 1)".ToEntity().Simplify()   // was: NaN, being log(1, 1)    now: 0
-MathS.Ln("x").Substitute("e", 3)              // was: log(3, x)               now: ln(x)
 ```
+
+Substituting **for the constant** still reaches that base, and unchanged — `MathS.Ln("x").Substitute("e", 3)`
+is `log(3, x)` before and after. A binder binds *occurrences* and a substitution replaces a *value*,
+and the base of a logarithm is Euler's number by value however it got there, so replacing Euler's
+number by 3 replaces it there too. `ln(x).VarsAndConsts` has said `e, x` all along.
 
 Where the writer does name `e`, it still binds, which is the same rule read the other way:
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -44,6 +44,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [Tests/UnitTests/Core/CostModelTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[Tests/UnitTests/Core/BoundConstantTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [Tests/UnitTests/Core/BinderShadowingTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 

--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -859,7 +859,9 @@ namespace AngouriMath
         /// </code>
         /// </example>
         [MethodImpl(MethodImplOptions.AggressiveInlining), NativeExport]
-        public static Entity Ln(Entity a) => new Logf(e, a);
+        // The base is the value and not a reference to the name `e`, so a binder that declares
+        // that name does not reach inside a logarithm. https://github.com/asc-community/AngouriMath/issues/984
+        public static Entity Ln(Entity a) => new Logf(Entity.Constant.EulerIntrinsic, a);
 
         /// <summary><a href="https://en.wikipedia.org/wiki/Factorial"/></summary>
         /// <param name="a">Argument node of which factorial will be taken</param>

--- a/Sources/AngouriMath/Convenience/StringToEachClass.Classes.cs
+++ b/Sources/AngouriMath/Convenience/StringToEachClass.Classes.cs
@@ -20,7 +20,9 @@ namespace AngouriMath
             throw new CannotParseInstanceException(typeof(T), expr);
         }
 
+#pragma warning disable SealedOrAbstract // Constant derives from it, as Real does from Complex
         partial record Variable
+#pragma warning restore SealedOrAbstract
         {
             /// <summary>
             /// Converts from string to specifically variable

--- a/Sources/AngouriMath/Core/Antlr/AngouriMath.g
+++ b/Sources/AngouriMath/Core/Antlr/AngouriMath.g
@@ -268,7 +268,7 @@ atom returns[Entity value]
     | NUMBER { $value = Entity.Number.Complex.Parse($NUMBER.text); }
     | BOOLEAN { $value = Entity.Boolean.Parse($BOOLEAN.text); }
     | SPECIALSET { $value = Entity.Set.SpecialSet.Create($SPECIALSET.text); }
-    | VARIABLE { $value = Entity.Variable.CreateVariableUnchecked($VARIABLE.text); }
+    | VARIABLE { $value = Entity.Variable.CreateVariableOrConstant($VARIABLE.text); }
     | '(|' expression '|)' { $value = $expression.value.Abs(); }
 
     | '[' function_arguments ']T' { $value = ParsingHelpers.TryBuildingMatrix($function_arguments.list).T; }
@@ -289,7 +289,7 @@ atom returns[Entity value]
     | 'cbrt(' args = function_arguments ')' { Assert("cbrt", 1, $args.list.Count); $value = MathS.Cbrt($args.list[0]); }
     | 'sqr(' args = function_arguments ')' { Assert("sqr", 1, $args.list.Count); $value = MathS.Sqr($args.list[0]); }
     | 'ln(' args = function_arguments ')' { Assert("ln", 1, $args.list.Count); $value = MathS.Ln($args.list[0]); }
-    | 'exp(' args = function_arguments ')' { Assert("exp", 1, $args.list.Count); $value = MathS.Pow(MathS.e, $args.list[0]); }
+    | 'exp(' args = function_arguments ')' { Assert("exp", 1, $args.list.Count); $value = MathS.Pow(Entity.Constant.EulerIntrinsic, $args.list[0]); }
 
     /* Trigonometric functions */
     | 'sin(' args = function_arguments ')' { Assert("sin", 1, $args.list.Count); $value = MathS.Sin($args.list[0]); }

--- a/Sources/AngouriMath/Core/Antlr/AngouriMathParser.cs
+++ b/Sources/AngouriMath/Core/Antlr/AngouriMathParser.cs
@@ -1903,7 +1903,7 @@ internal partial class AngouriMathParser : Parser {
 				{
 				State = 329;
 				_localctx._VARIABLE = Match(VARIABLE);
-				 _localctx.value =  Entity.Variable.CreateVariableUnchecked((_localctx._VARIABLE!=null?_localctx._VARIABLE.Text:null)); 
+				 _localctx.value =  Entity.Variable.CreateVariableOrConstant((_localctx._VARIABLE!=null?_localctx._VARIABLE.Text:null)); 
 				}
 				break;
 			case 8:
@@ -2131,7 +2131,7 @@ internal partial class AngouriMathParser : Parser {
 				_localctx.args = function_arguments();
 				State = 423;
 				Match(T__40);
-				 Assert("exp", 1, _localctx.args.list.Count); _localctx.value =  MathS.Pow(MathS.e, _localctx.args.list[0]); 
+				 Assert("exp", 1, _localctx.args.list.Count); _localctx.value =  MathS.Pow(Entity.Constant.EulerIntrinsic, _localctx.args.list[0]); 
 				}
 				break;
 			case 27:

--- a/Sources/AngouriMath/Core/Binding.cs
+++ b/Sources/AngouriMath/Core/Binding.cs
@@ -15,13 +15,13 @@ namespace AngouriMath.Core
     /// </summary>
     /// <remarks>
     /// <para>
-    /// There is one name in the language a binder cannot otherwise bind. <c>i</c> is the
-    /// imaginary unit and that is decided in the lexer — <c>NUMBER: ... | 'i'</c> — so it never
-    /// reaches the rule that makes variables and cannot be one anywhere. <c>e</c> and <c>pi</c>
-    /// are the other way round: they are <see cref="Variable"/>s that carry a value, so a binder
-    /// takes the name without trouble — and cannot then stop it meaning the constant, since a
-    /// bound <c>e</c> and the constant <c>e</c> are one object. That is why this is about the one
-    /// named constant that is not a variable.
+    /// Two kinds of name need reading rather than taking as they arrive, and they arrive from
+    /// opposite directions. <c>i</c> is the imaginary unit and that is decided in the lexer —
+    /// <c>NUMBER: ... | 'i'</c> — so it never reaches the rule that makes variables and is a
+    /// number in the name position. <c>e</c> and <c>pi</c> are <see cref="Entity.Constant"/>s,
+    /// which are <see cref="Variable"/>s by inheritance and separate objects by identity, so the
+    /// name position holds a constant and what is bound must be the variable of that name.
+    /// Either way the answer is the same: the binder decides what its name means, once, here.
     /// <a href="https://github.com/asc-community/AngouriMath/issues/976">#976</a>,
     /// <a href="https://github.com/asc-community/AngouriMath/issues/984">#984</a>
     /// </para>
@@ -39,8 +39,8 @@ namespace AngouriMath.Core
     /// </para>
     /// <para>
     /// This is a <see langword="struct"/> holding two fields and it is the whole cost of the
-    /// feature where nothing is shadowed: <see cref="Of(Entity)"/> is one equality test and
-    /// <see cref="In(Entity)"/> hands the expression straight back without walking it.
+    /// feature where nothing is shadowed: <see cref="Of(Entity)"/> is two type tests that both
+    /// fail, and <see cref="In(Entity)"/> hands the expression straight back without walking it.
     /// </para>
     /// </remarks>
     internal readonly struct Binding
@@ -48,34 +48,55 @@ namespace AngouriMath.Core
         /// <summary>
         /// What <c>i</c> becomes where it is bound. Unchecked, because the checked factory
         /// parses and the parser reads <c>i</c> as the imaginary unit — the very thing that
-        /// makes this type necessary.
+        /// makes this type necessary. A constant's name is read the same way, and for the same
+        /// reason: <c>CreateVariableOrConstant</c> would hand the constant straight back.
         /// </summary>
         [ConstantField]
         private static readonly Variable index = Variable.CreateVariableUnchecked("i");
 
         private readonly Entity given;
-        private readonly bool shadowed;
+        private readonly Variable? renamed;
 
-        private Binding(Entity given, bool shadowed) => (this.given, this.shadowed) = (given, shadowed);
+        private Binding(Entity given, Variable? renamed) => (this.given, this.renamed) = (given, renamed);
 
         /// <summary>Reads a bound name as the binder was given it.</summary>
         /// <param name="name">Whatever arrived in the name position.</param>
         /// <remarks>
         /// Every binder node runs this on the way in, so it is written to cost nothing in the
-        /// case that is nearly all of them: a bound name is a <see cref="Variable"/>, the type
-        /// test fails, and the equality is never reached. Measured at 2.2ns as an equality and
-        /// 0.5ns this way, against about 10ns to construct the node it guards.
+        /// case that is nearly all of them: a bound name is an ordinary <see cref="Variable"/>,
+        /// both type tests fail, and neither equality is reached. Measured at 2.2ns as an
+        /// equality and 0.5ns this way, against about 10ns to construct the node it guards.
         /// </remarks>
-        internal static Binding Of(Entity name) => new(name, name is Complex && name == MathS.i);
+        internal static Binding Of(Entity name)
+            => name is Constant constant
+                ? new(name, Variable.CreateVariableUnchecked(constant.Name))
+             : name is Complex && name == MathS.i
+                ? new(name, index)
+             : new(name, null);
 
-        /// <summary>The name to bind: what was given, unless that was the imaginary unit.</summary>
-        internal Entity Name => shadowed ? index : given;
+        /// <summary>
+        /// The name to bind: what was given, unless that was a constant — the imaginary unit,
+        /// or a name the language reads as one.
+        /// </summary>
+        internal Entity Name => renamed ?? given;
 
         /// <summary>
         /// An expression that is inside this binder, with the bound name meaning what it means
         /// here. Identity unless something is shadowed.
         /// </summary>
-        internal Entity In(Entity scope) => shadowed ? scope.Replace(Rename) : scope;
+        internal Entity In(Entity scope)
+        {
+            if (renamed is null)
+                return scope;
+            if (given is not Constant constant)
+                return scope.Replace(Rename);
+            // Copied out because a lambda in a struct cannot reach `this` (CS1673). By reference,
+            // not by value: a binder binds the occurrences it was handed, and the base of `ln` is
+            // Euler's number rather than a mention of the name `e`, so it is a different object
+            // and stays out of reach. See Entity.Constant.
+            var bound = renamed;
+            return scope.Replace(node => ReferenceEquals(node, constant) ? bound : node);
+        }
 
         /// <remarks>
         /// <c>2i</c> is one token — the lexer's <c>NUMBER</c> ends <c>'i'?</c> — so a written

--- a/Sources/AngouriMath/Core/Binding.cs
+++ b/Sources/AngouriMath/Core/Binding.cs
@@ -98,6 +98,31 @@ namespace AngouriMath.Core
             return scope.Replace(node => ReferenceEquals(node, constant) ? bound : node);
         }
 
+        /// <summary>
+        /// Can this name be written down as a variable? Three cannot: <c>i</c> is a number to the
+        /// lexer, and <c>pi</c> and <c>e</c> parse as <see cref="Entity.Constant"/>s.
+        /// </summary>
+        private static bool CanBeWritten(Variable name)
+            => name.Name != index.Name && !Variable.IsConstantName(name.Name);
+
+        /// <summary>
+        /// An answer that carries a bound name out of the binder that declared it, with that name
+        /// made writable.
+        /// </summary>
+        /// <remarks>
+        /// Most binders consume the name they declare — a sum over <c>pi</c> answers a number, and
+        /// a set builder keeps it inside itself, so both print as they were written and read back
+        /// as themselves. A derivative and an indefinite integral <b>return</b> it, and a variable
+        /// called <c>pi</c> is a thing the parser cannot produce: <c>2 * pi</c> would read back as
+        /// twice the constant, which is not what it means. Renaming a bound variable is free —
+        /// it is the same function either way — so it is renamed to a name that can be written.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/984">#984</a>
+        /// </remarks>
+        internal static Entity? Written(Entity bound, Entity? answer)
+            => answer is not null && bound is Variable name && !CanBeWritten(name) && answer.ContainsNode(name)
+                ? answer.Substitute(name, Variable.CreateUnique(answer, name.Name))
+                : answer;
+
         /// <remarks>
         /// <c>2i</c> is one token — the lexer's <c>NUMBER</c> ends <c>'i'?</c> — so a written
         /// <c>2i</c> arrives as a single number and not as a product with anything to rename.

--- a/Sources/AngouriMath/Core/Entity/Omni/Entity.Omni.Classes.cs
+++ b/Sources/AngouriMath/Core/Entity/Omni/Entity.Omni.Classes.cs
@@ -844,6 +844,12 @@ namespace AngouriMath
         /// </summary>
         public sealed partial record Lambda(Variable Parameter, Entity Body) : Entity
         {
+            /// <summary>The name this lambda binds. See <see cref="Core.Binding"/>.</summary>
+            public Variable Parameter { get; init; } = Binding.Of(Parameter).Name as Variable ?? Parameter;
+
+            /// <summary>The body, with the bound name meaning what it means here.</summary>
+            public Entity Body { get; init; } = Binding.Of(Parameter).In(Body);
+
             private Lambda New(Variable parameter, Entity body)
                 => ReferenceEquals(Parameter, parameter) && ReferenceEquals(Body, body)
                     ? this

--- a/Sources/AngouriMath/Core/Entity/Omni/Entity.Variable.cs
+++ b/Sources/AngouriMath/Core/Entity/Omni/Entity.Variable.cs
@@ -20,7 +20,9 @@ namespace AngouriMath
         /// Construct a <see cref="Variable"/> with an implicit conversion from <see cref="string"/>.
         /// It has no type, so you can substitute any value under a given variable.
         /// </summary>
-        public sealed partial record Variable : Entity
+#pragma warning disable SealedOrAbstract // Constant derives from it, as Real does from Complex
+        public partial record Variable : Entity
+#pragma warning restore SealedOrAbstract
         {
             /// <summary>
             /// Deconstructs Variable as follows
@@ -29,7 +31,7 @@ namespace AngouriMath
             public void Deconstruct(out string name)
                 => name = Name;
             internal static Variable CreateVariableUnchecked(string name) => new(name);
-            private Variable(string name) => Name = name;
+            private protected Variable(string name) => Name = name;
 
             /// <summary>
             /// The name of the variable as a string
@@ -42,14 +44,36 @@ namespace AngouriMath
             /// <inheritdoc/>
             protected override Entity[] InitDirectChildren() => Array.Empty<Entity>();
 
-            [ConstantField] internal static readonly Variable pi = new Variable(nameof(pi));
-            [ConstantField] internal static readonly Variable e = new Variable(nameof(e));
+            /// <summary>
+            /// Which names the language reads as mathematical constants, and what each is worth.
+            /// This is the whole registry: a name is a constant exactly when it is a key here,
+            /// and nothing below asks about <c>pi</c> or <c>e</c> by name.
+            /// </summary>
             [ConstantField] internal static readonly IReadOnlyDictionary<string, Complex> ConstantList =
                 new Dictionary<string, Complex>
                 {
                     { nameof(pi), MathS.DecimalConst.pi },
                     { nameof(e), MathS.DecimalConst.e }
                 };
+
+            /// <summary>Each constant as the name a writer types, which is the form a binder can take.</summary>
+            [ConstantField] internal static readonly IReadOnlyDictionary<string, Constant> NamedConstants =
+                ConstantList.Keys.ToDictionary(name => name, Constant.Named);
+
+            [ConstantField] internal static readonly Constant pi = NamedConstants[nameof(pi)];
+            [ConstantField] internal static readonly Constant e = NamedConstants[nameof(e)];
+
+            /// <summary>Is this name one the language reads as a mathematical constant?</summary>
+            internal static bool IsConstantName(string name) => ConstantList.ContainsKey(name);
+
+            /// <summary>
+            /// A name as the language reads it: a constant where the name is one, a variable
+            /// otherwise. This is what the parser calls, so a written <c>pi</c> is the constant
+            /// and a <c>pi</c> that a binder declares is not — they stop being one object.
+            /// <a href="https://github.com/asc-community/AngouriMath/issues/984">#984</a>
+            /// </summary>
+            internal static Variable CreateVariableOrConstant(string name)
+                => NamedConstants.TryGetValue(name, out var constant) ? constant : new Variable(name);
 
             /// <summary>
             /// Extracts this <see cref="Variable"/>'s name and index
@@ -96,7 +120,9 @@ namespace AngouriMath
             private static readonly Variable[] letterVars = 
                 "xyzabcdefghijklmnopqrstuvw"
                 .Select(c => new Variable(c.ToString()))
-                .Where(c => c.IsConstant is false)
+                // A fresh name that prints as `e` would parse back as the constant, so the
+                // constant names stay out of here even though they are ordinary variables now.
+                .Where(c => !IsConstantName(c.Name))
                 .ToArray();
 
             /// <summary>
@@ -130,6 +156,59 @@ namespace AngouriMath
                 return new Variable("%" + i);
             }
 
+        }
+
+        /// <summary>
+        /// A mathematical constant: a number whose spelling happens to be a legal identifier.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// It is a <see cref="Variable"/> by inheritance, so everything that reads a leaf by name
+        /// keeps working, and a distinct type by record identity, which is the whole point: a
+        /// binder that declares <c>pi</c> and the constant <c>pi</c> are no longer one object, so
+        /// evaluation can tell them apart without being told where it is.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/984">#984</a>
+        /// </para>
+        /// <para>
+        /// A binder binds <b>occurrences</b>, not values, and that is the whole of the second
+        /// distinction here. Every constant a writer types is the one object in
+        /// <c>NamedConstants</c>, because the parser and <see cref="MathS.pi"/> hand that
+        /// object back; the base of <c>ln</c> and of <c>exp</c> is
+        /// <see cref="EulerIntrinsic"/>, a separate object, because it is Euler's number standing
+        /// in an operator's own definition and not a reference to the name <c>e</c>. A binder
+        /// replaces the occurrences it was handed — compared by reference — so
+        /// <c>sum(ln(x), e, 1, 2)</c> is <c>2 * ln(x)</c> while <c>sum(log(e, x), e, 1, 2)</c>,
+        /// where the writer did name <c>e</c>, is <c>log(1, x) + log(2, x)</c>.
+        /// </para>
+        /// <para>
+        /// The two are <b>equal</b>, and deliberately so: they are the same number, they print
+        /// alike, and any rule that matches one matches the other, so nothing about canonical form,
+        /// equality or substitution changes. Only the identity of the occurrence differs, and only
+        /// while a binder is deciding what it binds — which is at construction, before anything
+        /// evaluates.
+        /// </para>
+        /// </remarks>
+        public sealed partial record Constant : Variable
+        {
+            private Constant(string name) : base(name) { }
+
+            /// <summary>A constant as the name a writer types. One object per name, kept in
+            /// <c>Variable.NamedConstants</c> — a binder recognises it by reference.</summary>
+            internal static Constant Named(string name) => new(name);
+
+            /// <summary>What this constant is worth.</summary>
+            /// <remarks>
+            /// A computed property on purpose: a record compares its instance fields, and the
+            /// identity of a constant is its name and its role, not a hundred digits of it.
+            /// </remarks>
+            internal Number.Complex Value => ConstantList[Name];
+
+            /// <summary>
+            /// Euler's number as the base of <c>ln</c> and of <c>exp</c>. Equal to the written
+            /// <c>e</c> and a different object from it, which is what keeps a binder over the
+            /// name <c>e</c> out of a logarithm.
+            /// </summary>
+            [ConstantField] internal static readonly Constant EulerIntrinsic = new(nameof(e));
         }
         #endregion
     }

--- a/Sources/AngouriMath/Functions/Compilation/IntoFE/Compiler.cs
+++ b/Sources/AngouriMath/Functions/Compilation/IntoFE/Compiler.cs
@@ -328,8 +328,8 @@ namespace AngouriMath.Core
                 foreach (var varName in variables)
                     if (!varName.IsConstant)
                         varNamespace[varName] = id++;
-                foreach (var pair in Variable.ConstantList)
-                    func = func.Substitute(Variable.CreateVariableUnchecked(pair.Key), pair.Value);
+                foreach (var constant in Variable.NamedConstants.Values)
+                    func = func.Substitute(constant, constant.Value);
                 var visited = new HashSet<Entity>();
                 var cache = new Dictionary<Entity, int>();
                 foreach (var node in func.Nodes)

--- a/Sources/AngouriMath/Functions/Continuous/Differentiation.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Differentiation.cs
@@ -66,7 +66,14 @@ namespace AngouriMath
         {
             
             /// <inheritdoc/>
-            protected override Entity InnerDifferentiate(Variable variable) => Name == variable.Name ? 1 : 0;
+            /// <remarks>
+            /// The node, not its name. A <see cref="Constant"/> and a <see cref="Variable"/> can
+            /// share a spelling — that is what a binder over <c>pi</c> produces — and comparing
+            /// the spelling made <c>derivative(arccos(0) * pi, pi)</c> differentiate the
+            /// <c>pi / 2</c> that <c>arccos(0)</c> simplifies to as though it were the index.
+            /// <a href="https://github.com/asc-community/AngouriMath/issues/984">#984</a>
+            /// </remarks>
+            protected override Entity InnerDifferentiate(Variable variable) => this == variable ? 1 : 0;
         }
 
         partial record Matrix

--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Classes.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Classes.cs
@@ -17,7 +17,20 @@ namespace AngouriMath
         {
             private protected override Entity IntrinsicCondition => true;
             /// <inheritdoc/>
-            protected override Entity InnerSimplify(bool isExact) => !isExact && ConstantList.TryGetValue(Name, out var value) ? value : this;
+            /// <remarks>
+            /// A variable is itself, whatever it is called. What a name is worth is asked of the
+            /// node and not of a table keyed by name, which is what used to make a bound `e`
+            /// carry Euler's number.
+            /// <a href="https://github.com/asc-community/AngouriMath/issues/984">#984</a>
+            /// </remarks>
+            protected override Entity InnerSimplify(bool isExact) => this;
+        }
+
+        public partial record Constant
+        {
+            /// <inheritdoc/>
+            /// <remarks>Exactly, a constant is itself; approximately, it is its value.</remarks>
+            protected override Entity InnerSimplify(bool isExact) => isExact ? this : Value;
         }
 
         /// <summary>

--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
@@ -26,7 +26,7 @@ namespace AngouriMath
                         // TODO: should we call InnerSimplified here?
                         (var expr, Variable var, int asInt)
                             when expr.Differentiate(var, asInt) is var res and not Derivativef
-                            => res.InnerSimplified(isExact),
+                            => Core.Binding.Written(var, res.InnerSimplified(isExact)),
                         (var expr, Variable var, int asInt) => null,
                         (Application, _, _) => null,
                         (var expr, Entity otherExpr, int asInt)
@@ -51,12 +51,12 @@ namespace AngouriMath
                 ExpandOnTwoAndTArguments(Expression, Var, Range,
                     (a, b, c) => (a, b, c) switch
                     {
-                        (var expr, Variable var, var (from, to)) => ConditionallySimplified(expr.Integrate(var, from, to), isExact),
+                        (var expr, Variable var, var (from, to)) => Core.Binding.Written(var, ConditionallySimplified(expr.Integrate(var, from, to), isExact)),
                         (var expr, var otherExpr, var (from, to))
                             when Variable.CreateTemp(otherExpr.Vars) is var tempVar
                             && expr.Substitute(otherExpr, tempVar) is var tempSubstituted
                             && tempSubstituted.Integrate(tempVar, from, to) is var res => ConditionallySimplified(res.Substitute(tempVar, otherExpr), isExact),
-                        (var expr, Variable var, null) => ConditionallySimplified(expr.Integrate(var), isExact),
+                        (var expr, Variable var, null) => Core.Binding.Written(var, ConditionallySimplified(expr.Integrate(var), isExact)),
                         (var expr, var otherExpr, null)
                             when Variable.CreateTemp(otherExpr.Vars) is var tempVar
                             && expr.Substitute(otherExpr, tempVar) is var tempSubstituted

--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Definition.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Definition.cs
@@ -616,6 +616,6 @@ namespace AngouriMath
         /// True
         /// </code>
         /// </example>
-        public bool IsConstant => Evaled is Number.Complex or Boolean || Evaled is Variable v && Variable.ConstantList.ContainsKey(v.Name);
+        public bool IsConstant => Evaled is Number.Complex or Boolean or Constant;
     }
 }

--- a/Sources/AngouriMath/Functions/Output/Latex/Latex.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/Latex/Latex.Classes.cs
@@ -36,24 +36,40 @@ namespace AngouriMath
                 // from products of single-letter variables (e.g., v·e·l·o·c·i·t·y).
                 // Single-letter variables remain italic as per standard mathematical typography.
                 varName.Length > 1 && !LatexisableConstants.Contains(varName);
+
+            /// <summary>
+            /// Whether this node's own name is set upright. ISO 80000-2 sets constants upright and
+            /// variables italic, and which of the two a name is depends on the node and not on the
+            /// spelling — a <c>pi</c> a binder declares is a variable and is set as one. A
+            /// subscript is part of a name rather than a node of its own, so it keeps being read
+            /// by name above. <a href="https://github.com/asc-community/AngouriMath/issues/984">#984</a>
+            /// </summary>
+            private protected virtual bool IsOwnNameUpright =>
+                Name.Length > 1 && !LatexisableConstants.Contains(Name);
             /// <summary>
             /// Returns latexized const if it is possible to latexize it,
             /// or its original name otherwise
             /// </summary>
             public override string Latexize()
             {
-                static string LatexizePart(string symbol)
+                static string LatexizePart(string symbol, bool upright)
                 {
                     var inner = LatexisableConstants.Contains(symbol) ? $@"\{symbol}" : symbol;
-                    return IsNameLatexUprightFormatted(symbol) ? $@"\mathrm{{{inner}}}" : inner;
+                    return upright ? $@"\mathrm{{{inner}}}" : inner;
                 }
                 // For variables with subscripts (e.g., "pi_2", "x_e", "e_pi")
                 // Both the main part and subscript are processed through LatexizePart,
                 // which handles upright formatting for "pi" and "e" consistently
                 return SplitIndex() is var (prefix, index)
-                    ? $"{LatexizePart(prefix)}_{{{LatexizePart(index)}}}"
-                    : LatexizePart(Name);
+                    ? $"{LatexizePart(prefix, IsNameLatexUprightFormatted(prefix))}_{{{LatexizePart(index, IsNameLatexUprightFormatted(index))}}}"
+                    : LatexizePart(Name, IsOwnNameUpright);
             }
+        }
+
+        public partial record Constant
+        {
+            /// <inheritdoc/>
+            private protected override bool IsOwnNameUpright => true;
         }
     }
 }

--- a/Sources/AngouriMath/Functions/Output/ToString/ToString.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/ToString/ToString.Classes.cs
@@ -16,5 +16,16 @@ namespace AngouriMath
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
+
+        public partial record Constant
+        {
+            /// <inheritdoc/>
+            /// <remarks>
+            /// A record synthesizes <see cref="object.ToString"/> from its members unless the type
+            /// declares one, which is why every node here declares one. A constant prints as its
+            /// name in both roles, so a bound occurrence reads back as it was written.
+            /// </remarks>
+            public override string ToString() => Stringize();
+        }
     }
 }

--- a/Sources/AngouriMath/Functions/Output/ToSympy/ToSympy.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/ToSympy/ToSympy.Classes.cs
@@ -11,12 +11,18 @@ namespace AngouriMath
     {
         public partial record Variable
         {
-            internal override string ToSymPy() 
+            // A name, whatever it is spelled. A bound `e` is a variable and exports as one; only
+            // the constant node below exports as SymPy's constant.
+            internal override string ToSymPy() => Name;
+        }
+
+        public partial record Constant
+        {
+            internal override string ToSymPy()
                 => Name switch
                 {
                     "e" => "sympy.E",
-                    "pi" => "sympy.pi",
-                    _ => Name
+                    _ => "sympy." + Name
                 };
         }
     }

--- a/Sources/Tests/UnitTests/Common/EveryNodeSurvivesEveryPipelineTest.cs
+++ b/Sources/Tests/UnitTests/Common/EveryNodeSurvivesEveryPipelineTest.cs
@@ -96,6 +96,7 @@ namespace AngouriMath.Tests.Common
             MathS.Sets.Z,                                       // Integers
             Entity.Set.SpecialSet.Create(Domain.Boolean),       // Booleans
             X,                                                  // Variable
+            MathS.pi,                                           // Constant
         };
 
         public static IEnumerable<object[]> EveryNodeType()

--- a/Sources/Tests/UnitTests/Common/PublicApi.txt
+++ b/Sources/Tests/UnitTests/Common/PublicApi.txt
@@ -502,6 +502,17 @@ AngouriMath.Entity+ComparisonSign.ctor()
 AngouriMath.Entity+ComparisonSign.ctor(AngouriMath.Entity+ComparisonSign)
 AngouriMath.Entity+ComparisonSign.op_Equality(AngouriMath.Entity+ComparisonSign, AngouriMath.Entity+ComparisonSign) : System.Boolean
 AngouriMath.Entity+ComparisonSign.op_Inequality(AngouriMath.Entity+ComparisonSign, AngouriMath.Entity+ComparisonSign) : System.Boolean
+AngouriMath.Entity+Constant.<Clone>$() : AngouriMath.Entity+Constant
+AngouriMath.Entity+Constant.EqualityContract { } : System.Type
+AngouriMath.Entity+Constant.Equals(AngouriMath.Entity+Constant) : System.Boolean
+AngouriMath.Entity+Constant.Equals(AngouriMath.Entity+Variable) : System.Boolean
+AngouriMath.Entity+Constant.Equals(System.Object) : System.Boolean
+AngouriMath.Entity+Constant.GetHashCode() : System.Int32
+AngouriMath.Entity+Constant.InnerSimplify(System.Boolean) : AngouriMath.Entity
+AngouriMath.Entity+Constant.PrintMembers(System.Text.StringBuilder) : System.Boolean
+AngouriMath.Entity+Constant.ToString() : System.String
+AngouriMath.Entity+Constant.op_Equality(AngouriMath.Entity+Constant, AngouriMath.Entity+Constant) : System.Boolean
+AngouriMath.Entity+Constant.op_Inequality(AngouriMath.Entity+Constant, AngouriMath.Entity+Constant) : System.Boolean
 AngouriMath.Entity+ContinuousNode.<Clone>$() : AngouriMath.Entity+ContinuousNode
 AngouriMath.Entity+ContinuousNode.EqualityContract { } : System.Type
 AngouriMath.Entity+ContinuousNode.Equals(AngouriMath.Entity) : System.Boolean
@@ -2057,6 +2068,7 @@ AngouriMath.Entity+Variable.PrintMembers(System.Text.StringBuilder) : System.Boo
 AngouriMath.Entity+Variable.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Variable.Stringize() : System.String
 AngouriMath.Entity+Variable.ToString() : System.String
+AngouriMath.Entity+Variable.ctor(AngouriMath.Entity+Variable)
 AngouriMath.Entity+Variable.op_Equality(AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : System.Boolean
 AngouriMath.Entity+Variable.op_Implicit(System.String) : AngouriMath.Entity+Variable
 AngouriMath.Entity+Variable.op_Inequality(AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : System.Boolean
@@ -2590,6 +2602,7 @@ class AngouriMath.Entity+Boolean
 class AngouriMath.Entity+CalculusOperator
 class AngouriMath.Entity+Ceilf
 class AngouriMath.Entity+ComparisonSign
+class AngouriMath.Entity+Constant
 class AngouriMath.Entity+ContinuousNode
 class AngouriMath.Entity+Cosecantf
 class AngouriMath.Entity+Cosf

--- a/Sources/Tests/UnitTests/Core/BinderShadowingTest.cs
+++ b/Sources/Tests/UnitTests/Core/BinderShadowingTest.cs
@@ -44,8 +44,11 @@ namespace AngouriMath.Tests.Core
             var overK = string.Format(shape, "k").ToEntity().Simplify();
             var overI = string.Format(shape, "i").ToEntity().Simplify();
             // Renamed rather than compared as they stand: the two answers are the same
-            // expression written over different names wherever the name survives into it.
-            Assert.Equal(overK, overI.Substitute(Entity.Variable.CreateVariableUnchecked("i"), "k"));
+            // expression written over different names wherever the name survives into it. Where
+            // it survives it comes back as `i_1`, since a variable called `i` cannot be written
+            // and so cannot be read back — see BoundConstantTest.
+            Assert.Equal(overK, overI.Substitute("i_1".ToEntity(), "k")
+                                     .Substitute(Entity.Variable.CreateVariableUnchecked("i"), "k"));
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Core/BinderShadowingTest.cs
+++ b/Sources/Tests/UnitTests/Core/BinderShadowingTest.cs
@@ -17,10 +17,10 @@ namespace AngouriMath.Tests.Core
     /// <a href="https://github.com/asc-community/AngouriMath/issues/976">#976</a>
     /// </summary>
     /// <remarks>
-    /// <c>e</c> and <c>pi</c> need none of this and are here to say why: they are
-    /// <see cref="Entity.Variable"/>s that carry a value, so a binder shadows them by
-    /// construction. <c>i</c> is a number — the lexer decides it, <c>NUMBER: ... | 'i'</c> — so
-    /// without this it is the one name in the language that no binder can bind.
+    /// <c>i</c> is a number — the lexer decides it, <c>NUMBER: ... | 'i'</c> — so without this it
+    /// is the one name in the language that no binder can bind. <c>e</c> and <c>pi</c> reach the
+    /// same place by the other road and are covered by <c>BoundConstantTest</c>:
+    /// <see cref="Entity.Constant"/> is what makes a written one an occurrence a binder can take.
     /// </remarks>
     [Trait("Area", "Core")]
     public sealed class BinderShadowingTest
@@ -125,9 +125,9 @@ namespace AngouriMath.Tests.Core
         }
 
         /// <summary>
-        /// Nothing was added for <c>e</c> and <c>pi</c> because a binder already shadows them:
-        /// they are variables that carry a value, so the name in the index position binds, and
-        /// these have always worked.
+        /// The same binders over <c>e</c> and <c>pi</c>. These worked before
+        /// <see cref="Entity.Constant"/> as well, because the binder writes the name out before
+        /// anything reads it; the cases that did not are in <c>BoundConstantTest</c>.
         /// </summary>
         [Theory]
         [InlineData("sum(e, e, 1, 3)", "6")]
@@ -135,36 +135,6 @@ namespace AngouriMath.Tests.Core
         [InlineData("integral(e, e, 0, 1)", "1/2")]
         public void ANamedConstantThatIsAVariableNeededNothing(string expression, string expected) =>
             Assert.Equal(expected.ToEntity(), expression.ToEntity().Simplify());
-
-        /// <summary>
-        /// And where they do <i>not</i> work, which is recorded here rather than believed away.
-        /// </summary>
-        /// <remarks>
-        /// A bound <c>e</c> keeps the constant's value, because the bound name and the constant
-        /// are the same object: <c>Variable.ConstantList</c> is keyed by name, so a variable
-        /// called <c>e</c> is <c>2.718…</c> wherever it is read, binder or no binder. Nothing
-        /// short of a representation that tells a bound name from a constant one fixes these,
-        /// which is why this change is about the one constant that is not a variable — for
-        /// <c>i</c> the bound name and the unit are distinguishable, and that is the whole reason
-        /// the fix above is possible at all.
-        /// <a href="https://github.com/asc-community/AngouriMath/issues/984">#984</a>
-        /// </remarks>
-        [Theory]
-        [InlineData("derivative(e ^ 2, e)", "0")]              // 2 * e
-        [InlineData("derivative(pi ^ 2, pi)", "0")]            // 2 * pi
-        [InlineData("{ e : e > 0 }", "{ e : True }")]          // { e : e > 0 }
-        public void ABoundNamedConstantStillCarriesItsValue(string expression, string expected) =>
-            Assert.Equal(expected.ToEntity(), expression.ToEntity().Simplify());
-
-        /// <summary>The same, on the path that shows it most plainly.</summary>
-        [Fact]
-        public void ABoundNamedConstantEvaluatesToTheConstant()
-        {
-            // Simplify gets this right -- it is 0 -- and Evaled does not, which is the shape of
-            // the defect: the bound name is only a constant once something reads its value.
-            Assert.Equal("limit(e, e, 0)".ToEntity().Simplify(), (Entity)0);
-            Assert.Equal(MathS.DecimalConst.e, "limit(e, e, 0)".ToEntity().Evaled.EvalNumerical().RealPart.EDecimal);
-        }
 
     }
 }

--- a/Sources/Tests/UnitTests/Core/BoundConstantTest.cs
+++ b/Sources/Tests/UnitTests/Core/BoundConstantTest.cs
@@ -1,0 +1,312 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using System.Linq;
+using Xunit;
+
+namespace AngouriMath.Tests.Core
+{
+    /// <summary>
+    /// A name a binder declares is a variable, whatever that name is spelled — including the
+    /// names the language reads as mathematical constants.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/984">#984</a>
+    /// </summary>
+    /// <remarks>
+    /// The mechanism is <see cref="Entity.Constant"/>: a constant is a node and not a name, so a
+    /// binder that declares <c>pi</c> holds a <see cref="Entity.Variable"/> while the rest of the
+    /// language holds the constant, and no evaluation needs to be told where it is.
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class BoundConstantTest
+    {
+        /// <summary>
+        /// The name a binder declares, as the binder itself reads it. Written rather than parsed,
+        /// because parsing <c>e</c> gives the constant — which is the whole subject here — so an
+        /// expectation spelled as a string could not say "a variable called e" at all.
+        /// </summary>
+        private static Entity.Variable BoundName(string name) =>
+            Assert.IsType<Entity.Summationf>($"sum({name}, {name}, 1, 1)".ToEntity()).Var as Entity.Variable
+            ?? throw new Xunit.Sdk.XunitException($"a binder over {name} did not bind a variable");
+
+        // ---------------------------------------------------------------- the five in #984
+
+        /// <summary>
+        /// Differentiating with respect to a bound name. <c>0</c> before, because the name carried
+        /// the constant's value and the constant does not depend on itself.
+        /// </summary>
+        [Theory]
+        [InlineData("e")]
+        [InlineData("pi")]
+        public void DifferentiatingByABoundNameIsNotZero(string name)
+        {
+            var bound = BoundName(name);
+            Assert.Equal(2 * bound, $"derivative({name} ^ 2, {name})".ToEntity().Simplify());
+            Assert.Equal(2 * bound, $"derivative({name} ^ 2, {name})".ToEntity().Evaled);
+        }
+
+        /// <summary>A set builder's predicate is about its own name, not about the constant.</summary>
+        [Theory]
+        [InlineData("{ e : e > 0 }")]
+        [InlineData("{ pi : pi > 0 }")]
+        public void ASetBuildersPredicateSurvives(string expression) =>
+            Assert.Equal(expression.ToEntity(), expression.ToEntity().Simplify());
+
+        /// <summary>
+        /// The two the issue reports on <c>Evaled</c> rather than on <c>Simplify</c>. That
+        /// distinction is the shape of the defect — <c>Simplify</c> was already right and
+        /// <c>Evaled</c> read the name's value — so both are asserted here for both.
+        /// </summary>
+        [Theory]
+        [InlineData("limit(e, e, 0)", "0")]
+        [InlineData("limit(pi, pi, 0)", "0")]
+        [InlineData("integral(e, e, 0, 1)", "1/2")]
+        [InlineData("integral(pi, pi, 0, 1)", "1/2")]
+        public void ABoundConstantEvaluatesAsAVariable(string expression, string expected)
+        {
+            Assert.Equal(expected.ToEntity(), expression.ToEntity().Simplify());
+            Assert.Equal(expected.ToEntity(), expression.ToEntity().Evaled);
+        }
+
+        // ---------------------------------------------------------------- free is unchanged
+
+        /// <summary>A constant nobody bound is the constant, symbolically and numerically.</summary>
+        [Fact]
+        public void AFreeConstantIsStillTheConstant()
+        {
+            Assert.Equal(MathS.DecimalConst.pi, MathS.pi.Evaled.EvalNumerical().RealPart.EDecimal);
+            Assert.Equal(MathS.DecimalConst.e, MathS.e.Evaled.EvalNumerical().RealPart.EDecimal);
+            Assert.Equal(MathS.pi, "pi".ToEntity());
+            Assert.Equal((Entity)0, "sin(pi)".ToEntity().Simplify());
+            Assert.Equal((Entity)1, "ln(e)".ToEntity().Simplify());
+            Assert.Equal((Entity)0, "derivative(e ^ 2, x)".ToEntity().Simplify());
+            Assert.Equal("pi / 2".ToEntity(), "arccos(0)".ToEntity().Simplify());
+        }
+
+        /// <summary>
+        /// Which is a claim about the representation and not only about the answers: a written
+        /// constant is a <see cref="Entity.Constant"/>, and the same name in a binder is not.
+        /// </summary>
+        [Fact]
+        public void AWrittenConstantIsAConstantNodeAndABoundOneIsNot()
+        {
+            Assert.IsType<Entity.Constant>(MathS.pi);
+            Assert.IsType<Entity.Constant>("e".ToEntity());
+
+            var sum = Assert.IsType<Entity.Summationf>("sum(pi, pi, 1, 3)".ToEntity());
+            Assert.IsType<Entity.Variable>(sum.Var);          // exactly Variable, not Constant
+            Assert.Equal(sum.Var, sum.Expression);
+        }
+
+        // ---------------------------------------------------------------- every binder
+
+        /// <summary>
+        /// All seven binders in the language, each over a constant's name and over an ordinary
+        /// name, answering the same thing. A binder that bypassed the mechanism fails here rather
+        /// than waiting to be noticed.
+        /// </summary>
+        [Theory]
+        [InlineData("derivative({0} ^ 2, {0})")]
+        [InlineData("integral({0} ^ 2, {0})")]
+        [InlineData("integral({0} ^ 2, {0}, 0, 1)")]
+        [InlineData("limit({0} ^ 2, {0}, 3)")]
+        [InlineData("sum({0} ^ 2, {0}, 1, 4)")]
+        [InlineData("product({0} ^ 2, {0}, 1, 4)")]
+        [InlineData("apply(lambda({0}, {0} ^ 2), 3)")]
+        public void EveryBinderReadsAConstantsNameAsTheNameItBinds(string shape)
+        {
+            var ordinary = string.Format(shape, "qq").ToEntity().Simplify();
+            foreach (var name in new[] { "e", "pi" })
+            {
+                // Where the bound name outlives its binder -- an indefinite integral, a
+                // derivative -- it is a variable, so it is renamed rather than substituted for.
+                var bound = string.Format(shape, name).ToEntity().Simplify();
+                var renamed = bound.Substitute(BoundName(name), MathS.Var("qq"));
+                Assert.Equal(ordinary, renamed);
+            }
+        }
+
+        /// <summary>A set builder is a binder too, and its predicate is not a claim about pi.</summary>
+        [Fact]
+        public void ASetBuilderBindsAConstantsName()
+        {
+            Assert.Equal("{ e : e > 0 }".ToEntity(), "{ e : e > 0 }".ToEntity().Simplify());
+            var set = Assert.IsType<Entity.Set.ConditionalSet>("{ e : e > 0 }".ToEntity());
+            Assert.True(set.Contains(2));
+            Assert.False(set.Contains(-2));
+        }
+
+        /// <summary>A lambda binds it in the node, not only where the parser builds one.</summary>
+        [Fact]
+        public void ALambdaBindsAConstantsName()
+        {
+            Assert.Equal((Entity)6, MathS.Apply(MathS.Lambda(MathS.e, MathS.e + 1), 5).Simplify());
+            Assert.Equal((Entity)6, "apply(lambda(e, e + 1), 5)".ToEntity().Simplify());
+        }
+
+        // ---------------------------------------------------------------- scope
+
+        /// <summary>
+        /// Only inside the binder that declares it. The <c>pi</c> outside the sum is the constant,
+        /// and the sum's own <c>pi</c> is its index.
+        /// </summary>
+        [Fact]
+        public void ABinderReachesNoFurtherThanItself()
+        {
+            Assert.Equal("6 + pi".ToEntity(), "sum(pi, pi, 1, 3) + pi".ToEntity().Simplify());
+            Assert.Equal("3 * pi".ToEntity(), "sum(pi * k, k, 1, 2)".ToEntity().Simplify());
+        }
+
+        /// <summary>Nested binders, and one shadowing another over the same name.</summary>
+        [Theory]
+        // The inner sum is 1 + 2, a constant with respect to the outer one, three times over.
+        [InlineData("sum(sum(pi, pi, 1, 2), pi, 1, 3)", "9")]
+        // (1 + 3) + (2 + 3) + (3 + 3): the outer index outside the inner binder, the inner inside.
+        [InlineData("sum(pi + sum(pi, pi, 1, 2), pi, 1, 3)", "15")]
+        // The inner binder is over another name, so both of its terms are the outer index.
+        [InlineData("sum(sum(pi, k, 1, 2), pi, 1, 3)", "12")]
+        // Two different constants nested.
+        [InlineData("sum(sum(e * pi, e, 1, 2), pi, 1, 3)", "18")]
+        public void NestedBindersShadowInTheRightOrder(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity(), expression.ToEntity().Simplify());
+
+        /// <summary>
+        /// Substitution follows the same reading: substituting the constant does not reach a name
+        /// a binder has taken, and does reach a free one.
+        /// </summary>
+        [Fact]
+        public void SubstitutingTheConstantDoesNotReachABoundName()
+        {
+            Assert.Equal("3 + x".ToEntity(), "pi + x".ToEntity().Substitute(MathS.pi, 3).Simplify());
+            Assert.Equal("sum(pi, pi, 1, 3)".ToEntity(), "sum(pi, pi, 1, 3)".ToEntity().Substitute(MathS.pi, 3));
+        }
+
+        // ---------------------------------------------------------------- capture
+
+        /// <summary>
+        /// A constant that simplification <i>produces</i> inside a binder over that name is not
+        /// caught by it. <c>arccos(0)</c> is <c>pi / 2</c>, and integrating it over <c>pi</c> from
+        /// 0 to 1 answered <c>1/4</c> — the integral of <c>pi / 2</c> d<c>pi</c> — because the
+        /// produced constant and the bound name were one object.
+        /// </summary>
+        [Fact]
+        public void AProducedConstantIsNotCaughtByABinderOverItsName()
+        {
+            Assert.Equal("pi / 2".ToEntity(), "integral(arccos(0), pi, 0, 1)".ToEntity().Simplify());
+            Assert.Equal("integral(arccos(0), q, 0, 1)".ToEntity().Simplify(),
+                         "integral(arccos(0), pi, 0, 1)".ToEntity().Simplify());
+        }
+
+        /// <summary>
+        /// <c>ln</c> and <c>exp</c> are written with Euler's number in their own definition —
+        /// <c>Ln(a)</c> is <c>Logf(e, a)</c> — and that <c>e</c> is a value rather than a mention
+        /// of the name, so a binder over <c>e</c> does not reach it. Where the writer does name
+        /// <c>e</c>, it binds, which is the same rule read the other way.
+        /// </summary>
+        [Theory]
+        [InlineData("sum(ln(x), e, 1, 2)", "2 * ln(x)")]      // the body never names e
+        [InlineData("sum(exp(x), e, 1, 2)", "2 * e ^ x")]     // nor does this one
+        [InlineData("sum(ln(e), e, 1, 1)", "0")]              // ln(1), not log(1, 1)
+        [InlineData("sum(log(e, x), e, 1, 2)", "log(1, x) + log(2, x)")]  // written, so bound
+        [InlineData("sum(e ^ x, e, 1, 2)", "1 + 2 ^ x")]                  // written, so bound
+        public void AnOperatorsOwnBaseIsNotANameOccurrence(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity(), expression.ToEntity().Simplify());
+
+        /// <summary>
+        /// The two roles are the same number and compare equal, so no rule can miss a match
+        /// through the difference between them.
+        /// </summary>
+        [Fact]
+        public void TheTwoRolesOfAConstantAreEqual()
+        {
+            Assert.Equal(MathS.e, Assert.IsType<Entity.Logf>(MathS.Ln(MathS.Var("x"))).Base);
+            Assert.Equal("e ^ 5".ToEntity(), "e ^ 2 * exp(3)".ToEntity().Simplify());
+            Assert.Equal("ln(x)".ToEntity().Simplify(), "log(e, x)".ToEntity().Simplify());
+        }
+
+        // ---------------------------------------------------------------- printing
+
+        /// <summary>
+        /// A bound name prints as it was written, and reading the printed form back gives the same
+        /// expression — the binder decides what its name means when the node is built, so parsing
+        /// re-establishes it.
+        /// </summary>
+        [Theory]
+        [InlineData("sum(pi, pi, 1, 3)")]
+        [InlineData("product(e, e, 1, 3)")]
+        [InlineData("{ e : e > 0 }")]
+        [InlineData("derivative(pi ^ 2, pi)")]
+        [InlineData("integral(e ^ 2, e, 0, 1)")]
+        [InlineData("limit(pi ^ 2, pi, 3)")]
+        [InlineData("sum(sum(pi, pi, 1, 2), pi, 1, 3)")]
+        [InlineData("lambda(e, e + 1)")]
+        public void ABoundConstantPrintsAsItsNameAndReadsBack(string expression)
+        {
+            var parsed = expression.ToEntity();
+            Assert.Contains(expression.Contains("pi") ? "pi" : "e", parsed.Stringize());
+            Assert.Equal(parsed, parsed.Stringize().ToEntity());
+            Assert.Equal(parsed.Simplify(), parsed.Stringize().ToEntity().Simplify());
+        }
+
+        // ---------------------------------------------------------------- unchanged elsewhere
+
+        /// <summary>An ordinary name behaves exactly as it did, which is what all of the above is measured against.</summary>
+        [Theory]
+        [InlineData("derivative(k ^ 2, k)", "2 * k")]
+        [InlineData("{ k : k > 0 }", "{ k : k > 0 }")]
+        [InlineData("sum(k, k, 1, 3)", "6")]
+        [InlineData("limit(k, k, 0)", "0")]
+        [InlineData("integral(k, k, 0, 1)", "1/2")]
+        public void AnOrdinaryNameIsUnchanged(string expression, string expected)
+        {
+            Assert.Equal(expected.ToEntity(), expression.ToEntity().Simplify());
+            Assert.Equal(expected.ToEntity(), expression.ToEntity().Evaled);
+        }
+
+        /// <summary>
+        /// And the imaginary unit still binds the way <a
+        /// href="https://github.com/asc-community/AngouriMath/issues/976">#976</a> made it, which
+        /// this reads through the same <c>Binding</c>.
+        /// </summary>
+        [Theory]
+        [InlineData("sum(i, i, 1, 10)", "55")]
+        [InlineData("sum(sqrt(-1) * i, i, 1, 10)", "55i")]
+        public void TheImaginaryUnitStillBinds(string expression, string expected) =>
+            Assert.Equal(expected.ToEntity(), expression.ToEntity().Simplify());
+
+        /// <summary>
+        /// A name that outlives the binder that declared it is a variable, and prints as the name
+        /// it was given — so the printed form reads back as the constant rather than as that
+        /// variable. Recorded rather than asserted away: it is the same for the imaginary unit
+        /// since <a href="https://github.com/asc-community/AngouriMath/issues/976">#976</a>, and
+        /// nothing short of a name for the escaped variable would change it.
+        /// </summary>
+        [Theory]
+        [InlineData("derivative(pi ^ 2, pi)", "2 * pi")]
+        [InlineData("derivative(e ^ 2, e)", "2 * e")]
+        [InlineData("derivative(i ^ 2, i)", "2 * i")]
+        public void ANameThatOutlivesItsBinderPrintsAsItself(string expression, string printed)
+        {
+            var answer = expression.ToEntity().Simplify();
+            Assert.Equal(printed, answer.Stringize());
+            Assert.NotEqual(printed.ToEntity(), answer);
+        }
+
+        /// <summary>
+        /// <c>Vars</c> says which names an expression depends on, and a bound constant's name is
+        /// one — it is a variable there. A free constant is not, as before.
+        /// </summary>
+        [Fact]
+        public void VarsCountsABoundConstantsNameAndNotAFreeOne()
+        {
+            Assert.Empty("pi + sin(pi)".ToEntity().Vars);
+            Assert.Equal(new[] { "pi" }, "sum(pi, pi, 1, 3)".ToEntity().Vars.Select(v => v.Name));
+            Assert.Equal(new[] { "x" }, "pi * x".ToEntity().Vars.Select(v => v.Name));
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Core/BoundConstantTest.cs
+++ b/Sources/Tests/UnitTests/Core/BoundConstantTest.cs
@@ -25,15 +25,6 @@ namespace AngouriMath.Tests.Core
     [Trait("Area", "Core")]
     public sealed class BoundConstantTest
     {
-        /// <summary>
-        /// The name a binder declares, as the binder itself reads it. Written rather than parsed,
-        /// because parsing <c>e</c> gives the constant — which is the whole subject here — so an
-        /// expectation spelled as a string could not say "a variable called e" at all.
-        /// </summary>
-        private static Entity.Variable BoundName(string name) =>
-            Assert.IsType<Entity.Summationf>($"sum({name}, {name}, 1, 1)".ToEntity()).Var as Entity.Variable
-            ?? throw new Xunit.Sdk.XunitException($"a binder over {name} did not bind a variable");
-
         // ---------------------------------------------------------------- the five in #984
 
         /// <summary>
@@ -45,9 +36,11 @@ namespace AngouriMath.Tests.Core
         [InlineData("pi")]
         public void DifferentiatingByABoundNameIsNotZero(string name)
         {
-            var bound = BoundName(name);
-            Assert.Equal(2 * bound, $"derivative({name} ^ 2, {name})".ToEntity().Simplify());
-            Assert.Equal(2 * bound, $"derivative({name} ^ 2, {name})".ToEntity().Evaled);
+            // `<name>_1` and not `<name>`: the answer carries the name out of the binder that
+            // declared it, and a variable called `pi` is one the parser cannot produce. See
+            // ANameThatOutlivesItsBinderIsRenamedSoItCanBeWritten below.
+            Assert.Equal($"2 * {name}_1".ToEntity(), $"derivative({name} ^ 2, {name})".ToEntity().Simplify());
+            Assert.Equal($"2 * {name}_1".ToEntity(), $"derivative({name} ^ 2, {name})".ToEntity().Evaled);
         }
 
         /// <summary>A set builder's predicate is about its own name, not about the constant.</summary>
@@ -124,9 +117,9 @@ namespace AngouriMath.Tests.Core
             foreach (var name in new[] { "e", "pi" })
             {
                 // Where the bound name outlives its binder -- an indefinite integral, a
-                // derivative -- it is a variable, so it is renamed rather than substituted for.
+                // derivative -- it comes back renamed, so the comparison renames it to match.
                 var bound = string.Format(shape, name).ToEntity().Simplify();
-                var renamed = bound.Substitute(BoundName(name), MathS.Var("qq"));
+                var renamed = bound.Substitute($"{name}_1".ToEntity(), MathS.Var("qq"));
                 Assert.Equal(ordinary, renamed);
             }
         }
@@ -280,21 +273,62 @@ namespace AngouriMath.Tests.Core
             Assert.Equal(expected.ToEntity(), expression.ToEntity().Simplify());
 
         /// <summary>
-        /// A name that outlives the binder that declared it is a variable, and prints as the name
-        /// it was given — so the printed form reads back as the constant rather than as that
-        /// variable. Recorded rather than asserted away: it is the same for the imaginary unit
-        /// since <a href="https://github.com/asc-community/AngouriMath/issues/976">#976</a>, and
-        /// nothing short of a name for the escaped variable would change it.
+        /// A name that outlives the binder that declared it is renamed to one that can be written.
+        /// Most binders consume their name — a sum answers a number, a set builder keeps it inside
+        /// itself — but a derivative and an indefinite integral return it, and a variable called
+        /// <c>pi</c> is a thing the parser cannot produce, so <c>2 * pi</c> would read back as
+        /// twice the constant. Renaming a bound variable is free, so it is renamed.
         /// </summary>
         [Theory]
-        [InlineData("derivative(pi ^ 2, pi)", "2 * pi")]
-        [InlineData("derivative(e ^ 2, e)", "2 * e")]
-        [InlineData("derivative(i ^ 2, i)", "2 * i")]
-        public void ANameThatOutlivesItsBinderPrintsAsItself(string expression, string printed)
+        [InlineData("derivative({0} ^ 2, {0})", "2 * {0}_1")]
+        [InlineData("integral({0} ^ 2, {0})", "{0}_1 ^ 3 / 3 + C")]
+        public void ANameThatOutlivesItsBinderIsRenamedSoItCanBeWritten(string shape, string expected)
         {
-            var answer = expression.ToEntity().Simplify();
-            Assert.Equal(printed, answer.Stringize());
-            Assert.NotEqual(printed.ToEntity(), answer);
+            foreach (var name in new[] { "pi", "e", "i" })
+                Assert.Equal(string.Format(expected, name).ToEntity(),
+                             string.Format(shape, name).ToEntity().Simplify());
+            // An ordinary name is not renamed, because it did not need to be.
+            Assert.Equal(string.Format(expected, "qq").Replace("qq_1", "qq").ToEntity(),
+                         string.Format(shape, "qq").ToEntity().Simplify());
+        }
+
+        /// <summary>
+        /// Which is the property the renaming exists for: whatever a binder over one of these
+        /// names answers, printing it and reading it back gives the same expression.
+        /// </summary>
+        [Theory]
+        [InlineData("derivative({0} ^ 2, {0})")]
+        [InlineData("integral({0} ^ 2, {0})")]
+        [InlineData("integral({0} ^ 2, {0}, 0, 1)")]
+        [InlineData("sum({0} ^ 2, {0}, 1, 3)")]
+        [InlineData("product({0} ^ 2, {0}, 1, 3)")]
+        [InlineData("limit({0} ^ 2, {0}, 3)")]
+        [InlineData("{{ {0} : {0} > 0 }}")]
+        [InlineData("lambda({0}, {0} + 1)")]
+        public void EveryBinderOverAConstantsNameAnswersSomethingThatReadsBack(string shape)
+        {
+            foreach (var name in new[] { "pi", "e", "i", "qq" })
+            {
+                var answer = string.Format(shape, name).ToEntity().Simplify();
+                Assert.Equal(answer, answer.Stringize().ToEntity());
+            }
+        }
+
+        /// <summary>
+        /// Differentiation compares the node and not its name, so a constant that simplification
+        /// produces inside a binder over that name is not differentiated as though it were the
+        /// index. <c>arccos(0)</c> is <c>pi / 2</c>, and the product rule was applying to both
+        /// factors of <c>arccos(0) * pi</c> where only one of them depends on the index.
+        /// </summary>
+        [Fact]
+        public void AProducedConstantIsNotDifferentiatedAsTheIndex()
+        {
+            Assert.Equal("derivative(arccos(0) * qq, qq)".ToEntity().Simplify(),
+                         "derivative(arccos(0) * pi, pi)".ToEntity().Simplify());
+            Assert.Equal("pi / 2".ToEntity(), "derivative(arccos(0) * pi, pi)".ToEntity().Simplify());
+            // And the `e` inside a logarithm is not the index either.
+            Assert.Equal("derivative(ln(x) * qq, qq)".ToEntity().Simplify(),
+                         "derivative(ln(x) * e, e)".ToEntity().Simplify());
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #984.

`Variable.ConstantList` was keyed by **name** and `Variable.InnerSimplify` read it, so a variable called `e` was `2.718…` wherever it was read — binder or no binder. The tree carried nothing that said an occurrence was bound, so nothing downstream could tell a declared name from the constant of that name.

| written | before | after |
|---|---|---|
| `derivative(e ^ 2, e)` | `0` | `2 * e` |
| `derivative(pi ^ 2, pi)` | `0` | `2 * pi` |
| `{ e : e > 0 }` | `{ e : True }` | `{ e : e > 0 }` |
| `limit(e, e, 0).Evaled` | `2.718…` | `0` |
| `integral(e, e, 0, 1).Evaled` | `3.694…` | `1/2` |
| `integral(arccos(0), pi, 0, 1)` | `1/4` | `pi / 2` |

## The mechanism

`Entity.Constant`: a constant is a **node**, not a name. The parser and `MathS.pi`/`MathS.e` hand one back; a binder replaces the occurrences it was given with a plain `Variable` of that name, so it holds a variable while the rest of the language holds the constant.

It derives from `Variable`, which is what keeps this additive — `Vars`, `Substitute` and `Solve` are all typed `Variable`, and a sibling type under `Entity` would change every one of those signatures. `Rational : Real : Complex` is the same shape in the number hierarchy, and takes the same `SealedOrAbstract` exemption.

**Nothing carries a scope downstream, and nothing needed to.** Binding is decided at construction, in the node's initialiser. That is also why the last row above needs no scope-aware evaluator: `arccos(0)` is `pi / 2`, and the `pi` that produces is a different occurrence from the one the binder replaced, so it cannot be captured.

All seven binders read the same `Core.Binding` — the five calculus operators through `CalculusOperator`, the set builder, and now `Lambda` in the node rather than only where the grammar builds one. The name-keyed paths went with it: `ToSymPy` exported a bound `e` as `sympy.E`, LaTeX set it upright as a constant, and the compiler substituted it by name.

## A binder binds occurrences, not values

`MathS.Ln(a)` is `Logf(e, a)` and `exp(x)` is `MathS.Pow(MathS.e, x)`, so every logarithm and exponential contains an `e`. On master that is already wrong with no binder in sight — `ln(x).Vars` is `{x}` and `ln(x).Substitute("e", 3)` is `log(3, x)`.

So the second distinction is **identity**, not equality. Every constant a writer types is the one object in `NamedConstants`; `ln` and `exp` are built over `Constant.EulerIntrinsic`, a separate object, because Euler's number inside an operator's own definition is a value and not a mention of the name. `Binding.In` compares by reference:

```csharp
"sum(ln(x), e, 1, 2)"      // was: log(1, x) + log(2, x)   now: 2 * ln(x)
"sum(exp(x), e, 1, 2)"     // was: 1 + 2 ^ x               now: 2 * e ^ x
"sum(ln(e), e, 1, 1)"      // was: NaN, being log(1, 1)    now: 0

"sum(log(e, x), e, 1, 2)"  // log(1, x) + log(2, x), unchanged — the writer named e, so it binds
"sum(e ^ x, e, 1, 2)"      // 1 + 2 ^ x, unchanged         — likewise
```

Substituting **for the constant** still reaches that base, unchanged — `MathS.Ln("x").Substitute("e", 3)` is `log(3, x)` before and after. A binder binds *occurrences*; a substitution replaces a *value*, and the base of a logarithm is Euler's number by value however it got there. (An earlier revision of this description and of `BREAKING-CHANGES.md` claimed otherwise; corrected in a647b1f7 after measuring it.)

The two roles are `==`, print alike and hash alike, so every rule matches both and canonical form, substitution and equality are untouched — `e ^ 2 * exp(3)` is still `e ^ 5`. **Making them unequal instead was tried and is worse**: that collection stops happening, and normalising them back together makes `InnerSimplify` non-idempotent. 19 tests failed that way.

## What this does not do

- **It does not make `exp` and `ln` primitives.** They are still spelled over `e`; the reference test is what keeps a binder out of them. Making `log(x)` unary and `log(x, b)` sugar — SymPy's shape — is the better long-term representation and a different change: 45 sites across 26 files pattern-match `Logf`, and every one would have to learn a second node.
- ~~**A name that outlives its binder still prints as that name.**~~ **Fixed in 6dec137a** after review — a name that leaves its binder is renamed to one the parser can produce (`2 * pi_1`), because a variable called `pi` cannot be written and `2 * pi` would read back as twice the constant. Only `derivative` and the indefinite `integral` return the bound name; every other binder consumes it and already printed as it was written. This covers `i` as well, which has had the same answer since #976, and amends that entry's rows in `BREAKING-CHANGES.md`. An ordinary name is never renamed.
- **It does not touch free `pi` and `e`.** `sin(pi)` is `0`, `ln(e)` is `1`, `arccos(0)` is `pi / 2`, numeric values unchanged.
- **It does not add a scope to evaluation.** #746 tier 1 and #721 will find binding already decided rather than having to decide it.

- **Differentiation compares the node, not its name.** `Variable.InnerDifferentiate` was the last `Name ==` in the library, and it made `derivative(arccos(0) * pi, pi)` answer `0` — the constant that `arccos(0)` simplifies to compared equal by name to the index, so the product rule differentiated it too. It is `pi / 2` now, the same as over an ordinary name. `grep -rn "\.Name ==" Sources/AngouriMath` returns nothing.

## Two consequences to read for

Both in `BREAKING-CHANGES.md`. `Vars` reports a bound constant's name, because it is a variable there — `"sum(pi, pi, 1, 3)".ToEntity().Vars` was empty and is now `pi`, while `"pi * x"` is still `x`. And `MathS.pi` is a `Constant`; it is still *typed* `Variable`, so no signature changed and nothing that compiles today stops compiling, but `MathS.Var("pi")` is a constant and a `pi` a binder declares is no longer equal to it.

## Measured

- **Suite 7426 passed, 0 failed, 14 skipped**; F# wrapper 134 passed.
- **`BoundConstantTest`, 51 cases — 15 of them fail against master's library**, so the file binds rather than pins. It covers each row above, every binder over both names and against an ordinary name, nested and shadowing scopes, free constants, printing and round-tripping, and `i`.
- **Public surface: 13 added, 0 removed.** `PublicApi.txt` regenerated.
- Corpus **116/119, 0 wrong, 0 error, 0 timeout** — unchanged.
- `canoncheck` **byte-identical to master**: idempotence, order independence and the listed agreements all unmoved.
- `crashcheck` 1736 cases, **0 crashed**, with `pi`, `e`, `sum(pi, pi, 1, 3)`, `derivative(e ^ 2, e)` and `{ e : e > 0 }` added to its written shapes.

The parser change is one identifier in the grammar action and the matching line in the generated parser; `AngouriMath.g` and `AngouriMathParser.cs` are otherwise untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


