### PR TITLE
Emit SymPy code that runs (#985)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -35,6 +35,67 @@ read first.
 | **Silent** | `limit(i, i, 0)` | unevaluated | `0` |
 | **Silent** | `integral(i, i)` | `-1/2 + C` | `i ^ 2 / 2 + C` |
 | | `lambda(i, i + 1)` | `InvalidArgumentParseException` | the lambda |
+| **Silent** | `MathS.ToSympyCode` for any set, lambda, piecewise or non-vector matrix | Python that does not run — `NameError`, `SyntaxError`, `TypeError`, or an exception out of the exporter | Python that runs |
+
+### `ToSympyCode` emits Python that runs
+
+`MathS.ToSympyCode` is documented as producing code you can run in SymPy. For every set, every
+lambda, every `piecewise` and every non-vector matrix, it did not — and the failure was **silent**
+in the sense that matters here: the string came back looking like Python.
+
+The preamble is `import sympy` and nothing else, so every SymPy name in the body has to be
+qualified. Six exports were not, and a seventh threw before it got that far:
+
+```python
+expr = FiniteSet(1, 2)                        # was: NameError: name 'FiniteSet' is not defined
+expr = Interval(0, 1, ...)                    # was: NameError: name 'Interval' is not defined
+expr = Union(FiniteSet(1, 2), FiniteSet(3))   # was: NameError: name 'Union' is not defined
+expr = x in S.Reals                           # was: NameError: name 'S' is not defined
+expr = sympy.Lambda(x, )                      # was: TypeError: missing 1 required positional argument
+```
+
+| input | was | now |
+|---|---|---|
+| `{ 1, 2 }` | `FiniteSet(1, 2)` | `sympy.FiniteSet(1, 2)` |
+| `ZZ` | `S.Integers` | `sympy.S.Integers` |
+| `{1,2} \/ {3}` | `Union(FiniteSet(1, 2), FiniteSet(3))` | `sympy.Union(sympy.FiniteSet(1, 2), sympy.FiniteSet(3))` |
+| `lambda(x, sin(x) + 1)` | `sympy.Lambda(x, )` | `sympy.Lambda(x, sympy.sin(x) + 1)` |
+| `{ x : x > 0 }` | `AngouriBugException` out of the exporter | `sympy.ConditionSet(x, x > 0, sympy.S.UniversalSet)` |
+| `[sin(a); b]` | `Interval(sin(a), b, ...)` | `sympy.Interval(sympy.sin(a), b, ...)` |
+| `piecewise(sin(x) provided x > 0, …)` | `sympy.Piecewise((sin(x), x > 0), …)` | `sympy.Piecewise((sympy.sin(x), x > 0), …)` |
+| `[[sin(a), b], [c, d]]` | `sympy.ImmutableMatrix([[sin(a), b], …])` | `sympy.ImmutableMatrix([[sympy.sin(a), b], …])` |
+| `x in RR` | `x in S.Reals` | `(sympy.S.Reals).contains(x)` |
+
+Three separate faults, all of them invisible to the tests that were there:
+
+- **Unqualified names.** `import sympy` binds `sympy`, not `FiniteSet` or `S`.
+- **Parts interpolated rather than exported.** `Interval`, `Piecewise` and the non-vector `Matrix`
+  wrote their children with `{Left}` instead of `{Left.ToSymPy()}`. A bare variable spells the same
+  in both languages, so it only shows once the part is a function — `sin(a)`, which Python does not
+  have.
+- **A set builder threw.** `ConditionalSet.Codomain` is `Domain.Any`, which `SpecialSet.Create` has
+  no member for, so the exporter's cast raised `AngouriBugException` — "please report about it to
+  the official repository", which is [#985](https://github.com/asc-community/AngouriMath/issues/985).
+  SymPy names that set: `S.UniversalSet`, which is the one it prints `ConditionSet` *without* a
+  third argument for.
+
+`x in RR` also changes shape rather than just qualification. Python's `in` coerces its result to a
+`bool`, and a membership that is not decided is not one: `x in sympy.S.Reals` raises
+`TypeError: did not evaluate to a bool: (-oo < x) & (x < oo)`. `.contains` answers with the
+condition, and still answers `True` or `False` where it can.
+
+**Why the tests passed.** They asserted substring containment — `Assert.Contains("Piecewise((a, b),
+(c, d))")` — which holds whether the parts were exported or interpolated, and holds on a program
+that does not run at all. The new cases pin the whole emitted expression, and one of them asserts
+every SymPy name carries its qualifier.
+
+Measured with `work/sympycheck`, which executes the generated program rather than reading it: of 45
+emitted programs the corpus now covers, **43 run** and 0 return an inexact value. The two that do
+not are the set builders, whose preamble still declares the placeholder that
+[#989](https://github.com/asc-community/AngouriMath/issues/989) is about — `%1 = sympy.Symbol('%1')`
+is a `SyntaxError` whatever the body says. Their `expr` line is correct here, and with #989's fix
+in as well, 45 of 45 run. Suite 7385 passed, 0 failed; corpus unchanged at 116/119 with 0 wrong.
+[#985](https://github.com/asc-community/AngouriMath/issues/985).
 
 ### A rewritten node keeps its `Codomain`, so a domain constraint no longer disappears
 

--- a/Sources/AngouriMath/Functions/Output/ToSympy/ToSympy.Omni.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/ToSympy/ToSympy.Omni.Classes.cs
@@ -16,19 +16,28 @@ namespace AngouriMath
             partial record FiniteSet
             {
                 internal override string ToSymPy()
-                    => $"FiniteSet({string.Join(", ", Elements.Select(c => c.ToSymPy()))})";
+                    => $"sympy.FiniteSet({string.Join(", ", Elements.Select(c => c.ToSymPy()))})";
             }
 
             partial record Interval
             {
                 internal override string ToSymPy()
-                    => $"Interval({Left}, {Right}, left_open={((Boolean)!LeftClosed).ToSymPy()}, right_open={((Boolean)!RightClosed).ToSymPy()})";
+                    => $"sympy.Interval({Left.ToSymPy()}, {Right.ToSymPy()}, left_open={((Boolean)!LeftClosed).ToSymPy()}, right_open={((Boolean)!RightClosed).ToSymPy()})";
             }
 
             partial record ConditionalSet
             {
+                // A set builder's Codomain is Domain.Any, which SpecialSet.Create has no
+                // member for and throws on -- so every set builder threw an AngouriBugException
+                // out of the exporter. SymPy names that set: S.UniversalSet is the one it
+                // prints ConditionSet without a third argument for, which is what "no
+                // restriction beyond the predicate" means here too.
+                // https://github.com/asc-community/AngouriMath/issues/985
                 internal override string ToSymPy()
-                    => $"ConditionSet({Var.ToSymPy()}, {Predicate.ToSymPy()}, {((SpecialSet)Codomain).ToSymPy()})";
+                    => $"sympy.ConditionSet({Var.ToSymPy()}, {Predicate.ToSymPy()}, {CodomainToSymPy()})";
+
+                private string CodomainToSymPy()
+                    => Codomain is Domain.Any ? "sympy.S.UniversalSet" : SpecialSet.Create(Codomain).ToSymPy();
             }
 
             partial record SpecialSet
@@ -36,25 +45,25 @@ namespace AngouriMath
                 partial record Integers
                 {
                     internal override string ToSymPy()
-                        => "S.Integers";
+                        => "sympy.S.Integers";
                 }
 
                 partial record Rationals
                 {
                     internal override string ToSymPy()
-                        => "S.Rationals";
+                        => "sympy.S.Rationals";
                 }
 
                 partial record Reals
                 {
                     internal override string ToSymPy()
-                        => "S.Reals";
+                        => "sympy.S.Reals";
                 }
 
                 partial record Complexes
                 {
                     internal override string ToSymPy()
-                        => "S.Complexes";
+                        => "sympy.S.Complexes";
                 }
 
                 internal override string ToSymPy()
@@ -64,25 +73,30 @@ namespace AngouriMath
             partial record Unionf
             {
                 internal override string ToSymPy()
-                    => $"Union({Left.ToSymPy()}, {Right.ToSymPy()})";
+                    => $"sympy.Union({Left.ToSymPy()}, {Right.ToSymPy()})";
             }
 
             partial record Intersectionf
             {
                 internal override string ToSymPy()
-                    => $"Intersection({Left.ToSymPy()}, {Right.ToSymPy()})";
+                    => $"sympy.Intersection({Left.ToSymPy()}, {Right.ToSymPy()})";
             }
 
             partial record SetMinusf
             {
                 internal override string ToSymPy()
-                    => $"Complement({Left.ToSymPy()}, {Right.ToSymPy()})";
+                    => $"sympy.Complement({Left.ToSymPy()}, {Right.ToSymPy()})";
             }
 
             partial record Inf
             {
+                // Python's `in` forces its result to a bool, and a membership that is not
+                // decided is not one: `x in sympy.S.Reals` raises "did not evaluate to a
+                // bool: (-oo < x) & (x < oo)". `.contains` is the form that answers with the
+                // condition instead, and it still answers True or False when it can.
+                // https://github.com/asc-community/AngouriMath/issues/985
                 internal override string ToSymPy()
-                    => $"{Element.ToSymPy(Element.Priority < Priority)} in {SupSet.ToSymPy(SupSet.Priority < Priority)}";
+                    => $"({SupSet.ToSymPy()}).contains({Element.ToSymPy()})";
             }
         }
 
@@ -96,7 +110,7 @@ namespace AngouriMath
 
         partial record Piecewise
         {
-            internal override string ToSymPy() => $"sympy.Piecewise({string.Join(", ", Cases.Select(c => $"({c.Expression}, {c.Predicate})"))})";
+            internal override string ToSymPy() => $"sympy.Piecewise({string.Join(", ", Cases.Select(c => $"({c.Expression.ToSymPy()}, {c.Predicate.ToSymPy()})"))})";
         }
         
         partial record Matrix
@@ -107,7 +121,7 @@ namespace AngouriMath
                         IsVector switch
                         {
                             true => this.Select(c => c.ToSymPy()),
-                            false => this.Select(c => $"[{string.Join(", ", ((Matrix)c).T)}]"),
+                            false => this.Select(c => $"[{string.Join(", ", ((Matrix)c).T.Select(e => e.ToSymPy()))}]"),
                         }) +
                    "])";
         }
