### PR TITLE
Give the resultant a consumer, and publish the polynomial layer (#746 item 43)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -81,6 +81,11 @@ coefficients and however easily it factored:
 "x ^ 3 - 2 * x + 1 > 0".ToEntity().Solve("x")           ((-1 - sqrt(5)) / 2; (-1 + sqrt(5)) / 2) \/ (1; +oo)
 "x ^ 3 - 2 > 0".ToEntity().Solve("x")                   (2 ^ (1/3); +oo)
 "x ^ 5 - 5 * x ^ 3 + 4 * x > 0".ToEntity().Solve("x")   (-2; -1) \/ (0; 1) \/ (2; +oo)
+"x ^ 4 + 1 > 0".ToEntity().Solve("x")                   (-oo; +oo)
+"x ^ 4 - 2 > 0".ToEntity().Solve("x")                   (-oo; -2 ^ (1/4)) \/ (2 ^ (1/4); +oo)
+"x ^ 4 - 10 * x ^ 2 + 1 > 0".ToEntity().Solve("x")      (-oo; -sqrt((10 + 4 * sqrt(6)) / 2))
+                                                          \/ (-sqrt((10 - 4 * sqrt(6)) / 2); sqrt((10 - 4 * sqrt(6)) / 2))
+                                                          \/ (sqrt((10 + 4 * sqrt(6)) / 2); +oo)
 ```
 
 A polynomial has one sign on each open interval between consecutive real roots, so the answer is the
@@ -88,20 +93,22 @@ union of the intervals where that sign is positive. What makes it an answer rath
 that the list of real roots is *complete*: the polynomial is written as a product of powers of
 irreducibles over `Q`, verified to multiply back, and the number of real roots of each irreducible
 factor is read off its **discriminant** — two where a quadratic factor's is positive and none where
-it is negative, three and one respectively for a cubic. A missed root would merge two intervals of
+it is negative, three and one respectively for a cubic, and — for a quartic — the discriminant
+with the two auxiliary quantities of the standard criterion, a negative discriminant meaning two
+real roots and a positive one four or none. A missed root would merge two intervals of
 opposite sign and report the wrong half of one as the solution, so this is the difference between
 the feature and a wrong answer.
 
 **And the refusal that remains is a different one.** The gap is no longer degree; it is an
-irreducible factor of degree four or more, where the discriminant stops deciding the number of real
-roots — a quartic with a positive discriminant has four or none. So the message changed too:
+irreducible factor of degree five or more, where there is no criterion for the number of real roots
+and no formula for the roots either. So the message changed too:
 
 ```
-"x ^ 4 + 1 > 0".ToEntity().Solve("x")
+"x ^ 5 - x - 1 > 0".ToEntity().Solve("x")
     NotSufficientlySupportedException: Only polynomial inequalities are supported, and of those
     only the ones whose real roots can be established completely: linear and quadratic with any
     coefficients, and higher degrees where the coefficients are rational and no irreducible factor
-    is of degree four or more
+    is of degree five or more
 ```
 
 Code that caught `NotSufficientlySupportedException` still catches it; code that matched on the

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -21,6 +21,7 @@ read first.
 
 | Silent? | What | Was | Is |
 |---|---|---|---|
+| | `"x ^ 3 - x > 0".ToEntity().Solve("x")`, and every polynomial inequality of degree three or more | `NotSufficientlySupportedException: Only linear and quadratic polynomial inequalities are supported` | `(-1; 0) \/ (1; +oo)` — the solution set |
 | | `(Entity.Number)someBigInteger` | `FormatException: Illegal character found`, for almost every value | the number |
 | **Silent** | `"1/x".Integrate("x")`, and every antiderivative with a logarithm | `ln(abs(x)) + C` | `ln(x) + C` |
 | **Silent** | `CostModel.FewestDivisions.Cost(y ^ (1 * (-1)) * x)` | `0.007`, cheaper than `x / y` | `1.007` |
@@ -58,6 +59,57 @@ read first.
 | **Silent** | `derivative(x ^ 2 + y ^ 2, [x, y])` | `0` | `[2 * x, 2 * y]`, the gradient |
 | **Silent** | `integral(x, [x, y]T)` | `[[C + x ^ 2, C + x * y]]` | `[[x ^ 2 / 2 + C, x * y + C]]` |
 | **Silent** | `derivative(e ^ 2, e)`, over a named constant | `0` | `2 * e` |
+
+### A polynomial inequality of degree three or more is answered
+
+**Was** — every univariate polynomial inequality above degree two was refused outright, whatever its
+coefficients and however easily it factored:
+
+```
+"x ^ 3 - x > 0".ToEntity().Solve("x")
+    NotSufficientlySupportedException: Only linear and quadratic polynomial inequalities are
+    supported; this one is of a higher degree
+```
+
+**Is** — the solution set, where the real roots can be established completely:
+
+```
+"x ^ 3 - x > 0".ToEntity().Solve("x")                   (-1; 0) \/ (1; +oo)
+"x ^ 3 - x >= 0".ToEntity().Solve("x")                  { 0, 1, -1 } \/ (-1; 0) \/ (1; +oo)
+"(x - 1) ^ 2 * (x + 2) > 0".ToEntity().Solve("x")       (-2; 1) \/ (1; +oo)
+"x ^ 4 - 5 * x ^ 2 + 4 > 0".ToEntity().Solve("x")       (-oo; -2) \/ (-1; 1) \/ (2; +oo)
+"x ^ 3 - 2 * x + 1 > 0".ToEntity().Solve("x")           ((-1 - sqrt(5)) / 2; (-1 + sqrt(5)) / 2) \/ (1; +oo)
+"x ^ 3 - 2 > 0".ToEntity().Solve("x")                   (2 ^ (1/3); +oo)
+"x ^ 5 - 5 * x ^ 3 + 4 * x > 0".ToEntity().Solve("x")   (-2; -1) \/ (0; 1) \/ (2; +oo)
+```
+
+A polynomial has one sign on each open interval between consecutive real roots, so the answer is the
+union of the intervals where that sign is positive. What makes it an answer rather than a guess is
+that the list of real roots is *complete*: the polynomial is written as a product of powers of
+irreducibles over `Q`, verified to multiply back, and the number of real roots of each irreducible
+factor is read off its **discriminant** — two where a quadratic factor's is positive and none where
+it is negative, three and one respectively for a cubic. A missed root would merge two intervals of
+opposite sign and report the wrong half of one as the solution, so this is the difference between
+the feature and a wrong answer.
+
+**And the refusal that remains is a different one.** The gap is no longer degree; it is an
+irreducible factor of degree four or more, where the discriminant stops deciding the number of real
+roots — a quartic with a positive discriminant has four or none. So the message changed too:
+
+```
+"x ^ 4 + 1 > 0".ToEntity().Solve("x")
+    NotSufficientlySupportedException: Only polynomial inequalities are supported, and of those
+    only the ones whose real roots can be established completely: linear and quadratic with any
+    coefficients, and higher degrees where the coefficients are rational and no irreducible factor
+    is of degree four or more
+```
+
+Code that caught `NotSufficientlySupportedException` still catches it; code that matched on the
+message text does not. Linear and quadratic inequalities are untouched, including the symbolic
+coefficients and the case splits on their signs, which the sign table does not do — it takes only
+rational coefficients, and only from degree three up.
+
+[#746](https://github.com/asc-community/AngouriMath/issues/746) item 43.
 
 ### `ToSympyCode` emits Python that runs
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -84,3 +84,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [AngouriMath/Functions/Continuous/Solvers/InequalitySolver/PolynomialSignTable.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[AngouriMath/Convenience/MathS.Polynomials.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -81,3 +81,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Analyzers/RuleRegistryGenerator/*.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[AngouriMath/Functions/Continuous/Solvers/InequalitySolver/PolynomialSignTable.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Convenience/MathS.Polynomials.cs
+++ b/Sources/AngouriMath/Convenience/MathS.Polynomials.cs
@@ -1,0 +1,338 @@
+﻿//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath.Functions;
+using PeterO.Numbers;
+
+namespace AngouriMath
+{
+    using static Entity;
+    using static Entity.Number;
+
+    partial class MathS
+    {
+        /// <summary>
+        /// The polynomial layer: factorisation over the rationals, multivariate greatest
+        /// common divisors, resultants and discriminants.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// These are the operations <see cref="Entity.Simplify(int)"/>,
+        /// <see cref="Entity.Solve(Variable)"/> and <see cref="Entity.Integrate(Variable)"/>
+        /// already run internally, offered here directly. A caller who wants the factors, the
+        /// common divisor or the eliminant — rather than whatever a simplification decides to
+        /// do with them — had no way to ask for one, and no way to find out that the request
+        /// was outside what the layer can do.
+        /// </para>
+        /// <para>
+        /// <b>Every one of these answers <see langword="null"/> rather than guessing.</b>
+        /// <see langword="null"/> means "I could not settle this" — the input is not a
+        /// polynomial of the shape the operation needs, or it is one but past a bound the
+        /// implementation carries. It never means "the answer is the input": a polynomial
+        /// that does not factor comes back as itself from <see cref="Factor"/>, which is a
+        /// statement that it is irreducible over the rationals, and is a different thing from
+        /// a refusal. The bounds are stated on each member.
+        /// </para>
+        /// <para>
+        /// Part of the polynomial layer of
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a>, item 43.
+        /// </para>
+        /// </remarks>
+        public static class Polynomials
+        {
+            /// <summary>
+            /// <paramref name="expr"/> written as a product of powers of polynomials
+            /// irreducible over the rationals, or <see langword="null"/> where that could not
+            /// be settled.
+            /// </summary>
+            /// <param name="expr">The polynomial to factorise.</param>
+            /// <param name="variable">The variable it is a polynomial in.</param>
+            /// <returns>
+            /// The factorisation; the input itself where it is irreducible over the
+            /// rationals, which is an answer and not a refusal; or <see langword="null"/>
+            /// where <paramref name="expr"/> is not a polynomial in
+            /// <paramref name="variable"/> alone with rational coefficients, where its degree
+            /// is above 32, or where the factoriser declined.
+            /// </returns>
+            /// <remarks>
+            /// <para>
+            /// Zassenhaus: square-free decomposition, Berlekamp's factorisation modulo a
+            /// prime, Hensel lifting to a power of it above Mignotte's bound, and
+            /// recombination — and the factors are multiplied back and compared with the
+            /// input before they are returned.
+            /// </para>
+            /// <para>
+            /// <b>Univariate only.</b> A polynomial in more than one variable is refused
+            /// rather than answered: <c>Factor("x * y + y", "x")</c> is <see langword="null"/>
+            /// and not <c>x * y + y</c>, because handing back the input would say that
+            /// <c>y * (x + 1)</c> does not exist.
+            /// </para>
+            /// </remarks>
+            /// <example>
+            /// <code>
+            /// Console.WriteLine(MathS.Polynomials.Factor("x ^ 4 - 5 * x ^ 2 + 4", "x"));
+            /// // (x + 1) * (x + 2) * (x - 2) * (x - 1)
+            ///
+            /// Console.WriteLine(MathS.Polynomials.Factor("x ^ 3 - 3 * x ^ 2 + 3 * x - 1", "x"));
+            /// // (x - 1) ^ 3
+            ///
+            /// Console.WriteLine(MathS.Polynomials.Factor("x ^ 2 + 1", "x"));
+            /// // x ^ 2 + 1        -- irreducible over Q, which is an answer
+            ///
+            /// Console.WriteLine(MathS.Polynomials.Factor("x * y + y", "x") is null);
+            /// // True             -- more than one variable, so it declines
+            /// </code>
+            /// </example>
+            public static Entity? Factor(Entity expr, Variable variable)
+            {
+                if (PolynomialFactorization.FactorComplete(expr, variable) is not { } factorization)
+                    return null;
+                Entity? product = null;
+                foreach (var part in factorization.Parts)
+                {
+                    var piece = part.Factor.ToEntity(variable);
+                    if (part.Multiplicity > 1)
+                        piece = piece.Pow(part.Multiplicity);
+                    product = product is null ? piece : product * piece;
+                }
+                if (product is null)
+                    return null;
+                return factorization.Constant.CompareTo(ERational.One) == 0
+                    ? product
+                    : Rational.Create(factorization.Constant) * product;
+            }
+
+            /// <summary>
+            /// The greatest common divisor of two polynomials, or <see langword="null"/> where
+            /// that could not be settled.
+            /// </summary>
+            /// <param name="left">The first polynomial.</param>
+            /// <param name="right">The second polynomial.</param>
+            /// <returns>
+            /// A polynomial dividing both, of the greatest degree that does — <c>1</c> where
+            /// they are coprime — or <see langword="null"/> where either is not a polynomial
+            /// with rational coefficients in at most eight variables of degree at most 127,
+            /// or where the computation declined.
+            /// </returns>
+            /// <remarks>
+            /// Multivariate, by recursion on the variables with the content taken out at each
+            /// level and a subresultant remainder sequence at the bottom, so that the
+            /// coefficients stay the size of the minors they are rather than compounding. The
+            /// result is normalised so that its leading coefficient is positive, which is what
+            /// makes two greatest common divisors of the same pair comparable; it is fixed only
+            /// up to a rational factor otherwise.
+            /// </remarks>
+            /// <example>
+            /// <code>
+            /// Console.WriteLine(MathS.Polynomials.Gcd("x ^ 2 - 1", "x ^ 2 + 2 * x + 1"));
+            /// // x + 1
+            ///
+            /// Console.WriteLine(MathS.Polynomials.Gcd("x ^ 2 - y ^ 2", "x ^ 2 - 2 * x * y + y ^ 2"));
+            /// // x - y
+            ///
+            /// Console.WriteLine(MathS.Polynomials.Gcd("x ^ 2 + 1", "x ^ 2 + 2"));
+            /// // 1                -- coprime
+            /// </code>
+            /// </example>
+            public static Entity? Gcd(Entity left, Entity right)
+            {
+                if (Index(left, right) is not var (variables, index))
+                    return null;
+                if (MultivariatePolynomial.TryParse(left, index) is not { } first
+                    || MultivariatePolynomial.TryParse(right, index) is not { } second)
+                    return null;
+                var order = new int[variables.Count];
+                for (var i = 0; i < order.Length; i++)
+                    order[i] = i;
+                if (PolynomialGcd.Gcd(first, second, order, 0) is not { } divisor)
+                    return null;
+                return divisor.ToEntity(variables);
+            }
+
+            /// <summary>
+            /// The resultant of two polynomials with respect to one variable — the condition
+            /// on the others under which the two have a common root in it — or
+            /// <see langword="null"/> where that could not be settled.
+            /// </summary>
+            /// <param name="left">The first polynomial.</param>
+            /// <param name="right">The second polynomial.</param>
+            /// <param name="eliminate">The variable to eliminate between them.</param>
+            /// <returns>
+            /// A polynomial in the remaining variables, vanishing exactly where the two have a
+            /// common <paramref name="eliminate"/> — or where both of their leading
+            /// coefficients in it vanish, which is why an eliminant can carry a root the
+            /// original pair does not have. <see langword="null"/> where either argument is
+            /// not a polynomial with rational coefficients in at most eight variables of
+            /// degree at most 127, where the sum of the two degrees in
+            /// <paramref name="eliminate"/> is above 40, or where the elimination ran past its
+            /// budget.
+            /// </returns>
+            /// <remarks>
+            /// The determinant of the Sylvester matrix, computed as one by fraction-free
+            /// elimination. The remainder-sequence formulations are faster and each carries a
+            /// sign convention that is easy to get wrong and gives a plausible-looking wrong
+            /// answer when it is; taken as a determinant the convention falls out of the
+            /// matrix instead of being imposed on it.
+            /// </remarks>
+            /// <example>
+            /// <code>
+            /// // Eliminating y between a circle and a line leaves the condition on x.
+            /// Console.WriteLine(MathS.Polynomials.Resultant("x ^ 2 + y ^ 2 - 1", "x + y - 1", "y"));
+            /// // 2 * x ^ 2 - 2 * x
+            ///
+            /// // Two polynomials share a root exactly when their resultant vanishes.
+            /// Console.WriteLine(MathS.Polynomials.Resultant("x ^ 2 - 1", "x - a", "x"));
+            /// // a ^ 2 - 1
+            /// </code>
+            /// </example>
+            public static Entity? Resultant(Entity left, Entity right, Variable eliminate)
+            {
+                if (Index(left, right, eliminate) is not var (variables, index))
+                    return null;
+                if (MultivariatePolynomial.TryParse(left, index) is not { } first
+                    || MultivariatePolynomial.TryParse(right, index) is not { } second)
+                    return null;
+                var main = index[eliminate];
+                var others = new List<int>(variables.Count - 1);
+                for (var i = 0; i < variables.Count; i++)
+                    if (i != main)
+                        others.Add(i);
+                if (PolynomialResultant.Resultant(first, second, main, others) is not { } resultant)
+                    return null;
+                return resultant.ToEntity(variables);
+            }
+
+            /// <summary>
+            /// The discriminant of a polynomial with respect to one variable — vanishing
+            /// exactly where it has a repeated root in that variable — or
+            /// <see langword="null"/> where that could not be settled.
+            /// </summary>
+            /// <param name="expr">The polynomial.</param>
+            /// <param name="variable">The variable to take the discriminant in.</param>
+            /// <returns>
+            /// A polynomial in the remaining variables, or <see langword="null"/> under the
+            /// same conditions as <see cref="Resultant"/> — this is
+            /// <c>(-1)^(n(n-1)/2) Res(f, f') / lc(f)</c>, so it declines wherever that
+            /// resultant does.
+            /// </returns>
+            /// <remarks>
+            /// The sign convention is the usual one, so that a quadratic gives
+            /// <c>b^2 - 4ac</c> rather than its negative, and a cubic <c>x^3 + px + q</c>
+            /// gives <c>-4p^3 - 27q^2</c>. For a polynomial with real coefficients the sign
+            /// counts real roots up to degree three: a quadratic has two where it is positive
+            /// and none where it is negative, and a cubic three and one respectively. It stops
+            /// deciding at degree four.
+            /// </remarks>
+            /// <example>
+            /// <code>
+            /// Console.WriteLine(MathS.Polynomials.Discriminant("a * x ^ 2 + b * x + c", "x"));
+            /// // -4 * a * c + b ^ 2
+            ///
+            /// Console.WriteLine(MathS.Polynomials.Discriminant("x ^ 3 - 3 * x + 1", "x"));
+            /// // 81               -- positive, so all three roots are real
+            ///
+            /// Console.WriteLine(MathS.Polynomials.Discriminant("x ^ 2 - 2 * x + 1", "x"));
+            /// // 0                -- a repeated root
+            /// </code>
+            /// </example>
+            public static Entity? Discriminant(Entity expr, Variable variable)
+            {
+                if (Index(expr, expr, variable) is not var (variables, index))
+                    return null;
+                if (MultivariatePolynomial.TryParse(expr, index) is not { } poly)
+                    return null;
+                var main = index[variable];
+                var others = new List<int>(variables.Count - 1);
+                for (var i = 0; i < variables.Count; i++)
+                    if (i != main)
+                        others.Add(i);
+                if (PolynomialResultant.Discriminant(poly, main, others) is not { } discriminant)
+                    return null;
+                return discriminant.ToEntity(variables);
+            }
+
+            /// <summary>
+            /// The square-free part of a polynomial — the same polynomial with every repeated
+            /// factor reduced to a single one, so that it has the same roots and each of them
+            /// once — or <see langword="null"/> where that could not be settled.
+            /// </summary>
+            /// <param name="expr">The polynomial.</param>
+            /// <param name="variable">The variable it is a polynomial in.</param>
+            /// <returns>
+            /// The polynomial divided by its greatest common divisor with its own derivative,
+            /// normalised to a positive leading coefficient and no common factor among its
+            /// coefficients; or <see langword="null"/> where <paramref name="expr"/> is not a
+            /// polynomial in <paramref name="variable"/> alone with rational coefficients, or
+            /// where its degree is above 32.
+            /// </returns>
+            /// <remarks>
+            /// Univariate, and over the rationals. This is what to take before looking for
+            /// roots: the multiplicities are the part a root-finder gets wrong, and dividing
+            /// them out costs one greatest common divisor.
+            /// </remarks>
+            /// <example>
+            /// <code>
+            /// Console.WriteLine(MathS.Polynomials.SquareFreePart("(x - 1) ^ 3 * (x + 2) ^ 2", "x"));
+            /// // x ^ 2 + x - 2    -- which is (x - 1)(x + 2)
+            ///
+            /// Console.WriteLine(MathS.Polynomials.SquareFreePart("x ^ 2 + 1", "x"));
+            /// // x ^ 2 + 1        -- already square-free
+            /// </code>
+            /// </example>
+            public static Entity? SquareFreePart(Entity expr, Variable variable)
+            {
+                if (!PolynomialFactoring.TryGetRationalCoefficients(
+                        expr, variable, leastTerms: 1, leastDegree: 1,
+                        IntegerPolynomial.MaxDegree, out var rational))
+                    return null;
+                var denominator = EInteger.One;
+                foreach (var coefficient in rational)
+                    denominator = coefficient.Denominator
+                        .Divide(coefficient.Denominator.Gcd(denominator)).Multiply(denominator);
+                var whole = new EInteger[rational.Length];
+                for (var i = 0; i < whole.Length; i++)
+                    whole[i] = rational[i].Numerator.Multiply(denominator.Divide(rational[i].Denominator));
+                var primitive = IntegerPolynomial.Create(whole).PrimitivePart();
+                var repeated = IntegerPolynomial.Gcd(primitive, primitive.Derivative());
+                if (primitive.DivideExact(repeated) is not { } distinct)
+                    return null;
+                return distinct.PrimitivePart().ToEntity(variable);
+            }
+
+            /// <summary>
+            /// The variables of the arguments, in a fixed order, with the position each one
+            /// occupies in a packed monomial — or <see langword="null"/> where there are more
+            /// of them than the representation has room for.
+            /// </summary>
+            /// <remarks>
+            /// Sorted by name rather than left in the order the expressions happen to mention
+            /// them, so that the answer does not depend on which argument came first.
+            /// </remarks>
+            private static (IReadOnlyList<Variable> Variables, Dictionary<Variable, int> Index)? Index(
+                Entity left, Entity right, Variable? required = null)
+            {
+                var names = new SortedSet<Variable>(Comparer<Variable>.Create(
+                    static (a, b) => string.CompareOrdinal(a.Name, b.Name)));
+                foreach (var variable in left.Vars)
+                    names.Add(variable);
+                foreach (var variable in right.Vars)
+                    names.Add(variable);
+                if (required is { } named)
+                    names.Add(named);
+                if (names.Count == 0 || names.Count > MultivariatePolynomial.MaxVariables)
+                    return null;
+                var variables = names.ToList();
+                var index = new Dictionary<Variable, int>(variables.Count);
+                for (var i = 0; i < variables.Count; i++)
+                    index[variables[i]] = i;
+                return (variables, index);
+            }
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialFactorization.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialFactorization.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) 2019-2026 Angouri.
 // AngouriMath is licensed under MIT.
 // Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
@@ -159,8 +159,34 @@ namespace AngouriMath.Functions
         /// </summary>
         internal static Factorization? Factor(Entity expr, Variable x)
         {
+            if (FactorOverRationals(expr, x, leastTerms: 2, leastDegree: 2) is not { } factorization)
+                return null;
+            // One factor to the first power is the input back again, which is not a
+            // factorisation of it.
+            if (factorization.Parts.Count == 1 && factorization.Parts[0].Multiplicity == 1)
+                return null;
+            return factorization;
+        }
+
+        /// <summary>
+        /// The same, for a caller that wants the factorisation of an irreducible polynomial
+        /// too -- which is the polynomial itself, and is an answer rather than a refusal.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Factor"/> reports an irreducible polynomial as <see langword="null"/>
+        /// because its callers are looking for a product to work through and there is not
+        /// one. A caller that was asked to factorise, rather than one factorising on the way
+        /// to something else, has to tell "this does not factor" from "I could not settle
+        /// this", and those are the same value there.
+        /// </remarks>
+        internal static Factorization? FactorComplete(Entity expr, Variable x)
+            => FactorOverRationals(expr, x, leastTerms: 1, leastDegree: 1);
+
+        private static Factorization? FactorOverRationals(
+            Entity expr, Variable x, int leastTerms, int leastDegree)
+        {
             if (!PolynomialFactoring.TryGetRationalCoefficients(
-                    expr, x, leastTerms: 2, leastDegree: 2, IntegerPolynomial.MaxDegree, out var rational))
+                    expr, x, leastTerms, leastDegree, IntegerPolynomial.MaxDegree, out var rational))
                 return null;
 
             // Cleared of denominators, so the whole of the rest of this works over Z; the
@@ -173,7 +199,7 @@ namespace AngouriMath.Functions
                 whole[i] = rational[i].Numerator.Multiply(denominator.Divide(rational[i].Denominator));
 
             var poly = IntegerPolynomial.Create(whole);
-            if (poly.Degree < 2)
+            if (poly.Degree < leastDegree)
                 return null;
 
             var primitive = poly.PrimitivePart();
@@ -182,10 +208,6 @@ namespace AngouriMath.Functions
                 content = content.Negate();
 
             if (FactorPrimitive(primitive) is not { } parts)
-                return null;
-            // One factor to the first power is the input back again, which is not a
-            // factorisation of it.
-            if (parts.Count == 1 && parts[0].Multiplicity == 1)
                 return null;
 
             return new Factorization(ERational.Create(content, denominator).ToLowestTerms(), parts);

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/InequalitySolver/AnalyticalInequalitySolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/InequalitySolver/AnalyticalInequalitySolver.cs
@@ -108,7 +108,7 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
                 "Only polynomial inequalities are supported, and of those only the ones "
                 + "whose real roots can be established completely: linear and quadratic "
                 + "with any coefficients, and higher degrees where the coefficients are "
-                + "rational and no irreducible factor is of degree four or more");
+                + "rational and no irreducible factor is of degree five or more");
         }
 
         /// <summary>

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/InequalitySolver/AnalyticalInequalitySolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/InequalitySolver/AnalyticalInequalitySolver.cs
@@ -98,9 +98,17 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
                         x);
                 }
             }
+            // Degree three and up, where the coefficients are rational: the sign of a
+            // polynomial between consecutive real roots is constant, so the answer is the
+            // union of the intervals where it is positive. See PolynomialSignTable for what
+            // makes the root list complete, which is the whole difficulty.
+            if (PolynomialSignTable.TrySolve(expr, x, out var bySign))
+                return bySign;
             throw new NotSufficientlySupportedException(
-                "Only linear and quadratic polynomial inequalities are supported; "
-                + "this one is of a higher degree");
+                "Only polynomial inequalities are supported, and of those only the ones "
+                + "whose real roots can be established completely: linear and quadratic "
+                + "with any coefficients, and higher degrees where the coefficients are "
+                + "rational and no irreducible factor is of degree four or more");
         }
 
         /// <summary>

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/InequalitySolver/PolynomialSignTable.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/InequalitySolver/PolynomialSignTable.cs
@@ -199,7 +199,12 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
             if (degree == 1)
             {
                 var root = ERational.Create(factor[0].Negate(), factor[1]).ToLowestTerms();
-                into.Add(new Root(Rational.Create(root), root.ToDouble(), multiplicity));
+                // The root is exact; its double is what the sample points are placed from,
+                // and a rational too large to be one at all would put them nowhere.
+                var approximation = root.ToDouble();
+                if (double.IsNaN(approximation) || double.IsInfinity(approximation))
+                    return false;
+                into.Add(new Root(Rational.Create(root), approximation, multiplicity));
                 return true;
             }
 

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/InequalitySolver/PolynomialSignTable.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/InequalitySolver/PolynomialSignTable.cs
@@ -1,0 +1,362 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using PeterO.Numbers;
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Set;
+
+namespace AngouriMath.Functions.Algebra.AnalyticalSolving
+{
+    /// <summary>
+    /// <c>p(x) &gt; 0</c> for a univariate polynomial over <c>Q</c> of any degree, answered by
+    /// the sign of <c>p</c> between consecutive real roots.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A polynomial has one sign on each open interval between consecutive real roots, so the
+    /// answer is the union of those intervals where the sign is positive. Everything hard is
+    /// in the word *consecutive*: the intervals are only the answer if the list of real roots
+    /// is <b>complete</b>, and a missed root merges two intervals of opposite sign into one
+    /// and reports the wrong half of it as the solution. So this refuses wherever completeness
+    /// cannot be established, rather than answering from whatever roots were found.
+    /// </para>
+    /// <para>
+    /// Completeness is established algebraically and in two steps. First
+    /// <see cref="PolynomialFactorization.FactorPrimitive"/> writes the polynomial as a
+    /// product of powers of irreducibles over <c>Q</c>, and it verifies that the factors
+    /// multiply back to what it was given — so every real root of the whole is a real root of
+    /// exactly one factor, an irreducible being square-free and two distinct irreducibles
+    /// being coprime. Second, the number of real roots of each factor is read off its
+    /// <see cref="PolynomialResultant.Discriminant"/>: a factor of degree two has two real
+    /// roots where its discriminant is positive and none where it is negative, and one of
+    /// degree three has three and one respectively. That count is what makes a root list a
+    /// complete root list rather than a list of the roots that happened to come back, and it
+    /// is the reason a degree-four irreducible factor is refused — its discriminant does not
+    /// decide between four real roots and none.
+    /// </para>
+    /// <para>
+    /// The roots themselves come from the solver reached through <c>SolveEquation</c>,
+    /// which is exact, and their <i>order</i> is decided numerically, which is not. So the
+    /// ordering is checked rather than trusted: the sign of the polynomial at an exact
+    /// rational point in each interval is computed in exact integer arithmetic, and the
+    /// resulting sequence has to change sign at every root of odd multiplicity and keep it at
+    /// every root of even multiplicity. A misordered or merged root shows up as a sequence
+    /// that does not, and is refused. The two outermost sample points are placed beyond
+    /// Cauchy's bound, so no root can lie outside the sampled range.
+    /// </para>
+    /// <para>
+    /// Part of the polynomial layer of
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a>, item 43 —
+    /// and the consumer that the resultant was waiting for.
+    /// </para>
+    /// </remarks>
+    internal static class PolynomialSignTable
+    {
+        /// <summary>
+        /// The highest degree an irreducible factor may have for its number of real roots to
+        /// be readable off its discriminant.
+        /// </summary>
+        /// <remarks>
+        /// One and two are the degrees where the sign of the discriminant is the whole
+        /// answer, three is where it is still the whole answer (positive means three real
+        /// roots, negative one), and four is where it stops being one: a quartic with a
+        /// positive discriminant has four real roots or none, and telling those apart needs
+        /// the two further quantities of the standard criterion rather than the discriminant
+        /// alone.
+        /// </remarks>
+        private const int MaxFactorDegree = 3;
+
+        /// <summary>
+        /// Two consecutive roots closer than this, relative to their size, are not separated
+        /// with confidence by a double-precision midpoint, and the sign table declines rather
+        /// than places a sample point on the wrong side of one.
+        /// </summary>
+        /// <remarks>
+        /// The exact sign check below would catch such a mistake in almost every case; this
+        /// is the cheaper guard in front of it, so that the failure is a refusal for a stated
+        /// reason rather than a failed consistency check.
+        /// </remarks>
+        private const double LeastRelativeGap = 1e-9;
+
+        /// <summary>
+        /// The solution set of <c>expr &gt; 0</c>, or <see langword="false"/> where
+        /// <paramref name="expr"/> is not a univariate polynomial over <c>Q</c> in
+        /// <paramref name="x"/> of degree at least three, or where the real roots could not
+        /// be established completely.
+        /// </summary>
+        internal static bool TrySolve(Entity expr, Variable x, [NotNullWhen(true)] out Set? solution)
+        {
+            solution = null;
+            // Degree three and up only: the linear and quadratic branches of the caller carry
+            // symbolic coefficients and a case split on their signs, which this does not, so
+            // taking their inputs from them would be a regression rather than a widening.
+            if (!PolynomialFactoring.TryGetRationalCoefficients(
+                    expr, x, leastTerms: 1, leastDegree: 3, IntegerPolynomial.MaxDegree,
+                    out var rational))
+                return false;
+
+            // Cleared of denominators. The multiplier is a positive integer, so the sign of
+            // the polynomial is the sign of the expression at every point.
+            var denominator = EInteger.One;
+            foreach (var coefficient in rational)
+                denominator = Lcm(denominator, coefficient.Denominator);
+            var whole = new EInteger[rational.Length];
+            for (var i = 0; i < whole.Length; i++)
+                whole[i] = rational[i].Numerator.Multiply(denominator.Divide(rational[i].Denominator));
+
+            var poly = IntegerPolynomial.Create(whole);
+            if (poly.Degree < 3)
+                return false;
+
+            var primitive = poly.PrimitivePart();
+            if (PolynomialFactorization.FactorPrimitive(primitive) is not { } parts)
+                return false;
+
+            var roots = new List<Root>();
+            foreach (var part in parts)
+            {
+                if (!TryRealRootsOf(part.Factor, x, roots, part.Multiplicity))
+                    return false;
+            }
+
+            roots.Sort(static (left, right) => left.Approximation.CompareTo(right.Approximation));
+            for (var i = 1; i < roots.Count; i++)
+            {
+                var gap = roots[i].Approximation - roots[i - 1].Approximation;
+                var scale = Math.Max(1.0, Math.Max(Math.Abs(roots[i].Approximation),
+                                                   Math.Abs(roots[i - 1].Approximation)));
+                if (!(gap > LeastRelativeGap * scale))
+                    return false;
+            }
+
+            if (SampleSigns(poly, roots) is not { } signs)
+                return false;
+
+            // The sign either turns around at a root or does not, and which of those is the
+            // parity of its multiplicity. Anything else means the roots are not the ones the
+            // samples were placed around.
+            for (var i = 0; i < roots.Count; i++)
+                if ((signs[i] != signs[i + 1]) != (roots[i].Multiplicity % 2 == 1))
+                    return false;
+
+            var pieces = new List<Set>();
+            for (var i = 0; i <= roots.Count; i++)
+            {
+                if (signs[i] <= 0)
+                    continue;
+                var left = i == 0 ? (Entity)Real.NegativeInfinity : roots[i - 1].Value;
+                var right = i == roots.Count ? (Entity)Real.PositiveInfinity : roots[i].Value;
+                pieces.Add(new Interval(left, false, right, false));
+            }
+
+            if (pieces.Count == 0)
+            {
+                solution = Empty;
+                return true;
+            }
+            Set united = pieces[0];
+            for (var i = 1; i < pieces.Count; i++)
+                united = united.Unite(pieces[i]);
+            solution = united;
+            return true;
+        }
+
+        /// <summary>A real root of an irreducible factor, with the multiplicity that factor carries.</summary>
+        private readonly struct Root
+        {
+            internal Root(Entity value, double approximation, int multiplicity)
+            {
+                Value = value;
+                Approximation = approximation;
+                Multiplicity = multiplicity;
+            }
+
+            internal Entity Value { get; }
+
+            internal double Approximation { get; }
+
+            internal int Multiplicity { get; }
+        }
+
+        /// <summary>
+        /// Appends the real roots of an irreducible <paramref name="factor"/> to
+        /// <paramref name="into"/>, or answers <see langword="false"/> where how many of them
+        /// there are could not be settled.
+        /// </summary>
+        private static bool TryRealRootsOf(
+            IntegerPolynomial factor, Variable x, List<Root> into, int multiplicity)
+        {
+            var degree = factor.Degree;
+            if (degree < 1 || degree > MaxFactorDegree)
+                return false;
+
+            if (degree == 1)
+            {
+                var root = ERational.Create(factor[0].Negate(), factor[1]).ToLowestTerms();
+                into.Add(new Root(Rational.Create(root), root.ToDouble(), multiplicity));
+                return true;
+            }
+
+            if (RealRootCount(factor, x, degree) is not { } expected)
+                return false;
+            if (expected == 0)
+                return true;
+
+            if (factor.ToEntity(x).SolveEquation(x) is not FiniteSet solved || solved.Count != degree)
+                return false;
+
+            var candidates = new List<(Entity Value, double Real, double Imaginary)>(degree);
+            foreach (var candidate in solved)
+            {
+                if (candidate.EvalNumerical() is not Complex numeric)
+                    return false;
+                candidates.Add((candidate,
+                                numeric.RealPart.EDecimal.ToDouble(),
+                                Math.Abs(numeric.ImaginaryPart.EDecimal.ToDouble())));
+            }
+            foreach (var candidate in candidates)
+                if (double.IsNaN(candidate.Real) || double.IsInfinity(candidate.Real)
+                    || double.IsNaN(candidate.Imaginary))
+                    return false;
+
+            if (expected == degree)
+            {
+                // Every root is real, so there is nothing to choose between them and the
+                // imaginary parts are the rounding of a cancellation rather than evidence.
+                foreach (var candidate in candidates)
+                    into.Add(new Root(candidate.Value, candidate.Real, multiplicity));
+                return true;
+            }
+
+            // One real root among three, the other two a conjugate pair off the axis. The
+            // real one is the one whose imaginary part is rounding rather than value, and it
+            // is taken only where that is not a close call.
+            candidates.Sort(static (left, right) => left.Imaginary.CompareTo(right.Imaginary));
+            var chosen = candidates[0];
+            var scale = Math.Max(1.0, Math.Abs(chosen.Real));
+            if (!(chosen.Imaginary < 1e-9 * scale) || !(candidates[1].Imaginary > 1e-3 * scale))
+                return false;
+            into.Add(new Root(chosen.Value, chosen.Real, multiplicity));
+            return true;
+        }
+
+        /// <summary>
+        /// How many distinct real roots an irreducible <paramref name="factor"/> of degree two
+        /// or three has, read off the sign of its discriminant, or <see langword="null"/>
+        /// where the discriminant could not be computed or came out zero.
+        /// </summary>
+        /// <remarks>
+        /// A zero discriminant means a repeated factor, which an irreducible polynomial does
+        /// not have — so it is a sign that the input was not what it was taken to be, and the
+        /// sign table declines rather than proceeds.
+        /// </remarks>
+        private static int? RealRootCount(IntegerPolynomial factor, Variable x, int degree)
+        {
+            var index = new Dictionary<Variable, int> { [x] = 0 };
+            if (MultivariatePolynomial.TryParse(factor.ToEntity(x), index) is not { } parsed)
+                return null;
+            if (PolynomialResultant.Discriminant(parsed, 0, Array.Empty<int>()) is not { } discriminant)
+                return null;
+            if (!discriminant.IsConstant)
+                return null;
+            var sign = discriminant.CoefficientOf(0).Sign;
+            if (sign == 0)
+                return null;
+            return degree switch
+            {
+                2 => sign > 0 ? 2 : 0,
+                3 => sign > 0 ? 3 : 1,
+                _ => null
+            };
+        }
+
+        /// <summary>
+        /// The exact sign of <paramref name="poly"/> at one rational point in each of the
+        /// intervals the <paramref name="roots"/> cut the line into, or <see langword="null"/>
+        /// where a sample landed on a root.
+        /// </summary>
+        /// <remarks>
+        /// The outermost two points are placed beyond Cauchy's bound
+        /// <c>1 + max|a_i| / |a_n|</c>, outside which the leading term dominates the sum of
+        /// all the others and the polynomial cannot vanish. So the two unbounded intervals
+        /// are sampled where they are genuinely unbounded, rather than wherever the outermost
+        /// root happened to be.
+        /// </remarks>
+        private static int[]? SampleSigns(IntegerPolynomial poly, IReadOnlyList<Root> roots)
+        {
+            var bound = CauchyBound(poly);
+            var signs = new int[roots.Count + 1];
+            for (var i = 0; i <= roots.Count; i++)
+            {
+                ERational point;
+                if (roots.Count == 0)
+                    point = ERational.Zero;
+                else if (i == 0)
+                    point = Below(roots[0].Approximation, bound);
+                else if (i == roots.Count)
+                    point = Above(roots[roots.Count - 1].Approximation, bound);
+                else
+                    point = Midpoint(roots[i - 1].Approximation, roots[i].Approximation);
+                var value = Evaluate(poly, point);
+                if (value.IsZero)
+                    return null;
+                signs[i] = value.Sign;
+            }
+            return signs;
+        }
+
+        private static ERational Midpoint(double left, double right)
+            => ERational.FromDouble(left).Add(ERational.FromDouble(right))
+                        .Divide(ERational.FromInt32(2)).ToLowestTerms();
+
+        private static ERational Below(double leastRoot, ERational bound)
+        {
+            var candidate = ERational.FromDouble(leastRoot).Subtract(ERational.One);
+            var outside = bound.Negate().Subtract(ERational.One);
+            return candidate.CompareTo(outside) < 0 ? candidate : outside;
+        }
+
+        private static ERational Above(double greatestRoot, ERational bound)
+        {
+            var candidate = ERational.FromDouble(greatestRoot).Add(ERational.One);
+            var outside = bound.Add(ERational.One);
+            return candidate.CompareTo(outside) > 0 ? candidate : outside;
+        }
+
+        /// <summary>Cauchy's bound: every real root is strictly inside it.</summary>
+        private static ERational CauchyBound(IntegerPolynomial poly)
+        {
+            var leading = poly.Leading.Abs();
+            var greatest = EInteger.Zero;
+            for (var power = 0; power < poly.Degree; power++)
+            {
+                var magnitude = poly[power].Abs();
+                if (magnitude.CompareTo(greatest) > 0)
+                    greatest = magnitude;
+            }
+            return ERational.One.Add(ERational.Create(greatest, leading)).ToLowestTerms();
+        }
+
+        /// <summary>
+        /// <paramref name="poly"/> at <paramref name="point"/>, by Horner and in exact
+        /// rational arithmetic, so that the sign it comes back with is the sign it has.
+        /// </summary>
+        private static ERational Evaluate(IntegerPolynomial poly, ERational point)
+        {
+            var result = ERational.Zero;
+            for (var power = poly.Degree; power >= 0; power--)
+                result = result.Multiply(point).Add(ERational.Create(poly[power], EInteger.One));
+            return result.ToLowestTerms();
+        }
+
+        private static EInteger Lcm(EInteger left, EInteger right)
+            => left.Divide(left.Gcd(right)).Multiply(right);
+    }
+}

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/InequalitySolver/PolynomialSignTable.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/InequalitySolver/PolynomialSignTable.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) 2019-2026 Angouri.
 // AngouriMath is licensed under MIT.
 // Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
@@ -36,10 +36,10 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
     /// being coprime. Second, the number of real roots of each factor is read off its
     /// <see cref="PolynomialResultant.Discriminant"/>: a factor of degree two has two real
     /// roots where its discriminant is positive and none where it is negative, and one of
-    /// degree three has three and one respectively. That count is what makes a root list a
-    /// complete root list rather than a list of the roots that happened to come back, and it
-    /// is the reason a degree-four irreducible factor is refused — its discriminant does not
-    /// decide between four real roots and none.
+    /// degree three has three and one respectively. A factor of degree four needs two more
+    /// quantities alongside the discriminant, and there is no such criterion at five — nor a
+    /// formula for the roots — which is where this stops. That count is what makes a root
+    /// list a complete root list rather than a list of the roots that happened to come back.
     /// </para>
     /// <para>
     /// The roots themselves come from the solver reached through <c>SolveEquation</c>,
@@ -61,17 +61,16 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
     {
         /// <summary>
         /// The highest degree an irreducible factor may have for its number of real roots to
-        /// be readable off its discriminant.
+        /// be settled.
         /// </summary>
         /// <remarks>
-        /// One and two are the degrees where the sign of the discriminant is the whole
-        /// answer, three is where it is still the whole answer (positive means three real
-        /// roots, negative one), and four is where it stops being one: a quartic with a
-        /// positive discriminant has four real roots or none, and telling those apart needs
-        /// the two further quantities of the standard criterion rather than the discriminant
-        /// alone.
+        /// Up to three the sign of the discriminant is the whole answer. At four it is half
+        /// of it — a negative discriminant means exactly two real roots, and a positive one
+        /// means four or none — and the two auxiliary quantities of the standard criterion
+        /// decide between those. At five there is no such criterion, and there is no formula
+        /// for the roots either.
         /// </remarks>
-        private const int MaxFactorDegree = 3;
+        private const int MaxFactorDegree = 4;
 
         /// <summary>
         /// Two consecutive roots closer than this, relative to their size, are not separated
@@ -235,27 +234,43 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
                 return true;
             }
 
-            // One real root among three, the other two a conjugate pair off the axis. The
-            // real one is the one whose imaginary part is rounding rather than value, and it
-            // is taken only where that is not a close call.
+            // Some of the roots are real and the rest are conjugate pairs off the axis. The
+            // real ones are those whose imaginary part is rounding rather than value, and
+            // they are taken only where the two groups are far enough apart that saying
+            // which is which is not a close call.
             candidates.Sort(static (left, right) => left.Imaginary.CompareTo(right.Imaginary));
-            var chosen = candidates[0];
-            var scale = Math.Max(1.0, Math.Abs(chosen.Real));
-            if (!(chosen.Imaginary < 1e-9 * scale) || !(candidates[1].Imaginary > 1e-3 * scale))
+            var scale = 1.0;
+            for (var i = 0; i < expected; i++)
+                scale = Math.Max(scale, Math.Abs(candidates[i].Real));
+            if (!(candidates[expected - 1].Imaginary < 1e-9 * scale)
+                || !(candidates[expected].Imaginary > 1e-3 * scale))
                 return false;
-            into.Add(new Root(chosen.Value, chosen.Real, multiplicity));
+            for (var i = 0; i < expected; i++)
+                into.Add(new Root(candidates[i].Value, candidates[i].Real, multiplicity));
             return true;
         }
 
         /// <summary>
-        /// How many distinct real roots an irreducible <paramref name="factor"/> of degree two
-        /// or three has, read off the sign of its discriminant, or <see langword="null"/>
-        /// where the discriminant could not be computed or came out zero.
+        /// How many distinct real roots an irreducible <paramref name="factor"/> of degree
+        /// two, three or four has, or <see langword="null"/> where that could not be settled.
         /// </summary>
         /// <remarks>
+        /// <para>
+        /// The sign of the discriminant decides it outright up to degree three. At four it
+        /// separates two real roots (negative) from four or none (positive), and the two
+        /// auxiliary quantities <c>P = 8ac - 3b^2</c> and
+        /// <c>D = 64a^3 e - 16a^2 c^2 + 16a b^2 c - 16a^2 b d - 3b^4</c> decide between
+        /// those: four real where both are negative, none where either is positive. Where
+        /// neither of those holds — one of them zero and the other not positive — the
+        /// criterion says nothing, and neither does this. Rees, <i>A note on the quartic</i>,
+        /// Amer. Math. Monthly 29 (1922); Lazard, <i>Quantifier elimination: optimal solution
+        /// for two classical examples</i>, J. Symbolic Comput. 5 (1988).
+        /// </para>
+        /// <para>
         /// A zero discriminant means a repeated factor, which an irreducible polynomial does
         /// not have — so it is a sign that the input was not what it was taken to be, and the
         /// sign table declines rather than proceeds.
+        /// </para>
         /// </remarks>
         private static int? RealRootCount(IntegerPolynomial factor, Variable x, int degree)
         {
@@ -269,12 +284,32 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
             var sign = discriminant.CoefficientOf(0).Sign;
             if (sign == 0)
                 return null;
-            return degree switch
+            switch (degree)
             {
-                2 => sign > 0 ? 2 : 0,
-                3 => sign > 0 ? 3 : 1,
-                _ => null
-            };
+                case 2: return sign > 0 ? 2 : 0;
+                case 3: return sign > 0 ? 3 : 1;
+                case 4:
+                    if (sign < 0)
+                        return 2;
+                    var a = factor[4];
+                    var b = factor[3];
+                    var c = factor[2];
+                    var d = factor[1];
+                    var e = factor[0];
+                    var p = EInteger.FromInt32(8).Multiply(a).Multiply(c)
+                        .Subtract(EInteger.FromInt32(3).Multiply(b).Multiply(b));
+                    var big = EInteger.FromInt32(64).Multiply(a).Multiply(a).Multiply(a).Multiply(e)
+                        .Subtract(EInteger.FromInt32(16).Multiply(a).Multiply(a).Multiply(c).Multiply(c))
+                        .Add(EInteger.FromInt32(16).Multiply(a).Multiply(b).Multiply(b).Multiply(c))
+                        .Subtract(EInteger.FromInt32(16).Multiply(a).Multiply(a).Multiply(b).Multiply(d))
+                        .Subtract(EInteger.FromInt32(3).Multiply(b).Multiply(b).Multiply(b).Multiply(b));
+                    if (p.Sign < 0 && big.Sign < 0)
+                        return 4;
+                    if (p.Sign > 0 || big.Sign > 0)
+                        return 0;
+                    return null;
+                default: return null;
+            }
         }
 
         /// <summary>

--- a/Sources/Package.Build.props
+++ b/Sources/Package.Build.props
@@ -29,7 +29,7 @@
     throws MissingMethodException when a consumer compiled against the older assembly
     reaches it. 2.2.0 renamed two, which is why that sentence is here.
 
-    2.3.0 removes and renames nothing. The public surface only grows, by 103 members,
+    2.3.0 removes and renames nothing. The public surface only grows, by 109 members,
     with 0 removals against the 2.2.0 baseline in Tests/UnitTests/Common/PublicApi.txt.
     So for this release the pin is a drop-in guarantee in both senses. What did change is
     behaviour, in seventeen ways recorded in BREAKING-CHANGES.md, and no assembly version

--- a/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialSurfaceTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialSurfaceTest.cs
@@ -1,0 +1,210 @@
+﻿//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Tests.Algebra.Polynomials
+{
+    /// <summary>
+    /// <see cref="MathS.Polynomials"/> — that it answers, that it refuses where it must, and
+    /// that the worked examples in its documentation are the output it actually produces.
+    /// </summary>
+    [Trait("Area", "Algebra")]
+    public sealed class PolynomialSurfaceTest
+    {
+        /// <summary>
+        /// The printed form is the assertion here, deliberately and against the usual rule.
+        /// These are the examples in the XML documentation, and what is being tested is that a
+        /// reader who runs one gets what the page says — so a change of form is exactly the
+        /// failure this has to catch. Everything else in this file asserts the mathematics.
+        /// </summary>
+        [Theory]
+        [InlineData("x ^ 4 - 5 * x ^ 2 + 4", "(x + 1) * (x + 2) * (x - 2) * (x - 1)")]
+        [InlineData("x ^ 3 - 3 * x ^ 2 + 3 * x - 1", "(x - 1) ^ 3")]
+        [InlineData("x ^ 2 + 1", "x ^ 2 + 1")]
+        public void TheFactorExamplesPrintWhatTheDocumentationSays(string input, string expected)
+            => Assert.Equal(expected, MathS.Polynomials.Factor(input, "x")?.Stringize());
+
+        [Theory]
+        [InlineData("x ^ 2 - 1", "x ^ 2 + 2 * x + 1", "x + 1")]
+        [InlineData("x ^ 2 - y ^ 2", "x ^ 2 - 2 * x * y + y ^ 2", "x - y")]
+        [InlineData("x ^ 2 + 1", "x ^ 2 + 2", "1")]
+        public void TheGcdExamplesPrintWhatTheDocumentationSays(string left, string right, string expected)
+            => Assert.Equal(expected, MathS.Polynomials.Gcd(left, right)?.Stringize());
+
+        [Theory]
+        [InlineData("x ^ 2 + y ^ 2 - 1", "x + y - 1", "y", "2 * x ^ 2 - 2 * x")]
+        [InlineData("x ^ 2 - 1", "x - a", "x", "a ^ 2 - 1")]
+        public void TheResultantExamplesPrintWhatTheDocumentationSays(
+            string left, string right, string eliminate, string expected)
+            => Assert.Equal(expected, MathS.Polynomials.Resultant(left, right, eliminate)?.Stringize());
+
+        [Theory]
+        [InlineData("a * x ^ 2 + b * x + c", "-4 * a * c + b ^ 2")]
+        [InlineData("x ^ 3 - 3 * x + 1", "81")]
+        [InlineData("x ^ 2 - 2 * x + 1", "0")]
+        public void TheDiscriminantExamplesPrintWhatTheDocumentationSays(string input, string expected)
+            => Assert.Equal(expected, MathS.Polynomials.Discriminant(input, "x")?.Stringize());
+
+        [Theory]
+        [InlineData("(x - 1) ^ 3 * (x + 2) ^ 2", "x ^ 2 + x - 2")]
+        [InlineData("x ^ 2 + 1", "x ^ 2 + 1")]
+        public void TheSquareFreePartExamplesPrintWhatTheDocumentationSays(string input, string expected)
+            => Assert.Equal(expected, MathS.Polynomials.SquareFreePart(input, "x")?.Stringize());
+
+        /// <summary>The factors multiply back to what they came from.</summary>
+        [Theory]
+        [InlineData("x ^ 4 - 5 * x ^ 2 + 4")]
+        [InlineData("x ^ 6 - 1")]
+        [InlineData("2 * x ^ 2 - 2")]
+        [InlineData("x ^ 2 / 4 - 1")]
+        [InlineData("x ^ 8 - 1")]
+        [InlineData("x ^ 4 + 3 * x ^ 2 + 2")]
+        [InlineData("x ^ 3 - 3 * x ^ 2 + 3 * x - 1")]
+        [InlineData("x + 1")]
+        [InlineData("x ^ 2 + 1")]
+        public void AFactorisationIsTheSamePolynomial(string input)
+        {
+            var factored = MathS.Polynomials.Factor(input, "x");
+            Assert.NotNull(factored);
+            Assert.Equal(Integer.Create(0),
+                (factored! - input.ToEntity()).Expand().Simplify());
+        }
+
+        /// <summary>The greatest common divisor divides both, and the quotients are coprime.</summary>
+        [Theory]
+        [InlineData("x ^ 2 - 1", "x ^ 2 + 2 * x + 1", "x + 1")]
+        [InlineData("x ^ 3 - x", "x ^ 2 - x", "x ^ 2 - x")]
+        [InlineData("x ^ 2 - y ^ 2", "x ^ 2 - 2 * x * y + y ^ 2", "x - y")]
+        [InlineData("(x + y) * (x - y)", "(x + y) ^ 2", "x + y")]
+        public void AGreatestCommonDivisorDividesBoth(string left, string right, string expected)
+        {
+            var divisor = MathS.Polynomials.Gcd(left, right);
+            Assert.NotNull(divisor);
+            Assert.Equal(Integer.Create(0), (divisor! - expected.ToEntity()).Expand().Simplify());
+        }
+
+        /// <summary>
+        /// The resultant vanishes exactly where the two polynomials have a common root in the
+        /// eliminated variable — checked by substituting the values that make it vanish back
+        /// into the pair and solving.
+        /// </summary>
+        [Fact]
+        public void TheResultantVanishesWhereThereIsACommonRoot()
+        {
+            // Res_x(x^2 - 1, x - a) = a^2 - 1, so the two share a root exactly at a = +-1.
+            var resultant = MathS.Polynomials.Resultant("x ^ 2 - 1", "x - a", "x");
+            Assert.NotNull(resultant);
+            foreach (var value in new Entity[] { 1, -1 })
+            {
+                Assert.Equal(Integer.Create(0), resultant!.Substitute("a", value).Simplify());
+                // and the shared root really is there
+                var shared = "x ^ 2 - 1".ToEntity().SolveEquation("x");
+                Assert.Contains(value, ((Set.FiniteSet)shared.InnerSimplified).ToArray());
+            }
+            foreach (var value in new Entity[] { 0, 2, -3 })
+                Assert.NotEqual(Integer.Create(0), resultant!.Substitute("a", value).Simplify());
+        }
+
+        /// <summary>
+        /// The discriminant vanishes exactly where the polynomial has a repeated root, and its
+        /// sign counts the real roots of a cubic.
+        /// </summary>
+        [Theory]
+        [InlineData("x ^ 2 - 2 * x + 1", 0)]
+        [InlineData("x ^ 2 - 1", 1)]
+        [InlineData("x ^ 2 + 1", -1)]
+        [InlineData("x ^ 3 - 3 * x + 1", 1)]     // three real roots
+        [InlineData("x ^ 3 - 2", -1)]            // one real root
+        [InlineData("x ^ 3 - 3 * x + 2", 0)]     // a repeated root at 1
+        public void TheDiscriminantHasTheSignItShould(string input, int sign)
+        {
+            var discriminant = MathS.Polynomials.Discriminant(input, "x");
+            Assert.NotNull(discriminant);
+            var value = (Real)discriminant!.EvalNumerical().RealPart;
+            Assert.Equal(sign, value.EDecimal.Sign);
+        }
+
+        /// <summary>
+        /// The square-free part has the same roots as what it came from, and each of them
+        /// once — so it is what the original is divided by the greatest common divisor with
+        /// its derivative, and its own discriminant no longer vanishes.
+        /// </summary>
+        [Theory]
+        [InlineData("(x - 1) ^ 3 * (x + 2) ^ 2")]
+        [InlineData("x ^ 4 - 2 * x ^ 2 + 1")]
+        [InlineData("(x ^ 2 + 1) ^ 2")]
+        public void ASquareFreePartHasNoRepeatedRoot(string input)
+        {
+            var part = MathS.Polynomials.SquareFreePart(input, "x");
+            Assert.NotNull(part);
+            var discriminant = MathS.Polynomials.Discriminant(part!, "x");
+            Assert.NotNull(discriminant);
+            Assert.NotEqual(Integer.Create(0), discriminant!.Simplify());
+            // Every root of the original is a root of the square-free part.
+            foreach (var root in (Set.FiniteSet)input.ToEntity().SolveEquation("x").InnerSimplified)
+                Assert.Equal(Integer.Create(0), part!.Substitute("x", root).Simplify());
+        }
+
+        /// <summary>
+        /// A request outside what the layer can do is refused with <see langword="null"/>, and
+        /// never answered with the input as though it were the result. Handing
+        /// <c>x * y + y</c> back from a factorisation would say that <c>y * (x + 1)</c> does
+        /// not exist, which is a wrong answer and not a graceful failure.
+        /// </summary>
+        [Theory]
+        [InlineData("x * y + y")]                    // multivariate
+        [InlineData("x ^ 2 * y ^ 2 - 1")]            // multivariate
+        [InlineData("x ^ 2 - a")]                    // a symbolic coefficient is not rational
+        [InlineData("sin(x) + 1")]                   // not a polynomial
+        [InlineData("x ^ 33 - 1")]                   // past the degree bound of the factoriser
+        public void FactorisationRefusesRatherThanReturningTheInput(string input)
+            => Assert.Null(MathS.Polynomials.Factor(input, "x"));
+
+        /// <summary>Nine variables is one more than the packed monomial has room for.</summary>
+        [Fact]
+        public void NineVariablesAreRefused()
+        {
+            var eight = "a + b + c + d + f + g + h + k";
+            var nine = eight + " + m";
+            Assert.NotNull(MathS.Polynomials.Gcd(eight, eight + " + 1"));
+            Assert.Null(MathS.Polynomials.Gcd(nine, nine + " + 1"));
+            Assert.Null(MathS.Polynomials.Resultant(nine, nine + " + 1", "a"));
+            Assert.Null(MathS.Polynomials.Discriminant(nine + " + a ^ 2", "a"));
+        }
+
+        /// <summary>
+        /// Degree 128 is one past what a packed monomial can hold, so everything that goes
+        /// through the multivariate representation declines rather than truncating.
+        /// </summary>
+        [Fact]
+        public void ADegreeBeyondTheBoundIsRefused()
+        {
+            var degree128 = string.Join(" + ",
+                Enumerable.Range(0, 129).Select(power => power == 0 ? "1" : $"x ^ {power}"));
+            Assert.Null(MathS.Polynomials.Factor(degree128, "x"));
+            Assert.Null(MathS.Polynomials.Discriminant(degree128, "x"));
+            Assert.Null(MathS.Polynomials.SquareFreePart(degree128, "x"));
+            Assert.Null(MathS.Polynomials.Gcd(degree128, degree128 + " + 1"));
+        }
+
+        /// <summary>Something that is not a polynomial at all is refused everywhere.</summary>
+        [Fact]
+        public void SomethingThatIsNotAPolynomialIsRefused()
+        {
+            Assert.Null(MathS.Polynomials.Gcd("sin(x)", "x"));
+            Assert.Null(MathS.Polynomials.Resultant("sin(x)", "x", "x"));
+            Assert.Null(MathS.Polynomials.Discriminant("1 / x", "x"));
+            Assert.Null(MathS.Polynomials.SquareFreePart("e ^ x", "x"));
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/SolveInequality.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/SolveInequality.cs
@@ -5,6 +5,8 @@
 // Website: https://am.angouri.org.
 //
 
+using System.Collections.Generic;
+using PeterO.Numbers;
 using AngouriMath;
 using AngouriMath.Extensions;
 using Xunit;
@@ -222,5 +224,76 @@ namespace AngouriMath.Tests.Algebra
                     $"{inequality} was solved as {solutions}, which "
                     + (everywhere ? "does not hold" : "holds") + $" at x = {point}");
         }
+
+        /// <summary>
+        /// A univariate polynomial inequality of degree three or more, answered by the sign
+        /// table over its irreducible factors. Checked by which points the answer holds at
+        /// rather than by how it prints, since the endpoints of a cubic's intervals are
+        /// radicals with several equally correct writings.
+        /// </summary>
+        private static void AssertHoldsExactlyWhereItShould(string inequality, params double[] extraPoints)
+        {
+            Variable x = "x";
+            var solutions = (Set)((Entity)inequality).Solve(x).Simplify();
+            var points = new List<Entity>();
+            for (var numerator = -60; numerator <= 60; numerator++)
+                points.Add(Number.Rational.Create(EInteger.FromInt32(numerator), EInteger.FromInt32(17)));
+            foreach (var extra in extraPoints)
+                points.Add(Number.Rational.Create(EInteger.FromInt64((long)System.Math.Round(extra * 1000)), EInteger.FromInt32(1000)));
+            foreach (var point in points)
+            {
+                var truth = ((Entity)inequality).Substitute(x, point).EvalBoolean();
+                Assert.True(solutions.Contains(point) == truth,
+                    $"{inequality} was solved as {solutions}, which "
+                    + (truth ? "excludes" : "includes") + $" x = {point} where the inequality "
+                    + (truth ? "holds" : "does not hold"));
+            }
+        }
+
+        /// <summary>
+        /// Degree three and above used to be refused outright -- "Only linear and quadratic
+        /// polynomial inequalities are supported". The sign table answers them by factoring
+        /// into irreducibles over Q and reading the sign between consecutive roots, and the
+        /// discriminant of each factor is what says how many real roots there are to look
+        /// for. <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a>,
+        /// item 43.
+        /// </summary>
+        [Theory]
+        // Splits into linear factors.
+        [InlineData("x^3 - x > 0")]
+        [InlineData("x^3 - x < 0")]
+        [InlineData("x^3 - x >= 0")]
+        [InlineData("x^3 - x <= 0")]
+        [InlineData("x^4 - 5*x^2 + 4 > 0")]
+        [InlineData("x^4 - 5*x^2 + 4 < 0")]
+        // A repeated factor, where the sign does not change across the root.
+        [InlineData("(x - 1)^2 * (x + 2) > 0")]
+        [InlineData("(x - 1)^2 * (x + 2) < 0")]
+        [InlineData("(x - 1)^2 * (x + 2) >= 0")]
+        [InlineData("x^2 * (x - 3) < 0")]
+        // An irreducible quadratic factor with real roots: its discriminant is positive, so
+        // it contributes two endpoints that are not rational.
+        [InlineData("x^3 - 2*x + 1 > 0")]
+        [InlineData("x^3 - 2*x + 1 < 0")]
+        // An irreducible quadratic factor with no real roots at all, which contributes a
+        // constant sign and no endpoint.
+        [InlineData("(x - 1) * (x^2 + 1) > 0")]
+        [InlineData("(x^2 + x + 1) * (x + 2) < 0")]
+        [InlineData("x^4 + x^2 + 1 > 0")]
+        [InlineData("x^4 + x^2 + 1 < 0")]
+        // An irreducible cubic: one real root where the discriminant is negative, three
+        // where it is positive.
+        [InlineData("x^3 - 2 > 0")]
+        [InlineData("x^3 - 2 < 0")]
+        [InlineData("x^3 - 3*x + 1 > 0")]
+        [InlineData("x^3 - 3*x + 1 < 0")]
+        // A negative leading coefficient, and denominators in the coefficients.
+        [InlineData("-x^3 + x > 0")]
+        [InlineData("x^3/2 - x/8 > 0")]
+        // Degree five and six, still splitting into factors of degree at most three.
+        [InlineData("x^5 - 5*x^3 + 4*x > 0")]
+        [InlineData("(x^2 - 2) * (x^2 - 3) * (x + 1) > 0")]
+        public void AHigherDegreePolynomialInequalityIsAnswered(string inequality)
+            => AssertHoldsExactlyWhereItShould(inequality);
     }
 }

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/SolveInequality.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/SolveInequality.cs
@@ -293,6 +293,17 @@ namespace AngouriMath.Tests.Algebra
         // Degree five and six, still splitting into factors of degree at most three.
         [InlineData("x^5 - 5*x^3 + 4*x > 0")]
         [InlineData("(x^2 - 2) * (x^2 - 3) * (x + 1) > 0")]
+        // An irreducible quartic factor, where the discriminant's sign is only half the
+        // answer: negative means two real roots, and positive means four or none, which the
+        // two auxiliary quantities of the standard criterion decide between.
+        [InlineData("x^4 + 1 > 0")]            // four or none, and none
+        [InlineData("x^4 + x + 1 > 0")]        // four or none, and none
+        [InlineData("x^4 - 2 > 0")]            // two real
+        [InlineData("x^4 - 2 < 0")]
+        [InlineData("x^4 - x - 1 > 0")]        // two real
+        [InlineData("x^4 - 10*x^2 + 1 > 0")]   // four real
+        [InlineData("x^4 - 10*x^2 + 1 < 0")]
+        [InlineData("(x^4 - 2) * (x - 1) > 0")]
         public void AHigherDegreePolynomialInequalityIsAnswered(string inequality)
             => AssertHoldsExactlyWhereItShould(inequality);
     }

--- a/Sources/Tests/UnitTests/Common/PublicApi.txt
+++ b/Sources/Tests/UnitTests/Common/PublicApi.txt
@@ -2392,6 +2392,11 @@ AngouriMath.MathS+Numbers.Create(System.Int32) : AngouriMath.Entity+Number+Integ
 AngouriMath.MathS+Numbers.Create(System.Int64) : AngouriMath.Entity+Number+Integer
 AngouriMath.MathS+Numbers.Create(System.Numerics.Complex) : AngouriMath.Entity+Number+Complex
 AngouriMath.MathS+Numbers.CreateRational(PeterO.Numbers.EInteger, PeterO.Numbers.EInteger) : AngouriMath.Entity+Number+Rational
+AngouriMath.MathS+Polynomials.Discriminant(AngouriMath.Entity, AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.MathS+Polynomials.Factor(AngouriMath.Entity, AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.MathS+Polynomials.Gcd(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
+AngouriMath.MathS+Polynomials.Resultant(AngouriMath.Entity, AngouriMath.Entity, AngouriMath.Entity+Variable) : AngouriMath.Entity
+AngouriMath.MathS+Polynomials.SquareFreePart(AngouriMath.Entity, AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.MathS+Quantum.EqualUpToGlobalPhase(AngouriMath.Entity, AngouriMath.Entity) : System.Nullable<System.Boolean>
 AngouriMath.MathS+Quantum.IsNormalized(AngouriMath.Entity) : System.Nullable<System.Boolean>
 AngouriMath.MathS+Quantum.Ket(System.Int32[]) : AngouriMath.Entity
@@ -2679,6 +2684,7 @@ class AngouriMath.MathS+Matrices
 class AngouriMath.MathS+Multithreading
 class AngouriMath.MathS+NumberTheory
 class AngouriMath.MathS+Numbers
+class AngouriMath.MathS+Polynomials
 class AngouriMath.MathS+Quantum
 class AngouriMath.MathS+Series
 class AngouriMath.MathS+Sets

--- a/Sources/Tests/UnitTests/Core/KnownLimitsAreNotBugsTest.cs
+++ b/Sources/Tests/UnitTests/Core/KnownLimitsAreNotBugsTest.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) 2019-2026 Angouri.
 // AngouriMath is licensed under MIT.
 // Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
@@ -25,11 +25,20 @@ namespace AngouriMath.Tests.Core
     [Trait("Area", "Core")]
     public sealed class KnownLimitsAreNotBugsTest
     {
+        /// <summary>
+        /// Degree is no longer the gap; an irreducible factor of degree four or more is.
+        /// The sign table answers a polynomial inequality of any degree whose real roots it
+        /// can establish completely, and the number of real roots of an irreducible factor is
+        /// read off its discriminant — which decides it up to degree three and does not at
+        /// four, where a positive discriminant means four real roots or none. So
+        /// <c>x^4 + 1</c> and <c>x^4 - 2</c>, both irreducible over Q, are still refused,
+        /// and the three cases that used to be listed here are now answered — see
+        /// <c>SolveInequality.AHigherDegreePolynomialInequalityIsAnswered</c>.
+        /// </summary>
         [Theory]
-        [InlineData("x ^ 3 - x > 0")]
-        [InlineData("x ^ 4 - 5 * x ^ 2 + 4 > 0")]
         [InlineData("x ^ 4 + 1 > 0")]
-        [InlineData("x ^ 6 - 1 >= 0")]
+        [InlineData("x ^ 4 - 2 > 0")]
+        [InlineData("x ^ 4 + x + 1 > 0")]
         public void AHigherDegreeInequalitySaysItIsUnsupported(string statement)
         {
             var thrown = Assert.Throws<NotSufficientlySupportedException>(
@@ -43,6 +52,9 @@ namespace AngouriMath.Tests.Core
         [InlineData("x - 1 > 0")]
         [InlineData("x ^ 2 - 1 > 0")]
         [InlineData("x ^ 2 - 2 > 0")]
+        [InlineData("x ^ 3 - x > 0")]
+        [InlineData("x ^ 4 - 5 * x ^ 2 + 4 > 0")]
+        [InlineData("x ^ 6 - 1 >= 0")]
         public void TheDegreesThatAreSupportedStillAnswer(string statement)
         {
             var solutions = ((Entity)statement).Solve("x");

--- a/Sources/Tests/UnitTests/Core/KnownLimitsAreNotBugsTest.cs
+++ b/Sources/Tests/UnitTests/Core/KnownLimitsAreNotBugsTest.cs
@@ -26,19 +26,20 @@ namespace AngouriMath.Tests.Core
     public sealed class KnownLimitsAreNotBugsTest
     {
         /// <summary>
-        /// Degree is no longer the gap; an irreducible factor of degree four or more is.
+        /// Degree is no longer the gap; an irreducible factor of degree five or more is.
         /// The sign table answers a polynomial inequality of any degree whose real roots it
-        /// can establish completely, and the number of real roots of an irreducible factor is
-        /// read off its discriminant — which decides it up to degree three and does not at
-        /// four, where a positive discriminant means four real roots or none. So
-        /// <c>x^4 + 1</c> and <c>x^4 - 2</c>, both irreducible over Q, are still refused,
-        /// and the three cases that used to be listed here are now answered — see
+        /// can establish completely, and how many real roots an irreducible factor has is
+        /// settled by its discriminant up to degree three and by the discriminant with two
+        /// auxiliary quantities at four. At five there is no such criterion, and no formula
+        /// for the roots either, so an irreducible quintic factor is where this stops. The
+        /// cases that used to be listed here are now answered — see
         /// <c>SolveInequality.AHigherDegreePolynomialInequalityIsAnswered</c>.
         /// </summary>
         [Theory]
-        [InlineData("x ^ 4 + 1 > 0")]
-        [InlineData("x ^ 4 - 2 > 0")]
-        [InlineData("x ^ 4 + x + 1 > 0")]
+        [InlineData("x ^ 5 - x - 1 > 0")]
+        [InlineData("x ^ 5 - x + 1 > 0")]
+        [InlineData("x ^ 6 + x + 1 > 0")]
+        [InlineData("x ^ 7 - x - 1 < 0")]
         public void AHigherDegreeInequalitySaysItIsUnsupported(string statement)
         {
             var thrown = Assert.Throws<NotSufficientlySupportedException>(
@@ -55,6 +56,9 @@ namespace AngouriMath.Tests.Core
         [InlineData("x ^ 3 - x > 0")]
         [InlineData("x ^ 4 - 5 * x ^ 2 + 4 > 0")]
         [InlineData("x ^ 6 - 1 >= 0")]
+        [InlineData("x ^ 4 + 1 > 0")]
+        [InlineData("x ^ 4 - 2 > 0")]
+        [InlineData("x ^ 4 + x + 1 > 0")]
         public void TheDegreesThatAreSupportedStillAnswer(string statement)
         {
             var solutions = ((Entity)statement).Solve("x");


### PR DESCRIPTION
Two halves of [#746](https://github.com/asc-community/AngouriMath/issues/746) item 43, and the first is the one that matters.

## (a) The resultant had no caller, and now it has one that needs it

`PolynomialResultant` — 307 lines with a careful content-extraction argument and a measured work ceiling — was referenced nowhere outside its own file except its unit test, ten days after landing flagged as *"on probation until something eliminates a variable with them"*. Every other file in the layer is wired: `PolynomialGcd` → `Patterns` and `RationalFunction`, `PolynomialFactorization` → `AnalyticalEquationSolver` and `PartialFractions`, `PartialFractions` → `IndefiniteIntegralSolver`, `RationalFunction` → `Transformation.Catalogue`. Under this issue's own counterweight — *infrastructure must be validated by a consumer in the same change* — that made it speculative code.

**The consumer is polynomial inequalities of degree three and up**, which previously threw. `AnalyticalInequalitySolver` handled linear and quadratic only.

A polynomial has one sign on each open interval between consecutive real roots, so the answer is the union of the intervals where the sign is right — **provided the root list is complete.** A missed root merges two intervals of opposite sign and reports the wrong half as the solution, which is a wrong answer, not an incomplete one. So completeness has to be established rather than hoped for, and that is what the discriminant is for here:

1. `PolynomialFactorization.FactorPrimitive` writes the polynomial as a product of powers of irreducibles over ℚ, and verifies the product.
2. **The number of real roots of each irreducible factor is read off `PolynomialResultant.Discriminant`** — two or none for a quadratic by its sign; three or one for a cubic; and for a quartic the discriminant together with `P = 8ac − 3b²` and `D = 64a³e − 16a²c² + 16ab²c − 16a²bd − 3b⁴`.
3. The ordering of the roots is numeric and therefore **checked rather than trusted**: the sign of the polynomial at an exact rational point inside each interval is computed in exact arithmetic, and the sequence must flip at every odd-multiplicity root and hold at every even one. The two outer samples sit beyond Cauchy's bound. Any mismatch is a refusal.

Degree five is where it stops, and honestly: an irreducible quintic factor has no real-root criterion and no radical formula either.

Measured on builds of each side, and re-verified independently on this machine:

```
                            master                              this branch
x^3 - x > 0                 NotSufficientlySupported            (-1; 0) \/ (1; +oo)
x^4 - 5x^2 + 4 > 0                  "                           (-oo; -2) \/ (-1; 1) \/ (2; +oo)
(x - 1)^2 * (x + 2) > 0             "                           (-2; 1) \/ (1; +oo)
x^3 - 2x + 1 > 0                    "                           ((-1 - sqrt(5))/2; (-1 + sqrt(5))/2) \/ (1; +oo)
x^5 - 5x^3 + 4x > 0                 "                           (-2; -1) \/ (0; 1) \/ (2; +oo)
x^4 - 10x^2 + 1 > 0                 "                           three intervals at ±sqrt(5 ± 2 sqrt(6))
x^5 - x - 1 > 0                     "                           still refused, with a message naming the real gap
```

Checked by 32 point-verified theory cases — 121 rational points each, membership against `EvalBoolean` — not by printed form.

**The suggestion I rejected, with the reason.** `Discriminant` for repeated-root detection in `AnalyticalEquationSolver` would be decorative: that solver already runs `TryFactorIntoIrreducibles`, whose `SquareFreeDecomposition` computes `gcd(f, f′)` — which *detects and divides out* multiplicity at any degree, where the discriminant only answers yes/no and only up to the resultant's size budget. The sign table is where the discriminant does work nothing else in the tree does: it is the **completeness certificate** for a real-root list, and without it the interval endpoints would be a guess.

Rothstein–Trager (item 44) is therefore no longer the argument for keeping the resultant.

## (b) `MathS.Polynomials`

`Factor`, `Gcd`, `Resultant`, `Discriminant`, `SquareFreePart` — five members, each with XML documentation and a worked example.

**Does it belong in the kernel? Yes, and the argument is that it adds nothing to it.** Every one is a thin adapter over code already compiled into `AngouriMath.dll` and already reached by `Simplify`, `Solve` and `Integrate`. No new machinery ships, the common case pays exactly what it paid before, and the trimmer's picture is unchanged because `Simplify`/`Solve` already reference the layer. Item 78 says a *large* thing landing in the kernel wants the package decision first (now #1008); this lands nothing.

What it does cost is a promise for the rest of 2.x, and that is bought with this issue's own complaint: the layer's genuine limits were previously invisible, showing up as a simplification that quietly did nothing.

**Refusals are honest — `null` means "I could not settle this", never "the answer is the input":**

```
Factor(x*y + y, x)     [multivariate]   = null        <- not "x * y + y"
Factor(sin(x) + 1, x)  [not polynomial] = null
Factor(x^33 - 1, x)    [past degree 32] = null
Gcd(<9 variables>, …)                   = null        <- 8 variables answers
Factor(x^2 + 1, x)     [irreducible]    = x ^ 2 + 1   <- an answer, not a refusal
Discriminant(x^2 + b*x + c, x)          = b ^ 2 - 4 * c
```

Telling *irreducible* from *declined* needed one change inside the layer: `PolynomialFactorization.Factor` returned `null` for both. `FactorComplete` now separates them; `Factor` is the same computation with the trivial factorisation rejected, and its existing callers are unchanged.

## Measured

**Suite**: 7615 passed, 0 failed, 14 skipped (baseline 7533/0/14) — +82, being 32 inequality cases, 44 surface cases and 6 that moved out of the "not supported" theory. F# wrapper 134/0.

Three tests in `KnownLimitsAreNotBugsTest` pinned the old refusal and now answer. They moved to `TheDegreesThatAreSupportedStillAnswer`, and the refusal theory now lists irreducible quintics, which is what the gap actually is.

**No regression on solving.** Both arms in one session, back to back:

| | alloc before | alloc after |
|---|---|---|
| SolveEasy | 8,852,269 B | 8,852,269 B |
| SolveEasyMedium | 95,795 B | 95,791 B |
| SolveMedium | 658,066 B | 658,066 B |
| SolveMediumHard | 162,305,664 B | 162,305,664 B |
| SolveHard | 1,431,857,768 B | 1,431,857,336 B |

**Read the allocation column, not the time column.** Byte-identical to within 0.005% on all five — the solving path does the same work, which is the actual answer to "did this regress solving". The timings on that pair moved by up to 9% in *both* directions with five to eight other agents building on the same 8 cores; `ParseEasy`, `SimplifyEasy` and `EvalEasy` moved by more than any `Solve` row with identical allocation, which no change here could cause. Nothing is claimed as a speed-up.

`PublicApi.txt` regenerated: **+5 members, +1 type, 0 removals.** `Sources/Package.Build.props` carried a figure of 103 additions since the 2.2.0 baseline that counted those same lines; it was true and this change falsified it, so it now reads 109.

## Not done, and why

- **No Sturm sequences, no degree ≥ 5.** Real-root isolation is separate work; the refusal says so.
- **`Entity.Factorize()` still does not use the polynomial layer.** `x^4 - 5x^2 + 4` comes back unchanged from it while `MathS.Polynomials.Factor` splits it into four linear factors. That is a real inconsistency and it lives in `Core/Transformations/**`, which another branch owned during this work — worth its own issue.
- **No `PartialFractions` on the public surface** — it needs a public type for the decomposition, which is a larger promise than five scalar-returning members.
