### PR TITLE
Build the terminal before merging, not at release time

### DIFF
--- a/.github/workflows/EverythingBuild.yml
+++ b/.github/workflows/EverythingBuild.yml
@@ -32,6 +32,14 @@ jobs:
     - name: Build Interactive
       run: dotnet build Sources/Wrappers/AngouriMath.Interactive/AngouriMath.Interactive.fsproj
 
+    # AngouriMath.Terminal is a published package -- Nuget.yml packs and pushes it as a
+    # dotnet tool -- and no pre-merge job built it. TerminalNightly.yml is the only job
+    # that does, and it fires on push to master behind a path filter on
+    # Sources/Terminal/VERSION/**, so a change that breaks the terminal is not seen until
+    # somebody bumps that file or cuts a release.
+    - name: Build Terminal
+      run: dotnet build Sources/Terminal/AngouriMath.Terminal/AngouriMath.Terminal.fsproj
+
     - name: Build Analyzers
       run: dotnet build Sources/Analyzers/Analyzers/Analyzers.csproj
 


### PR DESCRIPTION
`AngouriMath.Terminal` is one of the four published packages — `Nuget.yml` packs it as a dotnet tool
with the command name `amcli` and pushes it on release. **No pre-merge job compiled it.**

The only job that builds it is `TerminalNightly.yml`, and it fires on `push` to `master` behind a
path filter on `Sources/Terminal/VERSION/**`. So a change that breaks the terminal is not seen until
somebody bumps that file or cuts a release — and a release is the worst moment to find out, because
the tag is already published by then.

`EverythingBuild.yml` already builds the kernel, both wrappers, the analyzers, Utils and seven
samples on every pull request. The terminal is the one published thing missing from it.

This is the same gap the samples had, for the same reason. The comment above the samples step
records what that one cost: two samples called `integral(f, x, 1)`, which stopped parsing in 1.4.0,
and stayed broken for seven months because no job compiled them.

### Measured

On a fresh worktree at `6b93b401`:

```
dotnet build Sources/Terminal/AngouriMath.Terminal/AngouriMath.Terminal.fsproj
Build succeeded.
    4 Warning(s)
    0 Error(s)
Time Elapsed 00:00:24.18
```

The four warnings are `NU1608` — `FSharp.Compiler.Service 43.9.300` constrains `FSharp.Core` to
`9.0.300` and `10.1.302` resolves. They are pre-existing, they are not treated as errors on this
project, and this change does not fix them. It does make them visible on every pull request instead
of once a month, which is the point.

### Scope

One file, +8 lines, a single build step and the comment saying why it is there. Touches no file any
other open PR touches. No code, no behaviour change, no `BREAKING-CHANGES.md` entry.

Found while measuring the package boundaries for [#746](https://github.com/asc-community/AngouriMath/issues/746) item 78.