### PR TITLE
Differentiate n times where n times was asked for (#1002)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -35,6 +35,49 @@ read first.
 | **Silent** | `limit(i, i, 0)` | unevaluated | `0` |
 | **Silent** | `integral(i, i)` | `-1/2 + C` | `i ^ 2 / 2 + C` |
 | | `lambda(i, i + 1)` | `InvalidArgumentParseException` | the lambda |
+| **Silent** | `"x ^ 3".ToEntity().Differentiate(x, 2)`, and every `Differentiate(x, n)` with `n >= 1` | `(0 * x ^ 2 + 2 * x ^ 1 * 1 * 3) * 1 + 0 * 3 * x ^ 2` | `2 * x * 3` |
+
+### `Differentiate(x, n)` answers what `Differentiate(x)` n times answers
+
+The two overloads reached different code. `Differentiate(Variable)` goes through the transformation,
+which ends at `DifferentiateOnce` and simplifies; `Differentiate(Variable, int)` called
+`InnerDifferentiate` straight in its loop, so nothing was ever simplified — and because each pass
+differentiated the *unsimplified* result of the last, every `0 *` and `* 1` the chain rule produces
+was still there to be differentiated again.
+
+```csharp
+var x = MathS.Var("x");
+"x ^ 3".ToEntity().Differentiate(x, 1)   // was: 3 * x ^ 2 * 1                                   now: 3 * x ^ 2
+"x ^ 3".ToEntity().Differentiate(x, 2)   // was: (0 * x ^ 2 + 2 * x ^ 1 * 1 * 3) * 1 + 0 * 3 * x ^ 2   now: 2 * x * 3
+```
+
+At `n = 3` it is no longer just untidy:
+
+```
+"x ^ 4".Differentiate(x, 3)
+// was: (0 * x ^ 3 + 3 * x ^ 2 * 1 * 0 + ((0 * x ^ 2 + 2 * x ^ 1 * 1 * 3) * 1 + 0 * 3 * x ^ 2) * 4
+//       + 0 * 3 * x ^ 2 * 1) * 1 + 0 * (0 * x ^ 3 + 3 * x ^ 2 * 1 * 4) + 0 * 4 * x ^ 3
+//       + (0 * x ^ 3 + 3 * x ^ 2 * 1 * 4) * 0
+// now: 2 * x * 3 * 4
+```
+
+The value was never wrong — `Differentiate(x, 3)` and differentiating three times agree numerically
+on both versions — so this is a change of *form*, and it breaks anyone matching on the shape of the
+result. It also means the cost grew with the accumulated mess rather than with the derivative.
+
+`n = 0` (returns the input) and `n < 0` (integrates) are unchanged.
+
+**Why the two were not simply merged.** `Derivativef`'s simplification decides whether a derivative
+can be taken by asking for it and keeping the node when a `Derivativef` comes back — that test is
+what terminates it. Routing it through an overload that simplifies each pass makes it simplify the
+very node it is deciding about, arrive back at itself, and recurse: `derivative(x!, x, 2)` overflowed
+the stack after 3214 frames. So the raw loop still exists as an internal `InnerDifferentiate(Variable,
+int)`, which is what that caller uses, and only the public overload simplifies. There are cases for
+both in `work/crashcheck`.
+
+Measured: suite 7378 passed, 0 failed; corpus unchanged at 116/119 with 0 wrong, no case's verdict or
+answer altered; crashcheck 1834 cases, 0 crashed.
+[#1002](https://github.com/asc-community/AngouriMath/issues/1002).
 
 ### A rewritten node keeps its `Codomain`, so a domain constraint no longer disappears
 

--- a/Sources/AngouriMath/Functions/Continuous/Differentiation.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Differentiation.cs
@@ -75,6 +75,29 @@ namespace AngouriMath
             protected override Entity InnerDifferentiate(Variable variable) => Elementwise(e => e.InnerDifferentiate(variable));
         }
 
+        /// <summary>
+        /// <paramref name="power"/> raw passes, with nothing simplified in between.
+        /// <see cref="Derivativef"/>'s simplification needs exactly this and not the public
+        /// overload: it asks for the derivative and keeps the node when what comes back is
+        /// still a <see cref="Derivativef"/>, so a simplification anywhere inside would ask
+        /// that same node to simplify, which asks for the derivative again, without end.
+        /// </summary>
+        internal Entity InnerDifferentiate(Variable x, int power)
+        {
+            var ent = this;
+            // A negative power integrates, exactly as the public overload does -- dropping that
+            // here turned derivative(apply(f, x), x, -1) into apply(f, x) rather than into the
+            // integral, because a loop that never runs returns the input and the input is not a
+            // Derivativef, so the caller took it for a resolved answer.
+            if (power < 0)
+                for (var _ = 0; _ < -power; _++)
+                    ent = ent.Integrate(x);
+            else
+                for (var _ = 0; _ < power; _++)
+                    ent = ent.InnerDifferentiate(x);
+            return ent;
+        }
+
         /// <summary>Derives over <paramref name="x"/> <paramref name="power"/> times</summary>
         public Entity Differentiate(Variable x, int power)
         {
@@ -84,7 +107,14 @@ namespace AngouriMath
                     ent = ent.Integrate(x);
             else
                 for (var _ = 0; _ < power; _++)
-                    ent = ent.InnerDifferentiate(x);
+                    // DifferentiateOnce, not InnerDifferentiate: the raw chain rule leaves
+                    // every `0 *` and `* 1` it produces in place, and the next pass
+                    // differentiates those too, so the expression compounds rather than
+                    // reduces. Differentiate(Variable) reaches DifferentiateOnce through the
+                    // transformation, which is why one pass of it answered and n passes of
+                    // this did not.
+                    // https://github.com/asc-community/AngouriMath/issues/1002
+                    ent = ent.DifferentiateOnce(x);
             return ent;
         }
 

--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
@@ -23,16 +23,20 @@ namespace AngouriMath
                 ExpandOnTwoAndTArguments(Expression, Var, Iterations,
                     (a, b, c) => (a, b, c) switch
                     {
-                        // TODO: should we call InnerSimplified here?
+                        // InnerDifferentiate, not the public Differentiate: the test below is
+                        // "did the derivative come back unresolved", and the public overload
+                        // simplifies each pass, so asking it would simplify the very
+                        // Derivativef this is deciding about and arrive back here unchanged.
+                        // https://github.com/asc-community/AngouriMath/issues/1002
                         (var expr, Variable var, int asInt)
-                            when expr.Differentiate(var, asInt) is var res and not Derivativef
+                            when expr.InnerDifferentiate(var, asInt) is var res and not Derivativef
                             => res.InnerSimplified(isExact),
                         (var expr, Variable var, int asInt) => null,
                         (Application, _, _) => null,
                         (var expr, Entity otherExpr, int asInt)
                             when Variable.CreateTemp(otherExpr.Vars) is var tempVar
                             && expr.Substitute(otherExpr, tempVar) is var tempSubstituted
-                            && tempSubstituted.Differentiate(tempVar, asInt) is var res and not Derivativef
+                            && tempSubstituted.InnerDifferentiate(tempVar, asInt) is var res and not Derivativef
                             => res.Substitute(tempVar, otherExpr).InnerSimplified(isExact),
                         _ => null
                     },

--- a/Sources/Tests/UnitTests/Calculus/DerivativeTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/DerivativeTest.cs
@@ -238,5 +238,70 @@ namespace AngouriMath.Tests.Calculus
             Assert.True(limit.Evaled is Entity.Limitf,
                 $"the expansion should be refused here, and it came back {limit.Evaled}");
         }
+
+        /// <summary>
+        /// The two overloads reached different code. <c>Differentiate(Variable)</c> goes through
+        /// the transformation, which ends at <c>DifferentiateOnce</c> and simplifies;
+        /// <c>Differentiate(Variable, int)</c> called <c>InnerDifferentiate</c> straight in its
+        /// loop, so every <c>0 *</c> and <c>* 1</c> the chain rule produces stayed in and the
+        /// next iteration differentiated those too. <c>x ^ 3</c> twice came back as
+        /// <c>(0 * x ^ 2 + 2 * x ^ 1 * 1 * 3) * 1 + 0 * 3 * x ^ 2</c> where differentiating twice
+        /// by hand gives <c>2 * x * 3</c>.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1002">#1002</a>
+        /// </summary>
+        [Theory]
+        [InlineData("x ^ 4", 0)]
+        [InlineData("x ^ 4", 1)]
+        [InlineData("x ^ 4", 2)]
+        [InlineData("x ^ 4", 3)]
+        [InlineData("sin(x) * x", 2)]
+        [InlineData("sin(x) / x", 2)]
+        [InlineData("x ^ 5 + sin(x)", 3)]
+        public void DifferentiatingNTimesIsDifferentiatingOnceNTimes(string exprRaw, int power)
+        {
+            var expr = exprRaw.ToEntity();
+            var once = expr;
+            for (var k = 0; k < power; k++)
+                once = once.Differentiate(x);
+            Assert.Equal(once, expr.Differentiate(x, power));
+        }
+
+        /// <summary>
+        /// The negative-power path integrates instead, and is not what changed.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1002">#1002</a>
+        /// </summary>
+        [Fact] public void ANegativePowerStillIntegrates()
+            => Assert.Equal("x ^ 2".ToEntity().Integrate(x), "x ^ 2".ToEntity().Differentiate(x, -1));
+
+        /// <summary>
+        /// **Regression guard for a stack overflow.** <see cref="Derivativef"/>'s simplification
+        /// asks for the derivative and keeps the node when what comes back is still a
+        /// <c>Derivativef</c> -- that test is what terminates it. Routing it through the public
+        /// <c>Differentiate(Variable, int)</c>, which simplifies each pass, made it simplify the
+        /// very node it was deciding about, arrive back at itself, and recurse until the stack
+        /// ran out: <c>derivative(x!, x, 2)</c> overflowed after 3214 frames. The raw
+        /// <c>InnerDifferentiate(Variable, int)</c> is what that caller needs, and the public
+        /// overload is free to simplify.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1002">#1002</a>
+        /// </summary>
+        [Theory(Timeout = 30000)]
+        // a derivative that cannot be taken at all, so the node survives every pass
+        [InlineData("derivative(x!, x, 2)")]
+        [InlineData("derivative(x!, x, 3)")]
+        [InlineData("derivative(sin(x!) + x, x, 2)")]
+        public void ADerivativeThatCannotBeTakenTerminatesAtEveryPower(string exprRaw)
+        {
+            var expr = exprRaw.ToEntity();
+            Assert.NotNull(expr.InnerSimplified);
+            Assert.NotNull(expr.Evaled);
+        }
+
+        /// <summary>
+        /// And it is still refused rather than answered.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1002">#1002</a>
+        /// </summary>
+        [Fact] public void ADerivativeThatCannotBeTakenIsStillUnevaluated()
+            => Assert.True("derivative(x!, x, 2)".ToEntity().InnerSimplified is Derivativef,
+                $"expected it to stay a Derivativef, got {"derivative(x!, x, 2)".ToEntity().InnerSimplified}");
     }
 }


