### PR TITLE
Make the derivation a path from the input to the answer (#28, #273)

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/DerivationPath.cs
+++ b/Sources/AngouriMath/Core/Transformations/DerivationPath.cs
@@ -1,0 +1,188 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AngouriMath.Core.Transformations
+{
+    /// <summary>
+    /// One whole expression turning into another: the grain a derivation is read at.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Not the same thing as <see cref="RewriteStep"/>, and the difference is the whole point.
+    /// A <see cref="RewriteStep"/> is one rule firing on one <i>subexpression</i>, somewhere in
+    /// the middle of a pass; a <see cref="DerivationStep"/> is a pass, with the entire expression
+    /// as it stood before it and as it stood after. The second is what can be chained — the
+    /// <see cref="After"/> of one step is the <see cref="Before"/> of the next — and the first is
+    /// what says which identity was used, which is why the rewrites are carried along in
+    /// <see cref="Rewrites"/> rather than replaced by the pass that contained them.
+    /// </para>
+    /// </remarks>
+    public readonly struct DerivationStep
+    {
+        internal DerivationStep(Entity before, Entity after, RewriteRuleSet? ruleSet, string name, IReadOnlyList<RewriteStep> rewrites)
+            => (Before, After, RuleSet, Name, Rewrites) = (before, after, ruleSet, name, rewrites);
+
+        /// <summary>The whole expression as it stood before this step.</summary>
+        public Entity Before { get; }
+
+        /// <summary>The whole expression as it stood after it. Never equal to <see cref="Before"/>.</summary>
+        public Entity After { get; }
+
+        /// <summary>
+        /// Which registered rule set did it, where the step is one set applied once —
+        /// <see langword="null"/> where the step is something else the simplifier does
+        /// (inner simplification, expansion, factoring, polynomial rearrangement).
+        /// </summary>
+        /// <remarks>
+        /// The same "null where it is not addressable" convention as
+        /// <see cref="RewriteStep.Rule"/>: a step that is not a rule set has no rule set to
+        /// name, and saying so is better than inventing one.
+        /// </remarks>
+        public RewriteRuleSet? RuleSet { get; }
+
+        /// <summary>What did it, named. <see cref="RewriteRuleSet.Name"/> where there is one.</summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The individual rewrites that fired inside this step, in the order they fired.
+        /// </summary>
+        /// <remarks>
+        /// Not the same list as <see cref="RuleSet"/> being non-null. A step that is one rule set
+        /// applied once carries what that set matched; a step that is a chain of them — the
+        /// tidying pass every stage of the simplifier runs is six — carries everything that fired
+        /// anywhere inside it, and names no single set. And empty is ordinary: a polynomial
+        /// rearrangement or an expansion changes the expression without any rule matching.
+        /// </remarks>
+        public IReadOnlyList<RewriteStep> Rewrites { get; }
+
+        /// <summary>What this step claims about its output, where it is a rule set. See <see cref="RewriteRuleSet.Relation"/>.</summary>
+        public TransformationRelation? Relation => RuleSet?.Relation;
+
+        /// <summary>How well justified that claim is, where it is a rule set. See <see cref="Soundness"/>.</summary>
+        public Soundness? Soundness => RuleSet?.Soundness;
+
+        /// <inheritdoc/>
+        public override string ToString() => $"{Name}: {Before.Stringize()} -> {After.Stringize()}";
+    }
+
+    /// <summary>
+    /// How an expression became an answer: an ordered chain of whole expressions, each one the
+    /// result of the step before it, from the input to the value that was actually returned.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is what <see cref="RewriteRecording.Steps"/> and <see cref="RewriteRecording.Derivation"/>
+    /// are not. Those are the rewrites that fired, across every candidate
+    /// <see cref="Entity.Simplify(int)"/> generated including the ones it discarded, each on the
+    /// subexpression it matched. Reading them in order does not walk from the input to the answer.
+    /// This does: <c>Steps[i].After == Steps[i + 1].Before</c> holds for every <c>i</c>,
+    /// <c>Steps[0].Before</c> is the <see cref="Input"/>, and the last step lands on the
+    /// <see cref="Result"/>. Compared as expressions, not as printed forms.
+    /// </para>
+    /// <para>
+    /// <b>The losing candidates are not here.</b> The simplifier explores far more expressions than
+    /// it keeps — <see cref="ExpressionsExplored"/> says how many — and a route through a discarded
+    /// candidate is not a route to the answer. They are excluded rather than labelled because a
+    /// derivation is read forwards: a reader following the chain from the input needs every entry
+    /// to be a step towards the answer, and a marked dead end is something to skip, which is the
+    /// same as not being there while costing the reader the skip. What was explored but not taken
+    /// is a fact about the search, and it is reported as a count for that reason.
+    /// </para>
+    /// <para>
+    /// <b>Every step really happened.</b> Each one is an edge the engine actually traversed, with
+    /// the expression it started from and the one it produced. Where several recorded routes reach
+    /// the answer, the shortest is taken, and ties are settled by the order the engine recorded
+    /// them in — so the same input gives the same path.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// using AngouriMath;
+    /// using AngouriMath.Core.Transformations;
+    ///
+    /// foreach (var step in DerivationPath.OfSimplifying("x ^ (-1) / (y / z)")!.Steps)
+    ///     Console.WriteLine(step);
+    /// </code>
+    /// </example>
+    public sealed class DerivationPath
+    {
+        internal DerivationPath(Entity input, Entity result, IReadOnlyList<DerivationStep> steps, int expressionsExplored)
+            => (Input, Result, Steps, ExpressionsExplored) = (input, result, steps, expressionsExplored);
+
+        /// <summary>Where it started.</summary>
+        public Entity Input { get; }
+
+        /// <summary>Where it ended — the value the operation returned.</summary>
+        public Entity Result { get; }
+
+        /// <summary>
+        /// The steps, in order. Empty where the input was already the answer, which is a path of
+        /// length zero rather than a failure.
+        /// </summary>
+        public IReadOnlyList<DerivationStep> Steps { get; }
+
+        /// <summary>
+        /// How many distinct expressions the search produced on the way, of which
+        /// <see cref="Steps"/> is the chain it kept.
+        /// </summary>
+        /// <remarks>
+        /// Here so that the path does not read as though it were the whole of what happened. On
+        /// <c>x^(-1)/(y/z)</c> the search produces eleven expressions, keeps four of them, and
+        /// fires 270 rewrites doing it; a four-step derivation presented on its own says none of
+        /// that.
+        /// </remarks>
+        public int ExpressionsExplored { get; }
+
+        /// <summary>
+        /// Runs <see cref="Entity.Simplify(int)"/> under a recording and returns how it got there,
+        /// or <see langword="null"/> where the chain could not be reconstructed.
+        /// </summary>
+        /// <param name="expression">The expression to simplify.</param>
+        /// <param name="level">As <see cref="Entity.Simplify(int)"/>.</param>
+        /// <remarks>
+        /// The whole of <a href="https://github.com/asc-community/AngouriMath/issues/28">#28</a> in
+        /// one call, and it opens and closes the recording itself so that nothing is left on.
+        /// </remarks>
+        public static DerivationPath? OfSimplifying(Entity expression, int level = 2)
+        {
+            if (expression is null)
+                throw new ArgumentNullException(nameof(expression));
+            using var recording = RewriteRecording.Start();
+            var result = expression.Simplify(level);
+            return recording.PathFrom(expression, result);
+        }
+
+        /// <summary>
+        /// The path written out: the input, then one line per step giving what the expression
+        /// became and what made it so.
+        /// </summary>
+        /// <remarks>
+        /// The names are lined up in a column, which is what makes a derivation scannable — the
+        /// reader is looking down the list of identities used, not reading the expressions.
+        /// </remarks>
+        public override string ToString()
+        {
+            var stages = new string[Steps.Count];
+            var column = 0;
+            for (var i = 0; i < Steps.Count; i++)
+            {
+                stages[i] = "  = " + Steps[i].After.Stringize();
+                if (stages[i].Length > column)
+                    column = stages[i].Length;
+            }
+            var text = new StringBuilder(Input.Stringize());
+            for (var i = 0; i < stages.Length; i++)
+                text.Append('\n').Append(stages[i]).Append(' ', column - stages[i].Length)
+                    .Append("   // ").Append(Steps[i].Name);
+            return text.ToString();
+        }
+    }
+}

--- a/Sources/AngouriMath/Core/Transformations/RewriteRecording.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRecording.cs
@@ -38,20 +38,16 @@ namespace AngouriMath.Core.Transformations
     /// <see cref="Entity.Simplify(int)"/> is — is unaffected.
     /// </para>
     /// <para>
-    /// <b>What this is not.</b> It records rewrites — which is what
-    /// <a href="https://github.com/asc-community/AngouriMath/issues/28">#28</a> asks for —
-    /// and not everything <see cref="Entity.Simplify(int)"/> does. Simplification also
-    /// expands, factorises, divides polynomials, minimises boolean expressions and then
-    /// *chooses* among the candidates by a complexity metric; the steps below are the
-    /// rewrites, in the order they fired, across every candidate that was generated,
-    /// including the ones that lost. Reading them as a route from the input to the returned
-    /// answer would be reading in something that is not there.
-    /// </para>
-    /// <para>
-    /// <see cref="Steps"/> is that raw list. <see cref="Derivation"/> is the same list with the
-    /// normalisation and the repeats taken out, which is what a reader asking "how did it get
-    /// there" wants — 270 rewrites down to 6 on <c>x^(-1)/(y/z)</c>. It is still a set of
-    /// rewrites rather than a path; the paragraph above applies to both.
+    /// <b>Three views, and they answer different questions.</b> <see cref="Steps"/> is every
+    /// rewrite that fired, on the subexpression it matched, across every candidate
+    /// <see cref="Entity.Simplify(int)"/> generated including the ones that lost.
+    /// <see cref="Derivation"/> is the same list with the normalisation and the repeats taken
+    /// out — 270 rewrites down to 5 on <c>x^(-1)/(y/z)</c> — and it is still a *set* of
+    /// rewrites, so reading it in order does not walk from the input to the answer.
+    /// <see cref="PathFrom(Entity, Entity)"/> is the one that does: whole expressions, in
+    /// order, from the input to the value that was returned, with the losing candidates left
+    /// out. Ask the first what fired, the second which identities were used, the third how it
+    /// got there.
     /// </para>
     /// </remarks>
     /// <example>
@@ -84,6 +80,22 @@ namespace AngouriMath.Core.Transformations
         /// write rather than a merged list.
         /// </summary>
         private readonly ConcurrentQueue<RewriteStep> steps = new();
+
+        /// <summary>
+        /// One whole expression turning into another, which is what a path is made of. Kept
+        /// beside <see cref="steps"/> rather than derived from it, because a rewrite pass
+        /// records the subexpressions it changed and never the expression that contained
+        /// them — so the two grains are different measurements and neither reconstructs the
+        /// other.
+        /// </summary>
+        private readonly ConcurrentQueue<Edge> edges = new();
+
+        /// <summary>
+        /// How many rewrites have been recorded, so that an edge can say which of them fired
+        /// inside it by index. <see cref="ConcurrentQueue{T}.Count"/> walks the segments, and
+        /// this is read twice per edge.
+        /// </summary>
+        private int recorded;
 
         private volatile bool closed;
 
@@ -128,7 +140,7 @@ namespace AngouriMath.Core.Transformations
         /// way in each, so the raw list repeats itself many times over.
         /// </para>
         /// <para>
-        /// On <c>x^(-1)/(y/z)</c> that is 270 recorded rewrites down to 6.
+        /// On <c>x^(-1)/(y/z)</c> that is 270 recorded rewrites down to 5.
         /// </para>
         /// <para>
         /// <b>This is a set of rewrites, not a path.</b> Each entry is a real rewrite that really
@@ -136,9 +148,8 @@ namespace AngouriMath.Core.Transformations
         /// forms and keeps the best, so these come from several branches and some belong to
         /// candidates that were discarded. Reading them in order does not walk from the input to
         /// the answer, and a step's <see cref="RewriteStep.Before"/> is a subexpression rather than
-        /// the whole expression at that moment. Producing a single path, with a whole expression at
-        /// each stage, needs the simplifier to record which candidate each rewrite belonged to,
-        /// which it does not do yet.
+        /// the whole expression at that moment. <see cref="PathFrom(Entity, Entity)"/> is the view
+        /// that does walk it, at the grain of whole expressions.
         /// </para>
         /// </remarks>
         public IReadOnlyList<RewriteStep> Derivation
@@ -185,6 +196,134 @@ namespace AngouriMath.Core.Transformations
             if (closed)
                 return;
             steps.Enqueue(new RewriteStep(ruleSet, rule, before, after));
+            Interlocked.Increment(ref recorded);
+        }
+
+        /// <summary>Where the rewrite list stands now, so that an edge can bracket its own.</summary>
+        internal int Mark() => Volatile.Read(ref recorded);
+
+        /// <summary>
+        /// One whole expression having become another. <paramref name="from"/> is the
+        /// <see cref="Mark()"/> taken before the work started.
+        /// </summary>
+        internal void Note(Entity before, Entity after, RewriteRuleSet? ruleSet, string name, int from)
+        {
+            if (closed)
+                return;
+            edges.Enqueue(new Edge(before, after, ruleSet, name, from, Mark()));
+        }
+
+        /// <summary>
+        /// How <paramref name="input"/> became <paramref name="result"/>: the steps, in order,
+        /// each one a whole expression. <see langword="null"/> where this recording holds no
+        /// chain of steps joining the two.
+        /// </summary>
+        /// <param name="input">The expression the work started from.</param>
+        /// <param name="result">The value it returned.</param>
+        /// <remarks>
+        /// <para>
+        /// Reconstructed rather than logged, and it has to be: the simplifier does not walk one
+        /// expression to an answer, it grows a family of candidates and keeps the cheapest, so
+        /// "the route" only exists once the winner is known. Every edge here is one the engine
+        /// really traversed; what this does is pick out the ones joining these two ends.
+        /// </para>
+        /// <para>
+        /// The shortest such chain is taken, breadth-first over the edges in the order they were
+        /// recorded — so the answer is the same every time for the same work, and a candidate the
+        /// search abandoned cannot appear, since nothing leads from it to the result.
+        /// </para>
+        /// <para>
+        /// <see langword="null"/> means "this recording cannot account for that", not "there was
+        /// no route". It is what you get from a result this recording never saw produced — a
+        /// different operation, or work done before the recording opened.
+        /// </para>
+        /// </remarks>
+        public DerivationPath? PathFrom(Entity input, Entity result)
+        {
+            if (input is null)
+                throw new ArgumentNullException(nameof(input));
+            if (result is null)
+                throw new ArgumentNullException(nameof(result));
+
+            var all = edges.ToArray();
+            var produced = new HashSet<Entity>();
+            var outgoing = new Dictionary<Entity, List<int>>();
+            for (var i = 0; i < all.Length; i++)
+            {
+                produced.Add(all[i].After);
+                if (!outgoing.TryGetValue(all[i].Before, out var fromHere))
+                    outgoing[all[i].Before] = fromHere = new List<int>();
+                fromHere.Add(i);
+            }
+
+            // Already there. A path of length zero, and not a failure: `2 + 2` simplifies to
+            // `4` before the candidate search starts, and asking how is a fair question with
+            // "it did not have to do anything" as the answer.
+            if (input == result)
+                return new DerivationPath(input, result, Array.Empty<DerivationStep>(), produced.Count);
+
+            var reachedBy = new Dictionary<Entity, int>();
+            var seen = new HashSet<Entity> { input };
+            var frontier = new Queue<Entity>();
+            frontier.Enqueue(input);
+            var arrived = false;
+            while (frontier.Count > 0 && !arrived)
+                if (outgoing.TryGetValue(frontier.Dequeue(), out var fromHere))
+                    foreach (var edge in fromHere)
+                    {
+                        var next = all[edge].After;
+                        if (!seen.Add(next))
+                            continue;
+                        reachedBy[next] = edge;
+                        if (next == result)
+                        {
+                            arrived = true;
+                            break;
+                        }
+                        frontier.Enqueue(next);
+                    }
+            if (!arrived)
+                return null;
+
+            var chain = new List<int>();
+            for (var at = result; reachedBy.TryGetValue(at, out var edge); at = all[edge].Before)
+                chain.Add(edge);
+            chain.Reverse();
+
+            var recordedSteps = steps.ToArray();
+            var path = new List<DerivationStep>(chain.Count);
+            foreach (var edge in chain)
+            {
+                var (before, after, ruleSet, name, from, to) = all[edge];
+                // Clamped because a recording that is still being written to can hand back
+                // fewer rewrites than an edge counted, and a torn read is not worth throwing over.
+                from = Math.Min(from, recordedSteps.Length);
+                to = Math.Min(to, recordedSteps.Length);
+                var rewrites = to > from ? new RewriteStep[to - from] : Array.Empty<RewriteStep>();
+                Array.Copy(recordedSteps, from, rewrites, 0, rewrites.Length);
+                path.Add(new DerivationStep(before, after, ruleSet, name, rewrites));
+            }
+            return new DerivationPath(input, result, path, produced.Count);
+        }
+
+        /// <summary>One recorded whole-expression step, before the rewrites inside it are attached.</summary>
+        private readonly struct Edge
+        {
+            internal Edge(Entity before, Entity after, RewriteRuleSet? ruleSet, string name, int from, int to)
+                => (this.before, this.after, this.ruleSet, this.name, this.from, this.to)
+                    = (before, after, ruleSet, name, from, to);
+
+            private readonly Entity before, after;
+            private readonly RewriteRuleSet? ruleSet;
+            private readonly string name;
+            private readonly int from, to;
+
+            internal Entity After => after;
+
+            internal Entity Before => before;
+
+            internal void Deconstruct(out Entity before, out Entity after, out RewriteRuleSet? ruleSet, out string name, out int from, out int to)
+                => (before, after, ruleSet, name, from, to) = (this.before, this.after, this.ruleSet, this.name, this.from, this.to);
         }
     }
 }