@@ -123,7 +137,7 @@ namespace AngouriMath
         partial record Lambda
         {
             internal override string ToSymPy()
-                => $"sympy.Lambda({Parameter.ToSymPy()}, )";
+                => $"sympy.Lambda({Parameter.ToSymPy()}, {Body.ToSymPy()})";
         }
     }
 }

--- a/Sources/Tests/UnitTests/Convenience/ToSymPyTEst.cs
+++ b/Sources/Tests/UnitTests/Convenience/ToSymPyTEst.cs
@@ -68,8 +68,11 @@ namespace AngouriMath.Tests.Convenience
         [InlineData(@"A \/ B", "Union(A, B)")]
         [InlineData(@"A /\ B", "Intersection(A, B)")]
         [InlineData(@"A \ B", "Complement(A, B)")]
-        [InlineData(@"a in B", "a in B")]
-        [InlineData("domain({ x : x > 0 }, RR)", "ConditionSet(x, x > 0, S.Reals)")]
+        // both of these recorded the old output, and neither of those outputs ran:
+        // `a in B` raises rather than answering, and `ConditionSet`/`S` are unqualified.
+        // https://github.com/asc-community/AngouriMath/issues/985
+        [InlineData(@"a in B", "(B).contains(a)")]
+        [InlineData("domain({ x : x > 0 }, RR)", "sympy.ConditionSet(x, x > 0, sympy.S.Reals)")]
         [InlineData("sec(x)", "sympy.sec(x)")]
         [InlineData("csc(x)", "sympy.csc(x)")]
         [InlineData("arcsec(x)", "sympy.asec(x)")]