### PR DESCRIPTION
Closes #1002 — **and the fix that issue proposes is wrong**; see *Why the two cannot simply be merged*.

## The defect

`Differentiate(Variable)` goes through the transformation, which ends at `DifferentiateOnce` and simplifies. `Differentiate(Variable, int)` called `InnerDifferentiate` straight in its loop, so nothing was ever simplified — and because each pass differentiated the *unsimplified* result of the last, every `0 *` and `* 1` the chain rule produces was still there to be differentiated again.

```csharp
var x = MathS.Var("x");
"x ^ 3".ToEntity().Differentiate(x, 1)   // was: 3 * x ^ 2 * 1
                                         // now: 3 * x ^ 2
"x ^ 3".ToEntity().Differentiate(x, 2)   // was: (0 * x ^ 2 + 2 * x ^ 1 * 1 * 3) * 1 + 0 * 3 * x ^ 2
                                         // now: 2 * x * 3
```

I wrote in the issue that `power = 1` was fine. It is not — one raw pass still leaks its `* 1`. At `n = 3` it stops being untidy:

```
"x ^ 4".Differentiate(x, 3)
was: (0 * x ^ 3 + 3 * x ^ 2 * 1 * 0 + ((0 * x ^ 2 + 2 * x ^ 1 * 1 * 3) * 1 + 0 * 3 * x ^ 2) * 4
      + 0 * 3 * x ^ 2 * 1) * 1 + 0 * (0 * x ^ 3 + 3 * x ^ 2 * 1 * 4) + 0 * 4 * x ^ 3
      + (0 * x ^ 3 + 3 * x ^ 2 * 1 * 4) * 0
now: 2 * x * 3 * 4
```

The value was never wrong — the two routes agree numerically on both versions — so this is a change of **form**, and it breaks anyone matching on the shape. It also means the cost grew with the accumulated mess rather than with the derivative.

## Why the two cannot simply be merged

#1002 says "use `DifferentiateOnce` in the loop". Doing exactly that **overflows the stack**:

```
$ probe 'innersimp::derivative(x!, x, 2)'
Stack overflow.
Repeated 3214 times: ...
   at AngouriMath.Entity.DifferentiateOnce(Variable)
   at AngouriMath.Entity.Differentiate(Variable, Int32)
   at AngouriMath.Entity+Derivativef+<>c__DisplayClass20_0.<InnerSimplify>b__0(...)
```

`Derivativef`'s simplification decides whether a derivative can be taken by **asking for it and keeping the node when a `Derivativef` comes back**. That test is what terminates it. An overload that simplifies each pass makes it simplify the very node it is deciding about, which asks for the derivative again, forever.

So the raw loop stays, as an internal `InnerDifferentiate(Variable, int)` that `Derivativef.InnerSimplify` uses, and only the public overload simplifies. That is also the answer to the `// TODO: should we call InnerSimplified here?` sitting above that arm — no, and now there is a comment saying why.

## And the raw variant must keep the negative-power branch

My first version of it did not, on the reasoning that "raw differentiation" has nothing to do with integration. Three tests disagreed:

```
DerivativeToIntegralSimplify   Expected: integral(apply(f, x), x)   Actual: apply(f, x)
```

A loop that never runs returns its input, and the input is not a `Derivativef`, so the caller took it for a resolved answer and the integral vanished. That is a wrong answer rather than a crash, so nothing but the suite would have caught it.

## Measured

- Suite: **7378 passed, 0 failed**, 14 skipped.
- Corpus: **116/119, 0 wrong, 0 error, 0 timeout**, compared row by row — no verdict or answer changed.
- `work/crashcheck`: **1834 cases, 0 crashed**, with seven cases added for this shape (both signs of the power, and a derivative that cannot be taken nested inside an expression).
- 12 new cases: the two routes agree at powers 0–3 over several expressions, the negative power still integrates, and a `[Theory(Timeout = 30000)]` guarding the overflow.
- `BREAKING-CHANGES.md` entry with both values measured on a build of each arm.

## Against the other open PRs

Derived with `git merge-tree --write-tree` — this one is **not** doc-only:

| against | conflicts |
|---|---|
| #990 `fix/bound-name-must-be-symbolic` | `BREAKING-CHANGES.md` **+ `Evaluation.Continuous.Calculus.Classes.cs`** |
| #991 `constant-node-984` | `BREAKING-CHANGES.md` **+ `Evaluation.Continuous.Calculus.Classes.cs`** |
| #997, #998, #1000, #1001 | `BREAKING-CHANGES.md` only |

Both source conflicts are one line each and additive — #990 adds a guard to the arm, #991 wraps the result in `Core.Binding.Written`, and this changes which method the arm calls. I resolved all three on a local integration branch of #1002 + #990 + #991 and ran it: **7467 passed, 0 failed**. I will do the rebase whichever way they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbKcbJP266A3EGyQ5kq7Ru