### PR TITLE
Fail the build when the popular use cases allocate more (#529, #500)

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -55,6 +55,22 @@ jobs:
         cd Sources/Tests/DotnetBenchmark
         dotnet run -c Release RAMUsageTest
 
+    # The step that makes the two above a gate rather than a report. It runs no benchmark:
+    # the CPU step wrote what it measured to benchmark_results.csv/measured-*.json, and this
+    # reads that against the committed performance-baseline.json. Allocation is what it fails
+    # on, in either direction; the wall clock is reported and only fails at 3x, because a
+    # GitHub-hosted runner shares its host and a tight time threshold would be red for
+    # reasons that are not the change. The argument, and the variance it was measured from,
+    # are in PerformanceGate.cs.
+    #
+    # Last, so that a failure here does not cost the RAM figures, and before the upload so
+    # that the file to copy over the baseline is in the artifact of the run that failed.
+    # https://github.com/asc-community/AngouriMath/issues/529
+    - name: 'Kernel performance gate'
+      run: |
+        cd Sources/Tests/DotnetBenchmark
+        dotnet run -c Release --no-build PerformanceGate
+
     # The numbers used to exist only in this job's log, which expires -- so there was no way to
     # see whether a figure had moved without re-running an old commit by hand. Retaining them is
     # step 1 of https://github.com/asc-community/AngouriMath/issues/500, and the only step that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,26 @@ suite is paid for on every commit. The harnesses in `work/` are where a measurem
 inputs, takes minutes, and gets read by a person; the two are not substitutes, and a finding from a
 harness that is worth keeping belongs in the corpus as a new problem.
 
+### And a second gate, on what the popular use cases allocate
+
+`Sources/Tests/DotnetBenchmark/performance-baseline.json` records allocated bytes and mean
+nanoseconds per operation for parse, `Simplify`, `Solve` and `Differentiate` on textbook-sized input.
+The Kernel Benchmark workflow runs the benchmarks and then `PerformanceGate`, which compares the run
+against that file and fails the build. It behaves like the corpus gate — including failing when a
+number gets **better**, because a baseline that overstates what the library allocates would let a
+later change give the gain back unnoticed.
+
+**It gates allocation and reports time.** Allocated bytes are a property of the code: the same input
+asks the allocator for the same number of bytes. A shared runner's wall clock is a property of
+whoever else is on that host, so the time column fails only above 3x — a catastrophe threshold, not
+a performance one. The measurement that chose those two numbers is in the remarks of
+`PerformanceGate.cs`.
+
+It runs on the benchmark job rather than in the suite, because it costs about ten minutes and
+everything in the suite is paid for on every commit. What to do when it fails, and when updating the
+baseline is legitimate, is in
+[`WhatsNew/version_performance_control.md`](Sources/AngouriMath/Docs/WhatsNew/version_performance_control.md).
+
 ## One structure under several features
 
 Four things in this library are the same shape, and three of them were written separately before
@@ -400,7 +420,7 @@ are short, and a stale one is worse than none — if you change what a file desc
 | [`Contributing/SimplificationContract.md`](Sources/AngouriMath/Docs/Contributing/SimplificationContract.md) | what a rewrite may assume, and the ten obligations one has to meet. Read it *before* adding or changing a rule |
 | [`Contributing/CanonicalForm.md`](Sources/AngouriMath/Docs/Contributing/CanonicalForm.md) | canonical versus simplest, why no canonical form exists for the whole language, and what one means per node class. Read it before comparing two expressions for equality |
 | [`Contributing/coding_rules.md`](Sources/AngouriMath/Docs/Contributing/coding_rules.md) | sealed-or-abstract, and immutability of `Entity` |
-| [`WhatsNew/version_performance_control.md`](Sources/AngouriMath/Docs/WhatsNew/version_performance_control.md) | the inter-version performance table, and how to add a column |
+| [`WhatsNew/version_performance_control.md`](Sources/AngouriMath/Docs/WhatsNew/version_performance_control.md) | the inter-version performance table, how to add a column, and when the CI performance baseline may be updated |
 | `Sources/Analyzers/` | the custom analyzers, including the static-field one behind `[ConstantField]` |
 
 Anything added for the library's own purposes is not `public` — see
@@ -434,7 +454,8 @@ whatever else it delivered:
    [`WhatsNew/version_performance_control.md`](Sources/AngouriMath/Docs/WhatsNew/version_performance_control.md).
    Measure the previous column again on the same machine and publish the pair: columns taken on
    different hardware cannot be read as a ratio, and a uniform factor across every row is the machine
-   rather than the code.
+   rather than the code. Since #529 that is a gate and not only a record — see *And a second gate, on
+   what the popular use cases allocate* above.
 3. **Correctness coverage grows with the surface.** Each new layer adds ways to be wrong that the one
    below could not express.
 

--- a/Sources/AngouriMath/Docs/WhatsNew/version_performance_control.md
+++ b/Sources/AngouriMath/Docs/WhatsNew/version_performance_control.md
@@ -47,6 +47,82 @@ take a millisecond in total, while a thousand evaluations of freshly built nodes
 The row is kept as it is so the column history stays comparable, and the two trigonometric
 benchmarks build their expression afresh on every call for exactly this reason.
 
+---
+
+## The gate, and when the baseline may be updated
+
+This file is a history a person reads. `Sources/Tests/DotnetBenchmark/performance-baseline.json`
+is the same measurement in the form a build can fail on, which is what
+[#746](https://github.com/asc-community/AngouriMath/issues/746)'s standing condition -- *speed and
+memory on popular use cases are measured, not hoped for* -- asks for and what
+[#529](https://github.com/asc-community/AngouriMath/issues/529) asked for before it. The Kernel
+Benchmark workflow runs the benchmarks and then `dotnet run -c Release PerformanceGate`, which
+compares that run against the committed file.
+
+**It gates allocation and not time, because only one of the two is a property of the code.**
+Allocated bytes per operation is what the program asked the allocator for: the same code on the
+same input asks for the same number of bytes. Wall-clock time on a GitHub-hosted runner is a
+property of whoever else is on that host. Measured before choosing the thresholds -- all eighteen
+benchmarks, three consecutive runs of one unchanged build, on a machine deliberately left loaded
+(eight cores, load average around 16, which is closer to a shared runner than an idle desktop is):
+
+| | run to run |
+|---|---|
+| allocation, the sixteen gated benchmarks | at most **0.033%** apart -- six bytes on eighteen kilobytes, for `ParseEasy` -- and identical to the byte on seven of them |
+| mean time | up to **51.8%** apart, and 8-10% on nine of the eighteen |
+
+Three orders of magnitude between the two is the whole argument. Allocation is held to 3%, a
+hundred times the observed spread, and the wall clock fails only above 3.00x, which is a
+catastrophe threshold and deliberately catches nothing smaller. A gate that is red for reasons that
+are not the change is a gate people learn to ignore, and that is worse than not having one.
+
+**Two benchmarks are excluded by name.** `CompileEasy` and `CompileHard` moved 1.0% and 3.6% over
+those same three runs, because what they measure includes the runtime building and JIT-compiling a
+delegate, which is not reproducible the way the library's own allocation is. They are listed in the
+baseline's `ungated` map with that reason, and the gate prints the reason every time it runs -- an
+exclusion is a decision somebody made, not a benchmark that happens to be missing from the file.
+
+**It fails when a number gets better, too**, exactly as the corpus gate does and for the same
+reason: a baseline that overstates what the library allocates silently permits giving the gain
+back. The failure says `IMPROVED` rather than `REGRESSED`, and says what to do about it.
+
+### How to update it
+
+The run writes its numbers in the baseline's own format, so updating the baseline is a copy rather
+than a transcription:
+
+```
+cd Sources/Tests/DotnetBenchmark
+dotnet run -c Release CommonFunctionsInterVersion
+cp benchmark_results.csv/measured-CommonFunctionsInterVersion.json performance-baseline.json
+dotnet run -c Release --no-build PerformanceGate
+```
+
+The same file is in the `benchmark-results-<sha>` artifact of the CI job -- including of the job
+that just failed, which is why the upload step runs `if: always()`. That copy is the better source
+of the two, because it was taken on the machine and the runtime the gate is checked against.
+
+### When updating it is legitimate
+
+- **The allocation went down.** Record it, in the same change. This is the case the gate exists to
+  stop being absorbed, and it is the only one where a red build means nothing is wrong.
+- **The allocation went up and buys something.** [#918](https://github.com/asc-community/AngouriMath/pull/918)
+  is the worked example, below in this file: the polynomial layer made `SolveMedium` allocate 19%
+  more and made an incomplete root set complete. Say which in the pull request, next to the
+  `BREAKING-CHANGES.md` entry that a changed answer already owes.
+- **A benchmark was added or removed.** The gate reports `NEW` or `MISSING`, and the baseline
+  follows in the same change.
+- **The runtime moved under it.** Allocation is a property of the code *and* of the BCL beneath it,
+  so a .NET version bump can move a row with nothing here having changed. The baseline records the
+  `runtime` and `machine` it was taken on, and the gate prints both against the run's own, so check
+  those two lines before concluding this -- and say so in the commit, because it is the one reason
+  on this list that leaves no trace in the diff.
+
+And when it is not: **because the build is red and the number is inconvenient.** The gate names the
+benchmark and the size of the move. A move nobody can explain is the finding, not the obstacle.
+
+---
+
 |          Method |         [331st](https://github.com/asc-community/AngouriMath/commit/10e6e5a90e7270336b68dc5fd6aa36f3e0e65d2b) |          [380th](https://github.com/asc-community/AngouriMath/commit/73ae36488ddb863c1d6f35db5ed2f5dcf1484a26) |     [391st](https://github.com/asc-community/AngouriMath/commit/c7e08e6936bfdc2373377bec81ffd160e406244f)      |         [410th](https://github.com/asc-community/AngouriMath/commit/20814936bc740a9f410af4a4368e9895eab7aaf7) |           [483rd](https://github.com/asc-community/AngouriMath/commit/355963dcdf0ff9da568e9f1144ad2b7b68c19584) |         [520th](https://github.com/asc-community/AngouriMath/commit/70aa71acb73307c9f7df0aac006faae31b06058c) |         [690th](https://github.com/asc-community/AngouriMath/commit/5cc894939cb3657f0aa7ef5a25fd55011058929f) |         [826th](https://github.com/asc-community/AngouriMath/commit/87e33ec3590a95dd4ec59ff5c1f77064a64196d1) |         [914th](https://github.com/asc-community/AngouriMath/commit/6134338df083a908369b6bcfb69e70a4269ec51b) |         [920th](https://github.com/asc-community/AngouriMath/commit/501a0a3a9b2e07cddf92c4446b73ad6e2748253a) |        [1034th](https://github.com/asc-community/AngouriMath/commit/a3f48b47795b2dc2b3435152989a6e15639a65b4) |        [1066th](https://github.com/asc-community/AngouriMath/commit/a33746651f56a380b6c17913aa844f162f258d8c) |        [1090th](https://github.com/asc-community/AngouriMath/commit/9530c5b04484e98023941f7693bbeb1a3282cee6) |           [1446th](https://github.com/asc-community/AngouriMath/commit/2abb2b537c03977281f3fc2cab1da2c78c36a5f5) | [1620th](https://github.com/asc-community/AngouriMath/commit/e05d71797f53a9ac7dbdad6075cd7302a91036e7) | [1671st](https://github.com/asc-community/AngouriMath/commit/253b5a8d598a9a1d721b777340bd53ae3be12f99) | [1769th](https://github.com/asc-community/AngouriMath/commit/3ac24bc241e898509533bc980ec5dc91c5d79a07) |
 |---------------- |--------------:|---------------:|---------------:|--------------:|----------------:|--------------:|--------------:|--------------:|--------------:|--------------:|--------------:|--------------:|--------------:|-----------------:|--------------:|--------------:|--:|
 |       ParseEasy |        28,599 |         73,669 |        134,120 |        44,328 |          54,675 |        21,722 |        32,212 |        32,138 |        34,702 |        32,199 |        33,008 |        27,483 |        33,043 |        34,664 | 11,760 ns | 10,857 ns | 10,080 ns |

--- a/Sources/Tests/DotnetBenchmark/PerformanceGate.cs
+++ b/Sources/Tests/DotnetBenchmark/PerformanceGate.cs
@@ -1,0 +1,482 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BenchmarkDotNet.Reports;
+
+namespace DotnetBenchmark
+{
+    /// <summary>
+    /// Compares a <see cref="CommonFunctionsInterVersion"/> run against the committed
+    /// <c>performance-baseline.json</c> and fails the build when what the library allocates on the
+    /// popular use cases has moved -- in either direction.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Allocation is gated and time is not, because only one of the two is a property of the
+    /// code.</b> Allocated bytes per operation is what the program asked the allocator for; run the
+    /// same code on the same input and it comes back the same number. Wall-clock time on a
+    /// GitHub-hosted runner is a property of whoever else is on that host, so a threshold tight
+    /// enough to catch a real slowdown would be red for reasons that are not the change, and a gate
+    /// people learn to ignore is worse than no gate at all.
+    /// </para>
+    /// <para>
+    /// The thresholds come from measuring it. Three consecutive runs of one unchanged build, all
+    /// eighteen benchmarks, on a machine deliberately left loaded (eight cores, load average ~16,
+    /// which is closer to a shared runner than an idle desktop is):
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>
+    /// <b>allocation</b> spread at most 0.033% -- six bytes on eighteen kilobytes, for
+    /// <c>ParseEasy</c> -- across the sixteen benchmarks that do not compile a delegate, and
+    /// identical to the byte on seven of them;
+    /// </description></item>
+    /// <item><description>
+    /// <b>time</b> spread up to 51.8%, and 8-10% on nine of the eighteen.
+    /// </description></item>
+    /// </list>
+    /// <para>
+    /// Three orders of magnitude between the two is the whole argument. <see cref="AllocationBand"/>
+    /// is 3% -- a hundred times the observed spread -- rather than 0%, because the baseline is also
+    /// compared across .NET versions and machines, where a BCL change can move an allocation a
+    /// little with nothing in this repository having changed. <see cref="TimeCeilingFactor"/> is 3x
+    /// because that is not a performance threshold but a catastrophe one: it catches an accidental
+    /// blow-up and deliberately catches nothing smaller.
+    /// </para>
+    /// <para>
+    /// <b>The two <c>Compile</c> benchmarks are the exception, and are excluded by name</b> in the
+    /// baseline's <c>ungated</c> map. <c>CompileHard</c> moved 3.6% between those same three runs
+    /// and <c>CompileEasy</c> 1.0%, because what they measure includes the runtime's own work
+    /// building and JIT-compiling a delegate, which is not reproducible the way the library's
+    /// allocation is. They are the reason the exclusion is a recorded decision with a reason rather
+    /// than a benchmark quietly missing from the file.
+    /// </para>
+    /// <para>
+    /// <b>It fails on an improvement too</b>, exactly as the corpus gate does, and for the same
+    /// reason: a baseline that overstates what the library allocates silently permits giving the
+    /// gain back. An improvement is reported as an improvement, with the file to copy.
+    /// </para>
+    /// </remarks>
+    internal static class PerformanceGate
+    {
+        /// <summary>The argument that asks <c>Program</c> to compare rather than to measure.</summary>
+        internal const string Command = "PerformanceGate";
+
+        /// <summary>
+        /// The benchmark class the baseline covers: the popular use cases named by
+        /// https://github.com/asc-community/AngouriMath/issues/746.
+        /// </summary>
+        internal const string GatedBenchmark = nameof(CommonFunctionsInterVersion);
+
+        /// <summary>How far allocation may move, in either direction, before the gate fails.</summary>
+        private const double AllocationBand = 0.03;
+
+        /// <summary>
+        /// A move must also be this many bytes per operation to count, so that a benchmark
+        /// allocating almost nothing does not fail on a percentage of almost nothing.
+        /// </summary>
+        private const long AllocationFloorBytes = 128;
+
+        /// <summary>Time fails only above this factor. See the remarks: a catastrophe gate.</summary>
+        private const double TimeCeilingFactor = 3.0;
+
+        /// <summary>Time above this factor is called out for a human to look at, and does not fail.</summary>
+        private const double TimeNoticeFactor = 1.25;
+
+        private static readonly JsonSerializerOptions Json = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true,
+            WriteIndented = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
+
+        /// <summary>One benchmark's two numbers.</summary>
+        internal sealed record Measurement(long AllocatedBytes, double MeanNanoseconds);
+
+        /// <summary>
+        /// The shape of both <c>performance-baseline.json</c> and the file a run writes, on
+        /// purpose: updating the baseline is then copying one file over the other.
+        /// </summary>
+        internal sealed record Record(
+            string Comment,
+            string Benchmark,
+            string Commit,
+            string MeasuredOn,
+            string Runtime,
+            string Machine,
+            Dictionary<string, Measurement> Cases,
+            Dictionary<string, string>? Ungated = null);
+
+        private const string RecordComment =
+            "Allocated bytes and mean nanoseconds per operation for the popular use cases of "
+            + "https://github.com/asc-community/AngouriMath/issues/746. Checked by PerformanceGate.cs; "
+            + "see Sources/AngouriMath/Docs/WhatsNew/version_performance_control.md for when updating it is legitimate.";
+
+        /// <summary>
+        /// The project directory, found from the binary rather than from the working directory, so
+        /// that the gate answers the same whichever directory it is invoked from.
+        /// </summary>
+        private static string ProjectDirectory { get; } = FindProjectDirectory();
+
+        private static string BaselinePath => Path.Combine(ProjectDirectory, "performance-baseline.json");
+
+        private static string MeasurementPath(string benchmark)
+            => Path.Combine(ProjectDirectory, "benchmark_results.csv", $"measured-{benchmark}.json");
+
+        private static string FindProjectDirectory()
+        {
+            for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir is not null; dir = dir.Parent)
+                if (File.Exists(Path.Combine(dir.FullName, "DotnetBenchmark.csproj")))
+                    return dir.FullName;
+            return Environment.CurrentDirectory;
+        }
+
+        /// <summary>
+        /// Writes what a run measured, in the baseline's own format. Called for every benchmark
+        /// class, not only the gated one: the file is what a contributor copies over the baseline,
+        /// and what the CI job uploads so that the baseline can be refreshed from a run on the
+        /// hardware the gate will actually be checked on.
+        /// </summary>
+        internal static void WriteMeasurements(Summary summary)
+        {
+            var name = summary.BenchmarksCases.FirstOrDefault()?.Descriptor.Type.Name;
+            if (name is null) return;
+
+            var cases = new Dictionary<string, Measurement>(StringComparer.Ordinal);
+            foreach (var report in summary.Reports)
+            {
+                var method = report.BenchmarkCase.Descriptor.WorkloadMethod.Name;
+                var mean = report.ResultStatistics?.Mean;
+                if (mean is null) continue;
+                cases[method] = new Measurement(
+                    report.GcStats.BytesAllocatedPerOperation,
+                    mean.Value);
+            }
+            if (cases.Count == 0) return;
+
+            var record = new Record(
+                RecordComment,
+                name,
+                DescribeCommit(),
+                DateTime.UtcNow.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                RuntimeInformation.FrameworkDescription,
+                $"{RuntimeInformation.OSDescription.Split('\n')[0].Trim()}, "
+                    + $"{RuntimeInformation.ProcessArchitecture}, {Environment.ProcessorCount} logical cores",
+                cases.OrderBy(pair => pair.Key, StringComparer.Ordinal)
+                     .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal),
+                // Carried over from the baseline rather than recomputed, so that copying this file
+                // over the baseline keeps the exclusions and the reasons for them.
+                CarryOverUngated(name));
+
+            var path = MeasurementPath(name);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, JsonSerializer.Serialize(record, Json) + Environment.NewLine);
+            Console.WriteLine($"Measurements written to {path}");
+        }
+
+        /// <summary>
+        /// The exclusions the baseline already records, if any. A benchmark is left out of the gate
+        /// deliberately and with a reason written down, never by being absent.
+        /// </summary>
+        private static Dictionary<string, string>? CarryOverUngated(string benchmark)
+        {
+            if (benchmark != GatedBenchmark || !File.Exists(BaselinePath)) return null;
+            try
+            {
+                return Read(BaselinePath).Ungated;
+            }
+            catch (Exception e) when (e is JsonException or IOException)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>The commit the run was taken at, for the record. Never fails the run.</summary>
+        private static string DescribeCommit()
+        {
+            if (Environment.GetEnvironmentVariable("GITHUB_SHA") is { Length: > 0 } sha) return sha;
+            try
+            {
+                using var git = Process.Start(new ProcessStartInfo("git", "rev-parse HEAD")
+                {
+                    WorkingDirectory = ProjectDirectory,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                });
+                if (git is null) return "unknown";
+                var output = git.StandardOutput.ReadToEnd().Trim();
+                git.WaitForExit(5000);
+                return git.ExitCode == 0 && output.Length > 0 ? output : "unknown";
+            }
+            catch (Exception e) when (e is System.ComponentModel.Win32Exception or InvalidOperationException)
+            {
+                return "unknown";
+            }
+        }
+
+        private enum Verdict { Ok, Slow, Ungated, Regressed, Improved, Slower, Missing, New }
+
+        private sealed record Row(
+            string Method, Verdict Verdict,
+            Measurement? Baseline, Measurement? Measured,
+            double AllocationDelta, double TimeFactor);
+
+        /// <summary>
+        /// Reads the baseline and the last run of <see cref="GatedBenchmark"/> and reports on the
+        /// difference. Returns a process exit code: 0 when nothing moved, 1 otherwise.
+        /// </summary>
+        internal static int Compare(TextWriter to)
+        {
+            if (!File.Exists(BaselinePath))
+                return Fail(to, $"No baseline at {BaselinePath}.");
+
+            var measurementPath = MeasurementPath(GatedBenchmark);
+            if (!File.Exists(measurementPath))
+                return Fail(to,
+                    $"No measurements at {measurementPath}.\n"
+                    + $"The gate compares a run against the baseline; it does not run the benchmark itself.\n"
+                    + $"Run    dotnet run -c Release {GatedBenchmark}    first, from Sources/Tests/DotnetBenchmark.");
+
+            Record baseline, measured;
+            try
+            {
+                baseline = Read(BaselinePath);
+                measured = Read(measurementPath);
+            }
+            catch (JsonException e)
+            {
+                return Fail(to, $"Could not read the baseline or the measurements: {e.Message}");
+            }
+
+            var rows = Rows(baseline, measured).ToList();
+            to.WriteLine(Report(baseline, measured, rows));
+
+            var moved = rows.Where(r => r.Verdict is not (Verdict.Ok or Verdict.Slow or Verdict.Ungated)).ToList();
+            if (moved.Count == 0)
+            {
+                var gated = rows.Count(r => r.Verdict is not Verdict.Ungated);
+                to.WriteLine($"PASSED. Allocation is what the baseline says it is on all {gated} gated "
+                    + $"benchmarks; {rows.Count - gated} are not gated, for the reasons the baseline gives.");
+                var slow = rows.Where(r => r.Verdict is Verdict.Slow).ToList();
+                if (slow.Count > 0)
+                    to.WriteLine($"        {slow.Count} benchmark(s) are more than "
+                        + $"{TimeNoticeFactor:0.00}x the baseline time. That is reported, not gated -- "
+                        + "see the remarks in PerformanceGate.cs -- but it is worth a look if the "
+                        + "same rows are slow on a second run.");
+                return 0;
+            }
+
+            to.WriteLine(Explain(baseline, moved));
+            to.WriteLine();
+            to.WriteLine("To accept these numbers as the new baseline, copy the file this run wrote:");
+            to.WriteLine();
+            to.WriteLine($"    cp {Relative(measurementPath)} \\");
+            to.WriteLine($"       {Relative(BaselinePath)}");
+            to.WriteLine();
+            to.WriteLine("On a CI run it is in the benchmark-results artifact. Its content is:");
+            to.WriteLine();
+            to.WriteLine(File.ReadAllText(measurementPath).TrimEnd());
+            to.WriteLine();
+            return 1;
+        }
+
+        private static Record Read(string path)
+            => JsonSerializer.Deserialize<Record>(File.ReadAllText(path), Json)
+               ?? throw new JsonException($"{path} is empty");
+
+        private static int Fail(TextWriter to, string message)
+        {
+            to.WriteLine();
+            to.WriteLine("FAILED: " + message);
+            to.WriteLine();
+            return 1;
+        }
+
+        private static IEnumerable<Row> Rows(Record baseline, Record measured)
+        {
+            var ungated = baseline.Ungated ?? new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var method in baseline.Cases.Keys.Concat(measured.Cases.Keys)
+                                                      .Distinct(StringComparer.Ordinal)
+                                                      .OrderBy(m => m, StringComparer.Ordinal))
+            {
+                var was = baseline.Cases.TryGetValue(method, out var b) ? b : null;
+                var now = measured.Cases.TryGetValue(method, out var m) ? m : null;
+                if (ungated.ContainsKey(method))
+                {
+                    var delta = was is null || now is null || was.AllocatedBytes == 0
+                        ? 0
+                        : (now.AllocatedBytes - (double)was.AllocatedBytes) / was.AllocatedBytes;
+                    var ratio = was is null || now is null || was.MeanNanoseconds <= 0
+                        ? 1
+                        : now.MeanNanoseconds / was.MeanNanoseconds;
+                    yield return new Row(method, Verdict.Ungated, was, now, delta, ratio);
+                    continue;
+                }
+                if (was is null) { yield return new Row(method, Verdict.New, null, now, 0, 0); continue; }
+                if (now is null) { yield return new Row(method, Verdict.Missing, was, null, 0, 0); continue; }
+
+                var allocationDelta = was.AllocatedBytes == 0
+                    ? (now.AllocatedBytes == 0 ? 0 : double.PositiveInfinity)
+                    : (now.AllocatedBytes - (double)was.AllocatedBytes) / was.AllocatedBytes;
+                var timeFactor = was.MeanNanoseconds > 0 ? now.MeanNanoseconds / was.MeanNanoseconds : 1;
+                var byBytes = Math.Abs(now.AllocatedBytes - was.AllocatedBytes) >= AllocationFloorBytes;
+
+                var verdict =
+                    byBytes && allocationDelta > AllocationBand ? Verdict.Regressed
+                    : byBytes && allocationDelta < -AllocationBand ? Verdict.Improved
+                    : timeFactor > TimeCeilingFactor ? Verdict.Slower
+                    : timeFactor > TimeNoticeFactor ? Verdict.Slow
+                    : Verdict.Ok;
+                yield return new Row(method, verdict, was, now, allocationDelta, timeFactor);
+            }
+        }
+
+        private static string Report(Record baseline, Record measured, IReadOnlyList<Row> rows)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine();
+            sb.AppendLine(new string('=', 100));
+            sb.AppendLine($" Kernel performance gate -- {baseline.Benchmark}");
+            sb.AppendLine(new string('=', 100));
+            sb.AppendLine($" baseline  {Short(baseline.Commit)}, measured {baseline.MeasuredOn} on {baseline.Runtime}");
+            sb.AppendLine($"           {baseline.Machine}");
+            sb.AppendLine($" this run  {Short(measured.Commit)}, measured {measured.MeasuredOn} on {measured.Runtime}");
+            sb.AppendLine($"           {measured.Machine}");
+            sb.AppendLine();
+            sb.AppendLine($" Allocation must stay within {AllocationBand * 100:0}% of the baseline in either direction;"
+                + $" a move of under {AllocationFloorBytes} B/op");
+            sb.AppendLine($" does not count. Time is reported and fails only above {TimeCeilingFactor:0.00}x, because a"
+                + " shared runner's wall clock");
+            sb.AppendLine(" is not a property of the code. Both thresholds are argued for in PerformanceGate.cs.");
+            sb.AppendLine();
+            sb.AppendLine("                        allocated B/op                        mean ns/op");
+            sb.AppendLine(" method             baseline      measured  delta      baseline      measured  factor  verdict");
+            sb.AppendLine(" " + new string('-', 98));
+            foreach (var r in rows)
+                sb.AppendLine(
+                    $" {r.Method,-18}{Bytes(r.Baseline),13}{Bytes(r.Measured),14}{Delta(r),7}"
+                    + $"{Nanoseconds(r.Baseline),14}{Nanoseconds(r.Measured),14}{Factor(r),8}  {Word(r.Verdict)}");
+            sb.AppendLine(" " + new string('-', 98));
+            if (baseline.Ungated is { Count: > 0 } ungated)
+            {
+                sb.AppendLine();
+                sb.AppendLine(" Not gated, and why:");
+                foreach (var (method, reason) in ungated.OrderBy(pair => pair.Key, StringComparer.Ordinal))
+                    sb.AppendLine($"   {method,-18}{reason}");
+            }
+            return sb.ToString();
+        }
+
+        private static string Explain(Record baseline, IReadOnlyList<Row> moved)
+        {
+            var sb = new StringBuilder();
+            var counts = moved.GroupBy(r => r.Verdict)
+                              .OrderBy(g => g.Key)
+                              .Select(g => $"{g.Count()} {Word(g.Key).ToLowerInvariant()}");
+            sb.AppendLine($"FAILED: {string.Join(", ", counts)}.");
+            sb.AppendLine();
+            foreach (var r in moved)
+            {
+                switch (r.Verdict)
+                {
+                    case Verdict.Regressed:
+                        sb.AppendLine($"  REGRESSED  {r.Method} allocates {r.Measured!.AllocatedBytes:N0} B/op, "
+                            + $"{r.AllocationDelta * 100:0.0}% above the {r.Baseline!.AllocatedBytes:N0} B/op recorded at "
+                            + $"{Short(baseline.Commit)}.");
+                        sb.AppendLine("             Find what the change allocates that it did not before. If the "
+                            + "extra allocation buys");
+                        sb.AppendLine("             something the library now does and is worth it, say so in the "
+                            + "pull request and update");
+                        sb.AppendLine("             the baseline in the same change.");
+                        break;
+                    case Verdict.Improved:
+                        sb.AppendLine($"  IMPROVED   {r.Method} allocates {r.Measured!.AllocatedBytes:N0} B/op, "
+                            + $"{-r.AllocationDelta * 100:0.0}% BELOW the {r.Baseline!.AllocatedBytes:N0} B/op recorded at "
+                            + $"{Short(baseline.Commit)}.");
+                        sb.AppendLine("             Nothing is wrong. The gate fails so the gain gets recorded "
+                            + "rather than absorbed: a");
+                        sb.AppendLine("             baseline that overstates what the library allocates would let a "
+                            + "later change give it");
+                        sb.AppendLine("             back unnoticed. Update the baseline in this change, and say so "
+                            + "in the pull request.");
+                        break;
+                    case Verdict.Slower:
+                        sb.AppendLine($"  SLOWER     {r.Method} takes {r.TimeFactor:0.00}x the baseline time "
+                            + $"({r.Measured!.MeanNanoseconds:N0} ns/op against {r.Baseline!.MeanNanoseconds:N0}).");
+                        sb.AppendLine($"             The time gate is deliberately loose at {TimeCeilingFactor:0.00}x "
+                            + "and a shared runner does not");
+                        sb.AppendLine("             explain a factor this size, so treat it as real and re-run to "
+                            + "confirm before");
+                        sb.AppendLine("             updating anything.");
+                        break;
+                    case Verdict.Missing:
+                        sb.AppendLine($"  MISSING    {r.Method} is in the baseline and was not measured.");
+                        sb.AppendLine("             Either the benchmark was removed -- then remove it from the "
+                            + "baseline in the same");
+                        sb.AppendLine("             change -- or the run did not finish, in which case the gate has "
+                            + "nothing to say and");
+                        sb.AppendLine("             the benchmark step is what to look at.");
+                        break;
+                    case Verdict.New:
+                        sb.AppendLine($"  NEW        {r.Method} was measured and is not in the baseline "
+                            + $"({r.Measured!.AllocatedBytes:N0} B/op, {r.Measured.MeanNanoseconds:N0} ns/op).");
+                        sb.AppendLine("             A benchmark nobody has recorded a number for is not gated. "
+                            + "Add it to the baseline.");
+                        break;
+                }
+                sb.AppendLine();
+            }
+            return sb.ToString().TrimEnd();
+        }
+
+        private static string Word(Verdict verdict) => verdict switch
+        {
+            Verdict.Ok => "ok",
+            Verdict.Slow => "ok (slow)",
+            Verdict.Ungated => "not gated",
+            Verdict.Regressed => "REGRESSED",
+            Verdict.Improved => "IMPROVED",
+            Verdict.Slower => "SLOWER",
+            Verdict.Missing => "MISSING",
+            _ => "NEW",
+        };
+
+        private static string Short(string commit)
+            => commit.Length >= 8 ? "commit " + commit[..8] : "commit " + commit;
+
+        private static string Relative(string path)
+        {
+            var index = path.Replace('\\', '/').IndexOf("Sources/", StringComparison.Ordinal);
+            return index < 0 ? path : path.Replace('\\', '/')[index..];
+        }
+
+        private static string Bytes(Measurement? m) => m is null ? "-" : m.AllocatedBytes.ToString("N0");
+
+        private static string Nanoseconds(Measurement? m) => m is null
+            ? "-"
+            : m.MeanNanoseconds >= 1e7 ? m.MeanNanoseconds.ToString("0.00e+0")
+            : m.MeanNanoseconds < 10 ? m.MeanNanoseconds.ToString("N2") : m.MeanNanoseconds.ToString("N0");
+
+        private static string Delta(Row r) => r.Baseline is null || r.Measured is null
+            ? "-"
+            : double.IsInfinity(r.AllocationDelta) ? "+inf" : $"{r.AllocationDelta:+0.0%;-0.0%;0.0%}";
+
+        private static string Factor(Row r) => r.Baseline is null || r.Measured is null
+            ? "-"
+            : $"{r.TimeFactor:0.00}x";
+    }
+}

--- a/Sources/Tests/DotnetBenchmark/Program.cs
+++ b/Sources/Tests/DotnetBenchmark/Program.cs
@@ -66,9 +66,13 @@ namespace DotnetBenchmark
 
     public class Program
     {
-        public static void Main(string[] args)
+        public static int Main(string[] args)
         {
-            var benchmarkName = args.Length > 0 ? args[0] : "";
+            // PerformanceGate is not a benchmark: it compares the file the last run wrote against
+            // the committed baseline, so it is cheap and can be its own CI step without paying for
+            // the measurement twice. https://github.com/asc-community/AngouriMath/issues/529
+            if (args.Contains(PerformanceGate.Command))
+                return PerformanceGate.Compare(Console.Out);
 
             var reports =
                 args
@@ -105,10 +109,17 @@ namespace DotnetBenchmark
             }
             // BenchmarkRunner.Run<BenchLinqCompilation>();
             Console.ReadLine(); Console.ReadLine(); Console.ReadLine();
+            return 0;
         }
 
         public static string GetReportByBenchmark(Type report, params string[] columns)
-            => TableToString(BenchmarkRunner.Run(report).Table, columns);
+        {
+            var summary = BenchmarkRunner.Run(report);
+            // Both numbers, in the baseline's own format, so that updating the baseline is copying
+            // a file rather than transcribing a table.
+            PerformanceGate.WriteMeasurements(summary);
+            return TableToString(summary.Table, columns);
+        }
 
         public static string TableToString(SummaryTable table, params string[] columns)
         {

--- a/Sources/Tests/DotnetBenchmark/performance-baseline.json
+++ b/Sources/Tests/DotnetBenchmark/performance-baseline.json
@@ -1,0 +1,86 @@
+{
+  "comment": "Allocated bytes and mean nanoseconds per operation for the popular use cases of https://github.com/asc-community/AngouriMath/issues/746. Checked by PerformanceGate.cs; see Sources/AngouriMath/Docs/WhatsNew/version_performance_control.md for when updating it is legitimate.",
+  "benchmark": "CommonFunctionsInterVersion",
+  "commit": "6b93b4012d54c354537821cc8e768ed8570563ce",
+  "measuredOn": "2026-08-23",
+  "runtime": ".NET 10.0.10",
+  "machine": "Ubuntu 26.04 LTS, X64, 8 logical cores",
+  "cases": {
+    "CompileEasy": {
+      "allocatedBytes": 16230,
+      "meanNanoseconds": 217683.91618652345
+    },
+    "CompileHard": {
+      "allocatedBytes": 37733,
+      "meanNanoseconds": 373193.7995876736
+    },
+    "Derivate": {
+      "allocatedBytes": 52824,
+      "meanNanoseconds": 17214.95599332063
+    },
+    "EvalEasy": {
+      "allocatedBytes": 0,
+      "meanNanoseconds": 0.984684884129092
+    },
+    "EvalTrig": {
+      "allocatedBytes": 1341376,
+      "meanNanoseconds": 867492.3806423611
+    },
+    "EvalTrigPrecise": {
+      "allocatedBytes": 12742205,
+      "meanNanoseconds": 26845828.055484693
+    },
+    "ParseEasy": {
+      "allocatedBytes": 18064,
+      "meanNanoseconds": 6918.623293346829
+    },
+    "ParseHard": {
+      "allocatedBytes": 3522432,
+      "meanNanoseconds": 1706600.9333379837
+    },
+    "RunEasy": {
+      "allocatedBytes": 0,
+      "meanNanoseconds": 23.025308667736894
+    },
+    "RunHard": {
+      "allocatedBytes": 0,
+      "meanNanoseconds": 345.98671662012737
+    },
+    "RunMedium": {
+      "allocatedBytes": 0,
+      "meanNanoseconds": 202.93889632432357
+    },
+    "SimplifyEasy": {
+      "allocatedBytes": 128100,
+      "meanNanoseconds": 102040.96768465909
+    },
+    "SimplifyHard": {
+      "allocatedBytes": 3620668728,
+      "meanNanoseconds": 2160215953.7802196
+    },
+    "SolveEasy": {
+      "allocatedBytes": 8852269,
+      "meanNanoseconds": 6083866.387073863
+    },
+    "SolveEasyMedium": {
+      "allocatedBytes": 95795,
+      "meanNanoseconds": 37080.269161224365
+    },
+    "SolveHard": {
+      "allocatedBytes": 1431860248,
+      "meanNanoseconds": 1056388966.8536586
+    },
+    "SolveMedium": {
+      "allocatedBytes": 658130,
+      "meanNanoseconds": 567993.1599434095
+    },
+    "SolveMediumHard": {
+      "allocatedBytes": 162304592,
+      "meanNanoseconds": 99270727.66666667
+    }
+  },
+  "ungated": {
+    "CompileEasy": "Measured allocation includes the runtime building and JIT-compiling a delegate, which is not reproducible: 16,230 / 16,269 / 16,391 B/op over three runs of one unchanged build.",
+    "CompileHard": "The same, and further out: 37,733 / 39,065 / 37,700 B/op over the same three runs, a 3.6% spread against 0.033% for the worst gated benchmark. Gating this would make the gate red for reasons that are not the change."
+  }
+}


### PR DESCRIPTION
The benchmark has run on every kernel-touching push and PR since #775 repaired its path filters, and #962 made it keep its numbers. Nothing has ever read them. #746 item 80 asks for the other half:

> *"…and wire a **regression threshold** into CI rather than leaving it to review."*

## Gate allocation. Report time. The evidence, not the taste

The threshold was chosen from measured variance rather than picked. Three consecutive runs of **one unchanged build**, all 18 benchmarks, deliberately on a machine at load ~16 on 8 cores — closer to a shared runner than to an idle desktop:

| | run-to-run spread |
|---|---|
| allocation, the 16 gated benchmarks | **≤ 0.033%** — six bytes on 18 KB, and identical to the byte on seven of them |
| allocation, `CompileEasy` / `CompileHard` | 1.0% / 3.6% |
| mean time | **up to 51.8%**, and 8–10% on nine of the eighteen |

Three orders of magnitude apart, which decides it:

- **Allocation fails the build**, in either direction, at **±3%** — a hundred times the observed spread, with headroom for a BCL that allocates differently — plus a 128 B/op floor so a benchmark allocating a handful of bytes is not gated on noise.
- **Time is reported and fails only above 3.00×**, stated in the output as the catastrophe threshold it is. A tight time threshold on a GitHub-hosted runner would be red for reasons that are not the change, and a gate nobody trusts is worse than no gate.

A fourth run, taken later with the machine quieter, is the whole argument in one line: **every** timing came in at 0.87–0.95× of baseline while allocation stayed byte-identical.

## A finding that changed the design

`CompileEasy` and `CompileHard` measure the runtime building and JIT-compiling a delegate, and their allocation is genuinely not reproducible. The choice was to loosen the band for everyone, drop them silently, or say so — so the baseline carries an `ungated` map of name → reason, which is **printed on every run**:

```
CompileHard: The same, and further out: 37,733 / 39,065 / 37,700 B/op over the same three runs,
a 3.6% spread against 0.033% for the worst gated benchmark. Gating this would make the gate red
for reasons that are not the change.
```

An exclusion is a recorded decision, not a benchmark quietly missing from a file.

## Failing, and passing

**A deliberate regression** — `GC.KeepAlive(new byte[512])` per node in `Entity.DirectChildren`, since reverted — exit 1:

```
 Derivate                 52,824        70,512 +33.5%   ...  REGRESSED
 SimplifyHard      3,620,668,728 4,115,549,512 +13.7%   ...  REGRESSED
FAILED: 7 regressed.
  REGRESSED  Derivate allocates 70,512 B/op, 33.5% above the 52,824 B/op recorded at commit 6b93b401.
             Find what the change allocates that it did not before. If the extra allocation buys
             something the library now does and is worth it, say so in the pull request and update
             the baseline in the same change.
```

`ParseEasy`/`ParseHard` correctly stayed green — the parser does not touch that path.

**An improvement**, from real data (the regressed run as baseline, the clean run as measurement) — also exit 1, and worded so nobody reads it as breakage:

```
  IMPROVED   SolveMedium allocates 658,130 B/op, 24.0% BELOW the 866,041 B/op recorded at ...
             Nothing is wrong. The gate fails so the gain gets recorded rather than absorbed: a
             baseline that overstates what the library allocates would let a later change give it
             back unnoticed.
```

That matches PR #948's convention for the corpus gate rather than inventing a second one.

**Passing** on unmodified master, on three separate runs the gate had never seen. `MISSING`, `NEW`, `SLOWER` and the no-measurements path were each exercised too. Full suite **7533 passed, 0 failed, 14 skipped**, matching master; build lines read, 0 warnings.

## Mechanics

Each run now writes its numbers **in the baseline's own format**, so updating the baseline is `cp` rather than transcription. The gate step is last — after the CPU and RAM steps, so a failure there does not cost the RAM figures — and before the `if: always()` upload, so the file to copy is in the artifact of the run that just failed. Path filters were verified programmatically: all three resolve and none has a leading `./` (#775).

No new document: the "when may I update this" section went into `WhatsNew/version_performance_control.md`, which `AGENTS.md`'s *Where things are written down* table already names as the home for this.

## One thing I could not verify, and it may make the first CI run red

**The baseline was measured here on .NET 10.0.10; CI asks for `10.x` with `dotnet-quality: preview`.** Allocation is a property of the code *and* the BCL, so a legitimate difference between the two runtimes would show as a regression on the first run. The recovery is mechanical and documented — copy the artifact's JSON over the baseline — but someone has to do it once, or bootstrap the baseline from a CI run before this merges. I have no way to run CI from here, so I am flagging it rather than hoping.

## Two decisions that are yours

1. **Failing on an improvement** is a policy choice. Matched to #948 deliberately; if that is too noisy for performance, one comparison in `Rows` changes.
2. **A sub-3% real regression passes.** My first attempt at a demo — a defensive per-node array copy — came in at +1–2.3% and the gate correctly stayed green. That is the price of a band wide enough to survive a runtime change, and it is better known now than discovered later.

`RAMUsageTest` is not gated: its rows are allocation micro-probes rather than use cases, and #746 names parse, `Simplify`, `Solve` and `Differentiate`, which is exactly what `CommonFunctionsInterVersion` measures. Its run does write `measured-RAMUsageTest.json`, so a second baseline is a small change if wanted.
