### PR TITLE
Do not fail the time gate on a benchmark too small to time

### DIFF
--- a/Sources/Tests/DotnetBenchmark/PerformanceGate.cs
+++ b/Sources/Tests/DotnetBenchmark/PerformanceGate.cs
@@ -93,6 +93,29 @@ namespace DotnetBenchmark
         /// <summary>Time fails only above this factor. See the remarks: a catastrophe gate.</summary>
         private const double TimeCeilingFactor = 3.0;
 
+        /// <summary>
+        /// A benchmark whose baseline is under this many nanoseconds is reported but never fails on
+        /// time, for the same reason <see cref="AllocationFloorBytes"/> exists: a ratio taken over a
+        /// interval this short measures the runner, not the code.
+        /// </summary>
+        /// <remarks>
+        /// Measured rather than picked. One run of an unchanged kernel on a 4-core runner against a
+        /// baseline taken on an 8-core one made every single benchmark slower, and by an amount that
+        /// tracks how small it is:
+        /// <code>
+        ///   EvalEasy         0.98 ns    3.58x      ParseEasy      6,919 ns   1.59x
+        ///   RunEasy            23 ns    1.81x      Derivate      17,215 ns   1.52x
+        ///   RunHard           346 ns    1.74x      SimplifyHard   2.16e9 ns  1.30x
+        ///   RunMedium         203 ns    1.57x
+        /// </code>
+        /// Allocation was 0.0% on every one of them, so nothing about the code had moved. The
+        /// inflation is fixed per-call overhead — scheduling, cache state, one fewer core — and it
+        /// disappears into the measurement above roughly a microsecond. Below it, 3x is reachable
+        /// without a defect, and a gate that goes red without a defect is a gate people learn to
+        /// ignore.
+        /// </remarks>
+        private const double TimeFloorNanoseconds = 1_000;
+
         /// <summary>Time above this factor is called out for a human to look at, and does not fail.</summary>
         private const double TimeNoticeFactor = 1.25;
 
@@ -334,11 +357,12 @@ namespace DotnetBenchmark
                     : (now.AllocatedBytes - (double)was.AllocatedBytes) / was.AllocatedBytes;
                 var timeFactor = was.MeanNanoseconds > 0 ? now.MeanNanoseconds / was.MeanNanoseconds : 1;
                 var byBytes = Math.Abs(now.AllocatedBytes - was.AllocatedBytes) >= AllocationFloorBytes;
+                var timeIsMeasurable = was.MeanNanoseconds >= TimeFloorNanoseconds;
 
                 var verdict =
                     byBytes && allocationDelta > AllocationBand ? Verdict.Regressed
                     : byBytes && allocationDelta < -AllocationBand ? Verdict.Improved
-                    : timeFactor > TimeCeilingFactor ? Verdict.Slower
+                    : timeIsMeasurable && timeFactor > TimeCeilingFactor ? Verdict.Slower
                     : timeFactor > TimeNoticeFactor ? Verdict.Slow
                     : Verdict.Ok;
                 yield return new Row(method, verdict, was, now, allocationDelta, timeFactor);
@@ -359,7 +383,8 @@ namespace DotnetBenchmark
             sb.AppendLine();
             sb.AppendLine($" Allocation must stay within {AllocationBand * 100:0}% of the baseline in either direction;"
                 + $" a move of under {AllocationFloorBytes} B/op");
-            sb.AppendLine($" does not count. Time is reported and fails only above {TimeCeilingFactor:0.00}x, because a"
+            sb.AppendLine($" does not count. Time under {TimeFloorNanoseconds:N0} ns/op is reported and never fails,"
+                + $" for the same reason. Otherwise time fails only above {TimeCeilingFactor:0.00}x, because a"
                 + " shared runner's wall clock");
             sb.AppendLine(" is not a property of the code. Both thresholds are argued for in PerformanceGate.cs.");
             sb.AppendLine();


### PR DESCRIPTION
The performance gate added in #1014 failed on **#1027** — a branch that changes exception message
strings and a documentation file:

```
 baseline  commit 6b93b401 ... Ubuntu 26.04 LTS, X64, 8 logical cores
 this run  commit d96f311f ... Ubuntu 24.04.4 LTS, X64, 4 logical cores

 method          allocated B/op   delta        mean ns/op          factor  verdict
 EvalEasy             0 →     0    0.0%     0.98 →     3.52         3.58x  SLOWER
```

**It is not a regression.** Allocation moved `0.0%` there and on nearly every other row, and *every
one of the seventeen benchmarks* came out slower — between 1.30× and 3.58× — because the baseline
was captured on an 8-core runner and pull requests run on a 4-core one.

### The inflation tracks how small the benchmark is

Which is what says it is overhead rather than code:

| benchmark | baseline | factor | | benchmark | baseline | factor |
|---|--:|--:|---|---|--:|--:|
| `EvalEasy` | 0.98 ns | **3.58×** | | `ParseEasy` | 6,919 ns | 1.59× |
| `RunEasy` | 23 ns | 1.81× | | `Derivate` | 17,215 ns | 1.52× |
| `RunHard` | 346 ns | 1.74× | | `SimplifyHard` | 2.16e9 ns | 1.30× |
| `RunMedium` | 203 ns | 1.57× | | | | |

Fixed per-call cost — scheduling, cache state, one fewer core — is a large fraction of a
nanosecond-scale measurement and a rounding error at second scale.

### The fix is the guard allocation already has

`AllocationFloorBytes` exists so that *"a benchmark allocating almost nothing does not fail on a
percentage of almost nothing"*. The same argument applies to time, and time had no floor at all.
So: **a baseline under 1,000 ns/op is reported and never fails on time.** The constant carries the
measurement above as its justification, not an assertion.

### What the gate still catches

- **Allocation is untouched** — still ±3% on every benchmark regardless of size, and it is the
  metric that fails. That is the point of the gate and #746 item 80.
- The time ceiling still applies above a microsecond: `SimplifyHard` at 2.16 s would have to reach
  6.5 s.
- Everything under the floor still prints its factor, so a real slowdown there is visible to a reader
  even though it does not fail the build.

### Also worth recording

The baseline and the pull-request runners are **different machine classes**, which the gate prints
but does not otherwise account for. That is a separate question — re-baselining on the class actually
used would be the fuller answer — and it is not this change.

A gate that goes red without a defect is a gate people learn to ignore, and this one is a day old.