### PR TITLE
A rewrite rule that can be read backwards (#746 tier 2)

### DIFF
--- a/Sources/Analyzers/RuleRegistryGenerator/RuleRegistryGenerator.cs
+++ b/Sources/Analyzers/RuleRegistryGenerator/RuleRegistryGenerator.cs
@@ -461,8 +461,10 @@ namespace AngouriMath.Generators
         /// <remarks>
         /// A syntactic proxy, and deliberately a crude one: it counts what is written rather than
         /// what the expression evaluates to, so a rule whose replacement calls a helper is counted
-        /// as the call. It is enough for the question a saturation scheduler asks, which is which
-        /// pairs of rules are each other's inverse.
+        /// as the call. It says which way a rule moves and no more: two rules that both collect
+        /// need not be related at all, so a saturation scheduler asking which rule undoes which
+        /// gets no answer from this. That question needs a rule with two sides —
+        /// <c>Docs/Contributing/ReversibleRules.md</c>.
         /// </remarks>
         private static string Growth(PatternSyntax pattern, ExpressionSyntax replacement)
         {

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchPattern.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchPattern.cs
@@ -189,6 +189,103 @@ namespace AngouriMath.Core.Transformations.Matching
         /// <summary>The names this pattern binds, so a right-hand side can be checked for a typo.</summary>
         internal abstract IEnumerable<string> BoundNames { get; }
 
+        /// <summary>
+        /// Whether this pattern can be read as a <b>template</b> as well as a pattern — whether
+        /// <see cref="TryBuild"/> can put an expression together out of it.
+        /// </summary>
+        /// <remarks>
+        /// Structural, and independent of any bindings, so a rule is classified once where it is
+        /// written rather than once per expression it is asked about. False only where a node type
+        /// is one <see cref="Construct"/> does not build.
+        /// </remarks>
+        internal abstract bool IsBuildable { get; }
+
+        /// <summary>
+        /// The expression this pattern stands for under <paramref name="bindings"/>, or
+        /// <see langword="false"/> where those bindings do not satisfy it.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The other direction of <see cref="Match"/>, at the grain of one pattern: matching takes
+        /// an expression apart into bindings, and this puts one together out of them. A rule whose
+        /// two sides are both patterns therefore has two directions rather than one, which is what
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> tier 2 means
+        /// by a rule that can be read backwards.
+        /// </para>
+        /// <para>
+        /// <b>A hole's own constraint is checked here as well as when matching.</b> That is what
+        /// makes reversal lose nothing: a constraint is written once, on the side that states it,
+        /// and is enforced whenever that side is built — so the reverse of
+        /// <c>(a/b)^c -&gt; a^c/b^c</c> may match any <c>c</c> at all and still refuses to build
+        /// the quotient-of-powers unless <c>c</c> is the positive integer the forward rule
+        /// required.
+        /// </para>
+        /// </remarks>
+        internal abstract bool TryBuild(Bindings bindings, out Entity built);
+
+        /// <summary>
+        /// A node of <paramref name="nodeType"/> over <paramref name="children"/>, or
+        /// <see langword="null"/> where that is not a node this builds.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Written out rather than reflected. <c>Activator.CreateInstance</c> would build any node
+        /// type and would make this un-trimmable and un-AOT-publishable, which
+        /// <c>Docs/Contributing/Trimming.md</c> forbids for the kernel; and a node's constructor is
+        /// not reachable through <c>IUnaryNode</c> or <c>IBinaryNode</c>, which expose the children
+        /// and nothing else.
+        /// </para>
+        /// <para>
+        /// A node type absent from here is <b>matchable but not buildable</b>: a pattern over it is
+        /// still a rule's left-hand side, and <see cref="IsBuildable"/> is what says it cannot be a
+        /// right-hand side or be reached by reading a rule backwards. Adding a type is one line,
+        /// and <c>EveryDataRuleIsBuildableOnBothSides</c> is the test that says when one is owed.
+        /// </para>
+        /// </remarks>
+        private static Entity? Construct(Type nodeType, Entity[] children)
+        {
+            if (children.Length == 1)
+            {
+                var only = children[0];
+                return
+                    nodeType == typeof(Entity.Sinf) ? new Entity.Sinf(only) :
+                    nodeType == typeof(Entity.Cosf) ? new Entity.Cosf(only) :
+                    nodeType == typeof(Entity.Tanf) ? new Entity.Tanf(only) :
+                    nodeType == typeof(Entity.Cotanf) ? new Entity.Cotanf(only) :
+                    nodeType == typeof(Entity.Absf) ? new Entity.Absf(only) :
+                    nodeType == typeof(Entity.Signumf) ? new Entity.Signumf(only) :
+                    (Entity?)null;
+            }
+            if (children.Length == 2)
+            {
+                Entity first = children[0], second = children[1];
+                return
+                    nodeType == typeof(Entity.Sumf) ? new Entity.Sumf(first, second) :
+                    nodeType == typeof(Entity.Minusf) ? new Entity.Minusf(first, second) :
+                    nodeType == typeof(Entity.Mulf) ? new Entity.Mulf(first, second) :
+                    nodeType == typeof(Entity.Divf) ? new Entity.Divf(first, second) :
+                    nodeType == typeof(Entity.Powf) ? new Entity.Powf(first, second) :
+                    nodeType == typeof(Entity.Logf) ? new Entity.Logf(first, second) :
+                    (Entity?)null;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Whether <see cref="Construct"/> builds this type at this arity, asked by building one
+        /// over placeholders rather than by listing the types a second time — a list written twice
+        /// is a list that drifts.
+        /// </summary>
+        private static bool CanConstruct(Type nodeType, int arity)
+        {
+            if (arity is not (1 or 2))
+                return false;
+            var placeholders = new Entity[arity];
+            for (var i = 0; i < arity; i++)
+                placeholders[i] = Entity.Number.Integer.Zero;
+            return Construct(nodeType, placeholders) is not null;
+        }
+
         /// <summary>Whether it matches at all, which is <see cref="Match"/> asked for one answer.</summary>
         internal bool Matches(Entity expr) => Match(expr, Bindings.Empty).Any();
 
@@ -313,6 +410,21 @@ namespace AngouriMath.Core.Transformations.Matching
                 result = bindings.With(name, expr);
                 return true;
             }
+
+            internal override bool IsBuildable => true;
+
+            internal override bool TryBuild(Bindings bindings, out Entity built)
+            {
+                built = null!;
+                if (!bindings.TryGet(name, out var value)) return false;
+                // The same two constraints the match imposes, imposed again on the way out. A
+                // rule read backwards binds this hole from its other side, where the constraint
+                // is not written, so this is the only place left to enforce it.
+                if (required is not null && !required.IsInstanceOfType(value)) return false;
+                if (where is not null && !where(value)) return false;
+                built = value;
+                return true;
+            }
         }
 
         private sealed class ExactPattern : MatchPattern
@@ -343,6 +455,14 @@ namespace AngouriMath.Core.Transformations.Matching
                 result = bindings;
                 return value.Equals(expr);
             }
+
+            internal override bool IsBuildable => true;
+
+            internal override bool TryBuild(Bindings bindings, out Entity built)
+            {
+                built = value;
+                return true;
+            }
         }
 
         private sealed class NodePattern : MatchPattern
@@ -359,7 +479,12 @@ namespace AngouriMath.Core.Transformations.Matching
                 if (commutative && children.Length != 2)
                     throw new ArgumentException("commutative matching is over a two-child node",
                         nameof(children));
+                buildable = CanConstruct(nodeType, children.Length)
+                    && children.All(child => child.IsBuildable);
             }
