### PR TITLE
Let the C++ build fire again (#775)

### DIFF
--- a/.github/workflows/CPPBuild.yml
+++ b/.github/workflows/CPPBuild.yml
@@ -1,16 +1,30 @@
 name: 'C++ Build'
 
+# A path filter is a glob matched against paths relative to the repository root, and the leading
+# "./" these patterns carried matches nothing: from the day the filter was added (f51c7e03,
+# 2026-01-02) this workflow ran zero times, while three commits touching the very directories it
+# names were merged. It is the same defect that silenced Benchmark.yml for ninety-eight PRs --
+# see the comment at the top of that file, and
+# https://github.com/asc-community/AngouriMath/issues/775.
+#
+# The kernel is in the list because the exported native library is compiled from it, so a kernel
+# change is exactly what can break this build; and this file is in the list so that a change to
+# these filters demonstrates itself rather than being reasoned about.
 on:
   push:
     branches:
       - master
     paths:
-      - "./Sources/Wrappers/AngouriMath.CPP.*/**"
+      - "Sources/Wrappers/AngouriMath.CPP.*/**"
+      - "Sources/AngouriMath/**"
+      - ".github/workflows/CPPBuild.yml"
   pull_request:
     branches:
       - '*'
     paths:
-      - "./Sources/Wrappers/AngouriMath.CPP.*/**"
+      - "Sources/Wrappers/AngouriMath.CPP.*/**"
+      - "Sources/AngouriMath/**"
+      - ".github/workflows/CPPBuild.yml"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
`.github/workflows/CPPBuild.yml` has not run since **2026-01-02**. Its path filters are:

```yaml
paths:
  - "./Sources/Wrappers/AngouriMath.CPP.*/**"
```

A GitHub path filter is a glob matched against paths **relative to the repository root**, so a leading `./` matches nothing. This is the identical defect that silenced `Benchmark.yml` for ninety-eight merged PRs — same commit (`f51c7e03`), same date, and the story is written up at the top of that file and in #775. Only one of the two was fixed.

## Measured, not reasoned

```
$ gh run list --workflow=CPPBuild.yml --limit 3
2026-01-02T14:24  pull_request  success
2026-01-02T14:13  pull_request  success
2026-01-02T14:07  pull_request  success
```

Zero runs since. Meanwhile **three** commits touching exactly the directories it names have merged (`4eb94458`, `dc349c3f`, `f4807c46`), none of them building the C++ wrapper.

## The fix, and two additions to the list

The `./` is removed. Two paths are added, each for a reason:

- **`Sources/AngouriMath/**`** — the exported native library is compiled *from* the kernel, so a kernel change is precisely what can break this build. Filtering it out meant the workflow could only ever fire for changes that were already about C++.
- **`.github/workflows/CPPBuild.yml`** — so that a change to these filters demonstrates itself rather than being argued about. That is the trick `Benchmark.yml` used to prove its own fix, and it is why this PR will make the workflow run.

## What this PR does not claim

The breakage is measured; **the fix is not yet**. It will be the moment this is pushed, and the run appearing on this PR is the evidence — which is the whole reason the workflow file is in its own filter list.

Split out of the trimming/NativeAOT work, where it was found, because it has nothing to do with AOT and should not wait on that review.