@@ -91,6 +94,69 @@ namespace AngouriMath.Tests.Convenience
             else
                 Assert.DoesNotContain(expectedToBeIn, MathS.ToSympyCode(ent));
         }
+
+        // Substring containment is what let these ship. `Assert.Contains("Piecewise((a, b),
+        // (c, d))")` passes whether the parts were exported or merely interpolated, because a
+        // bare variable spells the same in both languages -- and it passes on a program that
+        // does not run at all, because `import sympy` alone binds neither `FiniteSet` nor `S`.
+        // These pin the whole emitted expression instead. The harness that actually executes
+        // it is `work/sympycheck` in the analysis workspace.
+        // https://github.com/asc-community/AngouriMath/issues/985
+        [Theory]
+        // named without the qualifier the preamble's lone `import sympy` requires: NameError
+        [InlineData("{ 1, 2 }", "sympy.FiniteSet(1, 2)")]
+        [InlineData("[0; 1]", "sympy.Interval(0, 1, left_open=False, right_open=False)")]
+        [InlineData("ZZ", "sympy.S.Integers")]
+        [InlineData(@"{1,2} \/ {3}", "sympy.Union(sympy.FiniteSet(1, 2), sympy.FiniteSet(3))")]
+        [InlineData(@"{1,2} /\ {2}", "sympy.Intersection(sympy.FiniteSet(1, 2), sympy.FiniteSet(2))")]
+        [InlineData(@"{1,2} \ {2}", "sympy.Complement(sympy.FiniteSet(1, 2), sympy.FiniteSet(2))")]
+        // a body that was never emitted: sympy.Lambda(x, ) is a SyntaxError
+        [InlineData("lambda(x, sin(x) + 1)", "sympy.Lambda(x, sympy.sin(x) + 1)")]
+        // a set builder threw AngouriBugException out of the exporter, because its codomain is
+        // Domain.Any and SpecialSet.Create has no member for it
+        [InlineData("{ x : x > 0 }", "sympy.ConditionSet(x, x > 0, sympy.S.UniversalSet)")]
+        // parts interpolated as this library spells them rather than as SymPy does -- visible
+        // only once the part is a function, since a bare name spells the same either way
+        [InlineData("[sin(a); b]", "sympy.Interval(sympy.sin(a), b, left_open=False, right_open=False)")]
+        [InlineData("piecewise(sin(x) provided x > 0, 1 provided x < 0)",
+            "sympy.Piecewise((sympy.sin(x), x > 0), (1, x < 0))")]
+        [InlineData("[[sin(a), b], [c, d]]", "sympy.ImmutableMatrix([[sympy.sin(a), b], [c, d]])")]
+        // Python's `in` forces a bool, so `x in sympy.S.Reals` raises rather than answering
+        // with the condition
+        [InlineData("x in RR", "(sympy.S.Reals).contains(x)")]
+        public void TheWholeEmittedExpressionIsWhatItShouldBe(string expression, string expected)
+            => Assert.Equal(expected, EmittedExpressionOf(MathS.FromString(expression)));
+
+        private static string EmittedExpressionOf(Entity entity)
+        {
+            var code = MathS.ToSympyCode(entity);
+            var at = code.LastIndexOf("expr = ", System.StringComparison.Ordinal);
+            return code.Substring(at + "expr = ".Length).Trim();
+        }
+
+        // The preamble is `import sympy` and nothing else, so every SymPy name in the body has
+        // to carry the qualifier. Nothing was checking that, and six exports did not.
+        [Theory]
+        [InlineData("{ 1, 2 }")]
+        [InlineData("[0; 1]")]
+        [InlineData("RR")]
+        [InlineData(@"{1,2} \/ {3}")]
+        [InlineData("x in RR")]
+        [InlineData("lambda(x, sin(x))")]
+        [InlineData("piecewise(sin(x) provided x > 0, 1 provided x < 0)")]
+        public void EverySymPyNameIsQualified(string expression)
+        {
+            var code = EmittedExpressionOf(MathS.FromString(expression));
+            foreach (var name in new[]
+                { "FiniteSet", "Interval", "Union", "Intersection", "Complement",
+                  "ConditionSet", "Lambda", "Piecewise", "ImmutableMatrix", "S.", "sin" })
+                foreach (System.Text.RegularExpressions.Match match in
+                    System.Text.RegularExpressions.Regex.Matches(
+                        code, System.Text.RegularExpressions.Regex.Escape(name)))
+                    Assert.True(
+                        match.Index >= "sympy.".Length
+                        && code.Substring(match.Index - "sympy.".Length, "sympy.".Length) == "sympy.",
+                        $"`{name}` is unqualified in `{code}`");
+        }
     }
 }