+
+            /// <summary>Settled here because it depends on nothing that changes afterwards.</summary>
+            private readonly bool buildable;
 
             internal override IEnumerable<string> BoundNames => children.SelectMany(c => c.BoundNames);
 
@@ -416,6 +541,24 @@ namespace AngouriMath.Core.Transformations.Matching
                 for (var i = 0; i < children.Length; i++)
                     if (!children[i].TryMatchOnce(actual[i], result, out result))
                         return false;
+                return true;
+            }
+
+            internal override bool IsBuildable => buildable;
+
+            internal override bool TryBuild(Bindings bindings, out Entity built)
+            {
+                built = null!;
+                // The written order, and for a commutative node too. Both orders denote the same
+                // value, a template has to write one of them down, and the one the rule was
+                // written in is the one its author meant to read.
+                var parts = new Entity[children.Length];
+                for (var i = 0; i < children.Length; i++)
+                    if (!children[i].TryBuild(bindings, out parts[i]))
+                        return false;
+                if (Construct(nodeType, parts) is not { } node)
+                    return false;
+                built = node;
                 return true;
             }
         }
@@ -530,6 +673,32 @@ namespace AngouriMath.Core.Transformations.Matching
                 Entity expr, Bindings bindings, out Bindings result)
                 => throw new InvalidOperationException(
                     "a gathered pattern is a search and has to be asked through Match");
+
+            internal override bool IsBuildable => parts.All(part => part.IsBuildable);
+
+            internal override bool TryBuild(Bindings bindings, out Entity built)
+            {
+                built = null!;
+                Entity? chain = null;
+                foreach (var part in parts)
+                {
+                    if (!part.TryBuild(bindings, out var one)) return false;
+                    chain = chain is null ? one : Combine(chain, one);
+                }
+                if (!bindings.TryGet(restName, out var rest)) return false;
+                // The identity is dropped rather than written back. Matching a chain that holds
+                // nothing but the parts binds the rest to 0 or to 1 -- see Leftover -- and putting
+                // that in would build `sin(x)^2 + cos(x)^2 + 0`, which is the same value written
+                // worse. There is at least one part, so the chain is never empty.
+                built = IsIdentity(rest) ? chain! : Combine(chain!, rest);
+                return true;
+            }
+
+            private Entity Combine(Entity left, Entity right)
+                => OverSum ? new Entity.Sumf(left, right) : new Entity.Mulf(left, right);
+
+            private bool IsIdentity(Entity operand)
+                => operand.Equals(OverSum ? Entity.Number.Integer.Zero : Entity.Number.Integer.One);
 
             private sealed class Budget
             {

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
@@ -26,29 +26,68 @@ namespace AngouriMath.Core.Transformations.Matching
     /// same value and the field distinguishes nothing.
     /// </para>
     /// <para>
-    /// The right-hand side is a builder over the bindings rather than a second pattern. That is
-    /// a deliberate first step and not the end state: a rule whose right-hand side is also data
-    /// can be read backwards, which is what tier 2's "direction" field wants. Building it as
-    /// data before the matching half is proven would be guessing at two shapes at once.
+    /// <b>Where the right-hand side is a pattern too, the rule has two directions rather than
+    /// one.</b> <see cref="Reversed"/> is the same rule read the other way, and
+    /// <see cref="Reversal"/> says why a rule has no such reading when it has none. That is
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> tier 2's first
+    /// missing piece, and <c>Docs/Contributing/ReversibleRules.md</c> is the argument for when a
+    /// reversal is licensed.
     /// </para>
     /// </remarks>
     internal sealed class MatchedRule
     {
+        /// <summary>A rule whose right-hand side is a pattern, and which therefore has two directions.</summary>
+        internal MatchedRule(
+            string name,
+            MatchPattern left,
+            MatchPattern right,
+            Soundness soundness,
+            Func<Bindings, bool>? when = null)
+            : this(name, left, null, right ?? throw new ArgumentNullException(nameof(right)), soundness, when)
+        {
+            // A name the replacement reads and the pattern never binds is a typo, and it is a
+            // typo that would otherwise show up as a rule that silently never fires. Only a
+            // right-hand side written as data can be checked for it at all.
+            foreach (var wanted in right.BoundNames)
+                if (!left.BoundNames.Contains(wanted))
+                    throw new ArgumentException(
+                        $"'{name}' builds '{wanted}', which its pattern does not bind", nameof(right));
+        }
+
+        /// <summary>
+        /// A rule whose right-hand side is code. One-way: see <see cref="RuleReversal.ReplacementIsCode"/>.
+        /// </summary>
         internal MatchedRule(
             string name,
             MatchPattern left,
             Func<Bindings, Entity> right,
             Soundness soundness,
             Func<Bindings, bool>? when = null)
+            : this(name, left, right ?? throw new ArgumentNullException(nameof(right)), null, soundness, when)
+        {
+        }
+
+        private MatchedRule(
+            string name,
+            MatchPattern left,
+            Func<Bindings, Entity>? rightCode,
+            MatchPattern? rightPattern,
+            Soundness soundness,
+            Func<Bindings, bool>? when)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
             Left = left ?? throw new ArgumentNullException(nameof(left));
-            this.right = right ?? throw new ArgumentNullException(nameof(right));
+            this.right = rightCode;
+            Right = rightPattern;
             Soundness = soundness;
             this.when = when;
+            // Settled here rather than on first ask. It depends on nothing that changes
+            // afterwards, and a lazily cached enum is a field wider than a word: two threads
+            // arriving together could read a half-written one, where a reference cannot tear.
+            Reversal = Classify();
         }
 
-        private readonly Func<Bindings, Entity> right;
+        private readonly Func<Bindings, Entity>? right;
         private readonly Func<Bindings, bool>? when;
 
         /// <summary>What to call this rule in a report, a test or a bug.</summary>
@@ -56,6 +95,12 @@ namespace AngouriMath.Core.Transformations.Matching
 
         /// <summary>The shape it fires on.</summary>
         internal MatchPattern Left { get; }
+
+        /// <summary>
+        /// What it puts there instead, where that is a pattern — or <see langword="null"/> where
+        /// the replacement is code and there is nothing to match against.
+        /// </summary>
+        internal MatchPattern? Right { get; }
 
         /// <summary>How well justified this rule's claim is — per rule, which is the point.</summary>
         internal Soundness Soundness { get; }
@@ -75,8 +120,7 @@ namespace AngouriMath.Core.Transformations.Matching
             {
                 if (!Left.TryMatchOnce(expr, Bindings.Empty, out var only)) return null;
                 if (when is not null && !when(only)) return null;
-                try { return right(only); }
-                catch { return null; }
+                return Build(only);
             }
 
             // Every way the pattern matches, in order, and the first that also satisfies the
@@ -87,11 +131,112 @@ namespace AngouriMath.Core.Transformations.Matching
             {
                 if (when is not null && !when(bindings))
                     continue;
-                try { return right(bindings); }
-                catch { return null; }
+                // A match whose replacement cannot be built is a match that does not apply, and
+                // another way of matching may still. Only the last of them decides that the rule
+                // declines.
+                if (Build(bindings) is { } rewritten)
+                    return rewritten;
             }
             return null;
         }