--- a/Sources/AngouriMath/Core/Transformations/RewriteRuleSet.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRuleSet.cs
@@ -106,7 +106,7 @@ namespace AngouriMath.Core.Transformations
             if (node is null)
                 throw new ArgumentNullException(nameof(node));
             // The array, and by index: this is walked once per recorded rewrite and the sets are
-            // long -- CommonRules alone has 103 arms.
+            // long -- Common alone has 100 arms, and InequalityEquality 65.
             for (var i = 0; i < Rules.Count; i++)
                 if (Rules[i].TryApply(node) is { } rewritten && rewritten != node)
                     return Rules[i];
@@ -142,16 +142,25 @@ namespace AngouriMath.Core.Transformations
         /// fifth of its allocation on the benchmark expressions.
         /// </remarks>
         private Entity ApplyOnceRecording(Entity expression, RewriteRecording recording)
-            => expression.Replace(node =>
+        {
+            var mark = recording.Mark();
+            var rewritten = expression.Replace(node =>
             {
-                var rewritten = rules(node);
-                if (rewritten != node)
+                var inner = rules(node);
+                if (inner != node)
                     // Which rule did it, asked only of a node that actually changed and only
                     // while somebody is recording. The arms are tried in the same order the
                     // switch tries them, so the first that applies is the one that fired.
-                    recording.Add(this, RuleFiringAt(node), node, rewritten);
-                return rewritten;
+                    recording.Add(this, RuleFiringAt(node), node, inner);
+                return inner;
             });
+            // And the pass as a whole, which is the grain a derivation is read at: the steps
+            // above are subexpressions, and only this has the expression that contained them
+            // before and after. See RewriteRecording.PathFrom.
+            if (rewritten != expression)
+                recording.Note(expression, rewritten, this, Name, mark);
+            return rewritten;
+        }
 
         /// <summary>
         /// This set as a <see cref="Transformation"/>, so that it composes with the rest of

--- a/Sources/AngouriMath/Docs/Contributing/Transformations.md
+++ b/Sources/AngouriMath/Docs/Contributing/Transformations.md
@@ -38,6 +38,7 @@ same claim in the shape its callers expect, by handing back an unevaluated `Inte
 | `RewriteRuleSet` | a named, attributed group of rewrites — `Name`, `Description`, `Relation`, `Soundness`, `ApplyOnce` |
 | `RewriteRules` | the registry: every rule set the simplifier applies, explicitly listed, enumerable through `All` in a fixed order |
 | `RewriteRecording` / `RewriteStep` | a scope that collects the rewrites which fired while it was open — off unless asked for, and free when off |
+| `DerivationPath` / `DerivationStep` | the same recording read as a route: whole expressions, in order, from the input to the answer that was returned |
 
 Composition is `Then`, `Repeat(n)` and `UntilStable(max)`. All three take their bound from the
 caller: there is no unbounded rewrite loop anywhere in the layer, and `UntilStable` reports hitting
@@ -90,17 +91,58 @@ else's. Recordings nest, and an inner one hides the outer until it closes.
 
 **A step is a subexpression, not a snapshot.** A rewrite pass walks bottom-up and rewrites
 nodes as it goes, so there is no moment at which a partly-rewritten whole expression exists
-to photograph. #28's example shows whole-expression snapshots; reporting those would mean
-constructing something the engine never held.
+to photograph. #28's example shows whole-expression snapshots; those exist at the *boundaries*
+of a pass and not inside one, which is what `DerivationStep` below is made of.
 
-And the honest limit, which the type's own documentation states: **these are the rewrites,
-not everything `Simplify` did.** Simplification also expands, factorises, divides
-polynomials, minimises boolean expressions, and then *chooses* among candidates by a
-complexity metric. The steps are every rewrite that fired across every candidate generated —
-including candidates that lost. Reading them as a route from the input to the returned answer
-would be reading in something that is not there. Making that route available is the
-derivation work in #746's v5.0 tier, and it needs the candidate search to be attributable
-first, not just the rewrites.
+**A recording has three views, and they answer different questions.** `Steps` is every rewrite
+that fired. `Derivation` is that list with the normalisation and the repeats taken out — 270
+rewrites down to 5 on `x^(-1)/(y/z)` — which is what a reader asking *which identities were used*
+wants. Both are drawn from every candidate the simplifier generated, including the ones it
+discarded, so neither is a route. `PathFrom` is the third, and it is.
+
+## Reading it as a path
+
+```csharp
+using var recording = RewriteRecording.Start();
+var input = MathS.FromString("x^(-1)/(y/z)", useCache: false);
+var answer = input.Simplify();
+Console.WriteLine(recording.PathFrom(input, answer));
+```
+
+```
+x ^ (-1) / (y / z)
+  = 1 / x / (y / z)                               // InnerSimplified
+  = 1 * x ^ (-1) * y ^ (-1) * (z ^ (-1)) ^ (-1)   // CanonicalOrder
+  = 1 / x * 1 / y * 1 / (1 / z)                   // InnerSimplified
+  = z / (x * y)                                   // SimplifyChildren
+```
+
+`DerivationPath.OfSimplifying(expression)` is the same thing in one call. Four things about it:
+
+**It is a path, and that is a checkable claim.** `Steps[i].After` *is* `Steps[i + 1].Before`, the
+first step starts at the input, and the last lands on the value `Simplify` returned — compared as
+expressions, never as printed forms. `DerivationPathTest` asserts exactly that over eight shapes.
+
+**The losing candidates are not on it.** The simplifier grows a family of candidates and keeps the
+cheapest, so "the route" only exists once the winner is known; a step through a candidate that lost
+is not a step towards the answer. They are excluded rather than marked, because a derivation is read
+forwards and a marked dead end is something to skip. What the search produced and did not keep is
+reported as `ExpressionsExplored`, so the path does not read as though it were the whole story.
+
+**A step is a whole expression; the rewrites inside it are subexpressions.** That is the same fact
+as before — a rewrite pass walks bottom-up and there is no moment at which a partly-rewritten whole
+expression exists — resolved by putting the two grains in two types. `DerivationStep` is the pass,
+and its `Rewrites` are the `RewriteStep`s that fired inside it, each naming the rule that did it.
+
+**Not every step is a rule set.** `DerivationStep.RuleSet` is null for the ones that are not —
+inner simplification, the boolean minimiser, a polynomial rearrangement, the tidying chain
+`SimplifyChildren` runs — and null there is the same convention as `RewriteStep.Rule` being null
+for a set with no addressable rules: no name is invented for something that has none.
+
+Reconstructing this needs the simplifier to say what each of its stages turned into, since a rewrite
+pass only ever records the subexpressions it changed. `Simplificator` does that now, and it costs one
+ambient read per stage against a tree walk per stage — the same shape, and the same reason, as the
+one `ApplyOnce` already did.
 
 ## What is deliberately not here
 
@@ -165,20 +207,32 @@ Two things to get right:
 
 ## What the next step is
 
-The unit here is the rule *set*, not the single `pattern -> replacement` line — because that is what
-has been built, **not** because the finer grain costs too much. This document used to say it would
-trade one dispatch per node for one delegate call per rule per node. That was asserted, never
-measured, and it is wrong: [#825](https://github.com/asc-community/AngouriMath/issues/825) measures
-rules bucketed by the node type they match at **as fast as** the hand-written `switch` on a
+The unit the library *applies* is the rule set; the unit it can *name* is the single
+`pattern -> replacement` line, and has been since
+[#951](https://github.com/asc-community/AngouriMath/pull/951). Those lines are generated from the
+`switch` that defines each set rather than transcribed beside it, so the `switch` stays the thing a
+human edits and the thing the library calls, and the two cannot drift apart —
+[#825](https://github.com/asc-community/AngouriMath/issues/825), and #746's item 50. Only
+`RationalizeDenominator` has no addressable rules today, because it is a procedure rather than a
+`switch`; `RewriteRuleSet.Rules` is empty there and `RewriteStep.Rule` is null, which is the
+difference being reported rather than hidden.
+
+The performance objection that used to sit here is settled and was backwards: #825 measures rules
+bucketed by the node type they match at **as fast as** the hand-written `switch` on a
 realistic-sized set and **2.3× faster** on a small one, at identical allocation. A large `switch`
-over distinct node types is compiled into that same type dispatch anyway, so an explicit registry is
-not paying for anything — it is writing down what the compiler already infers from arm order.
+over distinct node types compiles into that same type dispatch anyway.
 
-What does stand in the way is transcription: splitting forty `switch` arms by hand is forty chances
-to change a pattern silently, and the per-rule metadata has to stay in step with the pattern. Both
-point at a source generator over the existing bodies, which is what #746 item 50 should decide.
-Nothing here forecloses it: a set whose rewrites become individually reachable keeps its name and its
-entry in the registry.
+So what is left, in dependency order:
 
-After that, in dependency order: the goal/tactic layer that `Solve` belongs in, and then derivations,
-which want every step to be attributable — which is what naming the steps was for.
+- **The goal/tactic layer `Solve` belongs in** — #746's item 64. Nothing about a derivation changes
+  for it; a tactic that fires is a step like any other, and it will want the same two grains.
+- **Reversible trees** — [#273](https://github.com/asc-community/AngouriMath/issues/273)'s second
+  half. The path is the recorder; what is not here is a *branch root* a failing method can be sent
+  back to. `Simplify` never needs one, because it does not backtrack — it generates candidates and
+  ranks them — so the case that wants it is the solvers, and it belongs with the tactic layer rather
+  than in front of it.
+- **Rendering a step as a sentence** — #746's v5.0. Everything a sentence needs is now on a step
+  except one thing: *why the rewrite is allowed*. `Soundness` is declared, not checked, and a rule
+  that holds only under an assumption does not say which. That is the same gap
+  [#721](https://github.com/asc-community/AngouriMath/issues/721) names, and it is the next piece of
+  metadata worth adding rather than the next layer.

--- a/Sources/AngouriMath/Docs/Contributing/Transformations.md
+++ b/Sources/AngouriMath/Docs/Contributing/Transformations.md
@@ -82,12 +82,13 @@ foreach (var step in recording.Steps)
 This is [#28](https://github.com/asc-community/AngouriMath/issues/28). Three things about it
 are deliberate and worth keeping:
 
-**Free when off.** With no recording open, applying a rule set costs one thread-static read
-more than it did before — per rule set, not per node — and allocates nothing. That is why it
-is a scope rather than a setting: a setting is something a caller can leave on.
+**Free when off.** With no recording open, applying a rule set costs one ambient read more
+than it did before — per rule set, not per node — and allocates nothing. That is why it is a
+scope rather than a setting: a setting is something a caller can leave on.
 
-**Per thread**, like `MathS.Settings`, so a parallel caller records its own work and nobody
-else's. Recordings nest, and an inner one hides the outer until it closes.
+**Per flow**, like `MathS.Settings`, so a parallel caller records its own work and nobody
+else's. It follows the call rather than the thread, so it survives an `await` and work started
+under it reports to it. Recordings nest, and an inner one hides the outer until it closes.
 
 **A step is a subexpression, not a snapshot.** A rewrite pass walks bottom-up and rewrites
 nodes as it goes, so there is no moment at which a partly-rewritten whole expression exists

--- a/Sources/AngouriMath/Functions/Simplification/Simplificator.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Simplificator.cs
@@ -22,7 +22,42 @@ namespace AngouriMath.Functions
             => one.SimplifiedRate < another.SimplifiedRate ? one : another;
 
         /// <summary>See more details in <see cref="Entity.Simplify(int)"/></summary>
-        internal static Entity Simplify(Entity expr, int level) => Alternate(expr, level).First().InnerSimplified;
+        internal static Entity Simplify(Entity expr, int level)
+            => Simplified(RewriteRecording.Current, Alternate(expr, level).First());
+
+        /// <summary>
+        /// <see cref="Entity.InnerSimplified"/>, and the whole-expression step it takes written
+        /// down where somebody is recording.
+        /// </summary>
+        /// <remarks>
+        /// A derivation is a chain of whole expressions, and a rewrite pass only ever records the
+        /// subexpressions it changed -- so the passes below have to say what they turned into or
+        /// the chain has a hole in it wherever the simplifier tidied up. Free when nobody is
+        /// listening: one ambient read per stage, against a tree walk per stage.
+        /// See <see cref="RewriteRecording.PathFrom(Entity, Entity)"/>.
+        /// </remarks>
+        private static Entity Simplified(RewriteRecording? recording, Entity expression)
+        {
+            if (recording is null)
+                return expression.InnerSimplified;
+            var mark = recording.Mark();
+            var simplified = expression.InnerSimplified;
+            if (simplified != expression)
+                recording.Note(expression, simplified, null, nameof(Entity.InnerSimplified), mark);
+            return simplified;
+        }
+
+        /// <summary>
+        /// An expression the simplifier produced by something that is not a rewrite pass, written
+        /// down for the same reason as <see cref="Simplified(RewriteRecording, Entity)"/>. The
+        /// mark is taken with <see cref="RewriteRecording.Mark"/> before the work started.
+        /// </summary>
+        private static Entity Noted(RewriteRecording? recording, Entity before, Entity after, string name, int mark)
+        {
+            if (recording is not null && after != before)
+                recording.Note(before, after, null, name, mark);
+            return after;
+        }
 
         /// <summary>
         /// The tidying pass every stage of <see cref="Alternate(Entity, int)"/> runs: get
@@ -44,16 +79,31 @@ namespace AngouriMath.Functions
                 .Then(Transformation.Rewriting(RewriteRules.Common))
                 .Then(Transformation.InnerSimplification);
 
-        internal static Entity SimplifyChildren(Entity expr) => simplifyChildren.ApplyOrKeep(expr);
+        internal static Entity SimplifyChildren(Entity expr)
+        {
+            var recording = RewriteRecording.Current;
+            if (recording is null)
+                return simplifyChildren.ApplyOrKeep(expr);
+            var mark = recording.Mark();
+            var simplified = simplifyChildren.ApplyOrKeep(expr);
+            // The chain above is six stages, two of which are inner simplifications that record
+            // nothing of their own, so the composition is the smallest step a reader can be
+            // handed here without the chain coming apart in the middle.
+            return Noted(recording, expr, simplified, nameof(SimplifyChildren), mark);
+        }
 
         /// <summary>Finds all alternative forms of an expression</summary>
         internal static IEnumerable<Entity> Alternate(Entity src, int level)
         {
+            var recording = RewriteRecording.Current;
             if (src is FiniteSet ss)
-                return new[] { ss.Apply(ent => ent.Simplify()).InnerSimplified };
+            {
+                var setMark = recording?.Mark() ?? 0;
+                return new[] { Noted(recording, src, ss.Apply(ent => ent.Simplify()).InnerSimplified, "Elementwise", setMark) };
+            }
             if (src is Number or Variable or Entity.Boolean)
                 return new[] { src };
-            var stage1 = src.InnerSimplified;
+            var stage1 = Simplified(recording, src);
 
 #if DEBUG
             if (MathS.Diagnostic.CatchOnSimplify.Value(stage1))
@@ -72,7 +122,7 @@ namespace AngouriMath.Functions
 #endif
                 void __IterAddHistory(Entity expr)
                 {
-                    var refexpr = expr.Rewrite(RewriteRules.CanonicalOrder).InnerSimplified;
+                    var refexpr = Simplified(recording, expr.Rewrite(RewriteRules.CanonicalOrder));
                     var compl1 = refexpr.SimplifiedRate;
                     var compl2 = expr.SimplifiedRate;
                     var n = compl1 > compl2 ? expr : refexpr;
@@ -103,8 +153,9 @@ namespace AngouriMath.Functions
             // rewrite won at 12 nodes against the 16-node input because the 4-node minimal
             // form was never generated for it to lose to.
             // https://github.com/asc-community/AngouriMath/issues/768
+            var minimiserMark = recording?.Mark() ?? 0;
             if (Functions.Boolean.Minimiser.Minimise(stage1) is { } minimised)
-                AddHistory(minimised);
+                AddHistory(Noted(recording, stage1, minimised, "Minimise", minimiserMark));
 
             for (int i = 0; i < Math.Abs(level); i++)
             {
@@ -121,15 +172,15 @@ namespace AngouriMath.Functions
                 // is an accident rather than a preference.
                 // https://github.com/asc-community/AngouriMath/issues/205
                 if (res.Nodes.Any(child => child is Divf))
-                    AddHistory(res = res.Rewrite(RewriteRules.RationalizeDenominator).InnerSimplified);
+                    AddHistory(res = Simplified(recording, res.Rewrite(RewriteRules.RationalizeDenominator)));
 
-                res = res.Rewrite(RewriteRules.CanonicalOrderAt(sortLevel)).InnerSimplified;
+                res = Simplified(recording, res.Rewrite(RewriteRules.CanonicalOrderAt(sortLevel)));
                 if (res.Nodes.Any(child => child is Powf))
-                    AddHistory(res = res.Rewrite(RewriteRules.Power).InnerSimplified);
+                    AddHistory(res = Simplified(recording, res.Rewrite(RewriteRules.Power)));
 
                 AddHistory(res = SimplifyChildren(res));
 
-                AddHistory(res = res.Rewrite(RewriteRules.InvertNegativePowers).Rewrite(RewriteRules.DivisionPreparing).InnerSimplified);
+                AddHistory(res = Simplified(recording, res.Rewrite(RewriteRules.InvertNegativePowers).Rewrite(RewriteRules.DivisionPreparing)));
 
                 // Lowest terms, offered as one more candidate rather than taken. Cancelling
                 // means multiplying out, and a quotient that cancels down to a polynomial
@@ -138,23 +189,23 @@ namespace AngouriMath.Functions
                 // stands, and u^2 + 4u + 4 only once this has expanded it. The complexity
                 // metric is what should decide between them.
                 if (res.Nodes.Any(child => child is Divf))
-                    AddHistory(res.Rewrite(RewriteRules.PolynomialGcdCancellation).InnerSimplified);
+                    AddHistory(Simplified(recording, res.Rewrite(RewriteRules.PolynomialGcdCancellation)));
 
-                AddHistory(res = res.Rewrite(RewriteRules.PolynomialLongDivision).InnerSimplified);
+                AddHistory(res = Simplified(recording, res.Rewrite(RewriteRules.PolynomialLongDivision)));
 
 
-                AddHistory(res = res.Rewrite(RewriteRules.NormalTrigonometricForm).InnerSimplified);
-                AddHistory(res = res.Rewrite(RewriteRules.CollapseMultipleFractions).InnerSimplified);
-                AddHistory(res = res.Rewrite(RewriteRules.CommonDenominatorAt(sortLevel)).InnerSimplified);
-                AddHistory(res = res.Rewrite(RewriteRules.InvertNegativePowers).Rewrite(RewriteRules.DivisionPreparing).InnerSimplified);
-                AddHistory(res = res.Rewrite(RewriteRules.Power).InnerSimplified);
-                AddHistory(res = res.Rewrite(RewriteRules.Trigonometric).InnerSimplified);
-                AddHistory(res = res.Rewrite(RewriteRules.CollapseTrigonometricFunctions).InnerSimplified);
+                AddHistory(res = Simplified(recording, res.Rewrite(RewriteRules.NormalTrigonometricForm)));
+                AddHistory(res = Simplified(recording, res.Rewrite(RewriteRules.CollapseMultipleFractions)));
+                AddHistory(res = Simplified(recording, res.Rewrite(RewriteRules.CommonDenominatorAt(sortLevel))));
+                AddHistory(res = Simplified(recording, res.Rewrite(RewriteRules.InvertNegativePowers).Rewrite(RewriteRules.DivisionPreparing)));
+                AddHistory(res = Simplified(recording, res.Rewrite(RewriteRules.Power)));
+                AddHistory(res = Simplified(recording, res.Rewrite(RewriteRules.Trigonometric)));
+                AddHistory(res = Simplified(recording, res.Rewrite(RewriteRules.CollapseTrigonometricFunctions)));
 
                 if (res.Nodes.Any(child => child is TrigonometricFunction))
                 {
-                    var res1 = res.Rewrite(RewriteRules.ExpandTrigonometric).InnerSimplified;
-                    AddHistory(res = res.Rewrite(RewriteRules.Trigonometric).Rewrite(RewriteRules.Common).InnerSimplified);
+                    var res1 = Simplified(recording, res.Rewrite(RewriteRules.ExpandTrigonometric));
+                    AddHistory(res = Simplified(recording, res.Rewrite(RewriteRules.Trigonometric).Rewrite(RewriteRules.Common)));
                     AddHistory(res1);
                     res = PickSimplest(res, res1);
                     AddHistory(res = res.Rewrite(RewriteRules.CollapseTrigonometricFunctions).Rewrite(RewriteRules.Trigonometric));
@@ -163,58 +214,59 @@ namespace AngouriMath.Functions
                     // Offered as a candidate rather than taken: written out, sin(4x) is far
                     // longer than it started, and only worth it where the pieces cancel --
                     // which is what the complexity metric is for.
-                    var expandedAngles = res
+                    var expandedAngles = Simplified(recording, res
                         .Rewrite(RewriteRules.ExpandMultipleAngle)
-                        .Rewrite(RewriteRules.NormalTrigonometricForm)
-                        .InnerSimplified;
+                        .Rewrite(RewriteRules.NormalTrigonometricForm));
                     if (expandedAngles != res)
                     {
                         AddHistory(expandedAngles);
-                        AddHistory(SimplifyChildren(expandedAngles)
+                        AddHistory(Simplified(recording, SimplifyChildren(expandedAngles)
                             .Rewrite(RewriteRules.Trigonometric)
-                            .Rewrite(RewriteRules.Common)
-                            .InnerSimplified);
+                            .Rewrite(RewriteRules.Common)));
                     }
                 }
 
 
                 if (res.Nodes.Any(child => child is Statement))
                 {
-                    AddHistory(res = res.Rewrite(RewriteRules.Boolean).InnerSimplified);
+                    AddHistory(res = Simplified(recording, res.Rewrite(RewriteRules.Boolean)));
                 }
 
 
                 if (res.Nodes.Any(child => child is ComparisonSign))
                 {
-                    AddHistory(res = res.Rewrite(RewriteRules.InequalityEquality).InnerSimplified);
+                    AddHistory(res = Simplified(recording, res.Rewrite(RewriteRules.InequalityEquality)));
                 }
 
                 if (res.Nodes.Any(child => child is Factorialf))
                 {
-                    AddHistory(res = res.Rewrite(RewriteRules.ExpandFactorialDivisions).InnerSimplified);
-                    AddHistory(res = res.Rewrite(RewriteRules.FactorizeFactorialMultiplications).InnerSimplified);
+                    AddHistory(res = Simplified(recording, res.Rewrite(RewriteRules.ExpandFactorialDivisions)));
+                    AddHistory(res = Simplified(recording, res.Rewrite(RewriteRules.FactorizeFactorialMultiplications)));
                 }
 
 
                 if (res.Nodes.Any(child => child is Powf or Logf))
-                    AddHistory(res = res.Rewrite(RewriteRules.Power).InnerSimplified);
+                    AddHistory(res = Simplified(recording, res.Rewrite(RewriteRules.Power)));
 
                 if (res.Nodes.Any(child => child is Set))
                 {
                     var replaced = res.Rewrite(RewriteRules.SetOperator);
 
-                    AddHistory(res = replaced.InnerSimplified);
+                    AddHistory(res = Simplified(recording, replaced));
                 }
 
 
                 if (res.Nodes.Any(child => child is Phif))
-                    AddHistory(res = res.Rewrite(RewriteRules.PhiFunction).InnerSimplified);
+                    AddHistory(res = Simplified(recording, res.Rewrite(RewriteRules.PhiFunction)));
 
                 Entity? possiblePoly = null;
                 foreach (var var in res.Vars)
+                {
+                    var polyMark = recording?.Mark() ?? 0;
                     if (TryPolynomial(res, var, out var resPoly)
                         && (possiblePoly is null || resPoly.Complexity < possiblePoly.Complexity))
-                        AddHistory(possiblePoly = resPoly);
+                        AddHistory(possiblePoly = Noted(recording, res, resPoly, "AsPolynomial", polyMark));
+                }
                 if (possiblePoly is { } && possiblePoly.Complexity < res.Complexity)
                     res = possiblePoly;
 
@@ -223,8 +275,11 @@ namespace AngouriMath.Functions
                 // something far longer than it started, and the complexity metric is what
                 // should decide between them.
                 foreach (var var in res.Vars)
+                {
+                    var factorMark = recording?.Mark() ?? 0;
                     if (PolynomialFactoring.TryFactor(res, var, out var factoredPoly))
-                        AddHistory(factoredPoly);
+                        AddHistory(Noted(recording, res, factoredPoly, "Factorize", factorMark));
+                }
 
 
                 AddHistory(res = res.Rewrite(RewriteRules.Common));
@@ -244,8 +299,10 @@ namespace AngouriMath.Functions
             }
             if (level > 0) // if level < 0 we don't check whether expanded version is better
             {
-                AddHistory(res.Expand().Simplify(-level));
-                AddHistory(res.Factorize().Simplify(-level));
+                var expandMark = recording?.Mark() ?? 0;
+                AddHistory(Noted(recording, res, res.Expand(), nameof(Entity.Expand), expandMark).Simplify(-level));
+                var factorizeMark = recording?.Mark() ?? 0;
+                AddHistory(Noted(recording, res, res.Factorize(), nameof(Entity.Factorize), factorizeMark).Simplify(-level));
 
                 // A multiple angle written out is worth having only where the pieces then
                 // cancel, so it has to be simplified in full before the metric can be
@@ -258,14 +315,16 @@ namespace AngouriMath.Functions
                 // That is https://github.com/asc-community/AngouriMath/issues/557: the
                 // reporter's second expression is 0, and reaches 0 through
                 // 2 sin(t) cos(t) and not through sin(2t).
-                var openedAngles = res
+                var openedAngles = Simplified(recording, res
                     .Rewrite(RewriteRules.ExpandMultipleAngle)
-                    .Rewrite(RewriteRules.NormalTrigonometricForm)
-                    .InnerSimplified;
+                    .Rewrite(RewriteRules.NormalTrigonometricForm));
                 if (openedAngles != res)
+                {
                     // Expanded, and for the same reason res is expanded above: the
                     // cancellation only shows up once the products are multiplied out.
-                    AddHistory(openedAngles.Expand().Simplify(-level));
+                    var openedMark = recording?.Mark() ?? 0;
+                    AddHistory(Noted(recording, openedAngles, openedAngles.Expand(), nameof(Entity.Expand), openedMark).Simplify(-level));
+                }
             }
 
             return history.Values.SelectMany(x => x);

--- a/Sources/Tests/UnitTests/Common/PublicApi.txt
+++ b/Sources/Tests/UnitTests/Common/PublicApi.txt
@@ -117,8 +117,23 @@ AngouriMath.Core.ReasonOfFailureWhileParsing.ctor()
 AngouriMath.Core.ReasonOfFailureWhileParsing.ctor(AngouriMath.Core.ReasonOfFailureWhileParsing)
 AngouriMath.Core.ReasonOfFailureWhileParsing.op_Equality(AngouriMath.Core.ReasonOfFailureWhileParsing, AngouriMath.Core.ReasonOfFailureWhileParsing) : System.Boolean
 AngouriMath.Core.ReasonOfFailureWhileParsing.op_Inequality(AngouriMath.Core.ReasonOfFailureWhileParsing, AngouriMath.Core.ReasonOfFailureWhileParsing) : System.Boolean
+AngouriMath.Core.Transformations.DerivationPath.ExpressionsExplored { } : System.Int32
+AngouriMath.Core.Transformations.DerivationPath.Input { } : AngouriMath.Entity
+AngouriMath.Core.Transformations.DerivationPath.OfSimplifying(AngouriMath.Entity, System.Int32) : AngouriMath.Core.Transformations.DerivationPath
+AngouriMath.Core.Transformations.DerivationPath.Result { } : AngouriMath.Entity
+AngouriMath.Core.Transformations.DerivationPath.Steps { } : System.Collections.Generic.IReadOnlyList<AngouriMath.Core.Transformations.DerivationStep>
+AngouriMath.Core.Transformations.DerivationPath.ToString() : System.String
+AngouriMath.Core.Transformations.DerivationStep.After { } : AngouriMath.Entity
+AngouriMath.Core.Transformations.DerivationStep.Before { } : AngouriMath.Entity
+AngouriMath.Core.Transformations.DerivationStep.Name { } : System.String
+AngouriMath.Core.Transformations.DerivationStep.Relation { } : System.Nullable<AngouriMath.Core.Transformations.TransformationRelation>
+AngouriMath.Core.Transformations.DerivationStep.Rewrites { } : System.Collections.Generic.IReadOnlyList<AngouriMath.Core.Transformations.RewriteStep>
+AngouriMath.Core.Transformations.DerivationStep.RuleSet { } : AngouriMath.Core.Transformations.RewriteRuleSet
+AngouriMath.Core.Transformations.DerivationStep.Soundness { } : System.Nullable<AngouriMath.Core.Transformations.Soundness>
+AngouriMath.Core.Transformations.DerivationStep.ToString() : System.String
 AngouriMath.Core.Transformations.RewriteRecording.Derivation { } : System.Collections.Generic.IReadOnlyList<AngouriMath.Core.Transformations.RewriteStep>
 AngouriMath.Core.Transformations.RewriteRecording.Dispose() : System.Void
+AngouriMath.Core.Transformations.RewriteRecording.PathFrom(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Core.Transformations.DerivationPath
 AngouriMath.Core.Transformations.RewriteRecording.Start() : AngouriMath.Core.Transformations.RewriteRecording
 AngouriMath.Core.Transformations.RewriteRecording.Steps { } : System.Collections.Generic.IReadOnlyList<AngouriMath.Core.Transformations.RewriteStep>
 AngouriMath.Core.Transformations.RewriteRule.Description { } : System.String
@@ -2583,6 +2598,7 @@ class AngouriMath.Core.ReasonOfFailureWhileParsing
 class AngouriMath.Core.ReasonOfFailureWhileParsing+InternalError
 class AngouriMath.Core.ReasonOfFailureWhileParsing+MissingOperator
 class AngouriMath.Core.ReasonOfFailureWhileParsing+Unknown
+class AngouriMath.Core.Transformations.DerivationPath
 class AngouriMath.Core.Transformations.RewriteRecording
 class AngouriMath.Core.Transformations.RewriteRule
 class AngouriMath.Core.Transformations.RewriteRuleSet
@@ -2700,6 +2716,7 @@ interface AngouriMath.Core.ILatexizeable
 interface AngouriMath.Core.IScalarClosedArithmetics<T>
 interface AngouriMath.Core.IUnaryNode
 struct AngouriMath.Convenience.Setting<T>
+struct AngouriMath.Core.Transformations.DerivationStep
 struct AngouriMath.Core.Transformations.RewriteStep
 struct AngouriMath.Core.Transformations.TransformationResult
 struct AngouriMath.Entity+Matrix+EntityTensorWrapperOperations

--- a/Sources/Tests/UnitTests/Core/Transformations/DerivationPathTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/DerivationPathTest.cs
@@ -1,0 +1,266 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Core.Transformations;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// The derivation as a path — <a href="https://github.com/asc-community/AngouriMath/issues/28">#28</a>
+    /// and <a href="https://github.com/asc-community/AngouriMath/issues/273">#273</a>.
+    /// </summary>
+    [Trait("Area", "Transformations")]
+    public sealed class DerivationPathTest
+    {
+        // Uncached, so that each expression is a fresh tree, as in RewriteRecordingTest: an
+        // Entity memoises InnerSimplified on itself, and a cached one handed back a second
+        // time has already done part of the work.
+        private static Entity Parse(string raw) => MathS.FromString(raw, useCache: false);
+
+        /// <summary>
+        /// Eight shapes, chosen so that between them they go through every kind of step the
+        /// path is made of: rewrite passes, inner simplification, the boolean minimiser, the
+        /// polynomial rearrangement, expansion and factoring.
+        /// </summary>
+        public static IEnumerable<object[]> Shapes => new[]
+        {
+            new object[] { "x^(-1)/(y/z)" },         // the reporter's expression on #28
+            new object[] { "a / (b / c)" },          // one rewrite and done
+            new object[] { "sin(x)^2 + cos(x)^2" },  // a trigonometric identity
+            new object[] { "(x2 - 1) / (x - 1)" },   // a quotient that cancels
+            new object[] { "x + x + x" },            // like terms
+            new object[] { "a and b or a and not b" },// boolean, which reaches the minimiser
+            new object[] { "(x + 1)^2 - x^2 - 2*x" },// only settles once expanded
+            new object[] { "1/(sqrt(3) + 5)" },      // a surd in the denominator
+        };
+
+        /// <summary>
+        /// The claim. Each step starts where the one before it ended, the first starts at the
+        /// input, and the last lands on what <see cref="Entity.Simplify(int)"/> returned —
+        /// compared as expressions, since two writings of one expression print differently
+        /// and a printed comparison would pass or fail for the wrong reason.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(Shapes))]
+        public void TheDerivationIsAPathFromTheInputToTheAnswer(string raw)
+        {
+            using var recording = RewriteRecording.Start();
+            var input = Parse(raw);
+            var answer = input.Simplify();
+
+            var path = recording.PathFrom(input, answer);
+            Assert.NotNull(path);
+            Assert.Equal(input, path!.Input);
+            Assert.Equal(answer, path.Result);
+
+            var at = input;
+            foreach (var step in path.Steps)
+            {
+                Assert.Equal(at, step.Before);
+                Assert.NotEqual(step.Before, step.After);
+                at = step.After;
+            }
+            Assert.Equal(answer, at);
+        }
+
+        /// <summary>
+        /// The path is the answer's, not a tour of the search: it can never be longer than what
+        /// the search produced, and none of what the search dropped is on it, since nothing
+        /// leads from a discarded candidate to the value that was returned.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(Shapes))]
+        public void ThePathIsNoLongerThanTheSearchThatFoundIt(string raw)
+        {
+            using var recording = RewriteRecording.Start();
+            var input = Parse(raw);
+            var path = recording.PathFrom(input, input.Simplify());
+
+            Assert.NotNull(path);
+            Assert.True(path!.ExpressionsExplored >= path.Steps.Count,
+                $"{raw}: the path is {path.Steps.Count} steps out of {path.ExpressionsExplored} "
+                + "expressions produced, which is more steps than there were expressions to take them between");
+        }
+
+        /// <summary>
+        /// And on an expression the search really has to work at, the path is a small part of
+        /// what happened — which is the whole difference between a derivation and a log.
+        /// </summary>
+        [Fact]
+        public void ThePathIsASmallPartOfWhatHappened()
+        {
+            using var recording = RewriteRecording.Start();
+            var input = Parse("x^(-1)/(y/z)");
+            var path = recording.PathFrom(input, input.Simplify());
+
+            Assert.NotNull(path);
+            Assert.True(path!.Steps.Count < path.ExpressionsExplored,
+                $"the path kept all {path.Steps.Count} of the expressions the search produced, so it "
+                + "left nothing out and there is nothing here to have chosen between");
+            Assert.True(recording.Steps.Count > 20 * path.Steps.Count,
+                $"{recording.Steps.Count} rewrites were recorded against a {path.Steps.Count}-step path, "
+                + "which is not enough of a difference to be evidence of anything");
+        }
+
+        /// <summary>
+        /// Recording is meant to be an observation and not a change of behaviour, so the answer
+        /// under a recording has to be the answer without one.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(Shapes))]
+        public void RecordingDoesNotMoveTheAnswer(string raw)
+        {
+            var unwatched = Parse(raw).Simplify();
+
+            using var recording = RewriteRecording.Start();
+            Assert.Equal(unwatched, Parse(raw).Simplify());
+        }
+
+        /// <summary>Every step says what did it, and names a set the registry knows where it was one.</summary>
+        [Theory]
+        [MemberData(nameof(Shapes))]
+        public void EveryStepNamesWhatDidIt(string raw)
+        {
+            using var recording = RewriteRecording.Start();
+            var input = Parse(raw);
+            var path = recording.PathFrom(input, input.Simplify());
+
+            Assert.NotNull(path);
+            foreach (var step in path!.Steps)
+            {
+                Assert.False(string.IsNullOrWhiteSpace(step.Name));
+                if (step.RuleSet is null)
+                {
+                    // Not one rule set applied once, so there is no set to name and none is
+                    // invented -- which is not the same as nothing having fired inside it, since
+                    // a step like SimplifyChildren is a chain of rule sets.
+                    Assert.Null(step.Relation);
+                    Assert.Null(step.Soundness);
+                    continue;
+                }
+                Assert.Contains(step.RuleSet, RewriteRules.All);
+                Assert.Equal(step.RuleSet.Name, step.Name);
+                Assert.Equal(step.RuleSet.Relation, step.Relation);
+                Assert.Equal(step.RuleSet.Soundness, step.Soundness);
+            }
+        }
+
+        /// <summary>
+        /// The rewrites inside a step are the ones that fired in it, and they are the grain #28
+        /// asked for: the reporter's own rule, on the reporter's own expression, on the step of
+        /// the path that applied it.
+        /// </summary>
+        [Fact]
+        public void AStepCarriesTheRulesThatFiredInsideIt()
+        {
+            using var recording = RewriteRecording.Start();
+            var input = Parse("x^(-1)/(y/z)");
+            var path = recording.PathFrom(input, input.Simplify());
+
+            Assert.NotNull(path);
+            var carrying = Assert.Single(path!.Steps.Where(step => step.Rewrites.Any(rewrite =>
+                rewrite.Rule?.PatternSource == "Divf(var any1, Divf(var any2, var any3))"
+                && rewrite.Rule?.ReplacementSource == "any1 * any3 / any2")));
+
+            // and the rewrite it carries is a rewrite of a subexpression of the step it is in
+            var rewrite = carrying.Rewrites.First(step => step.Rule?.ReplacementSource == "any1 * any3 / any2");
+            Assert.Contains(rewrite.Before, carrying.Before.Nodes);
+        }
+
+        /// <summary>
+        /// Why this exists at all, pinned so that the two views cannot be confused for one
+        /// another. <see cref="RewriteRecording.Derivation"/> is a set of rewrites drawn from
+        /// every candidate the search generated; read in order it does not chain, and it is a
+        /// list of subexpressions rather than of whole expressions.
+        /// </summary>
+        [Fact]
+        public void TheRewriteListIsStillNotAPath()
+        {
+            using var recording = RewriteRecording.Start();
+            var input = Parse("x^(-1)/(y/z)");
+            var answer = input.Simplify();
+
+            var rewrites = recording.Derivation;
+            Assert.True(rewrites.Count > 1, "with one rewrite there is nothing to fail to chain");
+            Assert.Contains(rewrites.Zip(rewrites.Skip(1)), pair => pair.First.After != pair.Second.Before);
+            Assert.NotEqual(answer, rewrites[rewrites.Count - 1].After);
+
+            // and the path, over the same recording, does chain and does land on the answer
+            var path = recording.PathFrom(input, answer);
+            Assert.NotNull(path);
+            Assert.Equal(answer, path!.Steps[path.Steps.Count - 1].After);
+        }
+
+        /// <summary>An expression that needed no work is a path of no steps, not a failure.</summary>
+        [Fact]
+        public void NothingToDoIsAPathOfLengthZero()
+        {
+            using var recording = RewriteRecording.Start();
+            Entity leaf = MathS.Var("x");
+            var answer = leaf.Simplify();
+
+            var path = recording.PathFrom(leaf, answer);
+            Assert.NotNull(path);
+            Assert.Empty(path!.Steps);
+            Assert.Equal(leaf, path.Result);
+        }
+
+        /// <summary>
+        /// A result this recording never saw produced has no path here, and that is reported as
+        /// "I cannot account for this" rather than as an empty one, which would read as
+        /// "nothing happened".
+        /// </summary>
+        [Fact]
+        public void AResultTheRecordingNeverSawHasNoPath()
+        {
+            using var recording = RewriteRecording.Start();
+            var input = Parse("a / (b / c)");
+            input.Simplify();
+
+            Assert.Null(recording.PathFrom(input, Parse("q + 17")));
+        }
+
+        /// <summary>The whole of it in one call, which is what a caller asking #28's question wants.</summary>
+        [Fact]
+        public void OfSimplifyingOpensAndClosesTheRecordingItself()
+        {
+            var input = Parse("x^(-1)/(y/z)");
+            var path = DerivationPath.OfSimplifying(input);
+
+            Assert.NotNull(path);
+            Assert.Equal(input.Simplify(), path!.Result);
+            Assert.NotEmpty(path.Steps);
+            // nothing left open afterwards
+            using var after = RewriteRecording.Start();
+            Assert.Empty(after.Steps);
+        }
+
+        /// <summary>
+        /// The path written out, which is the form #28 asked for: each stage of the expression,
+        /// and beside it what turned the one before into it.
+        /// </summary>
+        [Fact]
+        public void ThePathPrintsAsTheStagesAndWhatMadeThem()
+        {
+            var path = DerivationPath.OfSimplifying(Parse("x^(-1)/(y/z)"));
+
+            Assert.NotNull(path);
+            var lines = path!.ToString().Split('\n');
+            Assert.Equal(path.Steps.Count + 1, lines.Length);
+            Assert.Equal(path.Input.Stringize(), lines[0]);
+            foreach (var (line, step) in lines.Skip(1).Zip(path.Steps))
+            {
+                Assert.Contains(step.After.Stringize(), line);
+                Assert.Contains(step.Name, line);
+            }
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Core/Transformations/RewriteAllocationTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RewriteAllocationTest.cs
@@ -8,6 +8,7 @@
 using System;
 using AngouriMath;
 using AngouriMath.Core.Transformations;
+using AngouriMath.Functions;
 using Xunit;
 
 namespace AngouriMath.Tests.Core.Transformations
@@ -69,6 +70,41 @@ namespace AngouriMath.Tests.Core.Transformations
                 $"applying a rule set with no recording open allocated {allocated} bytes over {Iterations} calls, "
                 + $"which is over the {BudgetBytes} budget. Something on the fast path is allocating per call -- "
                 + "a closure in the method is the usual cause, and moving it into its own method is the usual fix.");
+        }
+
+        /// <summary>
+        /// The same claim one layer up. A derivation is a chain of whole expressions, so the
+        /// simplifier writes down what each of its stages turned into — and that has to be free
+        /// too, or #746's first standing condition is broken by the layer that reports on it.
+        /// </summary>
+        /// <remarks>
+        /// A leaf again, and for the same reason: the tidying pass matches nothing on one and
+        /// rebuilds nothing, so a stray per-stage allocation is the whole measurement instead of
+        /// a rounding error inside it. What this would catch is the step being noted through a
+        /// closure, or the ambient recording being read into something that boxes.
+        /// </remarks>
+        [Fact]
+        public void TakingAStepWithNoRecordingOpenAllocatesEssentiallyNothing()
+        {
+            Entity leaf = MathS.Var("x");
+
+            for (var i = 0; i < 100; i++)
+                Simplificator.SimplifyChildren(leaf);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            for (var i = 0; i < Iterations; i++)
+                Simplificator.SimplifyChildren(leaf);
+            var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            Assert.True(
+                allocated <= BudgetBytes,
+                $"a simplification stage with no recording open allocated {allocated} bytes over {Iterations} "
+                + $"calls, which is over the {BudgetBytes} budget. Something on the fast path is allocating "
+                + "per stage -- a closure capturing the recording is the usual cause.");
         }
 
         [Fact]


### PR DESCRIPTION
`RewriteRecording` collects every rewrite that fires. Its own documentation says what that is not:

> *these are the rewrites across every candidate generated, including the ones that lost… reading them in order does not walk input → answer.*

That limitation is stated in three places in the source and in `Docs/Contributing/Transformations.md`, and it is what #28 stops short of and what #273, #746 item 61 (Lean export), item 64 (the tactic layer) and item 67 (proof templates) are all queued behind. `RewriteRecording.PathFrom(input, result)` removes it.

```
x ^ (-1) / (y / z)
  = 1 / x / (y / z)                               // InnerSimplified
  = 1 * x ^ (-1) * y ^ (-1) * (z ^ (-1)) ^ (-1)   // CanonicalOrder
  = 1 / x * 1 / y * 1 / (1 / z)                   // InnerSimplified
  = z / (x * y)                                   // SimplifyChildren

270 rewrites recorded | 11 expressions produced | path 4 steps
```

## The design, and the objection it had to answer

The recorder's stated reason for not doing this was that **no partly-rewritten whole expression exists**: a bottom-up pass never holds one, so photographing one would mean constructing something the engine never had. That is true, and it is answered rather than denied — whole expressions exist at *pass boundaries*, not inside a pass.

So there are two grains and two types. `RewriteStep` is unchanged: one rule, one subexpression. The new `DerivationStep` is a pass — `Before`/`After` are whole expressions, `RuleSet` names the set where the step is one set applied once (`null` otherwise, the same convention `RewriteStep.Rule` already uses), and `Rewrites` carries the `RewriteStep`s that fired inside it. The second chains; the first says which identity was used.

Two producers of edges. `RewriteRuleSet.ApplyOnceRecording` notes `expression → rewritten`, on the recording branch only. And `Simplificator` notes the stages that are *not* rewrite passes — `InnerSimplified`, `SimplifyChildren`, the boolean minimiser, `AsPolynomial`, `Expand`, `Factorize`, the elementwise set case. Without those the chain has a hole wherever the simplifier tidies up, which is most of the interesting places.

**Extraction is a reconstruction, and it has to be.** `Simplify` does not walk to an answer; it grows candidates and ranks them, so "the route" only exists once the winner is known. `PathFrom` is a breadth-first search over the recorded edges in insertion order — shortest chain, ties by record order, no dictionary or hash *iteration* anywhere (a `Dictionary` is only ever probed by key). Every edge is a transition the engine really performed; none is inferred.

**Losing candidates are absent rather than labelled.** Nothing leads from a discarded candidate to the returned answer, so none can appear on a path to it. `DerivationPath.ExpressionsExplored` reports how many expressions the search produced, so the path never reads as the whole story.

## The consumer

#746 is binding here — *"infrastructure must be validated by a consumer in the same change… a derivation type nothing emits is not a foundation, it is speculative code"* — so `DerivationPath.OfSimplifying(expression)` opens the recording, simplifies, extracts and closes, and `ToString()` renders the block at the top of this description. 40 new tests.

## Measured

**The fast path is unchanged, and this is the number that matters.** Allocation on `CommonFunctionsInterVersion` with `[MemoryDiagnoser]`, before and after in the same session: **identical on six rows, 0.002% lower on the other two**.

Timings were taken and are *not* offered as evidence: the machine was running four other agents' test suites, load average 9–15 on 8 cores, and `SolveMediumHard` alone has a StdDev of 46,720 μs on a 125,394 μs mean. Two further paired runs flip the sign of every fast row. So the added cost was bounded directly instead:

```
SimplifyEasy: added ambient reads = 18      AsyncLocal<T>.Value read: 1.04 ns
SolveEasy:    added ambient reads = 0
SolveMedium:  added ambient reads = 0
```

18 × 1.04 ns ≈ **19 ns against `SimplifyEasy`'s 100 μs — 0.02%**, and literally zero on the solver rows. `RewriteAllocationTest` gains `TakingAStepWithNoRecordingOpenAllocatesEssentiallyNothing` (≤8 B/call over 20,000 calls), the same blunt shape as the existing `ApplyOnce` guard.

**Answers are unchanged.** `AddHistory` was not touched and no call to it moved — `history` is a `SortedDictionary` whose winner is `.First()` of a `HashSet`, so the notation sites record edges without filing anything. The raw recording is byte-for-byte the same work: 270 rewrites / 251 normalisation on `x^(-1)/(y/z)` on both builds. `PublicApi.txt`: **17 additions, 0 removals**, so no `BREAKING-CHANGES.md` entry is owed.

Suite: **7573 passed, 0 failed, 14 skipped** — 7533 plus exactly the 40 new tests. F# wrapper 134/0. The corpus gate is in that run.

## Docs, and three things corrected in them

`Transformations.md` gains a "Reading it as a path" section with real output, and its "these are the rewrites, not a route" limitation is replaced by the three views. Its "What the next step is" was stale — it said a source generator over the switch bodies "is what #746 item 50 should decide", and that generator shipped in #951 — so it now names what actually remains: the tactic layer, reversible trees, per-step assumptions.

Three figures were re-measured rather than copied: `Patterns.CommonRules` has **100** arms, not the 103 a comment in `RewriteRuleSet.cs` claimed; `Derivation` on `x^(-1)/(y/z)` is **5** rewrites, not 6 (wrong in `RewriteRecording.cs` too); and the "one thread-static read per rule set" has been an `AsyncLocal` read per *flow* since #863.

## What remains of #273, deliberately

Part 1 — record the steps — is done. Part 2, *"reverse to the branch's root whenever we fail to solve something within a method"*, is **not built**, and not for want of trying:

- `Simplify` never backtracks. It generates and ranks, so it has no branch root to return to. The consumer that wants one is the **solvers**.
- Because `Entity` is immutable, undo is already free — you keep the reference. What is missing is not a mechanism to reverse a tree but a **goal/tactic scope** that can declare a branch root, report failure, and resume with the alternatives it has not tried. That is #746 item 64 and tier 4's "backtracking explicit", and building it in front of the tactic layer would mean inventing the failure protocol twice.

What a follow-up needs: a `Goal` type, a `Tactic` returning success/failure/subgoals rather than `Entity?`, and the solvers re-expressed over it. **The path type here needs no change** — a tactic that fires is a step like any other.

## Two things for a maintainer

1. **`Simplify`'s tie-break depends on `HashSet<T>` enumeration order.** `history[history.Keys.Min()].First()` picks whichever equal-rate candidate was added first, which .NET does not guarantee. Pre-existing, and the code half-admits it in a comment. Out of scope here, but it is latent cross-runtime nondeterminism in the *answer*, not just in the path, and #746's Principle 3 asks for byte-identical reproduction across platforms.
2. **`Simplificator.Simplify` is entered zero times during `SolveEasy` and `SolveMedium`.** A measurement, not an explanation — worth checking whether the solvers genuinely bypass `Simplify`, since those rows get read as a performance signal for simplification.
