### PR TITLE
Do not report a name the expression does not contain (#989)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -35,6 +35,46 @@ read first.
 | **Silent** | `limit(i, i, 0)` | unevaluated | `0` |
 | **Silent** | `integral(i, i)` | `-1/2 + C` | `i ^ 2 / 2 + C` |
 | | `lambda(i, i + 1)` | `InvalidArgumentParseException` | the lambda |
+| **Silent** | `"{ k : k > 0 }".ToEntity().FreeVariables` — and `Vars`, and `VarsAndConsts` | `{ %1 }`, a name in no expression | `{ }`, `{ k }`, `{ k }` |
+
+### A set builder's internal placeholder no longer escapes into `Vars` or `FreeVariables`
+
+`ConditionalSet.DirectChildren` is its predicate with the bound name renamed to a fresh one, so that
+two builders differing only in that name compare and hash alike — `{ x : x > 0 } = { y : y > 0 }`
+is `True`, and stays `True`. Every property that reports names by walking `DirectChildren` picked
+that invented name up and returned it.
+
+```csharp
+"{ k : k > 0 }".ToEntity().FreeVariables   // was: { %1 }   now: { }
+"{ k : k > 0 }".ToEntity().Vars            // was: { %1 }   now: { k }
+"{ k : k > a }".ToEntity().FreeVariables   // was: { %1, a }      now: { a }
+"{ k : k > a }".ToEntity().Vars            // was: { %1, a }      now: { k, a }
+"x + { k : k > a }".ToEntity().Vars        // was: { x, %1, a }   now: { x, k, a }
+```
+
+`%1` is neither answer on anybody's definition. It is not the bound name, it is not in the
+expression the caller wrote, `Variable.CreateTemp` invents a different one for a different
+predicate, and it cannot be typed — the parser has no `%`. It broke `Vars`'s own promise too, which
+is the variables that *occur*: `k` occurs and was missing, `%1` does not occur and was there.
+
+A set builder binds the name it declares exactly as a lambda binds its parameter, so all three
+properties now answer for `{ k : ... }` what they already answered for `lambda(k, ...)`:
+
+| | `lambda(k, k > a)` | `{ k : k > a }` was | `{ k : k > a }` now |
+|---|---|---|---|
+| `FreeVariables` | `{ a }` | `{ %1, a }` | `{ a }` |
+| `Vars` | `{ k, a }` | `{ %1, a }` | `{ k, a }` |
+
+Only the reporting changed. `DirectChildren` still publishes the renamed predicate, because that is
+what makes two alpha-equivalent builders equal, and `Replace` and `Substitute` never used it — both
+override and work from `Var` and `Predicate` directly.
+
+This does **not** answer the second half of [#989](https://github.com/asc-community/AngouriMath/issues/989),
+which asks whether `sum`, `integral`, `limit` and `derivative` should bind their variable here too.
+That is a documented choice rather than a leak, and it is still open.
+
+Measured: suite 7376 passed, 0 failed; corpus unchanged at 116/119 with 0 wrong, and no case's
+verdict or answer altered. [#989](https://github.com/asc-community/AngouriMath/issues/989).
 
 ### A rewritten node keeps its `Codomain`, so a domain constraint no longer disappears
 

--- a/Sources/AngouriMath/Core/Entity/Entity.Definition.cs
+++ b/Sources/AngouriMath/Core/Entity/Entity.Definition.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) 2019-2022 Angouri.
 // AngouriMath is licensed under MIT.
 // Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
@@ -547,7 +547,19 @@ namespace AngouriMath
         /// </code>
         /// </example>
         public IReadOnlyCollection<Variable> VarsAndConsts => varsAndConsts.GetValue(
-            static @this => new HashSet<Variable>(@this is Variable v ? new[] { v } : @this.DirectChildren.SelectMany(x => x.VarsAndConsts)), this);
+            static @this => new HashSet<Variable>(@this switch
+                {
+                    Variable v => new[] { v },
+                    // A set builder's DirectChildren is its predicate with the bound name
+                    // renamed to a fresh one, so that two set builders differing only in
+                    // that name compare and hash alike. That name is invented, not written:
+                    // it is not in the expression, it cannot be typed, and a different
+                    // predicate gets a different one. Read the builder's own parts instead.
+                    // https://github.com/asc-community/AngouriMath/issues/989
+                    Set.ConditionalSet(var bound, var predicate)
+                        => predicate.VarsAndConsts.Concat(bound.VarsAndConsts),
+                    _ => @this.DirectChildren.SelectMany(x => x.VarsAndConsts)
+                }), this);
         private LazyPropertyA<IReadOnlyCollection<Variable>> varsAndConsts;
 
 
@@ -597,6 +609,13 @@ namespace AngouriMath
                         Lambda(var par, var body)
                             => body.FreeVariables.Where(v => v != par).ToList(),
                         Variable v => new []{ v },
+                        // Same as above: the renamed predicate that DirectChildren publishes
+                        // would put an invented name in the answer. A set builder also binds
+                        // the name it declares, exactly as a lambda binds its parameter, so
+                        // that name is not free either.
+                        // https://github.com/asc-community/AngouriMath/issues/989
+                        Set.ConditionalSet(var bound, var predicate)
+                            => predicate.FreeVariables.Where(v => !bound.VarsAndConsts.Contains(v)).ToList(),
                         _ => new HashSet<Variable>(@this.DirectChildren.SelectMany(c => c.FreeVariables))
                     }
                 ,