+
+        /// <summary>
+        /// The replacement under these bindings, or <see langword="null"/> where it cannot be
+        /// built — which is the rule declining rather than an error, whichever form the
+        /// right-hand side takes.
+        /// </summary>
+        private Entity? Build(Bindings bindings)
+        {
+            if (Right is not null)
+                return Right.TryBuild(bindings, out var built) ? built : null;
+            try { return right!(bindings); }
+            catch { return null; }
+        }
+
+        /// <summary>
+        /// Whether this rule can be read backwards, and where it cannot, why not.
+        /// </summary>
+        /// <remarks>
+        /// <b>Derived from the two sides, not declared.</b> Every clause below is a property of
+        /// what the rule is written as, so the distinction between a one-way rewrite and a
+        /// two-way one is something a test can fail on rather than something a comment asserts.
+        /// </remarks>
+        internal RuleReversal Reversal { get; }
+
+        private RuleReversal Classify()
+        {
+            if (Right is null)
+                return RuleReversal.ReplacementIsCode;
+            // Set equality, and the direction that can fail is the one checked: a name the
+            // replacement builds and the pattern does not bind is refused in the constructor, so
+            // what is left is a name the pattern binds and the replacement throws away.
+            foreach (var bound in Left.BoundNames)
+                if (!Right.BoundNames.Contains(bound))
+                    return RuleReversal.ReplacementDropsHoles;
+            if (!Left.IsBuildable || !Right.IsBuildable)
+                return RuleReversal.PatternCannotBeBuilt;
+            return RuleReversal.Reversible;
+        }
+
+        /// <summary>
+        /// This rule read the other way, or <see langword="null"/> where it has no such reading.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The two sides swap and nothing else does. The side condition is carried over
+        /// unchanged, because it is a predicate on the bindings and both directions produce the
+        /// same bindings; and <see cref="Soundness"/> is carried over unchanged, because what a
+        /// rewrite rule claims is an equality and an equality is symmetric.
+        /// </para>
+        /// <para>
+        /// <b>What does not carry over is termination.</b> A rule that collects becomes one that
+        /// expands, so a reversed rule composed with the rule it came from does not reach a fixed
+        /// point — <c>k*p + k*q</c> and <c>k*(p + q)</c> rewrite to each other forever. A reversed
+        /// set is a thing to ask questions of, not one to run to stability.
+        /// </para>
+        /// </remarks>
+        internal MatchedRule? Reversed
+            => Reversal is RuleReversal.Reversible
+                ? reversed ??= new MatchedRule($"reversed {Name}", Right!, Left, Soundness, when)
+                : null;
+
+        private MatchedRule? reversed;
+    }
+
+    /// <summary>
+    /// Whether a <see cref="MatchedRule"/> can be read backwards, and where it cannot, what stops
+    /// it.
+    /// </summary>
+    /// <remarks>
+    /// <b>Not every rewrite has an inverse worth having, and this says which do.</b>
+    /// <c>x - x -&gt; 0</c> is a rewrite nobody wants to read backwards and nobody could: from
+    /// <c>0</c> there is no recovering which <c>x</c> was cancelled. That is
+    /// <see cref="ReplacementDropsHoles"/>, and it is a fact about the rule rather than a
+    /// judgement about it.
+    /// </remarks>
+    internal enum RuleReversal
+    {
+        /// <summary>Both sides are patterns over the same holes, and both can be built.</summary>
+        Reversible,
+
+        /// <summary>
+        /// The replacement is a builder over the bindings rather than a pattern, so there is
+        /// nothing to match an expression against.
+        /// </summary>
+        ReplacementIsCode,
+
+        /// <summary>
+        /// The replacement does not mention every hole the pattern binds, so reading it backwards
+        /// would have to invent what the forward direction discarded. The Pythagorean identity is
+        /// the standing example: <c>sin(x)^2 + cos(x)^2 -&gt; 1</c> forgets the angle.
+        /// </summary>
+        ReplacementDropsHoles,
+
+        /// <summary>
+        /// One of the two sides is over a node type this cannot construct, so it can be matched
+        /// and not written. See <c>MatchPattern.Construct</c>.
+        /// </summary>
+        PatternCannotBeBuilt
     }
 
     /// <summary>
@@ -129,6 +274,31 @@ namespace AngouriMath.Core.Transformations.Matching
 
         /// <summary>The rules, in the order they are tried. <b>Enumerable</b>, which is the whole point.</summary>
         internal IReadOnlyList<MatchedRule> Rules => rules;
+
+        /// <summary>
+        /// The rules of this set that can be read backwards, read backwards — so that
+        /// <see cref="ApplyHere(Entity)"/> on it answers <i>what could this expression have come
+        /// from</i> rather than <i>what does it become</i>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Smaller than the set it comes from whenever some of its rules are one-way, and
+        /// <see cref="MatchedRule.Reversal"/> on each says which. A set none of whose rules
+        /// reverses has no rules here, which is the difference being reported rather than hidden.
+        /// </para>
+        /// <para>
+        /// <b>Not a rule set to run.</b> It is first-match-wins like any other, so applying it and
+        /// then the set it came from need not return what you started with — the two sets order
+        /// their rules independently. And every rule in it undoes one in the set it came from, so
+        /// composing the two does not terminate. What it is for is asking.
+        /// </para>
+        /// </remarks>
+        internal MatchedRuleSet Reversed
+            => reversed ??= new MatchedRuleSet(
+                $"reversed {Name}",
+                rules.Select(rule => rule.Reversed).OfType<MatchedRule>().ToArray());
+
+        private MatchedRuleSet? reversed;
 
         /// <summary>
         /// The weakest tier any of its rules is justified at — derived rather than declared,

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -28,6 +28,13 @@ namespace AngouriMath.Core.Transformations.Matching
     /// against the code it would replace.
     /// </para>
     /// <para>
+    /// <b>Both sides of every rule here are patterns</b>, so thirteen of the fourteen can be read
+    /// backwards — <see cref="MatchedRule.Reversed"/>, and
+    /// <c>Docs/Contributing/ReversibleRules.md</c> for what that requires and what it does not
+    /// claim. The fourteenth is the Pythagorean identity, which cannot, for a reason that is about
+    /// the mathematics rather than about the encoding.
+    /// </para>
+    /// <para>
     /// <b>What it costs to actually use one of these has been measured, once, end to end.</b>
     /// <see cref="DivisionPreparing"/> was put in place of its <c>switch</c> in
     /// <c>RewriteRules.DivisionPreparing</c> — which <c>Simplificator</c> runs twice per
@@ -59,7 +66,7 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Mulf>(
                     MatchPattern.Any("a"),
                     MatchPattern.Node<Divf>(MatchPattern.Exact(Integer.Create(1)), MatchPattern.Any("b"))),
-                bound => bound["a"] / bound["b"],
+                MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
                 // a * (1/b) and a/b are undefined at exactly the same points, but the quotient
                 // is a quotient either way, so this inherits division's own condition rather
                 // than adding one. Left at the conservative tier until the audit reaches it.
@@ -71,7 +78,9 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Divf>(
                     MatchPattern.Node<Mulf>(MatchPattern.Any<Number>("c"), MatchPattern.Any("a")),
                     MatchPattern.Any("b")),
-                bound => bound["c"] * (bound["a"] / bound["b"]),
+                MatchPattern.Node<Mulf>(
+                    MatchPattern.Any("c"),
+                    MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
                 Soundness.SoundUnderAssumptions),
 
             // (c / a) * b -> c * (b / a), for a numeric c
@@ -80,7 +89,9 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Mulf>(
                     MatchPattern.Node<Divf>(MatchPattern.Any<Number>("c"), MatchPattern.Any("a")),
                     MatchPattern.Any("b")),
-                bound => bound["c"] * (bound["b"] / bound["a"]),
+                MatchPattern.Node<Mulf>(
+                    MatchPattern.Any("c"),
+                    MatchPattern.Node<Divf>(MatchPattern.Any("b"), MatchPattern.Any("a"))),
                 Soundness.SoundUnderAssumptions));
 
         /// <summary>