-


### PR DESCRIPTION
Closes #985 — and the two defects it names turned out to be four, across every set export.

## The defect

`MathS.ToSympyCode` is documented as producing code you can run in SymPy. For every set, every lambda, every `piecewise` and every non-vector matrix, it did not. Run against SymPy 1.14:

```python
expr = FiniteSet(1, 2)                        # NameError: name 'FiniteSet' is not defined
expr = Interval(0, 1, ...)                    # NameError: name 'Interval' is not defined
expr = Union(FiniteSet(1, 2), FiniteSet(3))   # NameError: name 'Union' is not defined
expr = x in S.Reals                           # NameError: name 'S' is not defined
expr = sympy.Lambda(x, )                      # TypeError: missing 1 required positional argument
```

Three separate faults, plus the exception #985 reported:

**Unqualified names.** The preamble is `import sympy` and nothing else, so `FiniteSet`, `Interval`, `Union`, `Intersection`, `Complement`, `ConditionSet` and `S` were every one of them a `NameError`. #985 named the lambda and the set builder; this is the rest of the file.

**Parts interpolated rather than exported.** `Interval`, `Piecewise` and the non-vector `Matrix` wrote their children as `{Left}` instead of `{Left.ToSymPy()}`. A bare variable spells the same in both languages, which is why it went unnoticed — it only shows once the part is a function:

