### PR TITLE
Keep the corpus numbers after the job that produced them, and diff them against a record (#529, #500)

### DIFF
--- a/.github/workflows/CSharpTest.yml
+++ b/.github/workflows/CSharpTest.yml
@@ -1,5 +1,10 @@
 name: 'C# Test'
 
+# No path filters, on purpose: this is the suite, and every change is one it can break.
+# That also means it cannot carry the defect that silenced the benchmark for ninety-eight
+# merged PRs -- a leading "./" in a path filter matches nothing, because filters are globs
+# relative to the repository root. Check that before adding any filter here.
+# https://github.com/asc-community/AngouriMath/issues/775
 on:
   push:
     branches:
@@ -56,6 +61,28 @@ jobs:
         name: Report
         path: ./Sources/Tests/UnitTests/coverage.opencover.xml
         retention-days: 3
+
+    # The corpus gate reports solved / unsolved / wrong / error / timeout rather than pass or
+    # fail, and until now those numbers existed only in this job's log, which expires. This is
+    # the artefact half of https://github.com/asc-community/AngouriMath/issues/746 item 36; the
+    # per-commit history half is Sources/Tests/UnitTests/Corpus/corpus-baseline.tsv, which is
+    # committed, because an artefact cannot be diffed, cannot be attributed to the commit that
+    # moved a number, and expires.
+    #
+    # if: always() because a suite that fell over part way still measured the cases that ran,
+    # and those are the interesting ones when something has just broken. Uploaded from every
+    # operating system in the matrix: a verdict that differs between them is a finding.
+    #
+    # The glob spans bin/Debug and bin/Release because the two test steps above do not agree on
+    # the configuration -- the Windows one takes the default.
+    - name: 'Retain the corpus results'
+      if: always()
+      uses: actions/upload-artifact@v6
+      with:
+        name: corpus-report-${{ matrix.os }}-${{ github.sha }}
+        path: Sources/Tests/UnitTests/bin/**/corpus-report.tsv
+        if-no-files-found: warn
+        retention-days: 90
 
     - name: 'Send to codecov'
       if: ${{ matrix.os == 'windows-latest' }}

--- a/Sources/Tests/UnitTests/Corpus/Corpus.cs
+++ b/Sources/Tests/UnitTests/Corpus/Corpus.cs
@@ -87,6 +87,13 @@ namespace AngouriMath.Tests.Corpus
     /// as something that ought to work — plus a few standard limits. Nothing here is vendored
     /// from another project's test suite.
     /// </para>
+    /// <para>
+    /// The verdicts recorded here are also projected into <c>corpus-baseline.tsv</c> beside this
+    /// file, which is what gives the corpus a machine-readable history that outlives a CI job
+    /// log. Changing a <see cref="Problem.Expect"/> here means regenerating that file; see
+    /// <see cref="CorpusRecord"/> for how, and why the history lives in the repository rather
+    /// than in an artefact.
+    /// </para>
     /// </remarks>
     public static class Corpus
     {

--- a/Sources/Tests/UnitTests/Corpus/CorpusGateTest.cs
+++ b/Sources/Tests/UnitTests/Corpus/CorpusGateTest.cs
@@ -7,6 +7,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -87,23 +89,126 @@ namespace AngouriMath.Tests.Corpus
         [Fact]
         public void TheCorpusHasNotGotWorse()
         {
+            var clock = Stopwatch.StartNew();
             var results = Corpus.All.Select(Run).ToList();
+            clock.Stop();
             output.WriteLine(Report(results));
 
-            var wrong = results.Where(r => r.Verdict == Verdict.Wrong).ToList();
-            var regressed = results
-                .Where(r => r.Verdict != r.Problem.Expect && r.Verdict != Verdict.Wrong)
+            // Written before anything is asserted, so that a run which then fails still leaves
+            // the numbers behind. This is the file the workflow uploads.
+            var rows = results
+                .Select(r => new CorpusRecord.ReportRow(
+                    r.Problem.Name, r.Problem.Op, r.Problem.Expect, r.Verdict,
+                    Status(r.Problem.Expect, r.Verdict), r.Note, r.Answer))
                 .ToList();
+            File.WriteAllText(CorpusRecord.ReportPath,
+                              CorpusRecord.RenderReport(rows, clock.ElapsedMilliseconds));
+            output.WriteLine("Report written to " + CorpusRecord.ReportPath);
 
+            var moved = results.Zip(rows, (result, row) => (result, row.Status))
+                               .Where(pair => pair.Status is not "ok")
+                               .ToList();
+            if (moved.Count == 0) return;
+
+            // The four kinds are spelled out separately, and counted on the first line, because
+            // they ask the reader to do different things: a message that does not say which is
+            // a message that gets the record updated over a real regression.
             var complaint = new StringBuilder();
-            foreach (var r in wrong)
-                complaint.AppendLine($"WRONG    {r.Problem.Name}: {r.Problem.Input} -> {r.Answer} ({r.Note})");
-            foreach (var r in regressed)
-                complaint.AppendLine(
-                    $"CHANGED  {r.Problem.Name}: expected {r.Problem.Expect}, got {r.Verdict}"
-                    + $" ({r.Note}). If this is an improvement, record it in Corpus.cs.");
+            var kinds = new[] { "wrong", "worse", "better", "changed" };
+            complaint.AppendLine("The corpus moved: " + string.Join(", ", kinds
+                .Select(kind => (kind, n: moved.Count(pair => pair.Status == kind)))
+                .Where(pair => pair.n > 0)
+                .Select(pair => $"{pair.n} {pair.kind}")) + ".");
+            complaint.AppendLine();
 
-            Assert.True(complaint.Length == 0, "\n" + complaint + "\n" + Report(results));
+            foreach (var (r, _) in moved.Where(pair => pair.Status is "wrong"))
+                complaint.AppendLine(
+                    $"WRONG    {r.Problem.Name}: {r.Problem.Input} -> {r.Answer} ({r.Note})."
+                    + " An answer that is not right is worse than no answer, so this fails"
+                    + " whatever the record says. Do not record it: NoEntryExpectsAWrongAnswer"
+                    + " rejects Verdict.Wrong as an expectation.");
+            foreach (var (r, _) in moved.Where(pair => pair.Status is "worse"))
+                complaint.AppendLine(
+                    $"WORSE    {r.Problem.Name}: recorded {r.Problem.Expect}, measured {r.Verdict}"
+                    + $" ({r.Note}). THE LIBRARY GOT WORSE HERE. Fix it. Only lower the record if"
+                    + " the old verdict is shown to have been wrong, and say why in the commit.");
+            foreach (var (r, _) in moved.Where(pair => pair.Status is "better"))
+                complaint.AppendLine(
+                    $"BETTER   {r.Problem.Name}: recorded {r.Problem.Expect}, measured {r.Verdict}"
+                    + $" ({r.Note}). NOTHING IS BROKEN -- the library got better and the record"
+                    + $" does not say so. Set Expect = Verdict.{r.Verdict} on this problem in"
+                    + $" Corpus.cs, re-run with {CorpusRecord.UpdateVariable}=1 to refresh"
+                    + $" {CorpusRecord.BaselineFileName}, and commit both.");
+            foreach (var (r, _) in moved.Where(pair => pair.Status is "changed"))
+                complaint.AppendLine(
+                    $"CHANGED  {r.Problem.Name}: recorded {r.Problem.Expect}, measured {r.Verdict}"
+                    + $" ({r.Note}). Neither better nor worse -- both are the library producing"
+                    + " nothing, and there is no defensible ordering between throwing and"
+                    + " hanging. Look at it, then record it the way an improvement is recorded.");
+
+            Assert.True(false, "\n" + complaint + "\n" + Report(results));
+        }
+
+        /// <summary>
+        /// The record and the measurement compared, in the vocabulary the failure message uses.
+        /// </summary>
+        private static string Status(Verdict recorded, Verdict measured) =>
+            // Checked before equality: Expect can never be Wrong, so a wrong answer is always
+            // also a regression, and calling it "wrong" keeps the worst category its own.
+            measured is Verdict.Wrong ? "wrong"
+            : measured == recorded ? "ok"
+            : CorpusRecord.Rank(measured) > CorpusRecord.Rank(recorded) ? "worse"
+            : CorpusRecord.Rank(measured) < CorpusRecord.Rank(recorded) ? "better"
+            : "changed";
+
+        /// <summary>
+        /// The committed record is a projection of <see cref="Corpus.All"/>, and this checks it is
+        /// current. It says nothing about the library — that is what
+        /// <see cref="TheCorpusHasNotGotWorse"/> is for — and it exists so that the corpus has a
+        /// machine-readable history that outlives a job log.
+        /// </summary>
+        [Fact]
+        public void TheBaselineIsTheOneOnRecord()
+        {
+            var rendered = CorpusRecord.RenderBaseline(Corpus.All);
+
+            if (Environment.GetEnvironmentVariable(CorpusRecord.UpdateVariable) is "1")
+            {
+                // Written next to the sources, not to the output directory: the output copy is
+                // the build's, and the next build would overwrite it.
+                File.WriteAllText(CorpusRecord.BaselineSourcePath, rendered);
+                output.WriteLine("Rewrote " + CorpusRecord.BaselineSourcePath);
+                return;
+            }
+
+            Assert.True(File.Exists(CorpusRecord.BaselinePath),
+                $"No corpus baseline at {CorpusRecord.BaselinePath}. Re-run the suite with"
+                + $" {CorpusRecord.UpdateVariable}=1 to write"
+                + $" {CorpusRecord.BaselineSourcePath}, then commit it.");
+
+            var recorded = CorpusRecord.Lines(File.ReadAllText(CorpusRecord.BaselinePath));
+            var measured = CorpusRecord.Lines(rendered);
+            if (recorded.SequenceEqual(measured, StringComparer.Ordinal))
+                return;
+
+            var message = new StringBuilder();
+            message.AppendLine();
+            message.AppendLine($"{CorpusRecord.BaselineFileName} is not what Corpus.cs says.");
+            message.AppendLine("It is generated, so this is never a reason to edit it by hand:"
+                               + $" re-run with {CorpusRecord.UpdateVariable}=1 and commit the result.");
+            Describe(message, "ON RECORD but no longer true", recorded.Except(measured, StringComparer.Ordinal).ToList());
+            Describe(message, "TRUE but not on record", measured.Except(recorded, StringComparer.Ordinal).ToList());
+            Assert.True(false, message.ToString());
+        }
+
+        private static void Describe(StringBuilder into, string heading, IReadOnlyList<string> lines)
+        {
+            if (lines.Count == 0) return;
+            into.AppendLine().AppendLine($"{heading} ({lines.Count}):");
+            foreach (var line in lines.Take(40))
+                into.AppendLine("  " + line);
+            if (lines.Count > 40)
+                into.AppendLine($"  ... and {lines.Count - 40} more");
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Corpus/CorpusRecord.cs
+++ b/Sources/Tests/UnitTests/Corpus/CorpusRecord.cs
@@ -1,0 +1,201 @@
+﻿//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace AngouriMath.Tests.Corpus
+{
+    /// <summary>
+    /// How the corpus result leaves the process: a <b>baseline</b> that is committed and carries
+    /// the history, and a <b>report</b> that is written on every run and uploaded as a CI
+    /// artefact.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Item 36 of <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> asks
+    /// for the corpus result "as a CI artefact with per-commit history". Those are two different
+    /// files because they answer two different questions, and one file cannot be both.
+    /// </para>
+    /// <para>
+    /// The <b>report</b> answers <i>what happened in this run</i>. It carries the measured
+    /// verdict, the note explaining it and the answer the library gave, plus the machine it ran
+    /// on and the commit. It is written to the test output directory — never into the source
+    /// tree, which would make every local run dirty the working copy — and uploaded with
+    /// <c>if: always()</c>, because a run that fell over part way still measured the cases that
+    /// ran and those are the interesting ones when something has just broken.
+    /// </para>
+    /// <para>
+    /// The <b>baseline</b> answers <i>what did the corpus look like at commit X</i>, for every X,
+    /// forever. That is what "per-commit history" means, and an accumulated pile of artefacts
+    /// cannot supply it: artefacts expire (90 days at most on this plan), they cannot be diffed,
+    /// and they are not attributable to the commit that moved a number. A file in the repository
+    /// is, through <c>git log -p</c> and <c>git blame</c>, and it does not expire. The two
+    /// destination repositories <a href="https://github.com/asc-community/AngouriMath/issues/500">#500</a>
+    /// names for the equivalent job on the benchmark side — <c>AngouriMathLab/performance-reports</c>
+    /// and <c>-tools</c> — were checked and still do not exist, so pushing the history elsewhere
+    /// was not an option to weigh.
+    /// </para>
+    /// <para>
+    /// The baseline is <b>generated from <see cref="Corpus.All"/></b>, not from the run. That is
+    /// deliberate: the per-problem expectation already lives in the corpus, as
+    /// <see cref="Problem.Expect"/>, next to the problem it is about, and a second hand-maintained
+    /// copy of it would be a second thing to edit and a second thing to get wrong. This file is a
+    /// projection of the corpus, so keeping it current is mechanical rather than a judgement, and
+    /// it states the two things <see cref="Problem.Expect"/> does not state anywhere: the totals,
+    /// and the membership as a flat list, so that a corpus which quietly shrinks shows up in the
+    /// diff. The gate checks the projection is current; a separate gate checks the corpus itself
+    /// still measures what it claims. Neither can pass while the other is stale.
+    /// </para>
+    /// <para>
+    /// The shape — a committed record, an <c>AM_UPDATE_*</c> environment variable to regenerate
+    /// it, and a failure that spells out both directions — is the one
+    /// <c>Common/PublicApiSurfaceTest</c> already uses for the public API surface. It is followed
+    /// here rather than a second convention invented alongside it.
+    /// </para>
+    /// </remarks>
+    public static class CorpusRecord
+    {
+        /// <summary>The environment variable that rewrites <see cref="BaselineSourcePath"/>.</summary>
+        public const string UpdateVariable = "AM_UPDATE_CORPUS_BASELINE";
+
+        /// <summary>The name of the committed record, in the source tree and in the output.</summary>
+        public const string BaselineFileName = "corpus-baseline.tsv";
+
+        /// <summary>The name of the per-run report, in the output directory only.</summary>
+        public const string ReportFileName = "corpus-report.tsv";
+
+        /// <summary>
+        /// The copy the test reads. The build preserves the folder the <c>Content</c> item sits
+        /// in, so it lands under <c>Corpus/</c>.
+        /// </summary>
+        public static string BaselinePath { get; } =
+            Path.Combine(AppContext.BaseDirectory, "Corpus", BaselineFileName);
+
+        /// <summary>The committed original, which is what an update has to rewrite.</summary>
+        public static string BaselineSourcePath => Path.Combine(SourceDirectory(), BaselineFileName);
+
+        /// <summary>
+        /// Written next to the test binary, which is what the workflow uploads. Not written into
+        /// the source tree: a test must not dirty the working copy it is run from.
+        /// </summary>
+        public static string ReportPath { get; } =
+            Path.Combine(AppContext.BaseDirectory, ReportFileName);
+
+        /// <summary>
+        /// How bad a verdict is, worst last. Used only to say whether a change is an improvement
+        /// or a regression, and it deliberately leaves a gap.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Verdict.Solved"/> beats everything and <see cref="Verdict.Wrong"/> loses to
+        /// everything — AGENTS.md is explicit that an answer which is not right is worse than no
+        /// answer. <see cref="Verdict.Unsolved"/> beats <see cref="Verdict.Error"/> and
+        /// <see cref="Verdict.Timeout"/> because declining, in bounded time, is a legitimate
+        /// answer and the other two are defects. Between <i>threw</i> and <i>hung</i> there is no
+        /// defensible ordering, so they are given the <b>same</b> rank and a move between them is
+        /// reported as a change rather than as progress in either direction.
+        /// </remarks>
+        public static int Rank(Verdict verdict) => verdict switch
+        {
+            Verdict.Solved => 0,
+            Verdict.Unsolved => 1,
+            Verdict.Timeout => 2,
+            Verdict.Error => 2,
+            Verdict.Wrong => 3,
+            _ => 3,
+        };
+
+        /// <summary>The committed record, rendered from the corpus.</summary>
+        public static string RenderBaseline(IReadOnlyList<Problem> problems)
+        {
+            var sb = new StringBuilder();
+            sb.Append("# AngouriMath corpus baseline. One line per problem, tab separated.\n");
+            sb.Append("# Generated from Corpus.All -- not hand-edited. To update it, change Expect\n");
+            sb.Append($"# in Corpus.cs, re-run the suite with {UpdateVariable}=1, and commit both.\n");
+            sb.Append("# Its git history is the per-commit history of the corpus -- item 36 of\n");
+            sb.Append("# https://github.com/asc-community/AngouriMath/issues/746.\n");
+            sb.Append(Totals(problems.Select(p => p.Expect), problems.Count));
+            sb.Append("name\top\tverdict\n");
+            // Ordered by name rather than by declaration, so that inserting a problem moves one
+            // line rather than every line after it.
+            foreach (var problem in problems.OrderBy(p => p.Name, StringComparer.Ordinal))
+                sb.Append($"{problem.Name}\t{problem.Op}\t{problem.Expect}\n");
+            return sb.ToString();
+        }
+
+        /// <summary>One <c># totals</c> line, in the order the verdicts are declared in.</summary>
+        private static string Totals(IEnumerable<Verdict> verdicts, int count)
+        {
+            var list = verdicts.ToList();
+            var sb = new StringBuilder("# totals");
+            foreach (var verdict in Enum.GetValues(typeof(Verdict)).Cast<Verdict>())
+                sb.Append($"\t{verdict}={list.Count(v => v == verdict)}");
+            return sb.Append($"\tTotal={count}\n").ToString();
+        }
+
+        /// <summary>
+        /// The per-run report: everything the baseline holds, plus what was actually measured,
+        /// why, and where.
+        /// </summary>
+        public static string RenderReport(IReadOnlyList<ReportRow> rows, long elapsedMilliseconds)
+        {
+            var sb = new StringBuilder();
+            sb.Append("# AngouriMath corpus report. One line per problem, tab separated.\n");
+            sb.Append("# Written by CorpusGateTest on every run; uploaded as a CI artefact.\n");
+            sb.Append($"# generated\t{DateTime.UtcNow:yyyy-MM-ddTHH:mm:ssZ}\n");
+            sb.Append($"# commit\t{Environment.GetEnvironmentVariable("GITHUB_SHA") ?? "-"}\n");
+            sb.Append($"# ref\t{Environment.GetEnvironmentVariable("GITHUB_REF") ?? "-"}\n");
+            sb.Append($"# os\t{Sanitize(System.Runtime.InteropServices.RuntimeInformation.OSDescription)}\n");
+            sb.Append($"# runtime\t{Sanitize(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription)}\n");
+            sb.Append($"# elapsed_ms\t{elapsedMilliseconds}\n");
+            sb.Append(Totals(rows.Select(r => r.Verdict), rows.Count));
+            sb.Append("name\top\texpect\tverdict\tstatus\tnote\tanswer\n");
+            foreach (var row in rows.OrderBy(r => r.Name, StringComparer.Ordinal))
+                sb.Append($"{row.Name}\t{row.Op}\t{row.Expect}\t{row.Verdict}\t{row.Status}"
+                          + $"\t{Sanitize(row.Note)}\t{Sanitize(row.Answer)}\n");
+            return sb.ToString();
+        }
+
+        /// <summary>One row of the report.</summary>
+        public sealed record ReportRow(
+            string Name, Op Op, Verdict Expect, Verdict Verdict, string Status, string Note, string Answer);
+
+        /// <summary>
+        /// A tab or a newline inside a field would make the row unreadable as TSV, and an answer
+        /// is the library's own printed output, so neither can be ruled out.
+        /// </summary>
+        private static string Sanitize(string field)
+        {
+            if (string.IsNullOrEmpty(field)) return "-";
+            var text = field.Replace('\t', ' ').Replace('\r', ' ').Replace('\n', ' ').Trim();
+            return text.Length == 0 ? "-" : text.Length > 160 ? text[..157] + "..." : text;
+        }
+
+        /// <summary>
+        /// Two texts compared as lines, so that the difference can be shown rather than asserted.
+        /// Line endings are normalised: the file is committed once and read on three operating
+        /// systems, and git may hand any of them a different ending for the same content.
+        /// </summary>
+        public static IReadOnlyList<string> Lines(string text) =>
+            text.Replace("\r\n", "\n").Split('\n').Where(l => l.Length > 0).ToList();
+
+        /// <summary>Walks up from the test binary to this file's directory in the source tree.</summary>
+        private static string SourceDirectory()
+        {
+            var path = AppContext.BaseDirectory;
+            while (path is not null && Path.GetFileName(path) is not "UnitTests")
+                path = Path.GetDirectoryName(path);
+            if (path is null)
+                throw new InvalidOperationException("Could not find the UnitTests directory from "
+                                                    + AppContext.BaseDirectory);
+            return Path.Combine(path, "Corpus");
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Corpus/corpus-baseline.tsv
+++ b/Sources/Tests/UnitTests/Corpus/corpus-baseline.tsv
@@ -1,0 +1,47 @@
+# AngouriMath corpus baseline. One line per problem, tab separated.
+# Generated from Corpus.All -- not hand-edited. To update it, change Expect
+# in Corpus.cs, re-run the suite with AM_UPDATE_CORPUS_BASELINE=1, and commit both.
+# Its git history is the per-commit history of the corpus -- item 36 of
+# https://github.com/asc-community/AngouriMath/issues/746.
+# totals	Solved=39	Unsolved=1	Wrong=0	Error=0	Timeout=0	Total=40
+name	op	verdict
+int:arctan-form	Integrate	Solved
+int:by-parts-cyclic	Integrate	Solved
+int:exponential	Integrate	Solved
+int:hard	Integrate	Unsolved
+int:partial-fractions	Integrate	Solved
+int:power	Integrate	Solved
+int:reciprocal	Integrate	Solved
+int:trig	Integrate	Solved
+int:u-sub	Integrate	Solved
+lim:0/0	Limit	Solved
+lim:0/0-arcsin	Limit	Solved
+lim:1^oo	Limit	Solved
+lim:log	Limit	Solved
+lim:oo-oo	Limit	Solved
+lim:ratio	Limit	Solved
+simp:abs	Simplify	Solved
+simp:collapse	Simplify	Solved
+simp:factoring	Simplify	Solved
+simp:inverse-trig	Simplify	Solved
+simp:log-ratio	Simplify	Solved
+simp:parity	Simplify	Solved
+simp:polynomial	Simplify	Solved
+simp:power-tower	Simplify	Solved
+simp:rational	Simplify	Solved
+simp:rational-two-vars	Simplify	Solved
+simp:surd-product	Simplify	Solved
+simp:surds	Simplify	Solved
+simp:trig-cyclic	Simplify	Solved
+simp:trig-double	Simplify	Solved
+simp:trig-pythagoras	Simplify	Solved
+solve:biquadratic	Solve	Solved
+solve:cubic	Solve	Solved
+solve:exponential	Solve	Solved
+solve:linear	Solve	Solved
+solve:product	Solve	Solved
+solve:quadratic	Solve	Solved
+solve:quadratic-complex	Solve	Solved
+solve:quartic-nested	Solve	Solved
+solve:quintic-factorable	Solve	Solved
+solve:trig	Solve	Solved

--- a/Sources/Tests/UnitTests/UnitTests.csproj
+++ b/Sources/Tests/UnitTests/UnitTests.csproj
@@ -48,6 +48,9 @@
 
     <!-- Read at run time by PublicApiSurfaceTest; see its remarks. -->
     <Content Include="Common\PublicApi.txt" CopyToOutputDirectory="PreserveNewest" />
+
+    <!-- Read at run time by CorpusGateTest; see CorpusRecord's remarks. -->
+    <Content Include="Corpus\corpus-baseline.tsv" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The corpus gate reports **solved / unsolved / wrong / error / timeout** on every commit, on three operating systems. Those numbers existed only in the job log, which expires — so there was no way to see whether a figure had moved without re-running an old commit by hand. [#746](https://github.com/asc-community/AngouriMath/issues/746) item 36 names two things, and this is both of them.

## Two files, because the item names two things one file cannot be

**`corpus-report.tsv` — the artefact.** Written to the test output directory (never into the source tree; a test must not dirty the working copy) **before any assertion**, so a run that then fails still leaves numbers behind. It carries the measured verdict, the note explaining it, the answer the library actually gave, plus commit, OS, runtime and how long the corpus took. Uploaded from all three matrix legs, `if: always()` — a verdict that differs between operating systems is itself a finding.

```
# generated	2026-08-23T02:32:33Z
# os	Ubuntu 26.04 LTS
# runtime	.NET 10.0.10
# elapsed_ms	1449
# totals	Solved=39	Unsolved=1	Wrong=0	Error=0	Timeout=0	Total=40
name	op	expect	verdict	status	note	answer
int:arctan-form	Integrate	Solved	Solved	ok	differentiates back	2 * arctan(2 * x / 2) / 2 + C
int:hard	Integrate	Unsolved	Unsolved	ok	integral remains	integral(sqrt(tan(x)), x)
solve:trig	Solve	Solved	Solved	ok	8 root(s) verified	{ 2 * pi * n_1, pi + 2 * pi * n_1 }
```

**`corpus-baseline.tsv` — the per-commit history**, committed. Chosen over accumulating artefacts on evidence rather than taste: artefacts expire (90 days is the cap), cannot be diffed, and cannot be attributed to the commit that moved a number. A file in the repository is all three, through `git log -p` and `git blame`, and it does not expire. #500's two named destinations, `AngouriMathLab/performance-reports` and `-tools`, were re-checked and **both still 404** — the org 404s on the REST listing — so pushing history elsewhere was not an option to weigh.

**The baseline is generated from `Corpus.All`, not maintained beside it.** The per-problem expectation already exists as `Problem.Expect`, next to the problem it is about; a second hand-kept copy is a second thing to get wrong. So the file is a projection — regenerating it is mechanical (`AM_UPDATE_CORPUS_BASELINE=1`), never a judgement — and it states the two things `Expect` does not: the totals, and membership as a flat sorted list, so a corpus that quietly *shrinks* shows up in the diff.

That shape — committed record, `AM_UPDATE_*`, and a failure that spells out both directions — is already this repository's convention in `Common/PublicApiSurfaceTest`. Followed rather than reinvented.

## Both failure modes, demonstrated

Three problems temporarily altered, then reverted:

```
The corpus moved: 1 wrong, 1 worse, 1 better.

WRONG    lim:ratio: (x ^ 2 + 1) / (x ^ 2 - 1) -> 1 (expected 2). An answer that is not right is
         worse than no answer, so this fails whatever the record says. Do not record it:
         NoEntryExpectsAWrongAnswer rejects Verdict.Wrong as an expectation.
WORSE    int:power: recorded Solved, measured Unsolved (integral remains). THE LIBRARY GOT WORSE
         HERE. Fix it. Only lower the record if the old verdict is shown to have been wrong, and
         say why in the commit.
BETTER   int:trig: recorded Unsolved, measured Solved (differentiates back). NOTHING IS BROKEN --
         the library got better and the record does not say so. Set Expect = Verdict.Solved on
         this problem in Corpus.cs, re-run with AM_UPDATE_CORPUS_BASELINE=1 to refresh
         corpus-baseline.tsv, and commit both.
```

A **wrong answer can never be recorded as expected** — `NoEntryExpectsAWrongAnswer` rejects it — because a record that says "this one is wrong and that is fine" is how a wrong answer becomes permanent.

Verdict ranking, used only for better-versus-worse: `Solved(0) < Unsolved(1) < Timeout(2) = Error(2) < Wrong(3)`. Solved beats everything and Wrong loses to everything, per `AGENTS.md`; Unsolved beats the other two because declining in bounded time is a legitimate answer. Between *threw* and *hung* there is no defensible ordering, so they share a rank and a move between them reports as `CHANGED` rather than as progress in either direction.

## Path filters

`CSharpTest.yml` has **no** `paths:` filter and so cannot carry the defect that silenced the benchmark for ninety-eight merged PRs (#775). None was added — it is the suite, and every change is one it can break — with a comment saying so, so that the first person to reach for a filter checks first.

**The same defect is still live in `CPPBuild.yml`**, lines 8 and 13: `"./Sources/Wrappers/AngouriMath.CPP.*/**"`. Its last run was **2026-01-02T14:24** — the same date `Benchmark.yml` stopped, from the same commit. That file belongs to another branch in flight and is being fixed there.

## Measured

- **Gate duration**: 3.51 / 3.92 / 3.79 s before, 3.08 / 3.17 / 3.12 s after (three runs each, `--no-build`, same machine). The corpus itself is 1.4 s of that; the added work is rendering and writing one 3.4 kB file.
- **Suite**: 7534 passed, 0 failed, 14 skipped — master's 7533 plus `TheBaselineIsTheOneOnRecord`. Build clean, the same 29 warnings as before.
- The failing test was written first: with no baseline present, `TheBaselineIsTheOneOnRecord` fails with `No corpus baseline at …/corpus-baseline.tsv. Re-run the suite with AM_UPDATE_CORPUS_BASELINE=1 to write …, then commit it.`

## One caveat worth stating plainly

The corpus is **40 problems**, all drawn from this project's own tracker, nothing vendored — and the baseline says `Solved=39, Unsolved=1`, so the gate has **one problem of headroom** in the improvement direction. Everything that finds *new* defects lives outside CI: `intbench` against Rubi moved 536 → 604 solved in the analysis workspace, an order of magnitude more cases than the in-CI gate holds in total.

This makes the gate a reliable regression detector. It does not make it the measurement the roadmap leans on, and closing that gap is separate work (#746 items 39 and 40). Not expanded here, deliberately.