@@ -109,7 +120,9 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Powf>(
                     MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
                     MatchPattern.Any<Integer>("c", whole => whole.IsPositive)),
-                bound => bound["a"].Pow(bound["c"]) / bound["b"].Pow(bound["c"]),
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("c")),
+                    MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("c"))),
                 Soundness.SoundUnderAssumptions),
 
             // (a * b) ^ c -> a^c * b^c, for a positive whole c
@@ -118,7 +131,9 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Powf>(
                     MatchPattern.Node<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
                     MatchPattern.Any<Integer>("c", whole => whole.IsPositive)),
-                bound => bound["a"].Pow(bound["c"]) * bound["b"].Pow(bound["c"]),
+                MatchPattern.Node<Mulf>(
+                    MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("c")),
+                    MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("c"))),
                 Soundness.SoundUnderAssumptions),
 
             // (a/b) * (c/d) -> (a*c) / (b*d). Before the two below it, which are more general.
@@ -127,7 +142,9 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Mulf>(
                     MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
                     MatchPattern.Node<Divf>(MatchPattern.Any("c"), MatchPattern.Any("d"))),
-                bound => bound["a"] * bound["c"] / (bound["b"] * bound["d"]),
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("c")),
+                    MatchPattern.Node<Mulf>(MatchPattern.Any("b"), MatchPattern.Any("d"))),
                 Soundness.SoundUnderAssumptions),
 
             new MatchedRule(
@@ -135,7 +152,9 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Mulf>(
                     MatchPattern.Any("a"),
                     MatchPattern.Node<Divf>(MatchPattern.Any("b"), MatchPattern.Any("c"))),
-                bound => bound["a"] * bound["b"] / bound["c"],
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
+                    MatchPattern.Any("c")),
                 Soundness.SoundUnderAssumptions),
 
             new MatchedRule(
@@ -143,7 +162,9 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Mulf>(
                     MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
                     MatchPattern.Any("c")),
-                bound => bound["a"] * bound["c"] / bound["b"],
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("c")),
+                    MatchPattern.Any("b")),
                 Soundness.SoundUnderAssumptions),
 
             // (a/b) / (c/d) -> (a*d) / (b*c). Likewise before the two below it.
@@ -152,7 +173,9 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Divf>(
                     MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
                     MatchPattern.Node<Divf>(MatchPattern.Any("c"), MatchPattern.Any("d"))),
-                bound => bound["a"] * bound["d"] / (bound["b"] * bound["c"]),
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("d")),
+                    MatchPattern.Node<Mulf>(MatchPattern.Any("b"), MatchPattern.Any("c"))),
                 Soundness.SoundUnderAssumptions),
 
             new MatchedRule(
@@ -160,7 +183,9 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Divf>(
                     MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
                     MatchPattern.Any("c")),
-                bound => bound["a"] / (bound["b"] * bound["c"]),
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Any("a"),
+                    MatchPattern.Node<Mulf>(MatchPattern.Any("b"), MatchPattern.Any("c"))),
                 Soundness.SoundUnderAssumptions),
 
             new MatchedRule(
@@ -168,7 +193,9 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Divf>(
                     MatchPattern.Any("a"),
                     MatchPattern.Node<Divf>(MatchPattern.Any("b"), MatchPattern.Any("c"))),
-                bound => bound["a"] * bound["c"] / bound["b"],
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("c")),
+                    MatchPattern.Any("b")),
                 Soundness.SoundUnderAssumptions));
 
         /// <summary>
@@ -202,7 +229,9 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Powf>(
                     MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
                     MatchPattern.Any("c")),
-                bound => new Powf(bound["a"], bound["b"] * bound["c"]),
+                MatchPattern.Node<Powf>(
+                    MatchPattern.Any("a"),
+                    MatchPattern.Node<Mulf>(MatchPattern.Any("b"), MatchPattern.Any("c"))),
                 Soundness.SoundUnderAssumptions,
                 // Two bindings at once, which no predicate on a single hole can express.
                 when: bound => bound["c"] is Integer
@@ -235,7 +264,9 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Commutative<Sumf>(
                     MatchPattern.Commutative<Mulf>(MatchPattern.Any("k"), MatchPattern.Any("p")),
                     MatchPattern.Commutative<Mulf>(MatchPattern.Any("k"), MatchPattern.Any("q"))),
-                bound => bound["k"] * (bound["p"] + bound["q"]),
+                MatchPattern.Node<Mulf>(
+                    MatchPattern.Any("k"),
+                    MatchPattern.Node<Sumf>(MatchPattern.Any("p"), MatchPattern.Any("q"))),
                 Soundness.Sound));
 
         /// <summary>
@@ -262,6 +293,13 @@ namespace AngouriMath.Core.Transformations.Matching
         /// <see cref="Soundness.Sound"/>: <c>sin²+cos² = 1</c> holds for every complex argument,
         /// with no branch to choose and no point excluded.
         /// </para>
+        /// <para>
+        /// <b>The one rule here with no backwards reading</b>, and the reason is the identity
+        /// rather than the way it is written: <c>1</c> does not say which angle it came from, so
+        /// <c>x</c> is bound on the left and mentioned nowhere on the right.
+        /// <see cref="MatchedRule.Reversal"/> is <see cref="RuleReversal.ReplacementDropsHoles"/>
+        /// and <see cref="MatchedRule.Reversed"/> is <see langword="null"/>.
+        /// </para>
         /// </remarks>
         internal static MatchedRuleSet PythagoreanIdentity { get; } = new(
             nameof(PythagoreanIdentity),
@@ -279,7 +317,7 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Exact(Integer.Create(2)))),
                 // "x" is bound by the first part and re-matched by the second, so the two terms
                 // are required to be about the same argument rather than merely both squared.
-                bound => 1 + bound["rest"],
+                MatchPattern.Node<Sumf>(MatchPattern.Exact(Integer.Create(1)), MatchPattern.Any("rest")),
                 Soundness.Sound));
     }
 }

--- a/Sources/AngouriMath/Docs/Contributing/README.md
+++ b/Sources/AngouriMath/Docs/Contributing/README.md
@@ -22,8 +22,11 @@ If you aren't sure about what to add, you may want to check the current projects
    `IsAotCompatible`, what checks it, and the four shapes of run-time name lookup that break it
 8. <a href="./coding_rules.md">Coding rules</a> — sealed-or-abstract, immutability, and what may be
    made `public`
-8. <a href="./Packaging.md">What ships in which package</a> — the four published packages, what the
+9. <a href="./Packaging.md">What ships in which package</a> — the four published packages, what the
    kernel measurably costs a caller, and the rule deciding where the next capability goes
+10. <a href="./ReversibleRules.md">Reading a rewrite rule backwards</a> — what a rule has to carry
+   before it can be read the other way, which rules can carry it, and what the mechanism costs the
+   fast path
 
 See also <a href="../../../../BREAKING-CHANGES.md">BREAKING-CHANGES.md</a>, where a change that makes
 the same input give a different answer is recorded, and