```
[sin(a); b]   was: Interval(sin(a), b, ...)   # Python has no sin
```

**A lambda emitted no body at all** — `sympy.Lambda(x, )`.

**A set builder threw.** `ConditionalSet.Codomain` is `Domain.Any`, which `SpecialSet.Create` has no member for, so the exporter's cast raised `AngouriBugException`. SymPy names that set: `S.UniversalSet` is the one it prints `ConditionSet` *without* a third argument for, which is what "no restriction beyond the predicate" means here too.

## `x in RR` changes shape, not just qualification

Python's `in` coerces its result to a `bool`, and a membership that is not decided is not one:

```python
>>> x in sympy.S.Reals
TypeError: did not evaluate to a bool: (-oo < x) & (x < oo)
>>> sympy.S.Reals.contains(x)
(-oo < x) & (x < oo)
>>> sympy.S.Reals.contains(2)
True
```

`.contains` answers with the condition and still answers `True`/`False` where it can, so that is what is emitted now.

## Why the tests passed

They assert substring containment. `Assert.Contains("Piecewise((a, b), (c, d))")` holds whether the parts were exported or merely interpolated — and holds on a program that does not run at all. Two of the existing cases were recording the broken output outright (`"a in B"` → `"a in B"`, and `ConditionSet(x, x > 0, S.Reals)` unqualified); both are updated.

The new cases pin the **whole** emitted expression with `Assert.Equal`, and one asserts every SymPy name carries its qualifier.

## Measured by running it

`work/sympycheck` in the analysis workspace executes the generated program rather than reading it — it exists because #909 and #911 were both invisible to string tests. Its corpus stopped at numbers; I extended it from 24 cases to 45 to reach sets, binders, piecewise and matrices.

| | programs that run |
|---|---|
| `master` | 24 of 45 |
| this PR | **43 of 45** |
| this PR + #1000 | **45 of 45** |

The two outstanding are the set builders, and they are not this PR's half: their `expr` line is correct here, but the preamble still declares `%1 = sympy.Symbol('%1')` — the placeholder leak of #989, fixed in #1000, and a `SyntaxError` whatever the body says. I built a local integration branch of both and ran it: **45 of 45, 0 inexact**, suite 7395 passed 0 failed.

Also: suite **7385 passed, 0 failed** on this branch alone; corpus **116/119, 0 wrong**, with no case's verdict or answer changed.

## Against the other open PRs

Derived with `git merge-tree --write-tree`:

| against | conflicts |
|---|---|
| #990, #991, #997, #998, #1000 | `BREAKING-CHANGES.md` only |

No source conflicts with any of them — this touches `ToSympy.Omni.Classes.cs`, which none of the others do. Whichever merges last takes the mechanical round and I will do it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbKcbJP266A3EGyQ5kq7Ru