### PR TITLE
Ask whether it is a member, not whether it might be (#995)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -35,6 +35,29 @@ read first.
 | **Silent** | `limit(i, i, 0)` | unevaluated | `0` |
 | **Silent** | `integral(i, i)` | `-1/2 + C` | `i ^ 2 / 2 + C` |
 | | `lambda(i, i + 1)` | `InvalidArgumentParseException` | the lambda |
+| **Silent** | `[1, 2] in RR`, and a matrix or a finite set against any of `BB`, `ZZ`, `QQ`, `RR`, `CC` | `True` | `False` |
+
+### A matrix is no longer a member of every special set at once
+
+`SpecialSet.TryContains` decided membership by asking `MayContain`, which is deliberately permissive
+about anything that is not a constant leaf — the right answer for a codomain guard, which has to let
+through what it has not ruled out, and the wrong one for a membership decision.
+
+```csharp
+"[1, 2] in BB".ToEntity().Simplify()              // was: True    now: False
+"[1, 2] in ZZ".ToEntity().Simplify()              // was: True    now: False
+"[1, 2] in RR".ToEntity().Simplify()              // was: True    now: False
+"[1, 2] in (ZZ /\\ BB)".ToEntity().Simplify()     // was: True    now: False
+"{ 1, 2 } in RR".ToEntity().Simplify()            // was: True    now: False
+```
+
+The old answers were mutually contradictory — `ZZ` and `BB` share no members, and the same matrix was
+in both — so nothing could have depended on all of them. `MayContain` itself is unchanged, and so is
+every answer for a number or a boolean: `3 in RR` is `True`, `i in RR` is `False`, `x in RR` is still
+undecided rather than answered.
+
+Measured: the whole suite passes with the fix in, and the corpus is unchanged at 116/119 with 0 wrong.
+[#995](https://github.com/asc-community/AngouriMath/issues/995).
 
 ### A rewritten node keeps its `Codomain`, so a domain constraint no longer disappears
 

--- a/Sources/AngouriMath/Core/Entity/Omni/Entity.Omni.Classes.cs
+++ b/Sources/AngouriMath/Core/Entity/Omni/Entity.Omni.Classes.cs
@@ -593,9 +593,22 @@ namespace AngouriMath
                 public override bool TryContains(Entity entity, out bool contains)
                 {
                     contains = false;
-                    if (entity.Evaled.IsSymbolic)
+                    var evaled = entity.Evaled;
+                    if (evaled.IsSymbolic)
                         return false;
-                    contains = MayContain(entity.Evaled);
+                    // MayContain asks whether something *might* be a member, and so is
+                    // permissive about everything that is not a constant leaf. That is what
+                    // its other caller needs -- a codomain guard has to let through what it
+                    // has not ruled out -- but membership is the opposite question, and
+                    // answering it with the permissive result made a matrix a member of BB,
+                    // ZZ, QQ, RR and CC at once, and of ZZ /\ BB with them.
+                    // A closed non-leaf -- a matrix, a finite set, an interval -- is neither
+                    // a number nor a boolean, so it is a member of none of these, and that
+                    // is decided rather than unknown.
+                    // https://github.com/asc-community/AngouriMath/issues/995
+                    if (!evaled.IsConstantLeaf)
+                        return true;
+                    contains = MayContain(evaled);
                     return true;
                 }
 

--- a/Sources/Tests/UnitTests/Core/Sets/Contains.cs
+++ b/Sources/Tests/UnitTests/Core/Sets/Contains.cs
@@ -88,6 +88,24 @@ namespace AngouriMath.Tests.Core.Sets
         [InlineData("{x} \\ {y}", "z", false, false)]
         [InlineData("{x} \\ {1}", "1", false, false)]
         [InlineData("{x} \\ {1}", "x", false, false)]
+
+        // A closed non-leaf is not a number and not a boolean, so it is a member of
+        // none of the special sets -- and that is decided, not unknown. It used to be
+        // a member of every one of them, because TryContains answered with MayContain's
+        // deliberately permissive result.
+        // https://github.com/asc-community/AngouriMath/issues/995
+        [InlineData("BB", "[1, 2]", false)]
+        [InlineData("ZZ", "[1, 2]", false)]
+        [InlineData("QQ", "[1, 2]", false)]
+        [InlineData("RR", "[1, 2]", false)]
+        [InlineData("CC", "[1, 2]", false)]
+        [InlineData("ZZ /\\ BB", "[1, 2]", false)]
+        [InlineData("RR", "{ 1, 2 }", false)]
+        [InlineData("RR", "[0; 1]", false)]
+        // and the leaves it always decided correctly still are decided correctly
+        [InlineData("RR", "2", true)]
+        [InlineData("BB", "RR", false)]
+        [InlineData("RR", "RR", false)]
         public void Test(string given, string expected, bool containsExpected, bool tryContainsExpected = true)
         {
             var actualRaw = given.ToEntity();


### PR DESCRIPTION
Fixes #995.

## The defect

`SpecialSet.TryContains` decided membership by asking `MayContain`, and every `MayContain` is written to be permissive:

```csharp
public override bool MayContain(Entity entity)
    => entity is Boolean || !entity.IsConstantLeaf;   // Booleans, and the same shape four more times
```

`IsConstantLeaf` is `Boolean or Number or SpecialSet`, so a matrix, a finite set and an interval were all "not ruled out" and therefore members — of every special set, simultaneously:

| | before | after |
|---|---|---|
| `[1, 2] in BB` | `True` | `False` |
| `[1, 2] in ZZ` | `True` | `False` |
| `[1, 2] in QQ` | `True` | `False` |
| `[1, 2] in RR` | `True` | `False` |
| `[1, 2] in CC` | `True` | `False` |
| `[1, 2] in (ZZ /\ BB)` | `True` | `False` |
| `{ 1, 2 } in RR` | `True` | `False` |
| `[0; 1] in RR` | `True` | `False` |

`ZZ` and `BB` share no members, so the old answers contradicted each other and nothing could have relied on all of them.

## Why the two disagree

The two names are asking two different questions, and only one implementation existed for both.

`MayContain` — *might this be a member* — is right for its other caller. `DomainsFunctional.FitsDomainOrNonNumeric` guards a codomain, and there the safe direction is to let through whatever has not been ruled out. **`MayContain` is unchanged by this PR.**

`TryContains` — *is this a member* — hands back a decision in an `out bool`. Reading the permissive result as the decided one turns "I cannot rule this out" into "yes".

The symbolic guard above it is why this survived: anything containing a variable is declined before `MayContain` is reached, and every numeric value *is* a constant leaf, so only the closed non-leaves took the permissive branch. For those the right answer is available — a matrix is not a real number — and it is `False`, decided rather than unknown.

## What did not change

```
3 in RR      -> decided: yes        i in RR    -> decided: no
true in BB   -> decided: yes        3 in BB    -> decided: no
3/4 in QQ    -> decided: yes        3/4 in ZZ  -> decided: no
x in RR      -> undecided           RR in BB   -> decided: no
```

Out of scope, and deliberately: `+oo in CC` and `0/0 in RR` are both `True` today. Those are constant leaves, so they go down the other branch — the same question as the `-oo` half of the domain-condition discussion, not this one. #995 says so too.

## Measured

- Full suite on this branch: **7377 passed, 0 failed**, 14 skipped.
- `casbench`: **116/119**, 0 wrong, 0 error, 0 timeout — the standing figure.
- 11 new cases in `Sources/Tests/UnitTests/Core/Sets/Contains.cs`, covering each special set against a matrix, the intersection, a finite set, an interval, and the leaf answers that must not move.
- `BREAKING-CHANGES.md` entry with both values measured on builds — `5211ccd6` for the old ones.