--- a/Sources/Tests/UnitTests/Common/FreeVariablesTest.cs
+++ b/Sources/Tests/UnitTests/Common/FreeVariablesTest.cs
@@ -68,5 +68,52 @@ namespace AngouriMath.Tests.Common
                 SeqVar("x", "y", "z"),
                 "x + lambda(f, y + z + x)".ToEntity().FreeVariables
             );
+
+        // A set builder's DirectChildren is its predicate with the bound name renamed
+        // to a fresh one, so that two builders differing only in that name compare and
+        // hash alike. Reading the answer off DirectChildren therefore reported a name
+        // that is in no expression: not the bound name, not typeable, and different for
+        // a different predicate. A set builder binds the name it declares exactly as a
+        // lambda binds its parameter, so these mirror the lambda cases above.
+        // https://github.com/asc-community/AngouriMath/issues/989
+        [Theory]
+        [InlineData("{ k : k > 0 }")]
+        [InlineData("{ k : k > a }")]
+        [InlineData("x + { k : k > a }")]
+        public void ASetBuildersPlaceholderIsInNoAnswer(string exprRaw)
+        {
+            var expr = exprRaw.ToEntity();
+            Assert.DoesNotContain(expr.FreeVariables, v => v.Name.StartsWith("%"));
+            Assert.DoesNotContain(expr.Vars, v => v.Name.StartsWith("%"));
+            Assert.DoesNotContain(expr.VarsAndConsts, v => v.Name.StartsWith("%"));
+        }
+
+        [Theory]
+        [InlineData("{ k : k > 0 }")]
+        [InlineData("lambda(k, k > 0)")]
+        public void ASetBuilderBindsItsNameAsALambdaDoes(string exprRaw)
+            => Assert.Equal(SeqVar(), exprRaw.ToEntity().FreeVariables);
+
+        [Theory]
+        [InlineData("{ k : k > a }")]
+        [InlineData("lambda(k, k > a)")]
+        public void ASetBuilderLeavesTheRestFree(string exprRaw)
+            => Assert.Equal(SeqVar("a"), exprRaw.ToEntity().FreeVariables);
+
+        [Theory]
+        [InlineData("{ k : k > a }")]
+        [InlineData("lambda(k, k > a)")]
+        public void ASetBuildersOwnNameStillOccurs(string exprRaw)
+            => Assert.Equal(
+                SeqVar("k", "a").OrderBy(v => v.Name),
+                exprRaw.ToEntity().Vars.OrderBy(v => v.Name));
+
+        // and the rename it publishes is still doing its job: two builders that differ
+        // only in the bound name are the same set
+        [Fact]
+        public void TwoSetBuildersDifferingOnlyInTheBoundNameAreStillEqual()
+            => Assert.Equal(
+                Entity.Boolean.True,
+                "{ x : x > 0 } = { y : y > 0 }".ToEntity().Simplify());
     }
 }


### PR DESCRIPTION
Fixes §1 of #989. **Leaves §2 open** — see the end.

## The defect

`ConditionalSet.DirectChildren` is its predicate with the bound name renamed to a fresh one, so that two builders differing only in that name compare and hash alike. Every property that reports names by walking `DirectChildren` picked that invented name up and returned it.

```csharp
"{ k : k > 0 }".ToEntity().FreeVariables   // was: { %1 }        now: { }
"{ k : k > 0 }".ToEntity().Vars            // was: { %1 }        now: { k }
"{ k : k > a }".ToEntity().FreeVariables   // was: { %1, a }     now: { a }
"{ k : k > a }".ToEntity().Vars            // was: { %1, a }     now: { k, a }
"x + { k : k > a }".ToEntity().Vars        // was: { x, %1, a }  now: { x, k, a }
```

`%1` is neither answer on anybody's definition. It is not the bound name, it is not in the expression the caller wrote, `Variable.CreateTemp` invents a different one for a different predicate, and it cannot be typed — the parser has no `%`.

## Wider than the issue says

I filed #989 against `FreeVariables` and wrote there that `Vars` "promises less: it is documented as the variables that occur, and an occurrence is what it counts". That was wrong, and measuring it is what showed it: the leak is one channel — `DirectChildren` — and `Vars` and `VarsAndConsts` go through it too. `%1` does not *occur* either, and `k`, which does, was missing. So `Vars` was not being lenient, it was breaking its own promise in both directions.

Fixing only the property the issue named would have left the same invented name in the more widely used one.

## The fix

A set builder binds the name it declares exactly as a lambda binds its parameter, so all three properties now answer for `{ k : ... }` what they already answered for `lambda(k, ...)`:

| | `lambda(k, k > a)` | `{ k : k > a }` was | `{ k : k > a }` now |
|---|---|---|---|
| `FreeVariables` | `{ a }` | `{ %1, a }` | **`{ a }`** |
| `Vars` | `{ k, a }` | `{ %1, a }` | **`{ k, a }`** |

Two cases added, next to the `Lambda` case that was already there.

## What is deliberately untouched

`DirectChildren` still publishes the renamed predicate. I checked whether the rename could simply be dropped at the source — it is what gives alpha-invariance to `SortHash`, `EqualsImprecisely` and pattern matching, and `{ x : x > 0 } = { y : y > 0 }` is `True` because of it. There is a test asserting that still holds.

It was worth checking because the two obvious rewriting consumers do *not* use it: `ConditionalSet.Replace` is `func(New(Var, Predicate.Replace(func)))` and `ConditionalSet.Substitute` does its own capture-avoiding rename, both from `Var` and `Predicate` directly. So only the reporting properties ever saw `%1`, and only they change.

## §2 is not answered here

Whether `sum`, `integral`, `limit` and `derivative` should bind their variable in `FreeVariables` too is the other half of #989. It is a documented choice — the XML doc says "a parameter of some outer lambda" — and a breaking change for anyone reading the property as "occurring variables", so I would rather have an answer than assume one. That issue stays open.

## Measured

- Suite: **7376 passed, 0 failed**, 14 skipped. Without the new tests it is 7366, the master baseline.
- Corpus: **116/119, 0 wrong, 0 error, 0 timeout** — compared row by row against the recorded report, **no case's verdict or answer changed**, only timings.
- 10 new cases. Controlled: with the fix reverted they are **6 failed, 11 passed**, the passes being the pre-existing lambda cases and the alpha-equivalence check, which should pass either way.
- `BREAKING-CHANGES.md` entry with both values measured on a build of each arm.

## Against the other open PRs

Derived with `git merge-tree --write-tree`:

| against | conflicts |
|---|---|
| #990 `fix/bound-name-must-be-symbolic` | `BREAKING-CHANGES.md` only |
| #991 `constant-node-984` | `BREAKING-CHANGES.md` only |
| #997 `fix/special-set-membership-995` | `BREAKING-CHANGES.md` only |
| #998 `fix/determinant-division-free-992` | `BREAKING-CHANGES.md` only |

No source conflicts with any of them. Whichever merges last takes the mechanical round and I will do it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbKcbJP266A3EGyQ5kq7Ru