--- a/Sources/AngouriMath/Docs/Contributing/ReversibleRules.md
+++ b/Sources/AngouriMath/Docs/Contributing/ReversibleRules.md
@@ -1,0 +1,168 @@
+# Reading a rewrite rule backwards
+
+[#746](https://github.com/asc-community/AngouriMath/issues/746) tier 2 names this as the first thing
+missing from the rewrite graph:
+
+> a rule that can be *matched* rather than only run — its pattern is a C# source string today and its
+> replacement is a closure, so **no rule can be read backwards**
+
+This file says what a rule has to carry before it can be read backwards, which rules can carry it,
+which cannot and why not, and what the mechanism costs the fast path. Read
+[`Transformations.md`](Transformations.md) first for the layer it sits in and
+[`SimplificationContract.md`](SimplificationContract.md) for what a rewrite may assume.
+
+## Where the library stands
+
+Measured on this checkout, and the commands are in the tests named below.
+
+| | |
+|---|--:|
+| rule sets registered in `RewriteRules.All` | 30 |
+| of those, addressable at rule grain | 29 |
+| addressable rules in total | 405 |
+| **of those, readable backwards** | **0** |
+| rule sets expressed as data in `Core/Transformations/Matching` | 5 |
+| rules in them | 14 |
+| **of those, readable backwards** | **13** |
+| registered rule sets that use the matcher at run time | 0 |
+
+The 405 cannot be read backwards for a reason no amount of care about the rules would fix. They are
+generated from the `switch` arms that define them, and an arm is a C# pattern and a C# expression:
+`RewriteRule.PatternSource` and `RewriteRule.ReplacementSource` are the *text* of those, named
+`Source` for exactly this reason. Text is something to print in a report, not something to match an
+expression against.
+
+## What a rule has to carry
+
+Four things, and the first two are the whole of it.
+
+**Both sides have to be patterns.** A `MatchPattern` is a term with named holes; it can be matched
+against an expression, which takes the expression apart into `Bindings`, and — since
+`MatchPattern.TryBuild` — it can be read as a template, which puts an expression together out of
+bindings. A rule whose two sides are both patterns is a pair of terms rather than a pattern and a
+procedure, and swapping them is the whole of reversal.
+
+**Both sides have to bind the same holes.** This is the condition that decides which rewrites have a
+backward reading and it is decidable from the two sides. If the replacement drops a hole the pattern
+binds, the backward direction would have to invent what the forward direction discarded:
+`sin(x)^2 + cos(x)^2 -> 1` cannot be read backwards because `1` does not say which angle, and
+`x - x -> 0` cannot for the same reason. The other direction — a replacement naming a hole the
+pattern never binds — is a typo, and the constructor refuses it. That check is only possible at all
+because the replacement is data: a builder over the bindings fails on the first expression that
+reaches it, or never.
+
+**A hole's constraint is written once, on the side that states it.**
+`(a/b)^c = a^c/b^c` needs a positive whole `c`, and that is written on the left, where the rule is
+written. Read backwards the rule matches `a^c/b^c` for any `c` at all — and then refuses to *build*
+`(a/b)^c` unless `c` passes. `MatchPattern.TryBuild` checks a hole's node type and its predicate on
+the way out as well as on the way in, so no constraint is lost by reversing and none is written
+twice.
+
+**Both sides have to be constructible.** `MatchPattern.Construct` builds a node from its children,
+written out as a switch over the node types rather than reflected, because
+[`Trimming.md`](Trimming.md) forbids reflection in the kernel and `IUnaryNode`/`IBinaryNode` expose
+the children and no constructor. A pattern over a node type absent from that switch is matchable and
+not writable, which is a gap in the mechanism rather than a fact about the mathematics — so it is
+reported as its own reason.
+
+## What the type says
+
+`MatchedRule.Reversal` is **derived from the two sides, never declared**, so the difference between a
+one-way rewrite and a two-way one is something a test fails on:
+
+| `RuleReversal` | means |
+|---|---|
+| `Reversible` | both sides are patterns over the same holes, and both can be built. `Reversed` is the rule with the sides swapped |
+| `ReplacementIsCode` | the replacement is a builder over the bindings, so there is nothing to match against |
+| `ReplacementDropsHoles` | the replacement does not mention every hole the pattern binds |
+| `PatternCannotBeBuilt` | one side is over a node type `Construct` does not build |
+
+`MatchedRule.Reversed` is `null` for every value but the first, and `MatchedRuleSet.Reversed` is the
+set of those of its rules that have one — smaller than the set it came from wherever some do not,
+and empty rather than absent where none do.
+
+## Why the reversal is licensed
+
+The forward rule claims `left = right` under its side condition. Two things follow, and they are the
+argument for carrying each over unchanged:
+
+- **The side condition carries over verbatim.** It is a predicate on the bindings, and matching the
+  right-hand side produces the same bindings that matching the left-hand side does. So the reversed
+  rule is guarded by exactly what the forward rule was guarded by, and `(a^b)^c = a^(b*c)` read
+  backwards still refuses `x^(y*z)`.
+- **`Soundness` carries over unchanged**, because what the rule claims is an equality and an equality
+  is symmetric. A rule sound wherever both sides are defined is sound wherever both sides are defined
+  read either way; the set of points is the same set.
+
+**This is a property of a rule, not of a transformation.** `Expand` and `Factorize` are still not
+inverses, `Unsolve` is still not well defined, and nothing here invents a symmetry the mathematics
+does not have — see [AGENTS.md](../../../../AGENTS.md). What it says is narrower and checkable:
+`k*p + k*q -> k*(p + q)` and `k*(p + q) -> k*p + k*q` are one rule read two ways, and the library can
+now say so.
+
+## What does not carry over
+
+**Termination.** A rule that collects becomes one that expands. Composing a rule with its own
+reversal does not reach a fixed point — `k*p + k*q` and `k*(p + q)` rewrite to each other forever —
+so `RuleConfluenceTest`, which asserts that every set in `RewriteRules.All` reaches one, must not be
+pointed at a reversed set. A reversed set is a thing to ask questions of, not one to run to
+stability.
+
+**Round-tripping through a *set*.** A reversed rule undoes the rule it came from, checked by value
+over generated expressions in `ReversibleRuleTest`. A reversed *set* need not undo the set it came
+from: both are first-match-wins and they order their rules independently, so a different rule may
+answer first.
+
+**The written order of a commutative operand.** Reversing a rule whose pattern is commutative writes
+the operands in the order the rule was written in, so `a*x + b*x` comes back as `x*a + x*b` — the
+same number written differently. The tests compare values, not trees, for exactly this reason.
+
+**Usefulness.** `a/b -> a*(1/b)` is reversible and is not a rewrite anyone wants to run. Whether a
+backward reading is worth taking is the caller's question; whether it exists is this file's.
+
+## What it costs the fast path
+
+Nothing, because nothing on the fast path reaches it. No type in
+`Core/Transformations/Matching` is referenced anywhere in `Sources/AngouriMath` outside that
+directory: 0 of the 30 registered rule sets use the matcher at run time, and the rule sets expressed
+as data are a statement *about* the `switch` sets rather than a replacement for them. That is the
+answer to #746's standing condition that the fast path survives as a path, and it is why the
+`switch` stays the thing the simplifier calls.
+
+The measurement, because "it should not cost anything" is not a measurement. Three copies of the
+kernel in one process — the commit before this work, this work, and a byte-identical copy of the
+first as a control — asked to `Simplify` seven expressions, sixty rounds, arm order rotating:
+
+| arm | median | min | vs before | allocated | distinct values |
+|---|--:|--:|--:|--:|--:|
+| before | 347.5 ms | 344.1 ms | — | 658,407,960 B | 1 |
+| after | 347.1 ms | 344.0 ms | −0.13% | 658,407,960 B | 1 |
+| control (a byte-identical copy of *before*) | 345.9 ms | 343.3 ms | −0.47% | 658,407,960 B | 1 |
+
+**Allocation is identical to the byte**, one distinct value per arm across all sixty rounds, and that
+is the column to read: it is deterministic where a timing on an ordinary machine is not. The control
+arm differs from the code it is a copy of by 0.47%, so half a percent is what this machine's noise
+looks like and the 0.13% is not a signal. For contrast, the one exchange that put a rule set
+expressed as data on the simplifier's path was measured at **+5% of `Simplify`** for that one set of
+thirty, and was reverted.
+
+## What is deliberately not built
+
+**No production caller.** [`Packaging.md`](Packaging.md) and #746's own counterweight both say
+speculative code without a consumer is not an asset, so this is one mechanism and its tests rather
+than a framework. The consumer tier 2 names next is the inverse-pair table an e-graph needs: equality
+saturation keeps both results where a pipeline keeps one, so it has to be told which rewrites undo
+each other or it grows without bound.
+
+`RewriteRuleGrowth` is what that question has today, and it does not answer it. Growth says a rule
+was written smaller or larger than its pattern; it does not say *which* rule is the inverse of
+*which*, and two rules can both collect without being related at all. A reversible rule is the
+answer, because its inverse is the rule itself read the other way.
+
+**No reversal for the 405.** Nothing here changes what `RewriteRules.All` can do. Making one of those
+sets reversible means writing it as data, which puts it on the matcher — and that is the exchange
+measured at 5%, so it is a decision about that set rather than a mechanical migration.
+
+**No `Sound` promotions and no per-rule tiers argued.** Reversal carries the tier over; it does not
+justify one. Per-rule soundness is tier 2's next item and wants an argument per rule, which is
+writing rather than plumbing.

--- a/Sources/AngouriMath/Docs/Contributing/Transformations.md
+++ b/Sources/AngouriMath/Docs/Contributing/Transformations.md
@@ -157,6 +157,14 @@ about what the operation does. Same for `Isolate`, `Eliminate` and `Parametrize`
 a well-defined operation. Where an inverse is mathematically meaningful there is room to add one; the
 API does not invent symmetry that the mathematics does not have.
 
+An individual *rule* is a different question, and one that has an answer: a rule both of whose sides
+are patterns over the same holes can be read backwards, and thirteen of the fourteen rules written as
+data can be. `k*p + k*q -> k*(p + q)` and its reverse are one rule read two ways; the Pythagorean
+identity is not, because `1` does not say which angle it came from. See
+[`ReversibleRules.md`](ReversibleRules.md) for what that requires, why the reversal is licensed, and
+what it deliberately does not claim. None of the 405 rules in `RewriteRules.All` can be read
+backwards, because their replacement is C# source text.
+
 **`Heuristic` currently has no instance in the catalogue.** That is a statement about what is
 registered so far, not a claim that nothing in the library guesses.
 
@@ -232,6 +240,11 @@ So what is left, in dependency order:
   back to. `Simplify` never needs one, because it does not backtrack — it generates candidates and
   ranks them — so the case that wants it is the solvers, and it belongs with the tactic layer rather
   than in front of it.
+- **A production caller for a rule read backwards** — the mechanism exists and nothing uses it. The
+  consumer #746 tier 2 names is the inverse-pair table equality saturation needs, since a saturation
+  engine keeps both results where this pipeline keeps one and so has to be told which rewrites undo
+  each other. `RewriteRuleGrowth` does not answer that: it says which way a rule moves, not which
+  rule is the inverse of which.
 - **Rendering a step as a sentence** — #746's v5.0. Everything a sentence needs is now on a step
   except one thing: *why the rewrite is allowed*. `Soundness` is declared, not checked, and a rule
   that holds only under an assumption does not say which. That is the same gap

--- a/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
@@ -1,0 +1,306 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath.Core.Transformations;
+using AngouriMath.Core.Transformations.Matching;
+using AngouriMath.Extensions;
+using Xunit;
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// A rule read backwards: what an expression could have <b>come from</b>, rather than what it
+    /// becomes. https://github.com/asc-community/AngouriMath/issues/746 tier 2 names this as its
+    /// first missing piece, and nothing in the library answers it today — the 405 addressable
+    /// rules in <see cref="RewriteRules"/> carry their replacement as C# source text, which is
+    /// something to read and not something to match against.
+    /// </summary>
+    /// <remarks>
+    /// Two claims are under test and they are different. That a rule <i>can</i> be reversed is
+    /// structural, decided from the two sides, and asserted rule by rule below. That the reversal
+    /// is <i>right</i> is mathematics, and is checked by value rather than by shape: the forward
+    /// rewrite and the backward one have to name the same number at the same point.
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class ReversibleRuleTest
+    {
+        private static IEnumerable<MatchedRuleSet> DataRuleSets()
+        {
+            yield return MatchedRules.DivisionPreparing;
+            yield return MatchedRules.CollapseMultipleFractions;
+            yield return MatchedRules.PowerOfPower;
+            yield return MatchedRules.SharedFactor;
+            yield return MatchedRules.PythagoreanIdentity;
+        }
+
+        private static readonly string[] Leaves = { "x", "y", "z", "2", "-1", "1/2", "1", "0" };
+
+        private static readonly string[] Binary =
+        {
+            "({0}) + ({1})", "({0}) - ({1})", "({0}) * ({1})", "({0}) / ({1})", "({0}) ^ ({1})",
+        };
+
+        private static List<Entity> Corpus()
+        {
+            var level1 = new List<string>(Leaves);
+            var level2 = new List<string>();
+            foreach (var shape in Binary)
+                foreach (var left in level1)
+                    foreach (var right in level1)
+                        level2.Add(string.Format(shape, left, right));
+            var level3 = new List<string>();
+            foreach (var shape in Binary)
+                foreach (var left in level2.Where((_, i) => i % 13 == 0))
+                    foreach (var right in level2.Where((_, i) => i % 19 == 0))
+                        level3.Add(string.Format(shape, left, right));
+
+            var parsed = new List<Entity>();
+            foreach (var source in level1.Concat(level2).Concat(level3))
+            {
+                try { parsed.Add(source.ToEntity()); }
+                catch { /* the generator makes some strings the parser declines; not its subject */ }
+            }
+            return parsed;
+        }
+
+        /// <summary>
+        /// Which of the rules written as data have two directions, listed one by one rather than
+        /// counted — a count agrees with itself after a rule changes shape and a list does not.
+        /// </summary>
+        [Fact]
+        public void EveryDataRuleIsClassifiedAsWritten()
+        {
+            var actual = DataRuleSets()
+                .SelectMany(set => set.Rules)
+                .ToDictionary(rule => rule.Name, rule => rule.Reversal);
+
+            var oneWay = actual.Where(pair => pair.Value is not RuleReversal.Reversible).ToList();
+
+            // The only rule here that cannot be read backwards, and the reason is the
+            // mathematics rather than the encoding: 1 does not say which angle it came from.
+            Assert.Equal(
+                new[] { "squared-sine-and-cosine-of-one-argument-sum-to-one" },
+                oneWay.Select(pair => pair.Key).ToArray());
+            Assert.Equal(RuleReversal.ReplacementDropsHoles, oneWay[0].Value);
+            Assert.Equal(13, actual.Count(pair => pair.Value is RuleReversal.Reversible));
+        }
+
+        /// <summary>
+        /// <b>The question no existing API answers.</b> Every entry point in the library runs
+        /// forwards: <c>Simplify</c>, <c>Expand</c> and <c>Factorize</c> all take an expression to
+        /// another one. This asks the other way — given an expression, which expression does one
+        /// rule of this set turn into it.
+        /// </summary>
+        /// <remarks>
+        /// <c>k*p + k*q -&gt; k*(p + q)</c> read backwards is the distributive law, and reading it
+        /// backwards is the only way the library has of knowing that the two are the same fact.
+        /// The forward rule is written four times in <c>Patterns.CommonRules</c> and nine times in
+        /// <c>Patterns.FactorizeRules</c>, none of which knows about the expansion that undoes it.
+        /// </remarks>
+        [Fact]
+        public void AReversedRuleSaysWhatAnExpressionCameFrom()
+        {
+            var factoring = MatchedRules.SharedFactor.Rules.Single();
+            Assert.Equal("x * (a + b)".ToEntity(), factoring.TryApply("x * a + x * b".ToEntity()));
+
+            var expanding = factoring.Reversed;
+            Assert.NotNull(expanding);
+            Assert.Equal("x * a + x * b".ToEntity(), expanding!.TryApply("x * (a + b)".ToEntity()));
+
+            // And the set, so that the question can be asked of a whole set of rules at once.
+            Assert.Equal(
+                "x * a + x * b".ToEntity(),
+                MatchedRules.SharedFactor.Reversed.ApplyHere("x * (a + b)".ToEntity()));
+        }
+
+        /// <summary>
+        /// A rule that throws information away has no backwards reading, and the type says so
+        /// rather than a comment saying so.
+        /// </summary>
+        [Fact]
+        public void ARuleThatForgetsAHoleHasNoBackwardsReading()
+        {
+            var pythagoras = MatchedRules.PythagoreanIdentity.Rules.Single();
+            Assert.Equal(RuleReversal.ReplacementDropsHoles, pythagoras.Reversal);
+            Assert.Null(pythagoras.Reversed);
+
+            // And the reversed set is empty rather than absent, which is the difference being
+            // reported rather than hidden.
+            Assert.Empty(MatchedRules.PythagoreanIdentity.Reversed.Rules);
+            Assert.Equal(
+                "1 + a".ToEntity(),
+                MatchedRules.PythagoreanIdentity.Reversed.ApplyHere("1 + a".ToEntity()));
+        }
+
+        /// <summary>
+        /// The reversal of a reversal is the rule it came from — not merely classified the same
+        /// way, but rewriting every expression in the corpus to the same thing.
+        /// </summary>
+        [Fact]
+        public void ReversingTwiceGivesTheRuleBack()
+        {
+            var corpus = Corpus();
+            Assert.True(corpus.Count > 500, $"the corpus is only {corpus.Count} expressions");
+
+            foreach (var rule in DataRuleSets().SelectMany(set => set.Rules))
+            {
+                if (rule.Reversed is not { } once) continue;
+                var twice = once.Reversed;
+                Assert.NotNull(twice);
+                foreach (var expr in corpus)
+                    Assert.Equal(rule.TryApply(expr), twice!.TryApply(expr));
+            }
+        }
+
+        /// <summary>
+        /// A reversed rule undoes the rule it came from, <b>by value</b>. Not by shape: reversing
+        /// a rule whose pattern is commutative writes the operands in the order the rule was
+        /// written in, so <c>a*x + b*x</c> comes back as <c>x*a + x*b</c>, which is the same
+        /// number written differently and would fail a comparison of trees.
+        /// </summary>
+        [Fact]
+        public void AReversedRuleUndoesTheRuleItCameFrom()
+        {
+            var corpus = Corpus();
+            var checkedPairs = 0;
+            var rewritten = 0;
+            var failures = new List<string>();
+
+            foreach (var rule in DataRuleSets().SelectMany(set => set.Rules))
+            {
+                if (rule.Reversed is not { } backwards) continue;
+                foreach (var expr in corpus)
+                {
+                    if (rule.TryApply(expr) is not { } forward) continue;
+                    if (backwards.TryApply(forward) is not { } back) continue;
+                    checkedPairs++;
+                    // The tree came back unchanged, which is the strongest answer there is and
+                    // needs no arithmetic -- and asking for arithmetic anyway would fail on the
+                    // corpus's expressions that have no value, such as anything over a literal 0.
+                    if (expr.Equals(back)) continue;
+                    rewritten++;
+                    if ((expr - back).Simplify() != Integer.Zero)
+                        failures.Add($"{rule.Name}: {expr.Stringize()} -> {forward.Stringize()} "
+                            + $"-> {back.Stringize()}");
+                }
+            }
+
+            Assert.True(checkedPairs > 100, $"only {checkedPairs} round trips were available");
+            // Without one of these the value check is a check of nothing: every round trip
+            // returning the same tree would pass it without ever comparing two numbers.
+            Assert.True(rewritten > 0, "no round trip came back written differently");
+            Assert.True(failures.Count == 0,
+                $"{failures.Count} of {rewritten} rewritten round trips changed the value:\n"
+                + string.Join("\n", failures.Take(10)));
+        }
+
+        /// <summary>
+        /// <b>A constraint on a hole is written once and holds in both directions.</b>
+        /// <c>(a/b)^c = a^c/b^c</c> needs a positive whole <c>c</c>, and the forward rule is where
+        /// that is written. Read backwards the rule matches <c>a^c/b^c</c> for any <c>c</c> at
+        /// all — and then refuses to build the quotient-to-a-power unless <c>c</c> passes the
+        /// constraint on the side that states it.
+        /// </summary>
+        [Theory]
+        [InlineData("x ^ 2 / y ^ 2", "(x / y) ^ 2")]
+        [InlineData("x ^ 3 / y ^ 3", "(x / y) ^ 3")]
+        [InlineData("x ^ n / y ^ n", null)]          // n is not known to be a positive integer
+        [InlineData("x ^ (-2) / y ^ (-2)", null)]    // negative, so the forward rule refuses it
+        [InlineData("x ^ (1/2) / y ^ (1/2)", null)]  // and this one is the branch-cut case
+        public void AHoleConstraintSurvivesBeingReadBackwards(string from, string? expected)
+        {
+            var rule = MatchedRules.CollapseMultipleFractions.Rules
+                .Single(one => one.Name == "positive-power-of-a-quotient-distributes");
+            var backwards = rule.Reversed;
+            Assert.NotNull(backwards);
+
+            var actual = backwards!.TryApply(from.ToEntity());
+            if (expected is null)
+                Assert.Null(actual);
+            else
+                Assert.Equal(expected.ToEntity(), actual);
+        }
+
+        /// <summary>
+        /// A pattern over a node this cannot construct is matchable and not writable, so a rule
+        /// using one is one-way — reported as its own reason rather than folded into the others,
+        /// because it is a gap in the mechanism where the rest are facts about the mathematics.
+        /// </summary>
+        [Fact]
+        public void APatternOverAnUnbuildableNodeIsMatchableAndNotReversible()
+        {
+            var overMod = new MatchedRule(
+                "modulus",
+                MatchPattern.Node<Modf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
+                MatchPattern.Node<Modf>(MatchPattern.Any("b"), MatchPattern.Any("a")),
+                Soundness.Heuristic);
+
+            // It still matches, which is what "matchable and not writable" means.
+            Assert.True(overMod.Left.Matches("x mod y".ToEntity()));
+            Assert.Equal(RuleReversal.PatternCannotBeBuilt, overMod.Reversal);
+            Assert.Null(overMod.Reversed);
+        }
+
+        /// <summary>
+        /// A replacement naming a hole the pattern never binds is a typo, and a typo that would
+        /// otherwise show as a rule that silently never fires. Only a right-hand side written as
+        /// data can be checked for it at all — a builder over the bindings throws at run time on
+        /// the first expression that reaches it, or not at all.
+        /// </summary>
+        [Fact]
+        public void AReplacementCannotNameAHoleThePatternDoesNotBind()
+        {
+            var thrown = Assert.Throws<ArgumentException>(() => new MatchedRule(
+                "typo",
+                MatchPattern.Node<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
+                MatchPattern.Node<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("c")),
+                Soundness.Sound));
+            Assert.Contains("'c'", thrown.Message);
+        }
+
+        /// <summary>
+        /// Both sides of every rule written as data can be built, so the node types the rules use
+        /// are all ones <c>MatchPattern.Construct</c> knows. A rule that adds a node type to a
+        /// right-hand side and not to that method fails here rather than becoming quietly one-way.
+        /// </summary>
+        [Fact]
+        public void EveryDataRuleIsBuildableOnBothSides()
+        {
+            foreach (var set in DataRuleSets())
+                foreach (var rule in set.Rules)
+                {
+                    Assert.True(rule.Left.IsBuildable, $"{set.Name}/{rule.Name}: left");
+                    Assert.NotNull(rule.Right);
+                    Assert.True(rule.Right!.IsBuildable, $"{set.Name}/{rule.Name}: right");
+                }
+        }
+
+        /// <summary>
+        /// Reversal carries the side condition and the soundness tier over unchanged. Both follow
+        /// from what a rewrite rule claims: the condition is a predicate on the bindings and both
+        /// directions produce the same bindings, and an equality is symmetric.
+        /// </summary>
+        [Fact]
+        public void ReversalCarriesTheConditionAndTheTier()
+        {
+            var powerOfPower = MatchedRules.PowerOfPower.Rules.Single();
+            var backwards = powerOfPower.Reversed;
+            Assert.NotNull(backwards);
+            Assert.Equal(powerOfPower.Soundness, backwards!.Soundness);
+
+            // (a^b)^c = a^(b*c) needs a whole c or a positive real a. Read backwards the same
+            // condition decides, so a^(b*c) is only rewritten to (a^b)^c where it is true.
+            Assert.Equal("(x ^ y) ^ 2".ToEntity(), backwards.TryApply("x ^ (y * 2)".ToEntity()));
+            Assert.Null(backwards.TryApply("x ^ (y * z)".ToEntity()));
+        }
+    }
+}


