### PR TITLE
Do not answer an exhausted search with the empty set (#1036, #746 tier 4)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -21,6 +21,9 @@ read first.
 
 | Silent? | What | Was | Is |
 |---|---|---|---|
+| **Silent** | `"x6 + x y + 1 = 0".ToEntity().Solve("x")`, and every equation no solver settles | `{  }` — there are no roots | `{ x : 1 + x ^ 6 + x * y = 0 }` — these are the roots, whichever they are |
+| **Silent** | `"(x - 1) * (x6 + x y + 1) = 0".ToEntity().Solve("x")` | `{ 1 }` | `{ 1 } \/ { x : 1 + x ^ 6 + x * y = 0 }` |
+| **Silent** | `"x6 + x y + 1 = 0 and x - 1 = 0".ToEntity().Solve("x")` | `{  }` | `{ x : x ^ 6 + x * y + 1 = 0 and x - 1 = 0 }` |
 | | `"x ^ 3 - x > 0".ToEntity().Solve("x")`, and every polynomial inequality of degree three or more | `NotSufficientlySupportedException: Only linear and quadratic polynomial inequalities are supported` | `(-1; 0) \/ (1; +oo)` — the solution set |
 | **Silent** | `"a implies (b implies c)".ToEntity().Stringize()` | `a implies b implies c`, which reads back as `(a implies b) implies c` | `a implies (b implies c)` |
 | | `"(a implies b) implies c".ToEntity().Stringize()` | `(a implies b) implies c` | `a implies b implies c` |
@@ -34,6 +37,105 @@ read first.
 | | any expression mixing a number with a `Complex` argument, `Compile`d in a NativeAOT app — `"x + 1".Compile<Complex, Complex>("x")` | `UncompilableNodeException: ... The binary operator Add is not defined for the types 'System.Numerics.Complex' and 'System.Numerics.Complex'` | the compiled function, answering as it does under the JIT |
 | | `Compile` to a nullable integral return type in a NativeAOT app | `AngouriBugException: IsNaN method expected for type System.Double`, which took the process down | the compiled function |
 | **Silent** | an app publishing with `PublishTrimmed` or NativeAOT | `AngouriMath.dll` was copied in whole, being unmarked | it is trimmed with the rest, since the assembly now declares `IsTrimmable` |
+
+### An equation nothing settled is no longer answered with the empty set
+
+`Solve` and `SolveEquation` returned an empty `FiniteSet` for two different things: an equation
+shown to have no roots, and an equation every solver in the chain declined. The empty set is a
+positive claim — *no x satisfies this* — so the second of those was a wrong answer rather than a
+graceful failure ([#1036](https://github.com/asc-community/AngouriMath/issues/1036),
+[#746](https://github.com/asc-community/AngouriMath/issues/746) tier 4).
+
+**Was** — indistinguishable, and false for the second column:
+
+```
+"x6 + x y + 1 = 0".ToEntity().Solve("x")            {  }        six roots for every y
+"sin(x) + x + y = 0".ToEntity().Solve("x")          {  }
+"e^x + x + y = 0".ToEntity().Solve("x")             {  }
+"x6 + x y + 1".ToEntity().SolveEquation("x")        {  }
+"e^x = 0".ToEntity().Solve("x")                     {  }        genuinely none
+"abs(x) = -1".ToEntity().Solve("x")                 {  }        genuinely none
+```
+
+**Is** — the equation itself, as the set of the x that satisfy it. It names the same set and
+asserts of it only what was established:
+
+```
+"x6 + x y + 1 = 0".ToEntity().Solve("x")            { x : 1 + x ^ 6 + x * y = 0 }
+"sin(x) + x + y = 0".ToEntity().Solve("x")          { x : sin(x) + x = -y }
+"e^x + x + y = 0".ToEntity().Solve("x")             { x : e ^ x + x = -y }
+"x6 + x y + 1".ToEntity().SolveEquation("x")        { x : 1 + x ^ 6 + x * y = 0 }
+"e^x = 0".ToEntity().Solve("x")                     {  }        unchanged
+"abs(x) = -1".ToEntity().Solve("x")                 {  }        unchanged
+```
+
+Turning Newton's method off leaves nothing numerical either, and those answers move the same way.
+A search over finitely many starting points inside a bounded region finding nothing is a fact about
+the search:
+
+```
+using var _ = MathS.Settings.AllowNewton.Set(false);
+
+"x5 + 3x + 1 = 0".ToEntity().Solve("x")             was {  }   is { x : x ^ 5 + 3 * x = -1 }
+"sin(x) * x - 3 = 0".ToEntity().Solve("x")          was {  }   is { x : sin(x) * x = 3 }
+
+"x + sqrt(x^0.1 + a) + c".ToEntity().SolveEquation("x")
+    was {  }   is { x : sqrt(a + x ^ (1/10)) + c + x = 0 }
+"(x + 6)^(1/6) + x + x3 + a".ToEntity().SolveEquation("x")
+    was {  }   is { x : (6 + x) ^ (1/6) + x + x ^ 3 = -a }
+"2 ^ (x sin(x)) + 4 ^ (x sin(x)) + c".ToEntity().SolveEquation("x")
+    was {  }
+    is  { x : sin(x) * x = ln(((-1 - sqrt(1 - 4 * c)) / 2) ^ (1 / ln(2)))
+              or sin(x) * x = ln(((-1 + sqrt(1 - 4 * c)) / 2) ^ (1 / ln(2))) }
+```
+
+The last of those is the shape of it: the exponential solver did settle the equation in
+`2 ^ (x sin(x))`, and it was the inversion of `x * sin(x)` that had nothing to say. What comes back
+now is the half that was solved, with the half that was not left standing as a condition.
+
+An answer that is partly settled keeps the part that is, so a product one of whose factors was
+solved comes back as a union rather than as the factor's roots alone:
+
+```
+"(x - 1) * (x6 + x y + 1) = 0".ToEntity().Solve("x")
+    was  { 1 }
+    is   { 1 } \/ { x : 1 + x ^ 6 + x * y = 0 }
+
+"x6 + x y + 1 = 0 or x - 1 = 0".ToEntity().Solve("x")
+    was  { 1 }
+    is   { 1 } \/ { x : 1 + x ^ 6 + x * y = 0 }
+
+"x6 + x y + 1 = 0 implies x - 1 = 0".ToEntity().Solve("x")
+    was  { 1 } \/ BB
+    is   { 1 } \/ (BB \ { x : 1 + x ^ 6 + x * y = 0 })
+```
+
+A conjunction with an unsettled side is answered as the conjunction. Intersecting a finite set with
+a condition keeps the elements whose membership could not be decided, so taking the intersection
+here would have replaced one false claim with another — `{ 1 }` says 1 solves
+`x^6 + x*y + 1 = 0`, and it does so only at `y = -2`:
+
+```
+"x6 + x y + 1 = 0 and x - 1 = 0".ToEntity().Solve("x")
+    was  {  }
+    is   { x : x ^ 6 + x * y + 1 = 0 and x - 1 = 0 }
+```
+
+**What this means for callers.** `Solve` has always been typed `Set` and has always been able to
+return an `Interval`, a `ConditionalSet` or a union; what changes is how often it does. Code that
+casts the result to `FiniteSet`, or that reads an empty result as "no solutions", has to say which
+of the two it means:
+
+```csharp
+var answer = equation.Solve(x);
+if (answer is FiniteSet roots)      { /* these are all of them */ }
+else if (answer.IsSetEmpty)         { /* shown to have none */ }
+else                                { /* not settled, or not finite */ }
+```
+
+Nothing that solved before stops solving, and no equation that was shown to have no roots gains
+any. Solving `x2 - 4 = 0`, `sin(x) = 1/2`, `x2 + 1 = 0` and the system solver's answers are
+unchanged, as is `Solve` on an inequality.
 
 ### A polynomial inequality of degree three or more is answered
 

--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -5652,7 +5652,9 @@ namespace AngouriMath
             }
 
             /// <summary>
-            /// If you only need analytical solutions and an empty set if no analytical solutions were found, disable Newton's method
+            /// If you only need analytical solutions, disable Newton's method. What comes back
+            /// where there are none is the equation itself as a set builder: the empty set
+            /// would say the equation has no roots, which is a claim nothing established.
             /// </summary>
             /// <example>
             /// <code>
@@ -5671,7 +5673,7 @@ namespace AngouriMath
             /// { 1.0050669478588620808778841819730587303638458251953125 + 0.93725915669289194820379407246946357190608978271484375i,
             /// ... omitting here most of the output, because it's huge
             /// }
-            /// {  } // nothing was found for 5-degree polynomial without numeric solution
+            /// { x : x ^ 5 + 3 * x = -1 } // no analytical solution was found for this quintic
             /// </code>
             /// </example>
             public static Setting<bool> AllowNewton { get; } = true;

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
@@ -330,11 +330,43 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
             // TODO: Solve factorials (Needs Lambert W function)
             // https://mathoverflow.net/a/28977
 
-            // if nothing has been found so far
+            // A numerical search that comes back with nothing has not shown there is
+            // nothing to find: Newton's method is started from finitely many points inside
+            // a bounded region, so an empty result is a fact about the search rather than
+            // about the equation. Where it does find roots the answer is theirs, unchanged.
             if (MathS.Settings.AllowNewton && expr.Vars.Count == 1)
-                return expr.SolveNt(x).Select(ent => TryDowncast(expr, x, ent)).ToSet();
+                return expr.SolveNt(x).Select(ent => TryDowncast(expr, x, ent)).ToSet()
+                    is FiniteSet { IsSetEmpty: false } found ? found : Unsolved(expr, x);
 
-            return Enumerable.Empty<Entity>().ToSet();
+            return Unsolved(expr, x);
         }
+
+        /// <summary>
+        /// The answer when every solver above has declined: the equation itself, as the set
+        /// of the <paramref name="x"/> that satisfy it.
+        /// </summary>
+        /// <remarks>
+        /// The empty set is a positive claim -- that no <paramref name="x"/> satisfies
+        /// <paramref name="equation"/> -- and returning it from an exhausted search asserts
+        /// something nothing here established. <c>x^6 + x*y + 1 = 0</c> has six roots for
+        /// every <c>y</c> and was answered <c>{ }</c>. A condition asserts only what was
+        /// established, which is that these are the roots, whichever they are; the set is
+        /// still exactly the solution set, so nothing downstream is told anything false.
+        ///
+        /// The spelling is the one <see cref="StatementSolver.UnsolvedWhereIndependenceIsDenied"/>
+        /// and the <a href="https://github.com/asc-community/AngouriMath/issues/278">#278</a>
+        /// case above already use, rather than a second way of saying the same thing.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1036">#1036</a>,
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a>
+        /// </remarks>
+        private static Set Unsolved(Entity equation, Variable x)
+            // Written back as an equation between the two sides where there are two, rather
+            // than as the residual the solvers pass around. A compensated call is handed its
+            // equation unsimplified on purpose, so the difference survives for them to read,
+            // and stating it as it stands leaves the reader `x^5 + 3*x - (-1) = 0` where the
+            // question was whether `x^5 + 3*x` is -1. The two admit the same x.
+            => new ConditionalSet(x, equation is Minusf(var lhs, var rhs)
+                ? lhs.Equalizes(rhs)
+                : equation.Equalizes(0));
     }
 }

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/SolveStatement.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/SolveStatement.cs
@@ -148,6 +148,23 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
             return largest;
         }
 
+        /// <summary>
+        /// Where both sides of a conjunction were settled, its solution set is the
+        /// intersection of theirs.
+        /// </summary>
+        /// <remarks>
+        /// Where one of them is a condition nothing settled, it is not: intersecting a
+        /// finite set with one keeps an element whose membership could not be decided, so
+        /// <c>x^6 + x*y + 1 = 0 and x - 1 = 0</c> comes back as <c>{ 1 }</c> — and 1 is a
+        /// root of the first only when <c>y</c> is -2. The conjunction as written asserts
+        /// exactly what is known about it and nothing more.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1036">#1036</a>
+        /// </remarks>
+        private static Set Conjunction(Set left, Set right, Entity statement, Variable x)
+            => (left, right) is (ConditionalSet, FiniteSet) or (FiniteSet, ConditionalSet)
+                ? new ConditionalSet(x, statement)
+                : (Set)MathS.Intersection(left, right);
+
         internal static Set Solve(Entity expr, Variable x)
             => expr switch
             {
@@ -161,8 +178,8 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
 
                 Equalsf => Empty,
 
-                Andf(var left, var right) => 
-                    MathS.Intersection(Solve(left, x), Solve(right, x)),
+                Andf(var left, var right) =>
+                    Conjunction(Solve(left, x), Solve(right, x), expr, x),
                 Orf(var left, var right) => 
                     MathS.Union(Solve(left, x), Solve(right, x)),
                 Impliesf(var left, var right) => 

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/Solvers.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/Solvers.Definition.cs
@@ -84,7 +84,7 @@ namespace AngouriMath
         /// { 9.08837698687877... }
         /// -----------------
         /// sin(x) * x - 3 = 0
-        /// {  }
+        /// { x : sin(x) * x = 3 }
         /// </code>
         /// </example>
         public Set Solve(Variable var)

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/SolveOneEquation.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/SolveOneEquation.cs
@@ -189,9 +189,6 @@ namespace AngouriMath.Tests.Algebra
         public void CDSolver(string expr, int rootCount, string? verifyRoots) => TestSolver(expr, rootCount, verifyRoots: verifyRoots);
 
         [Theory]
-        [InlineData("x + sqrt(x^0.1 + a) + c", 0)]
-        [InlineData("(x + 6)^(1/6) + x + x3 + a", 0)]
-        [InlineData("sqrt(x + 1) + sqrt(x + 2) + a + x", 0)]
         [InlineData("(x + 1)^(1/3) - x - a", 3)]
         public void FractionedPoly(string expr, int rootCount) => TestSolver(expr, rootCount);
 
@@ -233,7 +230,6 @@ namespace AngouriMath.Tests.Algebra
         [InlineData("4^x - a", 1, "{ log(4, a) }")]
         [InlineData("a^x + (a^2)^x - c", 2)]
         [InlineData("e^x + (e2)^x - 1", 2)]
-        [InlineData("2 ^ (x sin(x)) + 4 ^ (x sin(x)) + c", 0)]
         [InlineData("2^x - 4^x", 1, "{ 0 }")]
         public void TestExponentialSolver(string equation, int rootCount, string? verifyRoots = null)
             => TestSolver(equation, rootCount, verifyRoots: verifyRoots);

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/UnsolvedEquationTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/UnsolvedEquationTest.cs
@@ -1,0 +1,174 @@
+﻿//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+using static AngouriMath.Entity.Set;
+
+namespace AngouriMath.Tests.Algebra.SolveTest
+{
+    /// <summary>
+    /// An equation the solvers exhaust themselves on, against one that has been shown to
+    /// have no roots. Both were the empty set.
+    /// https://github.com/asc-community/AngouriMath/issues/1036
+    /// </summary>
+    /// <remarks>
+    /// The empty set is a positive mathematical claim, so it is only available where
+    /// something established it. Where nothing did, the answer is the equation as a set
+    /// builder: it names the same set, and asserts of it only what is known.
+    /// </remarks>
+    [Trait("Area", "Algebra")]
+    public sealed class UnsolvedEquationTest
+    {
+        /// <summary>An equation no solver settles comes back as a condition, not as no roots.</summary>
+        [Theory]
+        [InlineData("x6 + x y + 1 = 0")]
+        [InlineData("sin(x) + x + y = 0")]
+        [InlineData("e^x + x + y = 0")]
+        [InlineData("x y + sin(x) ^ 2 + ln(x) = 0")]
+        public void ExhaustedIsNotEmpty(string equation)
+        {
+            var answer = equation.ToEntity().Solve("x");
+            Assert.False(answer.IsSetEmpty, $"{equation} answered the empty set");
+            Assert.IsType<ConditionalSet>(answer);
+        }
+
+        /// <summary>
+        /// The same for the entry point that takes the equation as an expression read as
+        /// equal to zero, which reaches the solver by its own route.
+        /// </summary>
+        [Theory]
+        [InlineData("x6 + x y + 1")]
+        [InlineData("sin(x) + x + y")]
+        public void ExhaustedIsNotEmptyThroughSolveEquation(string expression)
+        {
+            Assert.False(expression.ToEntity().SolveEquation("x").IsSetEmpty);
+            Assert.False(MathS.SolveEquation(expression.ToEntity(), "x").IsSetEmpty);
+        }
+
+        /// <summary>
+        /// An equation shown to have no roots keeps the empty set. <c>e^x</c> is never zero
+        /// and <c>abs(x)</c> is never negative, and in both cases the solver reached that by
+        /// inverting rather than by running out of ideas.
+        /// </summary>
+        [Theory]
+        [InlineData("e^x = 0")]
+        [InlineData("abs(x) = -1")]
+        public void ImpossibleIsStillEmpty(string equation)
+        {
+            var answer = equation.ToEntity().Solve("x");
+            Assert.IsType<FiniteSet>(answer);
+            Assert.True(answer.IsSetEmpty, $"{equation} stopped answering the empty set");
+        }
+
+        /// <summary>
+        /// The two are distinguishable, which is the whole point: one is empty and the other
+        /// is not, where before both were <c>{ }</c>.
+        /// </summary>
+        [Fact]
+        public void ExhaustedAndImpossibleDisagree()
+        {
+            var exhausted = "x6 + x y + 1 = 0".ToEntity().Solve("x");
+            var impossible = "e^x = 0".ToEntity().Solve("x");
+            Assert.NotEqual(exhausted.IsSetEmpty, impossible.IsSetEmpty);
+        }
+
+        /// <summary>
+        /// The condition admits a root that the empty set denied. <c>x^6 + x*y + 1 = 0</c>
+        /// has six roots for every <c>y</c>; at <c>y = -2</c> one of them is 1.
+        /// </summary>
+        [Fact]
+        public void TheConditionAdmitsARootTheEmptySetDenied()
+        {
+            var answer = Assert.IsType<ConditionalSet>("x6 + x y + 1 = 0".ToEntity().Solve("x"));
+            var atTheRoot = answer.Predicate.Substitute("y", -2).Substitute("x", 1).Simplify();
+            Assert.Equal(Entity.Boolean.True, atTheRoot);
+        }
+
+        /// <summary>
+        /// Newton's method is asked from finitely many starting points inside a bounded
+        /// region, so finding nothing is a fact about the search. With it turned off there
+        /// is nothing numerical left either, and both of these were <c>{ }</c>.
+        /// </summary>
+        [Theory]
+        [InlineData("x5 + 3x + 1 = 0")]
+        [InlineData("sin(x) * x - 3 = 0")]
+        [InlineData("2 ^ (x sin(x)) + 4 ^ (x sin(x)) + c = 0")]
+        [InlineData("x + sqrt(x^0.1 + a) + c = 0")]
+        [InlineData("(x + 6)^(1/6) + x + x3 + a = 0")]
+        [InlineData("sqrt(x + 1) + sqrt(x + 2) + a + x = 0")]
+        public void WithoutNewtonTheAnswerIsTheEquation(string equation)
+        {
+            using var _ = MathS.Settings.AllowNewton.Set(false);
+            var answer = equation.ToEntity().Solve("x");
+            Assert.False(answer.IsSetEmpty, $"{equation} answered the empty set");
+            Assert.IsType<ConditionalSet>(answer);
+        }
+
+        /// <summary>
+        /// And where Newton does find roots they are still the answer, so nothing that
+        /// answered before stops answering.
+        /// </summary>
+        [Theory]
+        [InlineData("x5 + 3x + 1 = 0")]
+        [InlineData("sin(x) * x - 3 = 0")]
+        public void NewtonStillAnswers(string equation)
+        {
+            var answer = Assert.IsType<FiniteSet>(equation.ToEntity().Solve("x"));
+            Assert.False(answer.IsSetEmpty);
+        }
+
+        /// <summary>
+        /// A conjunction with an unsettled side must not name a root. Intersecting a finite
+        /// set with a condition keeps an element whose membership could not be decided, so
+        /// <c>{ 1 }</c> here would say 1 is a root of <c>x^6 + x*y + 1</c>, which it is only
+        /// at <c>y = -2</c>.
+        /// </summary>
+        [Fact]
+        public void AConjunctionDoesNotNameARootItCannotCheck()
+        {
+            var answer = "x6 + x y + 1 = 0 and x - 1 = 0".ToEntity().Solve("x");
+            Assert.IsType<ConditionalSet>(answer);
+            Assert.False(answer.TryContains(1, out var contains) && contains,
+                "the conjunction asserted that 1 is a solution");
+        }
+
+        /// <summary>A conjunction of two settled sides still intersects them.</summary>
+        [Fact]
+        public void ASettledConjunctionStillIntersects()
+        {
+            var answer = Assert.IsType<FiniteSet>(
+                "(x - 3) * (x - 6) = 0 and (x - 3) * (x - 7) = 0".ToEntity().Solve("x"));
+            Assert.Equal(new FiniteSet(3), answer);
+        }
+
+        /// <summary>
+        /// A disjunction is a union, and a union with an unsettled side is exactly right:
+        /// the roots that were found, together with the ones nothing settled.
+        /// </summary>
+        [Fact]
+        public void ADisjunctionKeepsTheRootsItFound()
+        {
+            var answer = "x6 + x y + 1 = 0 or x - 1 = 0".ToEntity().Solve("x");
+            Assert.True(answer.TryContains(1, out var contains) && contains,
+                "the disjunction lost the root it had");
+        }
+
+        /// <summary>
+        /// An equation that solves is untouched, including the one that has every complex
+        /// number as a root and the one that has none because it says nothing about x.
+        /// </summary>
+        [Theory]
+        [InlineData("x2 - 4 = 0", 2)]
+        [InlineData("x2 + 1 = 0", 2)]
+        [InlineData("(x - 1)(x2 - 3) = 0", 3)]
+        [InlineData("sin(x) = 1/2", 2)]
+        public void SolvingIsUnchanged(string equation, int rootCount)
+            => Assert.Equal(rootCount, Assert.IsType<FiniteSet>(equation.ToEntity().Solve("x")).Count);
+    }
+}


### PR DESCRIPTION
Step 1 of [#1036](https://github.com/asc-community/AngouriMath/issues/1036). Roadmap
[#746](https://github.com/asc-community/AngouriMath/issues/746) tier 4 — *"`Solve` still returns an
empty set both for 'no solutions' and for 'I gave up'."* Does not close #1036, which has five steps.

## What was wrong

`Solve` returns `Entity.Set`, and an empty `FiniteSet` meant two different things. Measured on
`cd0b56b9`, the merge base:

| | was | truth |
|---|---|---|
| `"x6 + x y + 1 = 0".ToEntity().Solve("x")` | `{  }` | six roots for every `y` |
| `"sin(x) + x + y = 0".ToEntity().Solve("x")` | `{  }` | roots for every `y` |
| `"e^x + x + y = 0".ToEntity().Solve("x")` | `{  }` | roots for every `y` |
| `"x6 + x y + 1".ToEntity().SolveEquation("x")` | `{  }` | same equation, other entry point |
| `"e^x = 0".ToEntity().Solve("x")` | `{  }` | genuinely none |
| `"abs(x) = -1".ToEntity().Solve("x")` | `{  }` | genuinely none |

Six identical answers; the last two are true and the first four are not. The empty set is a positive
mathematical claim — *no `x` satisfies this* — so asserting it from a search that ran out of ideas is
a wrong answer rather than a graceful failure.

## The two sites

The issue names `Solvers.Definition.cs:346` and `AnalyticalEquationSolver.cs:337`. Re-located on this
tree:

* **`Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs:337`** — `return
  Enumerable.Empty<Entity>().ToSet();`, still at that line. This is the chokepoint: every solver
  below `Solve` converges here.
* **`Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs:335`** — one line above
  it, `expr.SolveNt(x)` returning nothing. Newton is asked from finitely many starting points inside
  a bounded region, so finding nothing is a fact about the search.
* `Solvers.Definition.cs:346` is **not** in `Functions/Continuous/Solvers/` — that file is 102 lines
  long and holds `Entity.Solve`. Line 346 is in
  `Functions/Continuous/Limits/Solvers/Solvers.Definition.cs`, `return MathS.NaN;` at the end of the
  two-sided branch. It is a limit-pipeline site, not a `Solve` one, and it is left for step 2 — see
  *What this deliberately does not do*.

## What it returns now

The equation itself, as the set of the `x` that satisfy it:

```
"x6 + x y + 1 = 0".ToEntity().Solve("x")        { x : 1 + x ^ 6 + x * y = 0 }
"sin(x) + x + y = 0".ToEntity().Solve("x")      { x : sin(x) + x = -y }
"e^x + x + y = 0".ToEntity().Solve("x")         { x : e ^ x + x = -y }
"x6 + x y + 1".ToEntity().SolveEquation("x")    { x : 1 + x ^ 6 + x * y = 0 }
"e^x = 0".ToEntity().Solve("x")                 {  }        unchanged
"abs(x) = -1".ToEntity().Solve("x")             {  }        unchanged
```

With `AllowNewton` off there is nothing numerical left either:

```
"x5 + 3x + 1 = 0".ToEntity().Solve("x")         was {  }   is { x : x ^ 5 + 3 * x = -1 }
"sin(x) * x - 3 = 0".ToEntity().Solve("x")      was {  }   is { x : sin(x) * x = 3 }
```

And what was partly settled keeps the part that was — this one is the shape of the whole change,
because the exponential solver *did* settle the equation in `2 ^ (x sin(x))` and it was the inversion
of `x * sin(x)` that had nothing to say:

```
"2 ^ (x sin(x)) + 4 ^ (x sin(x)) + c".ToEntity().SolveEquation("x")
    was  {  }
    is   { x : sin(x) * x = ln(((-1 - sqrt(1 - 4 * c)) / 2) ^ (1 / ln(2)))
               or sin(x) * x = ln(((-1 + sqrt(1 - 4 * c)) / 2) ^ (1 / ln(2))) }
```

## Why a `ConditionalSet`, and what was rejected

**Chosen: the unsolved equation as a `ConditionalSet`.** It is already this codebase's spelling for
"I did not settle this" in the solver itself —
[#278](https://github.com/asc-community/AngouriMath/issues/278) (`a = b` answered `{ x : a - b = 0 }`)
and [#1025](https://github.com/asc-community/AngouriMath/pull/1025)/[#964](https://github.com/asc-community/AngouriMath/issues/964)
(`UnsolvedWhereIndependenceIsDenied`). It needs no new type, no new mechanism, and no change to
`Solve`'s return type. It is not merely a marker: it *names the solution set*, so a caller can
substitute into it, `Filter` it, unite it with what was found, or ask `TryContains` — all of which
this change exercises. And it composes: a product one of whose factors was solved comes back as
`{ 1 } \/ { x : ... }`, keeping the root that was found.

**Rejected: a `BudgetOutcome`-carrying result** (#1035's machinery, which merged today). That layer
answers *which resource ran out where*, and nothing here ran out of a resource — the solvers simply
have no method for these equations. Attaching a budget outcome to "no algorithm applies" would say
something false about why, and would put a second meaning into a type that has one. #1035 stays the
mechanism for the sites that really are resource limits, which is most of the remaining ~66.

**Rejected: something on the side a caller opts into** — a `TrySolve` overload, an out-parameter, an
ambient recording scope. All of them leave the default answer wrong, which is the whole complaint.
The rule at the top of `AGENTS.md` is that a published API returning the wrong answer is a bug with
users, not an asset to preserve.

**Rejected: leaving the empty set and documenting it.** It is not underspecified, it is false.

## The conjunction, which had to be handled

Once an unsettled equation is a `ConditionalSet`, `and` reaches
`SetOperators.IntersectFiniteSetAndSet`, which keeps an element whose membership in the other operand
could not be decided:

```
"{ 1, 2 } /\ { t : t > y }".ToEntity().InnerSimplified        { 1, 2 } \/ {  }      on cd0b56b9
```

That reading is older than this branch and reachable without it, but through `Solve` it would have
turned one false claim into another — `x^6 + x*y + 1 = 0 and x - 1 = 0` becoming `{ 1 }`, when 1
solves the first only at `y = -2`. So `StatementSolver` answers a conjunction with an unsettled side
as the conjunction:

```
"x6 + x y + 1 = 0 and x - 1 = 0".ToEntity().Solve("x")
    was  {  }
    is   { x : x ^ 6 + x * y + 1 = 0 and x - 1 = 0 }
```

Two settled sides still intersect (`(x - 3)(x - 6) = 0 and (x - 3)(x - 7) = 0` is `{ 3 }`), a
disjunction is still a union and keeps the root it had, and `implies` gets strictly more precise
(`{ 1 } \/ BB` becomes `{ 1 } \/ (BB \ { x : ... })`). The underlying
`IntersectFiniteSetAndSet` reading is left alone and reported on #1036 — it is the same confusion in
a shared set operator, and fixing it there is a change with repository-wide blast radius that wants
its own PR.

## Public-API blast radius

No signature changes. `Solve`, `SolveEquation` and `MathS.SolveEquation` have always been typed
`Set` and have always been able to return an `Interval`, a `ConditionalSet` or a union; what changes
is how often they do. What breaks is code that assumed a `FiniteSet`:

```csharp
var answer = equation.Solve(x);
if (answer is FiniteSet roots)      { /* these are all of them */ }
else if (answer.IsSetEmpty)         { /* shown to have none */ }
else                                { /* not settled, or not finite */ }
```

Checked and unaffected: the system solver (`EquationSolver.InSolveSystem` already tests
`is not FiniteSet` and moves on — `MathS.Equations("x + y - 3", "x - y - 1").Solve("x", "y")` is
`[[2, 1]]` on both builds, and so is the six-root system over `x6 + x y + 1`); the inequality
solvers; `Entity.Solve`'s `InnerSimplified`, since `ConditionalSet.InnerSimplify` does not call back
into `Solve`; the F# wrapper (`solutions` returns `Entity.Set`, 134 tests pass); and all four
`SampleNet5` `Solve` lines, byte-identical on both builds.

Two XML doc examples printed `{  }` for an equation the solver gives up on and are corrected here
(`Entity.Solve`'s own `<example>`, and `MathS.Settings.AllowNewton`'s).

`BREAKING-CHANGES.md` carries all of it under `Unreleased`, with three rows in the at-a-glance table.

## The tests, and the four that recorded the old answer

`Sources/Tests/UnitTests/Algebra/SolveTest/UnsolvedEquationTest.cs`, 25 tests. Built on the merge
base they fail 11 of 19 (before the conjunction ones were added), and the eight that pass there are
the controls: the impossible equations stay empty, the solvable ones stay solved, Newton still
answers.

Four theory rows asserted `rootCount: 0` for equations the solver gives up on:

* `SolveOneEquation.TestExponentialSolver("2 ^ (x sin(x)) + 4 ^ (x sin(x)) + c", 0)`
* `SolveOneEquation.FractionedPoly("x + sqrt(x^0.1 + a) + c", 0)`
* `SolveOneEquation.FractionedPoly("(x + 6)^(1/6) + x + x3 + a", 0)`
* `SolveOneEquation.FractionedPoly("sqrt(x + 1) + sqrt(x + 2) + a + x", 0)`

Each of these equations has roots for suitable parameter values, so `rootCount: 0` was pinning the
wrong answer. They move into the new file with the honest assertion — that the answer is the
condition and is not empty — rather than having their assertion loosened.

The new file takes the default `2019-2022` header: `Tests/UnitTests/Algebra/SolveTest/` has no
directory-wide scope in `Sources/.editorconfig`, and that file has been a conflict magnet today, so
it is left untouched.

## Measured

**Suite** — 8091 passed, 0 failed, 14 skipped (8105 total) against 8070 / 0 / 14 (8084) on the merge
base: 25 added, 4 removed rows. F# wrapper 134 passed, 0 failed. Every value in the tables above
measured on a build of each side.

**Cost** — three arms in one process, each an `AssemblyLoadContext` over its own `AngouriMath.dll`:
the merge base, this branch, and a byte-identical second copy of the merge base as the noise floor.
Ten equations that solve, three that do not, twenty repetitions, interleaved, third round reported;
three runs:

| arm | solves, ms | solves, bytes | gives up, ms | gives up, bytes |
|---|---|---|---|---|
| merge base | 184.8 / 210.8 / 183.5 | 300,852,373 / 300,840,202 / 300,852,117 | 3.64 / 3.83 / 3.89 | 10,102,074 / 10,102,458 / 10,102,074 |
| **this branch** | 188.0 / 200.2 / 187.4 | 301,209,973 / 301,209,973 / 301,222,762 | 4.21 / 4.22 / 4.13 | 10,170,858 |
| control (identical to merge base) | 189.2 / 186.2 / 186.4 | 301,208,309 / 301,209,717 / 301,220,842 | 4.26 / 4.27 / 4.01 | 10,166,186 |

Read against the control, not against the merge base: two byte-identical builds differ by up to 370
KB of allocation and 8% of wall clock depending on load position, and this branch sits inside that
on both arms — it is faster than the control on one run of each and slower on the others. On the
give-up arm it allocates 4,672 bytes more than the control on 10.1 MB (+0.046%), which is the
`ConditionalSet` it now builds. The common case is untouched by construction: an equation that
solves never reaches the changed lines.

The CI performance gate is safe — all five of `CommonFunctionsInterVersion`'s `Solve*` benchmarks
return the same `FiniteSet` on both builds.

## What this deliberately does not do

* **The other ~66 sites.** Step 1 only.
* **`InvertNode`'s empty returns**, which produce an empty answer at
  `AnalyticalEquationSolver.cs:157` and `:184` and are genuinely mixed. Measured, three cases:
  `abs(x) = -1` is empty because `Invert` produced a candidate carrying `provided -1 >= 0`, which is
  a proof; `e^x = 0` is empty because `Invert` produced `ln(0)` and dropped it as non-finite, also a
  proof; `x! - 6 = 0` is empty because `Factorialf.InvertNode` returns nothing at all, which is a
  give-up — and 3 *is* a root. `Modf`, `Summationf`, `Productf`, `Limitf` and `Derivativef` decline
  the same way, two of them with a comment saying so. Separating these means giving `InvertNode` a
  way to say "declined" across ~30 overrides, and it changes what `Invert`'s five callers read; it
  belongs to #1036's step 5 rather than to this one, and `x! - 6 = 0` is still `{  }` after this PR.
* **`Functions/Continuous/Limits/Solvers/Solvers.Definition.cs:346`.** Reached only where both
  one-sided descents returned a value; every limit probed that reaches it (`1/x`, `abs(x)/x`,
  `sin(1/x)` at 0) is one that genuinely does not exist, so nothing here demonstrates it live.
  Making it honest means separating a descent's `NaN` from a proof throughout the limit pipeline,
  which is step 2's ledger.
* **`SetOperators.IntersectFiniteSetAndSet`**, described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd
