### PR TITLE
Name the release 2.3.0, which removes nothing (#746)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -15,7 +15,7 @@ read first.
 
 ---
 
-## Unreleased — since 2.2.0
+## 2.3.0 — since 2.2.0
 
 ### At a glance
 

--- a/Sources/Package.Build.props
+++ b/Sources/Package.Build.props
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   
   <!--
@@ -17,7 +17,7 @@
     release tag, so what ships is named by the tag; this is what a local build and the
     assembly metadata carry.
     -->
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
 
     <!--
     Pinned to the major for the whole of 2.x, and deliberately not tracking Version.
@@ -27,11 +27,16 @@
 
     That is binding, not compatibility: a member removed or renamed within 2.x still
     throws MissingMethodException when a consumer compiled against the older assembly
-    reaches it. 2.2.0 renames two, both recorded in BREAKING-CHANGES.md. FileVersion
-    carries the release for anyone reading the file properties.
+    reaches it. 2.2.0 renamed two, which is why that sentence is here.
+
+    2.3.0 removes and renames nothing. The public surface only grows, by 103 members,
+    with 0 removals against the 2.2.0 baseline in Tests/UnitTests/Common/PublicApi.txt.
+    So for this release the pin is a drop-in guarantee in both senses. What did change is
+    behaviour, in seventeen ways recorded in BREAKING-CHANGES.md, and no assembly version
+    can express that. FileVersion carries the release for anyone reading file properties.
     -->
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.2.0.0</FileVersion>
+    <FileVersion>2.3.0.0</FileVersion>
 
     <Authors>WhiteBlackGoose and contributors</Authors>
     <Company>Angouri</Company>


### PR DESCRIPTION
Rafael picked the number; this is the mechanical half plus the checks behind it.

`Version` and `FileVersion` move to 2.3.0, `BREAKING-CHANGES.md`'s "Unreleased" section becomes "2.3.0 — since 2.2.0", and `AssemblyVersion` stays `2.0.0.0` as it has for the whole of 2.x.

## The AssemblyVersion comment changes, because this release is the other case

The pin's comment explains that holding it is *binding* compatibility and not *source* compatibility — 2.2.0 renamed two members, so a consumer that swapped the assembly without recompiling would bind and then throw `MissingMethodException`. That stays, because it is still the general truth.

But 2.3.0 removes and renames **nothing**. Measured against the 2.2.0 baseline in `Tests/UnitTests/Common/PublicApi.txt`:

```
$ git diff v2.2.0 master -- Sources/Tests/UnitTests/Common/PublicApi.txt
  103 additions, 0 removals
```

So for this release the pin is a drop-in guarantee in both senses, and the comment now says which release it is describing. What *did* change is behaviour, in seventeen ways, and no assembly version can express that.

## Checked against #746

2.3.0 advances tier 1 and tier 2 and completes neither. Nothing here is a new capability tier — it is behaviour correction plus the rule-registry work that tier 2 asks for — so it is a minor release. A note recording that goes on #746 when this merges.

## Measured

Suite on this tree: **7533 passed, 0 failed**, 14 skipped. Everything else on the merge base `3ac24bc2`, with CI green across all ten workflows including `C++ Test`, `F# Build` and `F# Test`:

| harness | result |
|---|---|
| corpus | 116/119, **0 wrong**, 0 error, 0 timeout |
| Rubi (`intbench`) | **604/1774** solved, **0 wrong** — was 536 and 7 at the last measure |
| `propcheck` | 1340 checks, 0 failures |
| `rootcheck` | 596/596, 0 incomplete, 0 unsound |
| `simpsweep` | 10463/10463 agree |
| `boundcheck` | 814 comparisons, 0 disagreements |
| `crashcheck` | 1834 cases, 0 crashed |
| `docsamples` | 84 samples, 0 compile errors, 0 output mismatches |
| `sympycheck` | 45/45 emitted programs run |

And every open issue that could still be a bug was re-measured rather than read: **#873, #878 and #890 are all fixed** and have the measurement posted on them. No known wrong answer is outstanding.

The performance pair is **#1005** — the 1769th column, taken on the same runner class as the 1620th and 1671st, every row faster or flat and `SolveEasy` 2.5× faster. That should merge before this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbKcbJP266A3EGyQ5kq7Ru