### PR DESCRIPTION
## What was missing

[#746](https://github.com/asc-community/AngouriMath/issues/746) tier 2 names this first, in
dependency order:

> a rule that can be *matched* rather than only run — its pattern is a C# source string today and
> its replacement is a closure, so **no rule can be read backwards** and nothing knows that
> expansion and factorisation are inverses

Re-measured on `9b6fb5b0` before touching anything: 30 rule sets registered, 29 addressable at rule
grain, **405 rules**, `RationalizeDenominator` the one with none. All 30 declare
`SoundUnderAssumptions` and `Equivalence`. Every type in `Core/Transformations/Matching` is
`internal`, 5 rule sets are expressed as data with 14 rules between them, and **0 of the 30
registered sets use the matcher at run time** — nothing in `Sources/AngouriMath` references that
directory from outside it. All of that is as the roadmap records it.

## What this adds

**`MatchPattern` is now a template as well as a pattern.** `TryBuild` puts an expression together
out of bindings where `Match` takes one apart into them. A rule whose two sides are both patterns
therefore has two directions, and swapping them is the whole of the reversal. All 14 data rules now
carry a pattern on the right where they carried a closure.

**Which rules have a second direction is derived, not declared.** `MatchedRule.Reversal`:

| | |
|---|---|
| `Reversible` | both sides are patterns over the same holes, and both can be built |
| `ReplacementIsCode` | the replacement is a closure — nothing to match against |
| `ReplacementDropsHoles` | the replacement forgets a hole the pattern binds |
| `PatternCannotBeBuilt` | a side is over a node type `Construct` does not build |

**13 of the 14 are reversible. The fourteenth is the Pythagorean identity**, and it is not for a
reason about the mathematics rather than the encoding: `1` does not say which angle it came from.
That is the point of item 2 of the brief — *"readable backwards" is a property of an individual
rule*. `Expand` and `Factor` are still not inverses and nothing here invents a symmetry the
mathematics does not have.

**The side condition and the soundness tier carry over unchanged**, and the argument for each is in
[`ReversibleRules.md`](Sources/AngouriMath/Docs/Contributing/ReversibleRules.md): the condition is a
predicate on the bindings and both directions produce the same bindings, and what a rewrite rule
claims is an equality, which is symmetric. What does *not* carry over is written down too —
termination, round-tripping through a *set*, and the written order of a commutative operand.

**A constraint on a hole is written once and holds both ways.** `(a/b)^c = a^c/b^c` needs a positive
whole `c`, written on the left. Read backwards the rule matches `a^c/b^c` for any `c` and then
refuses to *build* unless `c` passes, so `x^n / y^n` and `x^(1/2) / y^(1/2)` are declined.

## The question no existing API answers

Every entry point runs forwards. `ReversibleRuleTest.AReversedRuleSaysWhatAnExpressionCameFrom` asks
the other way:

```csharp
var factoring = MatchedRules.SharedFactor.Rules.Single();   // k*p + k*q -> k*(p + q)
factoring.TryApply("x * a + x * b")           // x * (a + b)
factoring.Reversed!.TryApply("x * (a + b)")   // x * a + x * b
```

The forward identity is written four times in `Patterns.CommonRules` and nine in
`Patterns.FactorizeRules`; none of them knows about the expansion that undoes it, and there is no
way to ask.

## What it costs `Simplify`

Nothing on the fast path reaches this, and the measurement says so rather than the argument. Three
copies of the kernel in one process — the commit before this work, this work, and a **byte-identical
copy of the first as a control** — `Simplify` on seven expressions, 60 rounds, arm order rotating:

| arm | median | min | vs before | allocated | distinct values |
|---|--:|--:|--:|--:|--:|
| before | 347.5 ms | 344.1 ms | — | 658,407,960 B | 1 |
| after | 347.1 ms | 344.0 ms | −0.13% | 658,407,960 B | 1 |
| control (a copy of *before*) | 345.9 ms | 343.3 ms | −0.47% | 658,407,960 B | 1 |

**Allocation is identical to the byte** in every arm, one distinct value across all 60 rounds. The
control arm differs from the code it is a copy of by 0.47%, so the −0.13% is not a signal. The
exchange that put a data rule set on the simplifier's path was measured at **+5%** and reverted;
this does not make that exchange.

## Deliberately not built

- **No production caller.** `Packaging.md` and #746's counterweight both say speculative code with no
  consumer is not an asset, so this is one mechanism, its tests and the design note. The consumer
  tier 2 names next is the inverse-pair table equality saturation needs.
- **No reversal for the 405.** Their replacement is C# source text; making one reversible means
  writing it as data, which is the 5% exchange and a decision per set.
- **No `Sound` promotions.** Reversal carries a tier over; it does not justify one.

## One thing that contradicts the tree

`RuleRegistryGenerator`'s note on `Growth` claimed it was *"enough for the question a saturation
scheduler asks, which is which pairs of rules are each other's inverse."* It is not: growth says
which way a rule moves, and two rules can both collect without being related. Corrected in place,
and the real answer is a rule with two sides.

## Verification

- `dotnet build Sources/AngouriMath -c Release` — clean, 0 warnings.
- `dotnet test Sources/Tests/UnitTests -c Release` — **7839 passed, 0 failed, 14 skipped** (7825
  before this branch; the 14 new ones are `ReversibleRuleTest`).
- `dotnet test Sources/Tests/FSharpWrapperUnitTests -c Release` — 134 passed.
- `MatchedRulesAgreeWithTheSwitchTest` still holds every data rule set against the `switch` it
  mirrors, which is what says the right-hand sides were transcribed and not altered.

No answer changed for any caller, so there is no `BREAKING-CHANGES.md` entry: everything here is
`internal`, and the library itself never reaches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd
