### PR TITLE
Name the ToString override a node has to carry

### DIFF
--- a/Sources/AngouriMath/Docs/Contributing/AddingNode.cs
+++ b/Sources/AngouriMath/Docs/Contributing/AddingNode.cs
@@ -25,6 +25,12 @@
 ///     c. Add <see cref="AngouriMath.Entity.Boolean.Replace"/> to your node
 ///     d. Add <see cref="AngouriMath.Entity.Boolean.Priority"/> to your node
 ///     e. Add <see cref="AngouriMath.Entity.Boolean.InitDirectChildren"/> to your node
+///     f. Add `public override string ToString() => Stringize();`. Every one of the 69 node types
+///        carries this line and nothing enforces it, because the failure is not a compiler error:
+///        Entity is a record, so C# synthesises ToString from PrintMembers, which prints every
+///        public property -- and Evaled and InnerSimplified are public and Entity-valued, so each
+///        calls ToString again. A node without the override does not print wrongly; it exhausts
+///        the stack.
 ///     
 /// 
 /// 3. A few essential methods


### PR DESCRIPTION
`Docs/Contributing/AddingNode.cs` exists to list *every* place a new node must be taught about —
`AGENTS.md` says to read it **before** adding one. It does not mention `ToString`.

Every one of the **69** node types carries `public override string ToString() => Stringize();`:

```
$ grep -rn "override string ToString" Sources/AngouriMath --include=*.cs | grep -c "=> Stringize();"
69
$ grep -c "ToString" Sources/AngouriMath/Docs/Contributing/AddingNode.cs
0
```

### Why omitting it is worse than a wrong string

`Entity` is a `record`, so C# synthesises `ToString` from `PrintMembers`, which prints every public
property. Two of `Entity`'s are `Entity`-valued:

```
Functions/Evaluation/Evaluation.Definition.cs:139:  public Entity Evaled => …
Functions/Evaluation/Evaluation.Definition.cs:168:  public Entity InnerSimplified => …
```

So the synthesised `ToString` calls `ToString` on each of them, which calls it on theirs, and so on.
A node missing the override does not print the wrong thing — it **exhausts the stack**, and it does so
at a call site nowhere near the node, which is the hard kind of failure to trace back.

Nothing enforces it. It is not a compiler error, no analyzer checks it, and the 69 existing
occurrences are the only reason it has never bitten: every node was copied from one that had it,
which is exactly the kind of invariant that survives until the first person who does not copy.

### Scope

One line of guidance in `AddingNode.cs`, +6 lines. No code, no behaviour change, no
`BREAKING-CHANGES.md` entry. Touches no file any other open PR touches.

Found while measuring what an `Entity` subclass outside the kernel assembly needs in order to work —
[#1026](https://github.com/asc-community/AngouriMath/issues/1026), and the design document for it is
#1040.