### PR TITLE
Print a node's Codomain, so the printed form stops losing it (#1022)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -34,6 +34,11 @@ read first.
 | | any expression mixing a number with a `Complex` argument, `Compile`d in a NativeAOT app — `"x + 1".Compile<Complex, Complex>("x")` | `UncompilableNodeException: ... The binary operator Add is not defined for the types 'System.Numerics.Complex' and 'System.Numerics.Complex'` | the compiled function, answering as it does under the JIT |
 | | `Compile` to a nullable integral return type in a NativeAOT app | `AngouriBugException: IsNaN method expected for type System.Double`, which took the process down | the compiled function |
 | **Silent** | an app publishing with `PublishTrimmed` or NativeAOT | `AngouriMath.dll` was copied in whole, being unmarked | it is trimmed with the rest, since the assembly now declares `IsTrimmable` |
+| **Silent** | `"domain(x, ZZ)".ToEntity().Stringize()`, and `ToString`, and `EntityJsonConverter` | `x`, which reads back with `Codomain = Any` | `domain(x, ZZ)`, which reads back narrowed |
+| **Silent** | `"domain(sqrt(-1), RR)".ToEntity().Stringize()` | `sqrt(-1)`, which evaluates to `i` when read back | `domain(sqrt(-1), RR)`, which evaluates to `NaN` |
+| **Silent** | `"domain(x, ZZ)".ToEntity().Latexize()` | `x` | `{\left(x\right)}_{\mathbb{Z}}` |
+| **Silent** | `"x - domain(x, ZZ)".ToEntity().Simplify()`, and any sum mixing a node with a narrowed codomain and the same node without | `0` — the two were collected as one monomial | `x - domain(x, ZZ)`, left alone |
+| | every node type's own `Stringize()` and `Latexize()` overrides — `Entity.Sumf.Stringize()` and 129 more | declared on each node | declared once on `Entity`; still callable on every node, and a consumer compiled against 2.3.0 has to be rebuilt |
 
 ### A polynomial inequality of degree three or more is answered
 
@@ -155,6 +160,78 @@ the same precedences this grammar uses — so those needed the same brackets —
 bracketing for. The change only ever adds `\left(`/`\right)` groups, which CSharpMath already
 parses, so nothing downstream needs a matching change
 ([#822](https://github.com/asc-community/AngouriMath/issues/822)).
+
+### A narrowed `Codomain` is printed, so it survives being read back
+
+`Codomain` decides evaluation — `sqrt(-1)` is `i`, and the same expression with `Codomain = Real`
+is `NaN`, which is the example on `Entity.Codomain` itself. No node printed it, so the two printed
+the same string and the annotation was lost the moment an expression was written out: to a file, to
+a database column, through `EntityJsonConverter`, or to another process.
+[#1022](https://github.com/asc-community/AngouriMath/issues/1022).
+
+The parser already had the syntax. `domain(expr, SET)` maps onto `WithCodomain` and works for every
+node, not only a variable, so only the printing half was missing. Measured on a build of 2.3.0 and a
+build of this branch:
+
+| expression | 2.3.0 printed | 2.3.0 read that back as | now prints |
+|---|---|---|---|
+| `"domain(x, ZZ)".ToEntity()` | `x` | a `Variable` with `Codomain = Any` | `domain(x, ZZ)` |
+| `"domain(x + 1, RR)".ToEntity()` | `x + 1` | a `Sumf` with `Codomain = Complex` | `domain(x + 1, RR)` |
+| `"domain(sqrt(-1), RR)".ToEntity()` | `sqrt(-1)` | a `Powf` that evaluates to `i` | `domain(sqrt(-1), RR)` |
+| `"domain([1, 2], RR)".ToEntity()` | `[1, 2]` | a `Matrix` with `Codomain = Any` | `domain([1, 2], RR)` |
+| `Sin(Var("x").WithCodomain(Integer)) + Var("y").WithCodomain(Real)` | `sin(x) + y` | both annotations gone | `sin(domain(x, ZZ)) + domain(y, RR)` |
+
+`EntityJsonConverter` serialises what `Stringize` prints, so it changes with it and needed no code:
+`JsonSerializer.Serialize("domain(x, ZZ)".ToEntity())` was `"x"` and is `"domain(x, ZZ)"`.
+
+**A sum stops collecting two terms that are not the same term.** `Simplify`'s polynomial
+collection keys a monomial by its base's *printed form*, so while the printed form did not
+distinguish `x` from `x` narrowed to the integers, it added them up as one:
+
+```
+"x - domain(x, ZZ)".ToEntity().Simplify()      2.3.0: 0                    now: x - domain(x, ZZ)
+"domain(x, ZZ) + x".ToEntity().Simplify()      2.3.0: 2 * x                now: domain(x, ZZ) + x
+```
+
+`0` is the answer only where `x` is an integer, and the annotation is what says it might not be, so
+this was a wrong answer rather than a tidier one. Confirmed as the cause by putting the collision
+back — keying on the base with its codomain erased brings `0` and `2 * x` straight back.
+
+**The ordinary expression is untouched.** The wrapper is printed only where the codomain is *not*
+the one that parsing the bare text would give back, and nothing inside the library narrows a
+codomain — `WithCodomain` is called from the parser and from callers, and from nowhere else. So
+`"x + 1".ToEntity().Stringize()` is `x + 1` on both versions, and of the 8,084 tests in the suite
+the only two that moved are the one written to pin this defect and the recorded public surface.
+
+That default is **not the same for every node**, which is why the rule is a comparison and not a
+check against `Complex`: a `Variable` and a `Matrix` default to `Any`, `Absf`, `Modf`, `Minf`,
+`Maxf` and `Interval` to `Real`, every boolean node to `Boolean`, each numeric literal to its own
+type's domain, `Phif` to `Integer`, the set nodes and `Providedf`, `Piecewise`, `Application` and
+`Lambda` to `Any`, and the rest to `Complex`. Each node now declares that default next to its
+`Codomain`, and a test asserts that every freshly built node of every node type carries it.
+
+**LaTeX** renders it as a subscripted set, `{\left(x\right)}_{\mathbb{Z}}`. The parentheses are
+unconditional because a variable renders its own index as a subscript, so `x_{\mathbb{Z}}` would be
+indistinguishable from a variable spelled that way. This is new output for
+[CSharpMath.Evaluation](https://github.com/verybadcat/CSharpMath/blob/master/CSharpMath.Evaluation/Evaluation.cs),
+which reads our LaTeX back and has no notion of a codomain; it appears only for an expression that
+carries a narrowed one ([#822](https://github.com/asc-community/AngouriMath/issues/822)).
+
+**Two annotations still do not survive, and both are the grammar's limit.** `Any` cannot be written
+at all — the second argument of `domain(...)` has to be one of the five special sets, and none of
+them means "no restriction" — so a node *widened* to `Any` from a narrower default still prints as
+though it had not been. And no input string yields a rational literal whose codomain is `Complex`,
+because the pass that reads `1/2` as a `Rational` rather than a quotient
+([#873](https://github.com/asc-community/AngouriMath/issues/873)) uses `Complex` as its "nobody
+annotated this" sentinel. Both are pinned by tests that fail if they start working, so neither can
+outlive itself.
+
+**The public surface.** Each node type used to declare its own `public override string Stringize()`
+and `Latexize()`; the codomain wrapper is one decision and now lives once on `Entity`, with the
+per-node rendering behind an internal member. All 130 overrides are therefore gone from
+`PublicApi.txt`. Nothing a caller can write stops compiling — `someSumf.Stringize()` still resolves,
+inherited from `Entity` — but an assembly *compiled* against 2.3.0 binds to
+`Entity+Sumf::Stringize()` where its static type is a concrete node, and has to be rebuilt.
 
 ### `Compile` works in a trimmed or NativeAOT application
 

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -43,7 +43,7 @@ read first.
 | **Silent** | `"domain(sqrt(-1), RR)".ToEntity().Stringize()` | `sqrt(-1)`, which evaluates to `i` when read back | `domain(sqrt(-1), RR)`, which evaluates to `NaN` |
 | **Silent** | `"domain(x, ZZ)".ToEntity().Latexize()` | `x` | `{\left(x\right)}_{\mathbb{Z}}` |
 | **Silent** | `"x - domain(x, ZZ)".ToEntity().Simplify()`, and any sum mixing a node with a narrowed codomain and the same node without | `0` — the two were collected as one monomial | `x - domain(x, ZZ)`, left alone |
-| | every node type's own `Stringize()` and `Latexize()` overrides — `Entity.Sumf.Stringize()` and 129 more | declared on each node | declared once on `Entity`; still callable on every node, and a consumer compiled against 2.3.0 has to be rebuilt |
+| | every node type's own `Stringize()` and `Latexize()` overrides — `Entity.Sumf.Stringize()` and 129 more | declared on each node | declared once on `Entity`; still callable on every node, and an assembly compiled against 2.3.0 keeps working without a rebuild |
 
 ### An equation nothing settled is no longer answered with the empty set
 
@@ -370,8 +370,20 @@ outlive itself.
 and `Latexize()`; the codomain wrapper is one decision and now lives once on `Entity`, with the
 per-node rendering behind an internal member. All 130 overrides are therefore gone from
 `PublicApi.txt`. Nothing a caller can write stops compiling — `someSumf.Stringize()` still resolves,
-inherited from `Entity` — but an assembly *compiled* against 2.3.0 binds to
-`Entity+Sumf::Stringize()` where its static type is a concrete node, and has to be rebuilt.
+inherited from `Entity` — and nothing already compiled stops running either.
+
+That second half was measured rather than assumed, because it is the kind of claim that reads
+plausibly in both directions. A consumer calling `((Entity.Sumf)e).Stringize()` was compiled against
+a build of 2.3.0, then run unchanged against a build of this branch: it prints what it printed
+before. Reading its metadata says why — C# binds a virtual call to the type that *declares* the
+method, so the emitted reference is `AngouriMath.Entity::Stringize()` whatever the static type of
+the receiver, and no consumer ever names `Entity+Sumf::Stringize()` at all. The removal is
+invisible except to reflection that asks a node type for its own declared members.
+
+Devirtualising `Stringize()` cannot orphan an override outside the library either: `Entity` already
+carried five `internal` or `private protected` abstract members (`Priority`, `SortHashName`,
+`IntrinsicCondition`, `ToSymPy`, `InvertNode`), so no assembly but this one has ever been able to
+derive a node from it.
 
 ### `Compile` works in a trimmed or NativeAOT application
 

--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -5945,8 +5945,12 @@ namespace AngouriMath
         {
             var sb = new System.Text.StringBuilder();
             sb.Append("import sympy\n\n");
+            // Name rather than Stringize: a variable narrowed with WithCodomain prints as
+            // `domain(x, ZZ)` since https://github.com/asc-community/AngouriMath/issues/1022, and
+            // that is not a Python identifier. The codomain itself does not survive the export --
+            // SymPy would spell it as an assumption on the symbol, which nothing here emits yet.
             foreach (var f in expr.Vars)
-                sb.Append($"{f.Stringize()} = sympy.Symbol('{f.Stringize()}')\n");
+                sb.Append($"{f.Name} = sympy.Symbol('{f.Name}')\n");
             sb.Append('\n');
             sb.Append("expr = ").Append(expr.ToSymPy());
             return sb.ToString();

--- a/Sources/AngouriMath/Core/Domains.Classes.cs
+++ b/Sources/AngouriMath/Core/Domains.Classes.cs
@@ -16,18 +16,24 @@ namespace AngouriMath
             {
                 /// <inheritdoc/>
                 public override Domain Codomain { get; protected init; } = Domain.Complex;
+                /// <inheritdoc/>
+                internal override Domain DefaultCodomain => Domain.Complex;
             }
 
             partial record Rational
             {
                 /// <inheritdoc/>
                 public override Domain Codomain { get; protected init; } = Domain.Rational;
+                /// <inheritdoc/>
+                internal override Domain DefaultCodomain => Domain.Rational;
             }
 
             partial record Real
             {
                 /// <inheritdoc/>
                 public override Domain Codomain { get; protected init; } = Domain.Real;
+                /// <inheritdoc/>
+                internal override Domain DefaultCodomain => Domain.Real;
             }
 #pragma warning restore SealedOrAbstract
 
@@ -35,6 +41,8 @@ namespace AngouriMath
             {
                 /// <inheritdoc/>
                 public override Domain Codomain { get; protected init; } = Domain.Integer;
+                /// <inheritdoc/>
+                internal override Domain DefaultCodomain => Domain.Integer;
             }
         }
 
@@ -42,174 +50,232 @@ namespace AngouriMath
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Any;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Any;
         }
 
         partial record Matrix
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Any;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Any;
         }
 
         partial record Sumf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Minusf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Mulf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Divf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Modf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Real;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Real;
         }
 
         partial record Sinf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Cosf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Tanf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Cotanf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Logf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Powf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Secantf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Cosecantf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Arcsecantf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Arccosecantf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Arcsinf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Arccosf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Arctanf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Arccotanf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Factorialf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Derivativef
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Integralf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Summationf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Productf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Limitf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Signumf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Absf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Real;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Real;
         }
 
         partial record Floorf
@@ -219,18 +285,24 @@ namespace AngouriMath
             // real case is stated by the value, not by this.
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Ceilf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Roundf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Minf
@@ -238,84 +310,112 @@ namespace AngouriMath
             // Only ordered arguments compare, so the value is real wherever there is one.
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Real;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Real;
         }
 
         partial record Maxf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Real;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Real;
         }
 
         partial record Gcdf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Complex;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Complex;
         }
 
         partial record Boolean
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Boolean;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Boolean;
         }
 
         partial record Notf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Boolean;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Boolean;
         }
 
         partial record Andf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Boolean;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Boolean;
         }
 
         partial record Orf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Boolean;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Boolean;
         }
 
         partial record Xorf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Boolean;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Boolean;
         }
 
         partial record Impliesf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Boolean;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Boolean;
         }
 
         partial record Equalsf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Boolean;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Boolean;
         }
 
         partial record Greaterf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Boolean;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Boolean;
         }
 
         partial record GreaterOrEqualf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Boolean;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Boolean;
         }
 
         partial record Lessf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Boolean;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Boolean;
         }
 
         partial record LessOrEqualf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Boolean;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Boolean;
         }
 
         partial record Set
@@ -324,48 +424,64 @@ namespace AngouriMath
             {
                 /// <inheritdoc/>
                 public override Domain Codomain { get; protected init; } = Domain.Any;
+                /// <inheritdoc/>
+                internal override Domain DefaultCodomain => Domain.Any;
             }
 
             partial record Interval
             {
                 /// <inheritdoc/>
                 public override Domain Codomain { get; protected init; } = Domain.Real;
+                /// <inheritdoc/>
+                internal override Domain DefaultCodomain => Domain.Real;
             }
 
             partial record ConditionalSet
             {
                 /// <inheritdoc/>
                 public override Domain Codomain { get; protected init; } = Domain.Any;
+                /// <inheritdoc/>
+                internal override Domain DefaultCodomain => Domain.Any;
             }
 
             partial record SpecialSet
             {
                 /// <inheritdoc/>
                 public override Domain Codomain { get; protected init; } = Domain.Any;
+                /// <inheritdoc/>
+                internal override Domain DefaultCodomain => Domain.Any;
             }
 
             partial record Unionf
             {
                 /// <inheritdoc/>
                 public override Domain Codomain { get; protected init; } = Domain.Any;
+                /// <inheritdoc/>
+                internal override Domain DefaultCodomain => Domain.Any;
             }
 
             partial record Intersectionf
             {
                 /// <inheritdoc/>
                 public override Domain Codomain { get; protected init; } = Domain.Any;
+                /// <inheritdoc/>
+                internal override Domain DefaultCodomain => Domain.Any;
             }
 
             partial record SetMinusf
             {
                 /// <inheritdoc/>
                 public override Domain Codomain { get; protected init; } = Domain.Any;
+                /// <inheritdoc/>
+                internal override Domain DefaultCodomain => Domain.Any;
             }
 
             partial record Inf
             {
                 /// <inheritdoc/>
                 public override Domain Codomain { get; protected init; } = Domain.Boolean;
+                /// <inheritdoc/>
+                internal override Domain DefaultCodomain => Domain.Boolean;
             }
         }
 
@@ -373,30 +489,40 @@ namespace AngouriMath
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Integer;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Integer;
         }
 
         partial record Providedf
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Any;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Any;
         }
 
         partial record Piecewise
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Any;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Any;
         }
 
         partial record Application
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Any;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Any;
         }
 
         partial record Lambda
         {
             /// <inheritdoc/>
             public override Domain Codomain { get; protected init; } = Domain.Any;
+            /// <inheritdoc/>
+            internal override Domain DefaultCodomain => Domain.Any;
         }
     }
 }

--- a/Sources/AngouriMath/Core/Domains.Definition.cs
+++ b/Sources/AngouriMath/Core/Domains.Definition.cs
@@ -36,12 +36,57 @@ namespace AngouriMath
         /// Complex
         /// i
         /// ------------------------------------
-        /// sqrt(-1)
+        /// domain(sqrt(-1), RR)
         /// Real
         /// NaN
         /// </code>
         /// </example>
         public abstract Domain Codomain { get; protected init; }
+
+        /// <summary>
+        /// The codomain a node of this type carries when nothing has narrowed it: the one that
+        /// parsing the node's own printed form, without a <c>domain(...)</c> around it, gives back.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// It is not <see cref="Domain.Complex"/> everywhere, which is why the printer cannot
+        /// assume a single default: a <see cref="Variable"/> and a <see cref="Matrix"/> are
+        /// <see cref="Domain.Any"/>, an <see cref="Absf"/> and an <see cref="Set.Interval"/> are
+        /// <see cref="Domain.Real"/>, every boolean node is <see cref="Domain.Boolean"/>, and each
+        /// numeric literal takes the domain of its own type.
+        /// </para>
+        /// <para>
+        /// <see cref="Stringize()"/> compares against this to decide whether to print the
+        /// annotation at all. A codomain equal to it is already what the bare text means, so
+        /// wrapping it would put <c>domain(...)</c> around every expression in the library; one
+        /// that differs is lost unless it is printed.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1022">#1022</a>
+        /// </para>
+        /// <para>
+        /// Abstract rather than defaulted, so that a node declaring a <see cref="Codomain"/> and
+        /// forgetting this one does not compile. The two are declared side by side in
+        /// <c>Domains.Classes.cs</c> and must name the same domain;
+        /// <c>CodomainSurvivesPrintingTest.AFreshNodeCarriesItsDefaultCodomainAndPrintsNoAnnotation</c>
+        /// is the check that they do.
+        /// </para>
+        /// </remarks>
+        internal abstract Domain DefaultCodomain { get; }
+
+        /// <summary>
+        /// Whether the printers have to spell this node's codomain out, because parsing what they
+        /// would otherwise print gives a node with a different one.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <see cref="Domain.Any"/> is excluded because the grammar has no way to write it: the
+        /// second argument of <c>domain(...)</c> must be a <see cref="Set.SpecialSet"/>, and there
+        /// is no node for "no restriction" — see <see cref="Set.SpecialSet.Create(Domain)"/>. So a
+        /// node widened to <see cref="Domain.Any"/> from a narrower default still prints as though
+        /// it had not been. Printing <c>CC</c> there would be a different lie, and throwing from a
+        /// printer would take out every diagnostic message that quotes an expression.
+        /// </para>
+        /// </remarks>
+        internal bool PrintsItsCodomain => Codomain != DefaultCodomain && Codomain != Domain.Any;
 
         /// <summary>
         /// Returns this node with the specified codomain, 
@@ -69,7 +114,7 @@ namespace AngouriMath
         /// Complex
         /// i
         /// ------------------------------------
-        /// sqrt(-1)
+        /// domain(sqrt(-1), RR)
         /// Real
         /// NaN
         /// </code>

--- a/Sources/AngouriMath/Core/Serialization/EntityJsonConverter.cs
+++ b/Sources/AngouriMath/Core/Serialization/EntityJsonConverter.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) 2019-2022 Angouri.
 // AngouriMath is licensed under MIT.
 // Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
@@ -40,16 +40,18 @@ namespace AngouriMath.Core.Serialization
     /// serialization uses.
     /// </para>
     /// <para>
-    /// What the printed form does not carry, and neither therefore does this:
-    /// <see cref="Entity.Codomain"/>, which no node prints, so a node narrowed with
-    /// <see cref="Entity.WithCodomain(Domain)"/> comes back with the default
-    /// (<a href="https://github.com/asc-community/AngouriMath/issues/1022">#1022</a>); and an
+    /// What the printed form does not carry, and neither therefore does this: an
     /// <see cref="Entity.Number.Complex"/> with both parts non-zero, which prints as a sum and
     /// reads back as one — the same number, a different node. Nor is a right nesting of an
     /// <em>associative</em> operator kept, since such an operand is not bracketed at its own
     /// precedence: <c>1 + (2 + 3)</c> comes back as <c>(1 + 2) + 3</c>, the same value written the
     /// other way round. Both are properties of printing rather than of this converter, and fixing
-    /// them there fixes them here.
+    /// them there fixes them here — which is what happened to the third,
+    /// <see cref="Entity.Codomain"/>: a node narrowed with
+    /// <see cref="Entity.WithCodomain(Domain)"/> used to come back with the default, and prints
+    /// as <c>domain(inner, SET)</c> since
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/1022">#1022</a>, with no
+    /// change here at all.
     /// </para>
     /// <a href="https://github.com/asc-community/AngouriMath/issues/323">#323</a>
     /// </remarks>

--- a/Sources/AngouriMath/Docs/Contributing/AddingNode.cs
+++ b/Sources/AngouriMath/Docs/Contributing/AddingNode.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) 2019-2022 Angouri.
 // AngouriMath is licensed under MIT.
 // Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
@@ -35,11 +35,15 @@
 /// 
 /// 3. A few essential methods
 ///     a. InnerEval and InnerSimplify (<see cref="AngouriMath.Entity.Sinf.InnerEval"/> for numerical and <see cref="AngouriMath.Entity.Andf.InnerEval"/> for boolean)
-///     b. Stringize (<see cref="AngouriMath.Entity.Sinf.Stringize"/>) (and tests to CircleTest.cs)
-///     c. Latexize (<see cref="AngouriMath.Entity.Sinf.Latexize"/>) (and tests to LatexTest.cs)
+///     b. StringizeNode (<see cref="AngouriMath.Entity.Sinf.StringizeNode"/>) (and tests to CircleTest.cs).
+///        It renders this node only; Entity.Stringize wraps the result in `domain(..., SET)`
+///        where the codomain is not the type's default, so that is not yours to do.
+///     c. LatexizeNode (<see cref="AngouriMath.Entity.Sinf.LatexizeNode"/>) (and tests to LatexTest.cs)
 ///     d. Limit computation (<see cref="AngouriMath.Entity.Sinf.ComputeLimitDivideEtImpera"/>) (and tests to LimitTest.cs)
 ///     e. Hash for sorting (<see cref="AngouriMath.Entity.Sinf.SortHashName"/>)
-///     f. Default domain <see cref="AngouriMath.Entity.Sinf.Codomain"/>
+///     f. Default domain <see cref="AngouriMath.Entity.Sinf.Codomain"/>, and
+///        <see cref="AngouriMath.Entity.Sinf.DefaultCodomain"/> beside it naming the same one.
+///        Both are abstract, so a node that declares one and forgets the other does not compile.
 ///     g. Substitute <see cref="AngouriMath.Entity.Sinf.Substitute"/> (and tests to SubstituteTest.cs)
 /// 
 /// 4. Pattern replacer (<see cref="AngouriMath.Functions.Patterns.CommonRules"/> and <see cref="AngouriMath.Functions.Simplificator.Alternate"/>)

--- a/Sources/AngouriMath/Docs/Contributing/NodeContract.md
+++ b/Sources/AngouriMath/Docs/Contributing/NodeContract.md
@@ -1,4 +1,4 @@
-# What a node type has to implement, and who may write one
+﻿# What a node type has to implement, and who may write one
 
 [#1026](https://github.com/asc-community/AngouriMath/issues/1026) asks a question the tree does not
 answer anywhere: **can a node type be defined outside `AngouriMath.dll`, and if not, what would it
@@ -19,7 +19,7 @@ a build, that is next to it. Run them again before quoting a figure at a later c
 
 ## 1. The contract as it is
 
-`Entity` declares **eleven abstract members**. Reflection over the shipped assembly, so this counts
+`Entity` declares **twelve abstract members**. Reflection over the shipped assembly, so this counts
 what a subclass actually has to satisfy rather than what the source appears to say:
 
 ```csharp
@@ -29,9 +29,10 @@ typeof(Entity).GetMethods(Instance | Public | NonPublic | DeclaredOnly).Where(m 
 | member | accessibility | read by | how many of the 68 node types write their own |
 |---|---|---|--:|
 | `Codomain` | `public` (`protected init`) | `InnerSimplifyWithCheck`, domain machinery | 62 |
-| `Latexize()` | `public` | the LaTeX printer, and CSharpMath downstream | 62 |
+| `DefaultCodomain` | **`internal`** | `Entity.Stringize()` and `Entity.Latexize()`, to decide whether the codomain has to be printed | 62 |
+| `LatexizeNode()` | **`private protected`** | `Entity.Latexize()`, hence the LaTeX printer and CSharpMath downstream | 62 |
 | `Replace(Func<Entity, Entity>)` | `public` | every traversal | 58 |
-| `Stringize()` | `public` | the text printer, and the parser round trip | 67 |
+| `StringizeNode()` | **`private protected`** | `Entity.Stringize()`, hence the text printer and the parser round trip | 67 |
 | `InitDirectChildren()` | `protected` | `DirectChildren`, hence everything | 58 |
 | `InnerSimplify(bool)` | `protected` | `InnerSimplified`, `Evaled` | 59 |
 | `Priority` | **`internal`** | `Functions/Output/` **only** | 35 |

--- a/Sources/AngouriMath/Docs/Contributing/Packaging.md
+++ b/Sources/AngouriMath/Docs/Contributing/Packaging.md
@@ -1,4 +1,4 @@
-# What ships in which package, and how to decide where the next thing goes
+﻿# What ships in which package, and how to decide where the next thing goes
 
 [#746](https://github.com/asc-community/AngouriMath/issues/746) item 78 asks for this file: which
 capabilities belong in the kernel package, which ship separately, and what the dependency rules
@@ -136,16 +136,16 @@ typeof(AngouriMath.Entity).Assembly     # measured by reflection on the built ne
 
 - 634 types, of which **158 are public**;
 - **68 concrete `Entity` subclasses** and 10 abstract ones;
-- **13 abstract members declared on `Entity`** — `<Clone>$` is the compiler's, and `Codomain`'s getter
-  and setter are one property, so **11 distinct capabilities**: `Codomain`, `InitDirectChildren`,
-  `InnerSimplify`, `IntrinsicCondition`, `InvertNode`, `Latexize`, `Priority`, `Replace`,
-  `SortHashName`, `Stringize`, `ToSymPy`;
+- **14 abstract members declared on `Entity`** — `<Clone>$` is the compiler's, and `Codomain`'s getter
+  and setter are one property, so **12 distinct capabilities**: `Codomain`, `DefaultCodomain`,
+  `InitDirectChildren`, `InnerSimplify`, `IntrinsicCondition`, `InvertNode`, `LatexizeNode`,
+  `Priority`, `Replace`, `SortHashName`, `StringizeNode`, `ToSymPy`;
 - 13 referenced assemblies, 4 of them third-party. (`System.Console` is on the list because the
   ANTLR-generated lexer and parser default their error streams to it.)
 
-**Eleven capabilities × 68 node types is the reason the kernel is one assembly.** A capability written
+**Twelve capabilities × 68 node types is the reason the kernel is one assembly.** A capability written
 as an abstract member of `Entity` cannot be in a different package than `Entity`, whatever anyone
-decides. Three of the eleven are output formats and one is a solver detail.
+decides. Three of the twelve are output formats and one is a solver detail.
 
 ---
 
@@ -260,7 +260,7 @@ subsystem's own directory.
 | capability | why it is where it is |
 |---|---|
 | `Entity` model, parser, evaluation, `InnerSimplify`, `ToString` | no clause fires; several are abstract members of `Entity` — **kernel by construction** |
-| LaTeX printer | `public abstract string Latexize()` on `Entity` — **kernel by construction** |
+| LaTeX printer | `private protected abstract string LatexizeNode()` on `Entity` — **kernel by construction** |
 | SymPy export | `internal abstract string ToSymPy()` on `Entity`, overridden by every node — **kernel by construction**, and has been since before `v1.4.0` |
 | simplification rules and the transformation layer | on the default path; 111 public members in the `AngouriMath.Core.Transformations` namespace — **kernel** |
 | polynomial layer | six inbound edges from the engine, including `Simplificator`, `RewriteRules`, `Patterns` and `Evaluation.Continuous.Arithmetics` — **kernel** |

--- a/Sources/AngouriMath/Docs/Contributing/Serialization.md
+++ b/Sources/AngouriMath/Docs/Contributing/Serialization.md
@@ -1,4 +1,4 @@
-## Serialization
+﻿## Serialization
 
 An `Entity` written out and read back is the expression that was written, as exactly as the
 printed form is — which is the whole of the design, and *What the printed form does not carry* below
@@ -54,16 +54,21 @@ free and a benchmark that reuses one measures nothing.
 
 ### What the printed form does not carry
 
-Two, and both are properties of printing rather than of the converter, so fixing them there fixes
-them here:
+One, and it is a property of printing rather than of the converter, so fixing it there fixes it
+here:
 
-- **`Codomain`.** No node prints it, so a node narrowed with `WithCodomain` — or written
-  `domain(x, ZZ)`, which the parser does accept — comes back with the default.
-  [#1022](https://github.com/asc-community/AngouriMath/issues/1022). Pinned by
-  `EntitySerializationTest.ACodomainDoesNotSurviveBecauseNothingPrintsIt`, which is written to fail
-  when the issue is fixed.
 - **`Number.Complex` with both parts non-zero.** It prints as a sum and reads back as `Sumf` — the
   same number, a different node. Already recorded in `EveryNodeSurvivesEveryPipelineTest`.
+
+**`Codomain` used to be on that list and no longer is.** A node narrowed with `WithCodomain` — or
+written `domain(x, ZZ)`, which the parser has always accepted — came back with the default, because
+nothing printed the annotation ([#1022](https://github.com/asc-community/AngouriMath/issues/1022)).
+It prints as `domain(inner, SET)` now, and the converter needed no change at all: it serialises what
+`Stringize` prints. `EntitySerializationTest.ACodomainSurvivesBecauseThePrintedFormCarriesIt` is
+where that is held. Two corners of it are still the *grammar*'s limit rather than the printer's:
+`Domain.Any` has no special set to name it, and no input yields a `Rational` whose codomain is
+`Complex`, since the pass that reads `1/2` as a rational treats `Complex` as "nobody annotated
+this".
 
 And one that is not about a node type but about how operands nest. An **associative** operator whose
 operands nest to the right comes back nested to the left, because the printed form does not bracket a

--- a/Sources/AngouriMath/Docs/Usage/Syntax.md
+++ b/Sources/AngouriMath/Docs/Usage/Syntax.md
@@ -13,8 +13,21 @@ notation is not in the grammar prints as its function call instead: a lambda pri
 `lambda(x, x + 1)` and not `x -> x + 1`, because `->` is the implication operator and the arrow
 form would silently come back as something else.
 
-One thing the printed form does not carry: a **codomain**. `domain(x, ZZ)` prints as `x`, and the
-narrowing is lost on the way back ([#1022](https://github.com/asc-community/AngouriMath/issues/1022)).
+A **codomain** is part of that. A node whose `Codomain` is not the one its type carries by default
+prints inside `domain(...)`, so `domain(x, ZZ)` prints as `domain(x, ZZ)` and reads back narrowed
+([#1022](https://github.com/asc-community/AngouriMath/issues/1022)); it is not decoration, since
+`sqrt(-1)` is `i` and `domain(sqrt(-1), RR)` is `NaN`. The wrapper is printed only where it says
+something, so the ordinary expression is unchanged — and the default is not the same for every node:
+a variable and a matrix default to `Any`, `abs` and an interval to `RR`, every boolean node to `BB`,
+each numeric literal to its own type's domain, and everything else to `CC`.
+
+Two annotations still do not survive, and both are the grammar's limit rather than the printer's.
+There is no way to write **`Any`**, because the second argument of `domain(...)` has to be one of
+the five special sets and none of them means "no restriction" — so a node *widened* to `Any` from a
+narrower default prints as though it had not been. And no input at all yields a rational literal
+whose codomain is `CC`: the pass that reads `1/2` as a rational rather than a quotient
+([#873](https://github.com/asc-community/AngouriMath/issues/873)) treats `CC` as "nobody annotated
+this", because that is what an un-annotated `/` carries.
 
 **LaTeX output has a round trip too, and it is checked in someone else's repository.**
 [CSharpMath.Evaluation](https://github.com/verybadcat/CSharpMath/blob/master/CSharpMath.Evaluation/Evaluation.cs)
@@ -192,6 +205,10 @@ range in [#657](https://github.com/asc-community/AngouriMath/pull/657).
 
 **Structural** — `piecewise(a provided p, b provided q)`, `lambda(param, body)`,
 `apply(f, arg, ...)`, `domain(expr, set)`.
+
+`domain` takes a special set — `CC` `RR` `QQ` `ZZ` `BB` — and narrows the *codomain* of whatever
+node it wraps, which is what makes the expression evaluate to `NaN` outside it. It applies to any
+node, not only a variable, and it is what `Stringize` prints for one.
 
 **Refused by name** — `trunc` `lcm` `erf` `conjugate`. AngouriMath has none of these, and each is
 what some other CAS calls a function, so a caller reaches for it. Left alone they would be read as

--- a/Sources/AngouriMath/Functions/Output/Latex.Definition.cs
+++ b/Sources/AngouriMath/Functions/Output/Latex.Definition.cs
@@ -44,7 +44,24 @@ namespace AngouriMath
         /// \frac{a}{{b}^{\lim_{x\to \infty } \left[\sin\left(x\right)-\frac{{e}^{y}+{e}^{-y}}{2}\right]}}
         /// </code>
         /// </example>
-        public abstract string Latexize();
+        /// <remarks>
+        /// A node whose <see cref="Codomain"/> is not its type's default is rendered as the node
+        /// subscripted with the set, <c>{\left(x\right)}_{\mathbb{Z}}</c>. The parentheses are
+        /// unconditional: a <see cref="Variable"/> already renders its own index as a subscript,
+        /// so <c>x_{\mathbb{Z}}</c> would be indistinguishable from a variable named that way.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1022">#1022</a>
+        /// </remarks>
+        public string Latexize()
+            => PrintsItsCodomain
+                ? $@"{{\left({LatexizeNode()}\right)}}_{{{Set.SpecialSet.Create(Codomain).Latexize()}}}"
+                : LatexizeNode();
+
+        /// <summary>
+        /// Renders this node, and this node only: the codomain subscript is
+        /// <see cref="Latexize()"/>'s to add, so that it is decided in one place.
+        /// </summary>
+        private protected abstract string LatexizeNode();
+
         /// <summary>
         /// Calculus operators, unlike other functions, have a <see cref="LatexPriority"/> between addition/subtraction
         /// and multiplication/division which is different from <see cref="Priority"/>.
@@ -53,7 +70,11 @@ namespace AngouriMath
 
         /// <summary>Returns the expression in LaTeX (for example, a / b -> \frac{a}{b})</summary>
         /// <param name="parenthesesRequired">Whether to wrap it with parentheses</param>
+        /// <remarks>
+        /// A node that renders its codomain needs no brackets: the subscript already applies to a
+        /// parenthesised group, so anything around it would be a second pair.
+        /// </remarks>
         protected internal string Latexize(bool parenthesesRequired) =>
-            parenthesesRequired ? @$"\left({Latexize()}\right)" : Latexize();
+            parenthesesRequired && !PrintsItsCodomain ? @$"\left({Latexize()}\right)" : Latexize();
     }
 }

--- a/Sources/AngouriMath/Functions/Output/Latex/Latex.Arithmetics.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/Latex/Latex.Arithmetics.Classes.cs
@@ -14,7 +14,7 @@ namespace AngouriMath
         public partial record Sumf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 Augend.Latexize(Augend.LatexPriority < LatexPriority)
                 + (Addend.Latexize(Addend.LatexPriority < LatexPriority) is var addend && addend.StartsWith("-")
                     ? addend : "+" + addend);
@@ -23,7 +23,7 @@ namespace AngouriMath
         public partial record Minusf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 Minuend.Latexize(Minuend.LatexPriority < LatexPriority)
                 + "-" + Subtrahend.Latexize(Subtrahend.LatexPriority <= LatexPriority);
         }
@@ -31,7 +31,7 @@ namespace AngouriMath
         public partial record Mulf
         {
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
             {
                 var longArray = GatherProducts(this).ToArray();
                 return longArray.AggregateIndexed("",
@@ -93,21 +93,21 @@ namespace AngouriMath
         public partial record Divf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 @"\frac{" + Dividend.Latexize() + "}{" + Divisor.Latexize() + "}";
         }
 
         public partial record Modf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 Dividend.Latexize(Dividend.Priority < Priority) + @" \bmod " + Divisor.Latexize(Divisor.Priority <= Priority);
         }
 
         public partial record Logf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 Base == 10
                 ? @"\log\left(" + Antilogarithm.Latexize() + @"\right)"
                 : Base == MathS.e
@@ -118,7 +118,7 @@ namespace AngouriMath
         public partial record Powf
         {
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
             {
                 if (Exponent is Rational { ERational: { Numerator: var numerator, Denominator: var denominator } }
                     and not Integer)
@@ -143,35 +143,35 @@ namespace AngouriMath
         public partial record Factorialf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 Argument.Latexize(Argument.LatexPriority <= LatexPriority) + "!";
         }
 
         partial record Signumf
         {
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
                 => $@"\operatorname{{sgn}}\left({Argument.Latexize()}\right)";
         }
 
         partial record Absf
         {
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
                 => $@"\left|{Argument.Latexize()}\right|";
         }
 
         partial record Floorf
         {
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
                 => $@"\left\lfloor{{{Argument.Latexize()}}}\right\rfloor";
         }
 
         partial record Ceilf
         {
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
                 => $@"\left\lceil{{{Argument.Latexize()}}}\right\rceil";
         }
 
@@ -179,28 +179,28 @@ namespace AngouriMath
         {
             // The nearest-integer brackets: a floor on the left, a ceiling on the right.
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
                 => $@"\left\lfloor{{{Argument.Latexize()}}}\right\rceil";
         }
 
         partial record Minf
         {
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
                 => $@"\min\left({Left.Latexize()}, {Right.Latexize()}\right)";
         }
 
         partial record Maxf
         {
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
                 => $@"\max\left({Left.Latexize()}, {Right.Latexize()}\right)";
         }
 
         partial record Gcdf
         {
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
                 => $@"\gcd\left({Left.Latexize()}, {Right.Latexize()}\right)";
         }
 
@@ -208,7 +208,7 @@ namespace AngouriMath
         {
             /// <inheritdoc/>
             // NOTE: \operatorname is used here to distinguish the phi function from variables, consistent with sgn and other functions.
-            public override string Latexize() => $@"\operatorname{{\varphi}}\left({Argument.Latexize()}\right)";
+            private protected override string LatexizeNode() => $@"\operatorname{{\varphi}}\left({Argument.Latexize()}\right)";
         }
     }
 }

--- a/Sources/AngouriMath/Functions/Output/Latex/Latex.Calculus.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/Latex/Latex.Calculus.Classes.cs
@@ -19,7 +19,7 @@ namespace AngouriMath
         public partial record Derivativef
         {
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
             {
                 if (Iterations < 0)
                 {
@@ -47,7 +47,7 @@ namespace AngouriMath
         public partial record Integralf
         {
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
             {
                 var sb = new StringBuilder(@"\int");
                 if (Range is var (from, to)) sb.Append('_').Append('{').Append(from.Latexize()).Append('}').Append('^').Append('{').Append(to.Latexize()).Append('}');
@@ -69,7 +69,7 @@ namespace AngouriMath
         public partial record Summationf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 @"\sum_{" + Var.Latexize() + "=" + From.Latexize() + "}^{" + To.Latexize() + "}"
                 + Expression.Latexize(Expression.Priority < Priority.Sum);
         }
@@ -77,7 +77,7 @@ namespace AngouriMath
         public partial record Productf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 @"\prod_{" + Var.Latexize() + "=" + From.Latexize() + "}^{" + To.Latexize() + "}"
                 + Expression.Latexize(Expression.Priority < Priority.Mul);
         }
@@ -85,7 +85,7 @@ namespace AngouriMath
         public partial record Limitf
         {
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
             {
                 var sb = new StringBuilder();
                 sb.Append(@"\lim_{").Append(Var.Latexize())

--- a/Sources/AngouriMath/Functions/Output/Latex/Latex.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/Latex/Latex.Classes.cs
@@ -50,7 +50,7 @@ namespace AngouriMath
             /// Returns latexized const if it is possible to latexize it,
             /// or its original name otherwise
             /// </summary>
-            public override string Latexize()
+            private protected override string LatexizeNode()
             {
                 static string LatexizePart(string symbol, bool upright)
                 {

--- a/Sources/AngouriMath/Functions/Output/Latex/Latex.Discrete.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/Latex/Latex.Discrete.Classes.cs
@@ -13,13 +13,13 @@ namespace AngouriMath
         partial record Boolean
         {
             /// <inheritdoc/>
-            public override string Latexize() => (bool)this ? @"\top " : @"\bot ";
+            private protected override string LatexizeNode() => (bool)this ? @"\top " : @"\bot ";
         }
 
         partial record Notf
         {
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
                 => Argument is Equalsf(var left, var right)
                    ? $@"{left.Latexize(left.LatexPriority <= Priority.Equal)} \neq {right.Latexize(right.LatexPriority <= Priority.Equal)}"
                    : $@"\neg{{{Argument.Latexize(Argument.LatexPriority < LatexPriority)}}}";
@@ -28,7 +28,7 @@ namespace AngouriMath
         partial record Andf
         {
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
             {
                 var result = new System.Text.StringBuilder();
                 Entity? left = null;
@@ -78,7 +78,7 @@ namespace AngouriMath
         partial record Orf
         {
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
                 => $@"{Left.Latexize(Left.LatexPriority < LatexPriority)} \lor {Right.Latexize(Right.LatexPriority < LatexPriority)}";
         }
 
@@ -86,7 +86,7 @@ namespace AngouriMath
         {
             /// <inheritdoc/>
             // NOTE: \veebar (⊻) can disambiguate better than \oplus (⊕) which can mean the direct sum in algebra.
-            public override string Latexize()
+            private protected override string LatexizeNode()
                 => $@"{Left.Latexize(Left.LatexPriority < LatexPriority)} \veebar {Right.Latexize(Right.LatexPriority < LatexPriority)}";
         }
 
@@ -98,21 +98,21 @@ namespace AngouriMath
             // \implies (⇒) is a metalanguage symbol indicating a logical consequence or entailment. It's used to express that one statement logically follows from another.
             // ISO 80000-2 puts ⇒ first for implies, but → is also accepted and is more common in logic contexts.
             // ⇒ can be used in steps for proofs if we were to add it later.
-            public override string Latexize()
+            private protected override string LatexizeNode()
                 => $@"{Assumption.Latexize(Assumption.LatexPriority <= LatexPriority)} \to {Conclusion.Latexize(Conclusion.LatexPriority < LatexPriority)}";
         }
 
         partial record Equalsf
         {
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
                 => $@"{Left.Latexize(Left.LatexPriority <= LatexPriority)} = {Right.Latexize(Right.LatexPriority <= LatexPriority)}";
         }
 
         partial record Greaterf
         {
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
                 => $@"{Left.Latexize(Left.LatexPriority <= LatexPriority)} > {Right.Latexize(Right.LatexPriority <= LatexPriority)}";
         }
 
@@ -121,14 +121,14 @@ namespace AngouriMath
             /// <inheritdoc/>
             // NOTE: While \geqslant (⩾) is more used in e.g. Russian texts, \geq (≥) is more universally used in English texts.
             // Since the output language of LaTeX is English (referencing Piecewise and Providedf), \geq is more appropriate.
-            public override string Latexize()
+            private protected override string LatexizeNode()
                 => $@"{Left.Latexize(Left.LatexPriority <= LatexPriority)} \geq {Right.Latexize(Right.LatexPriority <= LatexPriority)}";
         }
 
         partial record Lessf
         {
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
                 => $@"{Left.Latexize(Left.LatexPriority <= LatexPriority)} < {Right.Latexize(Right.LatexPriority <= LatexPriority)}";
         }
 
@@ -137,7 +137,7 @@ namespace AngouriMath
             /// <inheritdoc/>
             // NOTE: While \leqslant (⩽) is more used in e.g. Russian texts, \leq (≤) is more universally used in English texts.
             // Since the output language of LaTeX is English (referencing Piecewise and Providedf), \leq is more appropriate.
-            public override string Latexize()
+            private protected override string LatexizeNode()
                 => $@"{Left.Latexize(Left.LatexPriority <= LatexPriority)} \leq {Right.Latexize(Right.LatexPriority <= LatexPriority)}";
         }
     }

--- a/Sources/AngouriMath/Functions/Output/Latex/Latex.Number.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/Latex/Latex.Number.Classes.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) 2019-2022 Angouri.
 // AngouriMath is licensed under MIT.
 // Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
@@ -16,7 +16,7 @@ namespace AngouriMath
             partial record Complex
             {
                 /// <inheritdoc/>
-                public override string Latexize()
+                private protected override string LatexizeNode()
                 {
                     static string RenderNum(Real number)
                     {
@@ -40,7 +40,7 @@ namespace AngouriMath
             partial record Real
             {
                 /// <inheritdoc/>
-                public override string Latexize() => this switch
+                private protected override string LatexizeNode() => this switch
                 {
                     { IsFinite: true } => EDecimal.ToString(),
                     { IsNaN: true } => @"\mathrm{undefined}",
@@ -52,14 +52,14 @@ namespace AngouriMath
             partial record Rational
             {
                 /// <inheritdoc/>
-                public override string Latexize() => $@"\frac{{{ERational.Numerator}}}{{{ERational.Denominator}}}";
+                private protected override string LatexizeNode() => $@"\frac{{{ERational.Numerator}}}{{{ERational.Denominator}}}";
 
             }
 
             partial record Integer
             {
                 /// <inheritdoc/>
-                public override string Latexize() => EInteger.ToString();
+                private protected override string LatexizeNode() => EInteger.ToString();
             }
         }
     }

--- a/Sources/AngouriMath/Functions/Output/Latex/Latex.Omni.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/Latex/Latex.Omni.Classes.cs
@@ -16,7 +16,7 @@ namespace AngouriMath
             partial record FiniteSet
             {
                 /// <inheritdoc/>
-                public override string Latexize()
+                private protected override string LatexizeNode()
                     => IsSetEmpty ? @"\emptyset" : $@"\left\{{ {string.Join(", ", Elements.Select(c => c.Latexize()))} \right\}}";
             }
 
@@ -25,7 +25,7 @@ namespace AngouriMath
                 /// <inheritdoc/>
                 // NOTE: Comma is used as the separator following standard mathematical notation (ISO 80000-2).
                 // Some regional variants use semicolon, but comma is more universally recognized.
-                public override string Latexize()
+                private protected override string LatexizeNode()
                 {
                     var left = LeftClosed ? "[" : "(";
                     var right = RightClosed ? "]" : ")";
@@ -36,14 +36,14 @@ namespace AngouriMath
             partial record ConditionalSet
             {
                 /// <inheritdoc/>
-                public override string Latexize()
+                private protected override string LatexizeNode()
                     => $@"\left\{{ {Var.Latexize()} : {Predicate.Latexize()} \right\}}";
             }
 
             partial record SpecialSet
             {
                 /// <inheritdoc/>
-                public override string Latexize()
+                private protected override string LatexizeNode()
                     => $@"\mathbb{{{Stringize()[0]}}}";
             }
 
@@ -54,14 +54,14 @@ namespace AngouriMath
                 // them to the left, exactly as the grammar here does, so a \setminus on the right
                 // needs bracketing or it comes back as the outer operator. Union with union is
                 // associative and stays flat.
-                public override string Latexize()
+                private protected override string LatexizeNode()
                     => $@"{Left.Latexize(Left.LatexPriority < LatexPriority)} \cup {Right.Latexize(Right.LatexPriority < LatexPriority || Right is SetMinusf)}";
             }
 
             partial record Intersectionf
             {
                 /// <inheritdoc/>
-                public override string Latexize()
+                private protected override string LatexizeNode()
                     => $@"{Left.Latexize(Left.LatexPriority < LatexPriority)} \cap {Right.Latexize(Right.LatexPriority < LatexPriority)}";
             }
 
@@ -70,7 +70,7 @@ namespace AngouriMath
                 /// <inheritdoc/>
                 // Not associative, and sharing a precedence level with union: anything at that
                 // level on the right is bracketed, the same rule \frac's text form follows.
-                public override string Latexize()
+                private protected override string LatexizeNode()
                     => $@"{Left.Latexize(Left.LatexPriority < LatexPriority)} \setminus {Right.Latexize(Right.LatexPriority <= LatexPriority)}";
             }
 
@@ -78,7 +78,7 @@ namespace AngouriMath
             {
                 /// <inheritdoc/>
                 // \in is left-folded by CSharpMath too, and membership is not associative.
-                public override string Latexize()
+                private protected override string LatexizeNode()
                     => $@"{Element.Latexize(Element.LatexPriority < LatexPriority)} \in {SupSet.Latexize(SupSet.LatexPriority <= LatexPriority)}";
             }
         }
@@ -88,13 +88,13 @@ namespace AngouriMath
             /// <inheritdoc/>
             // Right-folding, so the left operand is the one that needs bracketing -- see the
             // remark on Stringize.
-            public override string Latexize() => $@"{Expression.Latexize(Expression.LatexPriority <= LatexPriority)} \quad \text{{for}} \quad {Predicate.Latexize(Predicate.LatexPriority < LatexPriority)}";
+            private protected override string LatexizeNode() => $@"{Expression.Latexize(Expression.LatexPriority <= LatexPriority)} \quad \text{{for}} \quad {Predicate.Latexize(Predicate.LatexPriority < LatexPriority)}";
         }
 
         partial record Piecewise
         {
             /// <inheritdoc/>
-            public override string Latexize() => @"\begin{cases}" +
+            private protected override string LatexizeNode() => @"\begin{cases}" +
                 string.Join(@"\\",
                 Cases.Select(c =>
                 {
@@ -110,7 +110,7 @@ namespace AngouriMath
         partial record Matrix
         {
             /// <inheritdoc/>
-            public override string Latexize()
+            private protected override string LatexizeNode()
             {
                 if (IsVector)
                 {
@@ -146,7 +146,7 @@ namespace AngouriMath
             /// <inheritdoc/>
             // NOTE: Application represents curried function application. Multiple arguments
             // are rendered as separate applications: f(x)(y) rather than f(x, y)
-            public override string Latexize()
+            private protected override string LatexizeNode()
             {
                 var result = new StringBuilder(Expression.Latexize(Expression.LatexPriority < LatexPriority));
                 foreach (var arg in Arguments)
@@ -162,7 +162,7 @@ namespace AngouriMath
             /// <inheritdoc/>
             // NOTE: \mapsto (↦) links the function variable with its output while
             // \rightarrow (→) links the function domain with its codomain. See https://math.stackexchange.com/a/651240, https://math.stackexchange.com/a/936591
-            public override string Latexize()
+            private protected override string LatexizeNode()
                 => Parameter.Latexize() + @" \mapsto " + Body.Latexize(Body.LatexPriority < LatexPriority);
         }
     }

--- a/Sources/AngouriMath/Functions/Output/Latex/Latex.Trigonometry.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/Latex/Latex.Trigonometry.Classes.cs
@@ -12,84 +12,84 @@ namespace AngouriMath
         public partial record Sinf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 @"\sin\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Cosf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 @"\cos\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Secantf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 @"\sec\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Cosecantf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 @"\csc\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Arcsecantf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 @"\operatorname{arcsec}\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Arccosecantf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 @"\operatorname{arccsc}\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Tanf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 @"\tan\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Cotanf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 @"\cot\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Arcsinf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 @"\arcsin\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Arccosf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 @"\arccos\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Arctanf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 @"\arctan\left(" + Argument.Latexize() + @"\right)";
         }
 
         public partial record Arccotanf
         {
             /// <inheritdoc/>
-            public override string Latexize() =>
+            private protected override string LatexizeNode() =>
                 @"\operatorname{arccot}\left(" + Argument.Latexize() + @"\right)";
         }
     }

--- a/Sources/AngouriMath/Functions/Output/ToString.Definition.cs
+++ b/Sources/AngouriMath/Functions/Output/ToString.Definition.cs
@@ -12,13 +12,37 @@ namespace AngouriMath
         /// <summary>
         /// Converts an expression into a string. Works synonymically into <see cref="Entity.ToString"/>.
         /// </summary>
-        public abstract string Stringize();
+        /// <remarks>
+        /// A node whose <see cref="Codomain"/> is not the one its type carries by default is
+        /// printed inside <c>domain(inner, SET)</c>, which is the syntax the parser already has
+        /// for it. Without that the annotation is dropped and the printed form reads back as a
+        /// different expression — <c>domain(sqrt(-1), RR)</c> is <see cref="MathS.NaN"/> and
+        /// <c>sqrt(-1)</c> is <c>i</c>, and the two used to print the same string.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1022">#1022</a>
+        /// </remarks>
+        public string Stringize()
+            => PrintsItsCodomain
+                ? $"domain({StringizeNode()}, {Set.SpecialSet.Create(Codomain).Stringize()})"
+                : StringizeNode();
+
+        /// <summary>
+        /// Converts this node, and this node only, into a string: the codomain wrapper is
+        /// <see cref="Stringize()"/>'s to add, so that it is decided in one place rather than in
+        /// each of the sixty-odd nodes.
+        /// </summary>
+        private protected abstract string StringizeNode();
 
         /// <summary>
         /// Converts an expression into a string
         /// </summary>
         /// <param name="parenthesesRequired">Whether to wrap with '(' and ')'</param>
+        /// <remarks>
+        /// A node that prints its codomain needs no brackets whatever its priority, because
+        /// <c>domain(...)</c> is a function call and so already binds tighter than any operator
+        /// around it.
+        /// </remarks>
         protected internal string Stringize(bool parenthesesRequired) =>
-            parenthesesRequired || MathS.Diagnostic.OutputExplicit ? $"({Stringize()})" : Stringize();
+            (parenthesesRequired && !PrintsItsCodomain) || MathS.Diagnostic.OutputExplicit
+                ? $"({Stringize()})" : Stringize();
     }
 }

--- a/Sources/AngouriMath/Functions/Output/ToString/ToString.Arithmetics.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/ToString/ToString.Arithmetics.Classes.cs
@@ -12,7 +12,7 @@ namespace AngouriMath
         public partial record Sumf
         {
             /// <inheritdoc/>
-            public override string Stringize() =>
+            private protected override string StringizeNode() =>
                 Augend.Stringize(Augend.Priority < Priority) + " + " + Addend.Stringize(Addend.Priority < Priority);
             /// <inheritdoc/>
             public override string ToString() => Stringize();
@@ -21,7 +21,7 @@ namespace AngouriMath
         public partial record Minusf
         {
             /// <inheritdoc/>
-            public override string Stringize() =>
+            private protected override string StringizeNode() =>
                 Minuend.Stringize(Minuend.Priority < Priority) + " - " + Subtrahend.Stringize(Subtrahend.Priority <= Priority);
             /// <inheritdoc/>
             public override string ToString() => Stringize();
@@ -34,7 +34,7 @@ namespace AngouriMath
             // unbracketed -- but `mod` shares this precedence level and is not associative, so a
             // `mod` on the right must be bracketed or it is re-read as the outer operator:
             // `2 * (3 mod 2)` is 2 and `(2 * 3) mod 2` is 0.
-            public override string Stringize() =>
+            private protected override string StringizeNode() =>
                 (Multiplier is Integer(-1) && !MathS.Diagnostic.OutputExplicit ? "-"
                     : Multiplier.Stringize(Multiplier.Priority < Priority) + " * ")
                 + Multiplicand.Stringize(Multiplicand.Priority < Priority || Multiplicand is Modf);
@@ -45,7 +45,7 @@ namespace AngouriMath
         public partial record Divf
         {
             /// <inheritdoc/>
-            public override string Stringize() =>
+            private protected override string StringizeNode() =>
                 Dividend.Stringize(Dividend.Priority < Priority) + " / " + Divisor.Stringize(Divisor.Priority <= Priority);
             /// <inheritdoc/>
             public override string ToString() => Stringize();
@@ -54,7 +54,7 @@ namespace AngouriMath
         public partial record Modf
         {
             /// <inheritdoc/>
-            public override string Stringize() =>
+            private protected override string StringizeNode() =>
                 Dividend.Stringize(Dividend.Priority < Priority) + " mod " + Divisor.Stringize(Divisor.Priority <= Priority);
             /// <inheritdoc/>
             public override string ToString() => Stringize();
@@ -63,7 +63,7 @@ namespace AngouriMath
         public partial record Logf
         {
             /// <inheritdoc/>
-            public override string Stringize()
+            private protected override string StringizeNode()
                 => Base == MathS.e ?
                 $"ln({Antilogarithm.Stringize()})"
                 :
@@ -76,7 +76,7 @@ namespace AngouriMath
         public partial record Powf
         {
             /// <inheritdoc/>
-            public override string Stringize() =>
+            private protected override string StringizeNode() =>
                 Exponent == 0.5m
                 ? "sqrt(" + Base.Stringize() + ")"
                 // The base takes <=, the exponent takes <, which is the mirror of the rule the
@@ -92,7 +92,7 @@ namespace AngouriMath
         partial record Phif
         {
             /// <inheritdoc/>
-            public override string Stringize() => $@"phi({Argument.Stringize()})";
+            private protected override string StringizeNode() => $@"phi({Argument.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -100,7 +100,7 @@ namespace AngouriMath
         public partial record Signumf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"sgn({Argument.Stringize()})";
+            private protected override string StringizeNode() => $"sgn({Argument.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -108,7 +108,7 @@ namespace AngouriMath
         public partial record Absf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"abs({Argument.Stringize()})";
+            private protected override string StringizeNode() => $"abs({Argument.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -116,7 +116,7 @@ namespace AngouriMath
         public partial record Floorf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"floor({Argument.Stringize()})";
+            private protected override string StringizeNode() => $"floor({Argument.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -124,7 +124,7 @@ namespace AngouriMath
         public partial record Ceilf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"ceil({Argument.Stringize()})";
+            private protected override string StringizeNode() => $"ceil({Argument.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -132,7 +132,7 @@ namespace AngouriMath
         public partial record Roundf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"round({Argument.Stringize()})";
+            private protected override string StringizeNode() => $"round({Argument.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -140,7 +140,7 @@ namespace AngouriMath
         public partial record Minf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"min({Left.Stringize()}, {Right.Stringize()})";
+            private protected override string StringizeNode() => $"min({Left.Stringize()}, {Right.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -148,7 +148,7 @@ namespace AngouriMath
         public partial record Maxf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"max({Left.Stringize()}, {Right.Stringize()})";
+            private protected override string StringizeNode() => $"max({Left.Stringize()}, {Right.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -156,7 +156,7 @@ namespace AngouriMath
         public partial record Gcdf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"gcd({Left.Stringize()}, {Right.Stringize()})";
+            private protected override string StringizeNode() => $"gcd({Left.Stringize()}, {Right.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -164,7 +164,7 @@ namespace AngouriMath
         public partial record Factorialf
         {
             /// <inheritdoc/>
-            public override string Stringize() => Argument.Stringize(Argument.Priority <= Priority) + "!";
+            private protected override string StringizeNode() => Argument.Stringize(Argument.Priority <= Priority) + "!";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }

--- a/Sources/AngouriMath/Functions/Output/ToString/ToString.Calculus.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/ToString/ToString.Calculus.Classes.cs
@@ -14,7 +14,7 @@ namespace AngouriMath
         public partial record Derivativef
         {
             /// <inheritdoc/>
-            public override string Stringize()
+            private protected override string StringizeNode()
             {
                 if (Iterations == 1)
                     return $"derivative({Expression.Stringize()}, {Var.Stringize()})";
@@ -28,7 +28,7 @@ namespace AngouriMath
         public partial record Integralf
         {
             /// <inheritdoc/>
-            public override string Stringize() =>
+            private protected override string StringizeNode() =>
                 Range is var (from, to)
                 ? $"integral({Expression.Stringize()}, {Var.Stringize()}, {from.Stringize()}, {to.Stringize()})"
                 : $"integral({Expression.Stringize()}, {Var.Stringize()})";
@@ -39,7 +39,7 @@ namespace AngouriMath
         public partial record Summationf
         {
             /// <inheritdoc/>
-            public override string Stringize() =>
+            private protected override string StringizeNode() =>
                 $"sum({Expression.Stringize()}, {Var.Stringize()}, {From.Stringize()}, {To.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
@@ -48,7 +48,7 @@ namespace AngouriMath
         public partial record Productf
         {
             /// <inheritdoc/>
-            public override string Stringize() =>
+            private protected override string StringizeNode() =>
                 $"product({Expression.Stringize()}, {Var.Stringize()}, {From.Stringize()}, {To.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
@@ -57,7 +57,7 @@ namespace AngouriMath
         public partial record Limitf
         {
             /// <inheritdoc/>
-            public override string Stringize() =>
+            private protected override string StringizeNode() =>
 
                 ApproachFrom switch
                 {

--- a/Sources/AngouriMath/Functions/Output/ToString/ToString.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/ToString/ToString.Classes.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) 2019-2022 Angouri.
 // AngouriMath is licensed under MIT.
 // Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
@@ -12,7 +12,7 @@ namespace AngouriMath
         public partial record Variable
         {
             /// <inheritdoc/>
-            public override string Stringize() => Name;
+            private protected override string StringizeNode() => Name;
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }

--- a/Sources/AngouriMath/Functions/Output/ToString/ToString.Discrete.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/ToString/ToString.Discrete.Classes.cs
@@ -12,7 +12,7 @@ namespace AngouriMath
         partial record Boolean
         {
             /// <inheritdoc/>
-            public override string Stringize() => ((bool)this).ToString();
+            private protected override string StringizeNode() => ((bool)this).ToString();
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -20,7 +20,7 @@ namespace AngouriMath
         partial record Notf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"not {Argument.Stringize(Argument.Priority < Priority)}";
+            private protected override string StringizeNode() => $"not {Argument.Stringize(Argument.Priority < Priority)}";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -28,7 +28,7 @@ namespace AngouriMath
         partial record Andf
         {
             /// <inheritdoc/>
-            public override string Stringize()
+            private protected override string StringizeNode()
                 => $"{Left.Stringize(Left.Priority < Priority)} and {Right.Stringize(Right.Priority < Priority)}";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
@@ -37,7 +37,7 @@ namespace AngouriMath
         partial record Orf
         {
             /// <inheritdoc/>
-            public override string Stringize()
+            private protected override string StringizeNode()
                 => $"{Left.Stringize(Left.Priority < Priority)} or {Right.Stringize(Right.Priority < Priority)}";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
@@ -46,7 +46,7 @@ namespace AngouriMath
         partial record Xorf
         {
             /// <inheritdoc/>
-            public override string Stringize()
+            private protected override string StringizeNode()
                 => $"{Left.Stringize(Left.Priority < Priority)} xor {Right.Stringize(Right.Priority < Priority)}";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
@@ -60,7 +60,7 @@ namespace AngouriMath
             // The two are not interchangeable: `false implies (true implies false)` is true, and
             // `(false implies true) implies false` is false, so printing the first without its
             // brackets said the opposite of what it meant.
-            public override string Stringize()
+            private protected override string StringizeNode()
                 => $"{Assumption.Stringize(Assumption.Priority < Priority)} implies {Conclusion.Stringize(Conclusion.Priority <= Priority)}";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
@@ -69,7 +69,7 @@ namespace AngouriMath
         partial record Equalsf
         {
             /// <inheritdoc/>
-            public override string Stringize()
+            private protected override string StringizeNode()
                 => $"{Left.Stringize(Left.Priority <= Priority)} = {Right.Stringize(Right.Priority <= Priority)}";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
@@ -78,7 +78,7 @@ namespace AngouriMath
         partial record Greaterf
         {
             /// <inheritdoc/>
-            public override string Stringize()
+            private protected override string StringizeNode()
                 => $"{Left.Stringize(Left.Priority <= Priority)} > {Right.Stringize(Right.Priority <= Priority)}";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
@@ -87,7 +87,7 @@ namespace AngouriMath
         partial record GreaterOrEqualf
         {
             /// <inheritdoc/>
-            public override string Stringize()
+            private protected override string StringizeNode()
                 => $"{Left.Stringize(Left.Priority <= Priority)} >= {Right.Stringize(Right.Priority <= Priority)}";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
@@ -96,7 +96,7 @@ namespace AngouriMath
         partial record Lessf
         {
             /// <inheritdoc/>
-            public override string Stringize()
+            private protected override string StringizeNode()
                 => $"{Left.Stringize(Left.Priority <= Priority)} < {Right.Stringize(Right.Priority <= Priority)}";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
@@ -105,7 +105,7 @@ namespace AngouriMath
         partial record LessOrEqualf
         {
             /// <inheritdoc/>
-            public override string Stringize()
+            private protected override string StringizeNode()
                 => $"{Left.Stringize(Left.Priority <= Priority)} <= {Right.Stringize(Right.Priority <= Priority)}";
             /// <inheritdoc/>
             public override string ToString() => Stringize();

--- a/Sources/AngouriMath/Functions/Output/ToString/ToString.Number.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/ToString/ToString.Number.Classes.cs
@@ -20,7 +20,7 @@ namespace AngouriMath
 #pragma warning restore SealedOrAbstract // AMAnalyzer
             {
                 /// <inheritdoc/>
-                public override string Stringize()
+                private protected override string StringizeNode()
                 {
                     static string RenderNum(Real number)
                     {
@@ -54,7 +54,7 @@ namespace AngouriMath
 #pragma warning restore SealedOrAbstract // AMAnalyzer
             {
                 /// <inheritdoc/>
-                public override string Stringize() => this switch
+                private protected override string StringizeNode() => this switch
                 {
                     { IsFinite: true } => EDecimal.ToString(),
                     { IsNaN: true } => "NaN",
@@ -70,7 +70,7 @@ namespace AngouriMath
 #pragma warning restore SealedOrAbstract // AMAnalyzer
             {
                 /// <inheritdoc/>
-                public override string Stringize() => ERational.ToString();
+                private protected override string StringizeNode() => ERational.ToString();
                 /// <inheritdoc/>
                 public override string ToString() => Stringize();
             }
@@ -78,7 +78,7 @@ namespace AngouriMath
             partial record Integer
             {
                 /// <inheritdoc/>
-                public override string Stringize() => EInteger.ToString();
+                private protected override string StringizeNode() => EInteger.ToString();
                 /// <inheritdoc/>
                 public override string ToString() => Stringize();
             }

--- a/Sources/AngouriMath/Functions/Output/ToString/ToString.Omni.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/ToString/ToString.Omni.Classes.cs
@@ -14,7 +14,7 @@ namespace AngouriMath
             partial record FiniteSet
             {
                 /// <inheritdoc/>
-                public override string Stringize()
+                private protected override string StringizeNode()
                     => $"{{ {string.Join(", ", Elements.Select(c => c.Stringize()))} }}";
                 /// <inheritdoc/>
                 public override string ToString() => Stringize();
@@ -23,7 +23,7 @@ namespace AngouriMath
             partial record Interval
             {
                 /// <inheritdoc/>
-                public override string Stringize()
+                private protected override string StringizeNode()
                 {
                     var left = LeftClosed ? "[" : "(";
                     var right = RightClosed ? "]" : ")";
@@ -36,7 +36,7 @@ namespace AngouriMath
             partial record ConditionalSet
             {
                 /// <inheritdoc/>
-                public override string Stringize()
+                private protected override string StringizeNode()
                     => $"{{ {Var.Stringize()} : {Predicate.Stringize()} }}";
                 /// <inheritdoc/>
                 public override string ToString() => Stringize();
@@ -47,7 +47,7 @@ namespace AngouriMath
                 partial record Booleans
                 {
                     /// <inheritdoc/>
-                    public override string Stringize() => "BB";
+                    private protected override string StringizeNode() => "BB";
                     /// <inheritdoc/>
                     public override string ToString() => Stringize();
                 }
@@ -55,7 +55,7 @@ namespace AngouriMath
                 partial record Integers
                 {
                     /// <inheritdoc/>
-                    public override string Stringize() => "ZZ";
+                    private protected override string StringizeNode() => "ZZ";
                     /// <inheritdoc/>
                     public override string ToString() => Stringize();
                 }
@@ -63,7 +63,7 @@ namespace AngouriMath
                 partial record Rationals
                 {
                     /// <inheritdoc/>
-                    public override string Stringize() => "QQ";
+                    private protected override string StringizeNode() => "QQ";
                     /// <inheritdoc/>
                     public override string ToString() => Stringize();
                 }
@@ -71,7 +71,7 @@ namespace AngouriMath
                 partial record Reals
                 {
                     /// <inheritdoc/>
-                    public override string Stringize() => "RR";
+                    private protected override string StringizeNode() => "RR";
                     /// <inheritdoc/>
                     public override string ToString() => Stringize();
                 }
@@ -79,7 +79,7 @@ namespace AngouriMath
                 partial record Complexes
                 {
                     /// <inheritdoc/>
-                    public override string Stringize() => "CC";
+                    private protected override string StringizeNode() => "CC";
                     /// <inheritdoc/>
                     public override string ToString() => Stringize();
                 }
@@ -93,7 +93,7 @@ namespace AngouriMath
                 // a *set difference* on the right must be bracketed or it is re-read as the outer
                 // operator: `{ 1, 2 } \/ ({ 3 } \ { 1, 2 })` is { 1, 2, 3 } and
                 // `({ 1, 2 } \/ { 3 }) \ { 1, 2 }` is { 3 }.
-                public override string Stringize()
+                private protected override string StringizeNode()
                     => $@"{Left.Stringize(Left.Priority < Priority)} \/ {Right.Stringize(Right.Priority < Priority || Right is SetMinusf)}";
                 /// <inheritdoc/>
                 public override string ToString() => Stringize();
@@ -102,7 +102,7 @@ namespace AngouriMath
             partial record Intersectionf
             {
                 /// <inheritdoc/>
-                public override string Stringize()
+                private protected override string StringizeNode()
                     => $@"{Left.Stringize(Left.Priority < Priority)} /\ {Right.Stringize(Right.Priority < Priority)}";
                 /// <inheritdoc/>
                 public override string ToString() => Stringize();
@@ -115,7 +115,7 @@ namespace AngouriMath
                 // union, so anything at that level on the right needs bracketing -- the same rule
                 // `-` and `/` follow. `{1,2,3} \ ({2,3} \ {3})` is { 1, 3 } where
                 // `({1,2,3} \ {2,3}) \ {3}` is { 1 }.
-                public override string Stringize()
+                private protected override string StringizeNode()
                     => $@"{Left.Stringize(Left.Priority < Priority)} \ {Right.Stringize(Right.Priority <= Priority)}";
                 /// <inheritdoc/>
                 public override string ToString() => Stringize();
@@ -126,7 +126,7 @@ namespace AngouriMath
                 /// <inheritdoc/>
                 // `in` is folded to the left and is not associative: `(a in b) in c` asks whether
                 // a truth value is an element of c, `a in (b in c)` whether a is an element of one.
-                public override string Stringize()
+                private protected override string StringizeNode()
                     => $@"{Element.Stringize(Element.Priority < Priority)} in {SupSet.Stringize(SupSet.Priority <= Priority)}";
                 /// <inheritdoc/>
                 public override string ToString() => Stringize();
@@ -145,7 +145,7 @@ namespace AngouriMath
             // back as `x provided (p provided q)` -- the same value, since both are `x` exactly
             // when `p` and `q` hold, and a different expression, which is what the round trip is
             // about.
-            public override string Stringize() => $@"{Expression.Stringize(Expression.Priority <= Priority.Provided)} provided {Predicate.Stringize(Predicate.Priority < Priority.Provided)}";
+            private protected override string StringizeNode() => $@"{Expression.Stringize(Expression.Priority <= Priority.Provided)} provided {Predicate.Stringize(Predicate.Priority < Priority.Provided)}";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -157,7 +157,7 @@ namespace AngouriMath
             // and neither is a bare comma-separated list, so a printed piecewise came back
             // either as a product with `if` read as an undeclared variable, or as nothing at
             // all once there was more than one case.
-            public override string Stringize()
+            private protected override string StringizeNode()
                 => "piecewise(" + string.Join(", ",
                     Cases.Select(n => n.Expression.Stringize(n.Expression.Priority < Priority)
                                       + " provided "
@@ -169,7 +169,7 @@ namespace AngouriMath
         partial record Matrix
         {
             /// <inheritdoc/>
-            public override string Stringize()
+            private protected override string StringizeNode()
                 => "[" +
                     string.Join(", ",
                         IsVector switch
@@ -187,7 +187,7 @@ namespace AngouriMath
             /// <inheritdoc/>
             // apply(f, a, b), for the same reason: juxtaposition is not application in the
             // grammar, and `(x -> x + 1) 2` came back as a power.
-            public override string Stringize()
+            private protected override string StringizeNode()
                 => "apply(" + Expression.Stringize() + ", " +
                     string.Join(", ", Arguments.Select(arg => arg.Stringize())) + ")";
 
@@ -201,7 +201,7 @@ namespace AngouriMath
             // lambda(p, body), because that is what the parser reads. The arrow spelling is
             // not in the grammar at all, and `->` there is the implication operator, so a
             // printed lambda used to come back as an implication.
-            public override string Stringize()
+            private protected override string StringizeNode()
                 => "lambda(" + Parameter.Stringize() + ", " + Body.Stringize() + ")";
 
             /// <inheritdoc/>

--- a/Sources/AngouriMath/Functions/Output/ToString/ToString.Trigonometry.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/ToString/ToString.Trigonometry.Classes.cs
@@ -12,7 +12,7 @@ namespace AngouriMath
         public partial record Sinf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"sin({Argument.Stringize()})";
+            private protected override string StringizeNode() => $"sin({Argument.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -20,7 +20,7 @@ namespace AngouriMath
         public partial record Cosf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"cos({Argument.Stringize()})";
+            private protected override string StringizeNode() => $"cos({Argument.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -28,7 +28,7 @@ namespace AngouriMath
         public partial record Secantf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"sec({Argument.Stringize()})";
+            private protected override string StringizeNode() => $"sec({Argument.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -36,7 +36,7 @@ namespace AngouriMath
         public partial record Cosecantf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"csc({Argument.Stringize()})";
+            private protected override string StringizeNode() => $"csc({Argument.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -44,7 +44,7 @@ namespace AngouriMath
         public partial record Arcsecantf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"arcsec({Argument.Stringize()})";
+            private protected override string StringizeNode() => $"arcsec({Argument.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -52,7 +52,7 @@ namespace AngouriMath
         public partial record Arccosecantf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"arccsc({Argument.Stringize()})";
+            private protected override string StringizeNode() => $"arccsc({Argument.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -60,7 +60,7 @@ namespace AngouriMath
         public partial record Tanf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"tan({Argument.Stringize()})";
+            private protected override string StringizeNode() => $"tan({Argument.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -68,7 +68,7 @@ namespace AngouriMath
         public partial record Cotanf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"cotan({Argument.Stringize()})";
+            private protected override string StringizeNode() => $"cotan({Argument.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -76,7 +76,7 @@ namespace AngouriMath
         public partial record Arcsinf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"arcsin({Argument.Stringize()})";
+            private protected override string StringizeNode() => $"arcsin({Argument.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -84,7 +84,7 @@ namespace AngouriMath
         public partial record Arccosf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"arccos({Argument.Stringize()})";
+            private protected override string StringizeNode() => $"arccos({Argument.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -92,7 +92,7 @@ namespace AngouriMath
         public partial record Arctanf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"arctan({Argument.Stringize()})";
+            private protected override string StringizeNode() => $"arctan({Argument.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }
@@ -100,7 +100,7 @@ namespace AngouriMath
         public partial record Arccotanf
         {
             /// <inheritdoc/>
-            public override string Stringize() => $"arccotan({Argument.Stringize()})";
+            private protected override string StringizeNode() => $"arccotan({Argument.Stringize()})";
             /// <inheritdoc/>
             public override string ToString() => Stringize();
         }

--- a/Sources/Tests/UnitTests/Common/CodomainSurvivesPrintingTest.cs
+++ b/Sources/Tests/UnitTests/Common/CodomainSurvivesPrintingTest.cs
@@ -1,0 +1,241 @@
+﻿//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Core;
+using Xunit;
+
+namespace AngouriMath.Tests.Common
+{
+    /// <summary>
+    /// A node's <see cref="Entity.Codomain"/> survives being printed and read back.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// It did not until
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/1022">#1022</a>: nothing
+    /// printed it, so <c>domain(x, ZZ)</c> printed as <c>x</c> and came back a different node.
+    /// The codomain is not decoration — <c>sqrt(-1)</c> is <c>i</c> and the same expression over
+    /// the reals is <see cref="MathS.NaN"/> — so the two printed the same string and evaluated
+    /// differently.
+    /// </para>
+    /// <para>
+    /// Everything here compares entities. A printed form is what the assertion is about only
+    /// where the assertion is that the printed form did <em>not</em> change.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Common")]
+    public sealed class CodomainSurvivesPrintingTest
+    {
+        /// <summary>The domains a <c>domain(...)</c> can name, which is every one but <see cref="Domain.Any"/>.</summary>
+        private static readonly Domain[] Writable =
+        {
+            Domain.Boolean, Domain.Integer, Domain.Rational, Domain.Real, Domain.Complex
+        };
+
+        public static IEnumerable<object[]> EveryNodeAndEveryWritableDomain() =>
+            from node in EveryNodeSurvivesEveryPipelineTest.EveryNodeType().Select(row => (Entity)row[0])
+            from domain in Writable
+            select new object[] { node, domain };
+
+        /// <summary>
+        /// The annotated forms that still do not read back, keyed by what they print as, with
+        /// the reason. Held strictly in both directions, so an entry that starts round tripping
+        /// fails the test rather than sitting here describing something that stopped being true.
+        /// </summary>
+        /// <remarks>
+        /// The one entry is a <em>parser</em> gap, not a printing one. No input string at all
+        /// yields a <see cref="Entity.Number.Rational"/> whose codomain is
+        /// <see cref="Domain.Complex"/>: the pass that reads a quotient of two integer literals
+        /// as the rational it denotes
+        /// (<a href="https://github.com/asc-community/AngouriMath/issues/873">#873</a>) uses
+        /// <see cref="Domain.Complex"/> as its "nobody annotated this" sentinel, because that is
+        /// what an un-annotated <see cref="Entity.Divf"/> carries, and drops it. So
+        /// <c>domain(1/2, CC)</c> parses to the same node <c>1/2</c> does, and there is nothing
+        /// the printer can emit instead.
+        /// </remarks>
+        private static readonly Dictionary<string, string> StillUnparseable = new(StringComparer.Ordinal)
+        {
+            ["domain(1/2, CC)"] =
+                "the parser's integer-quotient-to-rational pass reads Complex as `not annotated`, "
+                + "so no input produces a Rational whose codomain is Complex",
+        };
+
+        /// <summary>
+        /// Every node type there is, narrowed to every domain that can be written down, prints
+        /// and reads back as itself.
+        /// </summary>
+        /// <remarks>
+        /// The sample list is <see cref="EveryNodeSurvivesEveryPipelineTest.EveryNodeType"/>'s,
+        /// which fails the day a node type is added without one — so this cannot silently stop
+        /// covering a node either.
+        /// </remarks>
+        [Theory]
+        [MemberData(nameof(EveryNodeAndEveryWritableDomain))]
+        public void ANarrowedNodeReadsBackAsItself(Entity node, Domain domain)
+        {
+            // A node whose bare form does not round trip cannot have its annotated form round
+            // trip either, and the reason would be the older defect rather than this one.
+            // EveryNodeSurvivesEveryPipelineTest.StringizeRoundTripsToTheSameNode owns those.
+            if (MathS.FromString(node.Stringize()) != node)
+                return;
+
+            var narrowed = node.WithCodomain(domain);
+            var printed = narrowed.Stringize();
+            var back = MathS.FromString(printed);
+
+            if (StillUnparseable.TryGetValue(printed, out var reason))
+            {
+                Assert.True(narrowed != back,
+                    $"{printed} reads back as itself now — drop it from "
+                    + $"{nameof(StillUnparseable)}, where it reads \"{reason}\"");
+                return;
+            }
+
+            Assert.Equal(narrowed, back);
+            Assert.Equal(domain, back.Codomain);
+        }
+
+        /// <summary>
+        /// A codomain on a subnode is carried too: the annotation belongs to whichever node has
+        /// it, not to the expression as a whole.
+        /// </summary>
+        [Fact]
+        public void ACodomainDeepInTheTreeIsPrintedWhereItSits()
+        {
+            var x = MathS.Var("x");
+            var y = MathS.Var("y");
+            Entity expression = MathS.Sin(x.WithCodomain(Domain.Integer)) + y.WithCodomain(Domain.Real);
+
+            Assert.Equal("sin(domain(x, ZZ)) + domain(y, RR)", expression.Stringize());
+            Assert.Equal(expression, MathS.FromString(expression.Stringize()));
+        }
+
+        /// <summary>
+        /// The examples on the issue, measured.
+        /// </summary>
+        [Theory]
+        [InlineData("domain(x, ZZ)")]
+        [InlineData("domain(x + 1, RR)")]
+        [InlineData("domain(sqrt(-1), RR)")]
+        [InlineData("domain([1, 2], RR)")]
+        public void TheReportedExpressionsReadBackAsThemselves(string source)
+        {
+            var parsed = MathS.FromString(source);
+            Assert.Equal(parsed, MathS.FromString(parsed.Stringize()));
+        }
+
+        /// <summary>
+        /// Nothing is added to the ordinary case. A node carrying the codomain its own type
+        /// carries by default is what the bare text already means, so wrapping it would put a
+        /// <c>domain(...)</c> around every expression the library prints.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(EveryNodeSurvivesEveryPipelineTest.EveryNodeType), MemberType = typeof(EveryNodeSurvivesEveryPipelineTest))]
+        public void AFreshNodeCarriesItsDefaultCodomainAndPrintsNoAnnotation(Entity node)
+        {
+            foreach (var subnode in node.Nodes)
+            {
+                Assert.False(subnode.PrintsItsCodomain,
+                    $"{subnode.GetType().Name} was built without anything narrowing it and still "
+                    + $"prints an annotation: Codomain is {subnode.Codomain} where DefaultCodomain "
+                    + $"is {subnode.DefaultCodomain}. The two are declared side by side in "
+                    + "Domains.Classes.cs and have to name the same domain.");
+                Assert.Equal(subnode.DefaultCodomain, subnode.Codomain);
+            }
+        }
+
+        /// <summary>
+        /// A narrowing that changes nothing prints nothing: <see cref="Entity.WithCodomain"/> to
+        /// the default is the identity, and an expression that has been through it is
+        /// indistinguishable from one that has not.
+        /// </summary>
+        [Theory]
+        [InlineData("x + 1", Domain.Complex)]
+        [InlineData("x", Domain.Any)]
+        [InlineData("abs(x)", Domain.Real)]
+        [InlineData("a and b", Domain.Boolean)]
+        [InlineData("[1, 2]", Domain.Any)]
+        public void NarrowingToTheDefaultLeavesTheOutputAlone(string source, Domain @default)
+        {
+            var expression = MathS.FromString(source);
+            Assert.Equal(@default, expression.Codomain);
+            Assert.Equal(source, expression.Stringize());
+            Assert.Equal(source, expression.WithCodomain(@default).Stringize());
+        }
+
+        /// <summary>
+        /// <see cref="Domain.Any"/> is the one codomain that cannot be printed, and this pins it
+        /// rather than leaving it a hole nobody measured.
+        /// </summary>
+        /// <remarks>
+        /// The second argument of <c>domain(...)</c> has to be a
+        /// <see cref="Entity.Set.SpecialSet"/>, and there is no node for "no restriction" — see
+        /// <see cref="Entity.Set.SpecialSet.Create(Domain)"/>, which throws for it. So a node
+        /// <em>widened</em> to <see cref="Domain.Any"/> from a narrower default still prints as
+        /// though it had not been. Printing <c>CC</c> instead would be a different lie, since
+        /// <see cref="Domain.Complex"/> rejects a value <see cref="Domain.Any"/> admits.
+        /// </remarks>
+        [Fact]
+        public void WideningToAnyIsTheOneThingThePrintedFormStillCannotSay()
+        {
+            Entity widened = ((Entity)"x + 1").WithCodomain(Domain.Any);
+            Assert.Equal(Domain.Any, widened.Codomain);
+            Assert.Equal("x + 1", widened.Stringize());
+            Assert.NotEqual(widened, MathS.FromString(widened.Stringize()));
+        }
+
+        /// <summary>
+        /// A sum no longer collects a node and the same node narrowed as one term. `Simplify`'s
+        /// polynomial collection keys a monomial by its base's printed form, so while the printed
+        /// form did not distinguish the two it added them up — and <c>0</c> is the answer only
+        /// where <c>x</c> is an integer, which is exactly what the annotation says it might not
+        /// be.
+        /// </summary>
+        [Theory]
+        [InlineData("x - domain(x, ZZ)")]
+        [InlineData("domain(x, ZZ) + x")]
+        public void ANarrowedTermIsNotTheSameTermAsTheBareOne(string source)
+        {
+            var simplified = MathS.FromString(source).Simplify();
+            Assert.Contains("domain(x, ZZ)", simplified.Stringize(), StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// LaTeX carries it as a subscript. There is no LaTeX parser here, so this is a
+        /// statement about the rendering and not a round trip — the round trip for LaTeX is
+        /// CSharpMath's, and <a href="https://github.com/asc-community/AngouriMath/issues/822">#822</a>
+        /// is where it is tracked.
+        /// </summary>
+        [Fact]
+        public void LatexSubscriptsTheSet()
+        {
+            Assert.Equal(@"{\left(x\right)}_{\mathbb{Z}}",
+                         MathS.FromString("domain(x, ZZ)").Latexize());
+            Assert.Equal(@"\sin\left({\left(x\right)}_{\mathbb{Z}}\right)",
+                         MathS.FromString("sin(domain(x, ZZ))").Latexize());
+            // The default is not rendered, exactly as it is not printed.
+            Assert.Equal(@"x+1", MathS.FromString("x + 1").Latexize());
+        }
+
+        /// <summary>
+        /// The parentheses in the LaTeX form are not decoration: a variable renders its own index
+        /// as a subscript, so without them an annotated <c>x</c> and a variable called
+        /// <c>x_Z</c> would render the same.
+        /// </summary>
+        [Fact]
+        public void TheLatexParenthesesSeparateTheSetFromAVariableIndex()
+        {
+            Assert.Equal(@"x_{1}", MathS.Var("x_1").Latexize());
+            Assert.NotEqual(MathS.Var("x_1").Latexize(),
+                            MathS.FromString("domain(x, ZZ)").Latexize());
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Common/EntitySerializationTest.cs
+++ b/Sources/Tests/UnitTests/Common/EntitySerializationTest.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) 2019-2022 Angouri.
 // AngouriMath is licensed under MIT.
 // Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
@@ -268,22 +268,34 @@ namespace AngouriMath.Tests.Common
         }
 
         /// <summary>
-        /// The one thing the printed form does not carry, pinned so that it is a statement about
-        /// where the two part company rather than a hole nobody measured. Written to fail when
-        /// <a href="https://github.com/asc-community/AngouriMath/issues/1022">#1022</a> is fixed,
-        /// since the converter needs no change for it and this test would then be describing
-        /// something that had stopped being true.
+        /// A codomain survives the converter, because the printed form carries it. It did not
+        /// until <a href="https://github.com/asc-community/AngouriMath/issues/1022">#1022</a>,
+        /// and the converter needed no change for it: it serialises what
+        /// <see cref="Entity.Stringize()"/> prints, so teaching the printer taught this too.
         /// </summary>
         [Fact]
-        public void ACodomainDoesNotSurviveBecauseNothingPrintsIt()
+        public void ACodomainSurvivesBecauseThePrintedFormCarriesIt()
         {
             Entity narrowed = MathS.FromString("domain(x, ZZ)");
             Assert.Equal(Domain.Integer, narrowed.Codomain);
-            Assert.Equal("x", narrowed.Stringize());
+            Assert.Equal("domain(x, ZZ)", narrowed.Stringize());
 
             var back = JsonSerializer.Deserialize<Entity>(JsonSerializer.Serialize(narrowed))!;
-            Assert.NotEqual(narrowed, back);
-            Assert.Equal(Domain.Any, back.Codomain);
+            Assert.Equal(narrowed, back);
+            Assert.Equal(Domain.Integer, back.Codomain);
+        }
+
+        /// <summary>
+        /// And on a subnode, which is where it is easiest to lose: the annotation belongs to the
+        /// node that has it, not to the expression as a whole.
+        /// </summary>
+        [Fact]
+        public void ACodomainOnASubnodeSurvivesToo()
+        {
+            Entity expression = MathS.Sin(MathS.Var("x").WithCodomain(Domain.Integer))
+                                + MathS.Var("y").WithCodomain(Domain.Real);
+            var back = JsonSerializer.Deserialize<Entity>(JsonSerializer.Serialize(expression))!;
+            Assert.Equal(expression, back);
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Common/PublicApi.txt
+++ b/Sources/Tests/UnitTests/Common/PublicApi.txt
@@ -291,11 +291,9 @@ AngouriMath.Entity+Absf.GetHashCode() : System.Int32
 AngouriMath.Entity+Absf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Absf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Absf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Absf.Latexize() : System.String
 AngouriMath.Entity+Absf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Absf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Absf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Absf.Stringize() : System.String
 AngouriMath.Entity+Absf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Absf.ToString() : System.String
 AngouriMath.Entity+Absf.ctor(AngouriMath.Entity)
@@ -311,14 +309,12 @@ AngouriMath.Entity+Andf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Andf.GetHashCode() : System.Int32
 AngouriMath.Entity+Andf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Andf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Andf.Latexize() : System.String
 AngouriMath.Entity+Andf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Andf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Andf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Andf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Andf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Andf.Right { } : AngouriMath.Entity
-AngouriMath.Entity+Andf.Stringize() : System.String
 AngouriMath.Entity+Andf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Andf.ToString() : System.String
 AngouriMath.Entity+Andf.ctor(AngouriMath.Entity, AngouriMath.Entity)
@@ -337,10 +333,8 @@ AngouriMath.Entity+Application.GetHashCode() : System.Int32
 AngouriMath.Entity+Application.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Application.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Application.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Application.Latexize() : System.String
 AngouriMath.Entity+Application.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Application.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Application.Stringize() : System.String
 AngouriMath.Entity+Application.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Application.ToString() : System.String
 AngouriMath.Entity+Application.ctor(AngouriMath.Entity, HonkSharp.Functional.LList<AngouriMath.Entity>)
@@ -358,11 +352,9 @@ AngouriMath.Entity+Arccosecantf.GetHashCode() : System.Int32
 AngouriMath.Entity+Arccosecantf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Arccosecantf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Arccosecantf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Arccosecantf.Latexize() : System.String
 AngouriMath.Entity+Arccosecantf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Arccosecantf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Arccosecantf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Arccosecantf.Stringize() : System.String
 AngouriMath.Entity+Arccosecantf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Arccosecantf.ToString() : System.String
 AngouriMath.Entity+Arccosecantf.ctor(AngouriMath.Entity)
@@ -380,11 +372,9 @@ AngouriMath.Entity+Arccosf.GetHashCode() : System.Int32
 AngouriMath.Entity+Arccosf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Arccosf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Arccosf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Arccosf.Latexize() : System.String
 AngouriMath.Entity+Arccosf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Arccosf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Arccosf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Arccosf.Stringize() : System.String
 AngouriMath.Entity+Arccosf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Arccosf.ToString() : System.String
 AngouriMath.Entity+Arccosf.ctor(AngouriMath.Entity)
@@ -402,11 +392,9 @@ AngouriMath.Entity+Arccotanf.GetHashCode() : System.Int32
 AngouriMath.Entity+Arccotanf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Arccotanf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Arccotanf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Arccotanf.Latexize() : System.String
 AngouriMath.Entity+Arccotanf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Arccotanf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Arccotanf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Arccotanf.Stringize() : System.String
 AngouriMath.Entity+Arccotanf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Arccotanf.ToString() : System.String
 AngouriMath.Entity+Arccotanf.ctor(AngouriMath.Entity)
@@ -424,11 +412,9 @@ AngouriMath.Entity+Arcsecantf.GetHashCode() : System.Int32
 AngouriMath.Entity+Arcsecantf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Arcsecantf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Arcsecantf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Arcsecantf.Latexize() : System.String
 AngouriMath.Entity+Arcsecantf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Arcsecantf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Arcsecantf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Arcsecantf.Stringize() : System.String
 AngouriMath.Entity+Arcsecantf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Arcsecantf.ToString() : System.String
 AngouriMath.Entity+Arcsecantf.ctor(AngouriMath.Entity)
@@ -446,11 +432,9 @@ AngouriMath.Entity+Arcsinf.GetHashCode() : System.Int32
 AngouriMath.Entity+Arcsinf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Arcsinf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Arcsinf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Arcsinf.Latexize() : System.String
 AngouriMath.Entity+Arcsinf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Arcsinf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Arcsinf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Arcsinf.Stringize() : System.String
 AngouriMath.Entity+Arcsinf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Arcsinf.ToString() : System.String
 AngouriMath.Entity+Arcsinf.ctor(AngouriMath.Entity)
@@ -468,11 +452,9 @@ AngouriMath.Entity+Arctanf.GetHashCode() : System.Int32
 AngouriMath.Entity+Arctanf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Arctanf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Arctanf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Arctanf.Latexize() : System.String
 AngouriMath.Entity+Arctanf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Arctanf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Arctanf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Arctanf.Stringize() : System.String
 AngouriMath.Entity+Arctanf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Arctanf.ToString() : System.String
 AngouriMath.Entity+Arctanf.ctor(AngouriMath.Entity)
@@ -490,11 +472,9 @@ AngouriMath.Entity+Boolean.False : AngouriMath.Entity+Boolean
 AngouriMath.Entity+Boolean.GetHashCode() : System.Int32
 AngouriMath.Entity+Boolean.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Boolean.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Boolean.Latexize() : System.String
 AngouriMath.Entity+Boolean.Parse(System.String) : AngouriMath.Entity+Boolean
 AngouriMath.Entity+Boolean.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Boolean.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Boolean.Stringize() : System.String
 AngouriMath.Entity+Boolean.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Boolean.ToString() : System.String
 AngouriMath.Entity+Boolean.True : AngouriMath.Entity+Boolean
@@ -531,11 +511,9 @@ AngouriMath.Entity+Ceilf.GetHashCode() : System.Int32
 AngouriMath.Entity+Ceilf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Ceilf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Ceilf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Ceilf.Latexize() : System.String
 AngouriMath.Entity+Ceilf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Ceilf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Ceilf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Ceilf.Stringize() : System.String
 AngouriMath.Entity+Ceilf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Ceilf.ToString() : System.String
 AngouriMath.Entity+Ceilf.ctor(AngouriMath.Entity)
@@ -588,11 +566,9 @@ AngouriMath.Entity+Cosecantf.GetHashCode() : System.Int32
 AngouriMath.Entity+Cosecantf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Cosecantf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Cosecantf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Cosecantf.Latexize() : System.String
 AngouriMath.Entity+Cosecantf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Cosecantf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Cosecantf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Cosecantf.Stringize() : System.String
 AngouriMath.Entity+Cosecantf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Cosecantf.ToString() : System.String
 AngouriMath.Entity+Cosecantf.ctor(AngouriMath.Entity)
@@ -610,11 +586,9 @@ AngouriMath.Entity+Cosf.GetHashCode() : System.Int32
 AngouriMath.Entity+Cosf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Cosf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Cosf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Cosf.Latexize() : System.String
 AngouriMath.Entity+Cosf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Cosf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Cosf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Cosf.Stringize() : System.String
 AngouriMath.Entity+Cosf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Cosf.ToString() : System.String
 AngouriMath.Entity+Cosf.ctor(AngouriMath.Entity)
@@ -632,11 +606,9 @@ AngouriMath.Entity+Cotanf.GetHashCode() : System.Int32
 AngouriMath.Entity+Cotanf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Cotanf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Cotanf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Cotanf.Latexize() : System.String
 AngouriMath.Entity+Cotanf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Cotanf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Cotanf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Cotanf.Stringize() : System.String
 AngouriMath.Entity+Cotanf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Cotanf.ToString() : System.String
 AngouriMath.Entity+Cotanf.ctor(AngouriMath.Entity)
@@ -654,10 +626,8 @@ AngouriMath.Entity+Derivativef.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Derivativef.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Derivativef.InnerSimplify(System.Boolean) : AngouriMath.Entity
 AngouriMath.Entity+Derivativef.Iterations { } : System.Int32
-AngouriMath.Entity+Derivativef.Latexize() : System.String
 AngouriMath.Entity+Derivativef.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Derivativef.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Derivativef.Stringize() : System.String
 AngouriMath.Entity+Derivativef.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Derivativef.ToString() : System.String
 AngouriMath.Entity+Derivativef.ctor(AngouriMath.Entity, AngouriMath.Entity, System.Int32)
@@ -676,12 +646,10 @@ AngouriMath.Entity+Divf.GetHashCode() : System.Int32
 AngouriMath.Entity+Divf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Divf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Divf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Divf.Latexize() : System.String
 AngouriMath.Entity+Divf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Divf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Divf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Divf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Divf.Stringize() : System.String
 AngouriMath.Entity+Divf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Divf.ToString() : System.String
 AngouriMath.Entity+Divf.ctor(AngouriMath.Entity, AngouriMath.Entity)
@@ -697,14 +665,12 @@ AngouriMath.Entity+Equalsf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Equalsf.GetHashCode() : System.Int32
 AngouriMath.Entity+Equalsf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Equalsf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Equalsf.Latexize() : System.String
 AngouriMath.Entity+Equalsf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Equalsf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Equalsf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Equalsf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Equalsf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Equalsf.Right { } : AngouriMath.Entity
-AngouriMath.Entity+Equalsf.Stringize() : System.String
 AngouriMath.Entity+Equalsf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Equalsf.ToString() : System.String
 AngouriMath.Entity+Equalsf.ctor(AngouriMath.Entity, AngouriMath.Entity)
@@ -722,11 +688,9 @@ AngouriMath.Entity+Factorialf.GetHashCode() : System.Int32
 AngouriMath.Entity+Factorialf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Factorialf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Factorialf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Factorialf.Latexize() : System.String
 AngouriMath.Entity+Factorialf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Factorialf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Factorialf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Factorialf.Stringize() : System.String
 AngouriMath.Entity+Factorialf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Factorialf.ToString() : System.String
 AngouriMath.Entity+Factorialf.ctor(AngouriMath.Entity)
@@ -744,11 +708,9 @@ AngouriMath.Entity+Floorf.GetHashCode() : System.Int32
 AngouriMath.Entity+Floorf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Floorf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Floorf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Floorf.Latexize() : System.String
 AngouriMath.Entity+Floorf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Floorf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Floorf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Floorf.Stringize() : System.String
 AngouriMath.Entity+Floorf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Floorf.ToString() : System.String
 AngouriMath.Entity+Floorf.ctor(AngouriMath.Entity)
@@ -776,14 +738,12 @@ AngouriMath.Entity+Gcdf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Gcdf.GetHashCode() : System.Int32
 AngouriMath.Entity+Gcdf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Gcdf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Gcdf.Latexize() : System.String
 AngouriMath.Entity+Gcdf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Gcdf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Gcdf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Gcdf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Gcdf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Gcdf.Right { } : AngouriMath.Entity
-AngouriMath.Entity+Gcdf.Stringize() : System.String
 AngouriMath.Entity+Gcdf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Gcdf.ToString() : System.String
 AngouriMath.Entity+Gcdf.ctor(AngouriMath.Entity, AngouriMath.Entity)
@@ -799,14 +759,12 @@ AngouriMath.Entity+GreaterOrEqualf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+GreaterOrEqualf.GetHashCode() : System.Int32
 AngouriMath.Entity+GreaterOrEqualf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+GreaterOrEqualf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+GreaterOrEqualf.Latexize() : System.String
 AngouriMath.Entity+GreaterOrEqualf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+GreaterOrEqualf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+GreaterOrEqualf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+GreaterOrEqualf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+GreaterOrEqualf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+GreaterOrEqualf.Right { } : AngouriMath.Entity
-AngouriMath.Entity+GreaterOrEqualf.Stringize() : System.String
 AngouriMath.Entity+GreaterOrEqualf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+GreaterOrEqualf.ToString() : System.String
 AngouriMath.Entity+GreaterOrEqualf.ctor(AngouriMath.Entity, AngouriMath.Entity)
@@ -822,14 +780,12 @@ AngouriMath.Entity+Greaterf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Greaterf.GetHashCode() : System.Int32
 AngouriMath.Entity+Greaterf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Greaterf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Greaterf.Latexize() : System.String
 AngouriMath.Entity+Greaterf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Greaterf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Greaterf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Greaterf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Greaterf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Greaterf.Right { } : AngouriMath.Entity
-AngouriMath.Entity+Greaterf.Stringize() : System.String
 AngouriMath.Entity+Greaterf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Greaterf.ToString() : System.String
 AngouriMath.Entity+Greaterf.ctor(AngouriMath.Entity, AngouriMath.Entity)
@@ -847,12 +803,10 @@ AngouriMath.Entity+Impliesf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Impliesf.GetHashCode() : System.Int32
 AngouriMath.Entity+Impliesf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Impliesf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Impliesf.Latexize() : System.String
 AngouriMath.Entity+Impliesf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Impliesf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Impliesf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Impliesf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Impliesf.Stringize() : System.String
 AngouriMath.Entity+Impliesf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Impliesf.ToString() : System.String
 AngouriMath.Entity+Impliesf.ctor(AngouriMath.Entity, AngouriMath.Entity)
@@ -869,11 +823,9 @@ AngouriMath.Entity+Integralf.GetHashCode() : System.Int32
 AngouriMath.Entity+Integralf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Integralf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Integralf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Integralf.Latexize() : System.String
 AngouriMath.Entity+Integralf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Integralf.Range { } : System.Nullable<System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity>>
 AngouriMath.Entity+Integralf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Integralf.Stringize() : System.String
 AngouriMath.Entity+Integralf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Integralf.ToString() : System.String
 AngouriMath.Entity+Integralf.ctor(AngouriMath.Entity, AngouriMath.Entity, System.Nullable<System.ValueTuple<AngouriMath.Entity,AngouriMath.Entity>>)
@@ -890,11 +842,9 @@ AngouriMath.Entity+Lambda.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Lambda.GetHashCode() : System.Int32
 AngouriMath.Entity+Lambda.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Lambda.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Lambda.Latexize() : System.String
 AngouriMath.Entity+Lambda.Parameter { } : AngouriMath.Entity+Variable
 AngouriMath.Entity+Lambda.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Lambda.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Lambda.Stringize() : System.String
 AngouriMath.Entity+Lambda.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Lambda.ToString() : System.String
 AngouriMath.Entity+Lambda.ctor(AngouriMath.Entity+Variable, AngouriMath.Entity)
@@ -910,14 +860,12 @@ AngouriMath.Entity+LessOrEqualf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+LessOrEqualf.GetHashCode() : System.Int32
 AngouriMath.Entity+LessOrEqualf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+LessOrEqualf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+LessOrEqualf.Latexize() : System.String
 AngouriMath.Entity+LessOrEqualf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+LessOrEqualf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+LessOrEqualf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+LessOrEqualf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+LessOrEqualf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+LessOrEqualf.Right { } : AngouriMath.Entity
-AngouriMath.Entity+LessOrEqualf.Stringize() : System.String
 AngouriMath.Entity+LessOrEqualf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+LessOrEqualf.ToString() : System.String
 AngouriMath.Entity+LessOrEqualf.ctor(AngouriMath.Entity, AngouriMath.Entity)
@@ -933,14 +881,12 @@ AngouriMath.Entity+Lessf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Lessf.GetHashCode() : System.Int32
 AngouriMath.Entity+Lessf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Lessf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Lessf.Latexize() : System.String
 AngouriMath.Entity+Lessf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Lessf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Lessf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Lessf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Lessf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Lessf.Right { } : AngouriMath.Entity
-AngouriMath.Entity+Lessf.Stringize() : System.String
 AngouriMath.Entity+Lessf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Lessf.ToString() : System.String
 AngouriMath.Entity+Lessf.ctor(AngouriMath.Entity, AngouriMath.Entity)
@@ -959,10 +905,8 @@ AngouriMath.Entity+Limitf.GetHashCode() : System.Int32
 AngouriMath.Entity+Limitf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Limitf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Limitf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Limitf.Latexize() : System.String
 AngouriMath.Entity+Limitf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Limitf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Limitf.Stringize() : System.String
 AngouriMath.Entity+Limitf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Limitf.ToString() : System.String
 AngouriMath.Entity+Limitf.ctor(AngouriMath.Entity, AngouriMath.Entity, AngouriMath.Entity, AngouriMath.Core.ApproachFrom)
@@ -981,12 +925,10 @@ AngouriMath.Entity+Logf.GetHashCode() : System.Int32
 AngouriMath.Entity+Logf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Logf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Logf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Logf.Latexize() : System.String
 AngouriMath.Entity+Logf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Logf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Logf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Logf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Logf.Stringize() : System.String
 AngouriMath.Entity+Logf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Logf.ToString() : System.String
 AngouriMath.Entity+Logf.ctor(AngouriMath.Entity, AngouriMath.Entity)
@@ -1030,7 +972,6 @@ AngouriMath.Entity+Matrix.IsSquare { } : System.Boolean
 AngouriMath.Entity+Matrix.IsVector { } : System.Boolean
 AngouriMath.Entity+Matrix.Item { } : AngouriMath.Entity
 AngouriMath.Entity+Matrix.Item { } : AngouriMath.Entity+Matrix
-AngouriMath.Entity+Matrix.Latexize() : System.String
 AngouriMath.Entity+Matrix.MainDiagonal { } : AngouriMath.Entity+Matrix
 AngouriMath.Entity+Matrix.Pow(System.Int32) : AngouriMath.Entity+Matrix
 AngouriMath.Entity+Matrix.PrintMembers(System.Text.StringBuilder) : System.Boolean
@@ -1039,7 +980,6 @@ AngouriMath.Entity+Matrix.ReducedRowEchelonForm { } : AngouriMath.Entity+Matrix
 AngouriMath.Entity+Matrix.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Matrix.RowCount { } : System.Int32
 AngouriMath.Entity+Matrix.RowEchelonForm { } : AngouriMath.Entity+Matrix
-AngouriMath.Entity+Matrix.Stringize() : System.String
 AngouriMath.Entity+Matrix.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Matrix.T { } : AngouriMath.Entity+Matrix
 AngouriMath.Entity+Matrix.TensorPower(System.Int32) : AngouriMath.Entity+Matrix
@@ -1072,14 +1012,12 @@ AngouriMath.Entity+Maxf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Maxf.GetHashCode() : System.Int32
 AngouriMath.Entity+Maxf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Maxf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Maxf.Latexize() : System.String
 AngouriMath.Entity+Maxf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Maxf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Maxf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Maxf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Maxf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Maxf.Right { } : AngouriMath.Entity
-AngouriMath.Entity+Maxf.Stringize() : System.String
 AngouriMath.Entity+Maxf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Maxf.ToString() : System.String
 AngouriMath.Entity+Maxf.ctor(AngouriMath.Entity, AngouriMath.Entity)
@@ -1095,14 +1033,12 @@ AngouriMath.Entity+Minf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Minf.GetHashCode() : System.Int32
 AngouriMath.Entity+Minf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Minf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Minf.Latexize() : System.String
 AngouriMath.Entity+Minf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Minf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Minf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Minf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Minf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Minf.Right { } : AngouriMath.Entity
-AngouriMath.Entity+Minf.Stringize() : System.String
 AngouriMath.Entity+Minf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Minf.ToString() : System.String
 AngouriMath.Entity+Minf.ctor(AngouriMath.Entity, AngouriMath.Entity)
@@ -1119,13 +1055,11 @@ AngouriMath.Entity+Minusf.GetHashCode() : System.Int32
 AngouriMath.Entity+Minusf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Minusf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Minusf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Minusf.Latexize() : System.String
 AngouriMath.Entity+Minusf.Minuend { } : AngouriMath.Entity
 AngouriMath.Entity+Minusf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Minusf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Minusf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Minusf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Minusf.Stringize() : System.String
 AngouriMath.Entity+Minusf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Minusf.Subtrahend { } : AngouriMath.Entity
 AngouriMath.Entity+Minusf.ToString() : System.String
@@ -1145,12 +1079,10 @@ AngouriMath.Entity+Modf.GetHashCode() : System.Int32
 AngouriMath.Entity+Modf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Modf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Modf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Modf.Latexize() : System.String
 AngouriMath.Entity+Modf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Modf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Modf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Modf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Modf.Stringize() : System.String
 AngouriMath.Entity+Modf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Modf.ToString() : System.String
 AngouriMath.Entity+Modf.ctor(AngouriMath.Entity, AngouriMath.Entity)
@@ -1167,7 +1099,6 @@ AngouriMath.Entity+Mulf.GetHashCode() : System.Int32
 AngouriMath.Entity+Mulf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Mulf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Mulf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Mulf.Latexize() : System.String
 AngouriMath.Entity+Mulf.Multiplicand { } : AngouriMath.Entity
 AngouriMath.Entity+Mulf.Multiplier { } : AngouriMath.Entity
 AngouriMath.Entity+Mulf.Multiply(System.Collections.Generic.IEnumerable<AngouriMath.Entity>) : AngouriMath.Entity
@@ -1176,7 +1107,6 @@ AngouriMath.Entity+Mulf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Mulf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Mulf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Mulf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Mulf.Stringize() : System.String
 AngouriMath.Entity+Mulf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Mulf.ToString() : System.String
 AngouriMath.Entity+Mulf.ctor(AngouriMath.Entity, AngouriMath.Entity)
@@ -1193,11 +1123,9 @@ AngouriMath.Entity+Notf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Notf.GetHashCode() : System.Int32
 AngouriMath.Entity+Notf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Notf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Notf.Latexize() : System.String
 AngouriMath.Entity+Notf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Notf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Notf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Notf.Stringize() : System.String
 AngouriMath.Entity+Notf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Notf.ToString() : System.String
 AngouriMath.Entity+Notf.ctor(AngouriMath.Entity)
@@ -1221,7 +1149,6 @@ AngouriMath.Entity+Number+Complex.ImaginaryOne : AngouriMath.Entity+Number+Compl
 AngouriMath.Entity+Number+Complex.ImaginaryPart { } : AngouriMath.Entity+Number+Real
 AngouriMath.Entity+Number+Complex.IsExact { } : System.Boolean
 AngouriMath.Entity+Number+Complex.IsZero { } : System.Boolean
-AngouriMath.Entity+Number+Complex.Latexize() : System.String
 AngouriMath.Entity+Number+Complex.MinusImaginaryOne : AngouriMath.Entity+Number+Complex
 AngouriMath.Entity+Number+Complex.MultiplicativeIdentity { } : AngouriMath.Entity+Number+Complex
 AngouriMath.Entity+Number+Complex.NegNegInfinity : AngouriMath.Entity+Number+Complex
@@ -1232,7 +1159,6 @@ AngouriMath.Entity+Number+Complex.PosNegInfinity : AngouriMath.Entity+Number+Com
 AngouriMath.Entity+Number+Complex.PosPosInfinity : AngouriMath.Entity+Number+Complex
 AngouriMath.Entity+Number+Complex.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Number+Complex.RealPart { } : AngouriMath.Entity+Number+Real
-AngouriMath.Entity+Number+Complex.Stringize() : System.String
 AngouriMath.Entity+Number+Complex.ThisIsFinite { } : System.Boolean
 AngouriMath.Entity+Number+Complex.ToNumerics() : System.Numerics.Complex
 AngouriMath.Entity+Number+Complex.ToString() : System.String
@@ -1285,13 +1211,11 @@ AngouriMath.Entity+Number+Integer.Factorize() : System.Collections.Generic.IEnum
 AngouriMath.Entity+Number+Integer.GetHashCode() : System.Int32
 AngouriMath.Entity+Number+Integer.IntegerDiv(AngouriMath.Entity+Number+Integer) : AngouriMath.Entity+Number+Integer
 AngouriMath.Entity+Number+Integer.IsPrime { } : System.Boolean
-AngouriMath.Entity+Number+Integer.Latexize() : System.String
 AngouriMath.Entity+Number+Integer.MinusOne : AngouriMath.Entity+Number+Integer
 AngouriMath.Entity+Number+Integer.MultiplicativeIdentity { } : AngouriMath.Entity+Number+Integer
 AngouriMath.Entity+Number+Integer.One : AngouriMath.Entity+Number+Integer
 AngouriMath.Entity+Number+Integer.Phi() : AngouriMath.Entity+Number+Integer
 AngouriMath.Entity+Number+Integer.PrintMembers(System.Text.StringBuilder) : System.Boolean
-AngouriMath.Entity+Number+Integer.Stringize() : System.String
 AngouriMath.Entity+Number+Integer.ToString() : System.String
 AngouriMath.Entity+Number+Integer.Zero : AngouriMath.Entity+Number+Integer
 AngouriMath.Entity+Number+Integer.op_Addition(AngouriMath.Entity+Number+Integer, AngouriMath.Entity+Number+Integer) : AngouriMath.Entity+Number+Integer
@@ -1335,11 +1259,9 @@ AngouriMath.Entity+Number+Rational.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Number+Rational.FindRational(PeterO.Numbers.EDecimal, System.Int32) : AngouriMath.Entity+Number+Rational
 AngouriMath.Entity+Number+Rational.GetHashCode() : System.Int32
 AngouriMath.Entity+Number+Rational.IsExact { } : System.Boolean
-AngouriMath.Entity+Number+Rational.Latexize() : System.String
 AngouriMath.Entity+Number+Rational.MultiplicativeIdentity { } : AngouriMath.Entity+Number+Rational
 AngouriMath.Entity+Number+Rational.Numerator { } : AngouriMath.Entity+Number+Integer
 AngouriMath.Entity+Number+Rational.PrintMembers(System.Text.StringBuilder) : System.Boolean
-AngouriMath.Entity+Number+Rational.Stringize() : System.String
 AngouriMath.Entity+Number+Rational.ToString() : System.String
 AngouriMath.Entity+Number+Rational.ctor(AngouriMath.Entity+Number+Rational)
 AngouriMath.Entity+Number+Rational.op_Addition(AngouriMath.Entity+Number+Rational, AngouriMath.Entity+Number+Rational) : AngouriMath.Entity+Number+Rational
@@ -1384,14 +1306,12 @@ AngouriMath.Entity+Number+Real.GetHashCode() : System.Int32
 AngouriMath.Entity+Number+Real.IsExact { } : System.Boolean
 AngouriMath.Entity+Number+Real.IsNegative { } : System.Boolean
 AngouriMath.Entity+Number+Real.IsPositive { } : System.Boolean
-AngouriMath.Entity+Number+Real.Latexize() : System.String
 AngouriMath.Entity+Number+Real.MultiplicativeIdentity { } : AngouriMath.Entity+Number+Real
 AngouriMath.Entity+Number+Real.NaN : AngouriMath.Entity+Number+Real
 AngouriMath.Entity+Number+Real.NegativeInfinity : AngouriMath.Entity+Number+Real
 AngouriMath.Entity+Number+Real.PositiveInfinity : AngouriMath.Entity+Number+Real
 AngouriMath.Entity+Number+Real.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Number+Real.RealPart { } : AngouriMath.Entity+Number+Real
-AngouriMath.Entity+Number+Real.Stringize() : System.String
 AngouriMath.Entity+Number+Real.ToString() : System.String
 AngouriMath.Entity+Number+Real.ctor(AngouriMath.Entity+Number+Real)
 AngouriMath.Entity+Number+Real.op_Addition(AngouriMath.Entity+Number+Real, AngouriMath.Entity+Number+Real) : AngouriMath.Entity+Number+Real
@@ -1505,14 +1425,12 @@ AngouriMath.Entity+Orf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Orf.GetHashCode() : System.Int32
 AngouriMath.Entity+Orf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Orf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Orf.Latexize() : System.String
 AngouriMath.Entity+Orf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Orf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Orf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Orf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Orf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Orf.Right { } : AngouriMath.Entity
-AngouriMath.Entity+Orf.Stringize() : System.String
 AngouriMath.Entity+Orf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Orf.ToString() : System.String
 AngouriMath.Entity+Orf.ctor(AngouriMath.Entity, AngouriMath.Entity)
@@ -1529,11 +1447,9 @@ AngouriMath.Entity+Phif.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Phif.GetHashCode() : System.Int32
 AngouriMath.Entity+Phif.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Phif.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Phif.Latexize() : System.String
 AngouriMath.Entity+Phif.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Phif.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Phif.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Phif.Stringize() : System.String
 AngouriMath.Entity+Phif.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Phif.ToString() : System.String
 AngouriMath.Entity+Phif.ctor(AngouriMath.Entity)
@@ -1552,10 +1468,8 @@ AngouriMath.Entity+Piecewise.GetHashCode() : System.Int32
 AngouriMath.Entity+Piecewise.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Piecewise.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Piecewise.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Piecewise.Latexize() : System.String
 AngouriMath.Entity+Piecewise.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Piecewise.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Piecewise.Stringize() : System.String
 AngouriMath.Entity+Piecewise.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Piecewise.ToString() : System.String
 AngouriMath.Entity+Piecewise.ctor(System.Collections.Generic.IEnumerable<AngouriMath.Entity+Providedf>)
@@ -1574,12 +1488,10 @@ AngouriMath.Entity+Powf.GetHashCode() : System.Int32
 AngouriMath.Entity+Powf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Powf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Powf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Powf.Latexize() : System.String
 AngouriMath.Entity+Powf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Powf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Powf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Powf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Powf.Stringize() : System.String
 AngouriMath.Entity+Powf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Powf.ToString() : System.String
 AngouriMath.Entity+Powf.ctor(AngouriMath.Entity, AngouriMath.Entity)
@@ -1596,10 +1508,8 @@ AngouriMath.Entity+Productf.From { } : AngouriMath.Entity
 AngouriMath.Entity+Productf.GetHashCode() : System.Int32
 AngouriMath.Entity+Productf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Productf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Productf.Latexize() : System.String
 AngouriMath.Entity+Productf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Productf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Productf.Stringize() : System.String
 AngouriMath.Entity+Productf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Productf.To { } : AngouriMath.Entity
 AngouriMath.Entity+Productf.ToString() : System.String
@@ -1618,13 +1528,11 @@ AngouriMath.Entity+Providedf.GetHashCode() : System.Int32
 AngouriMath.Entity+Providedf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Providedf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Providedf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Providedf.Latexize() : System.String
 AngouriMath.Entity+Providedf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Providedf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Providedf.Predicate { } : AngouriMath.Entity
 AngouriMath.Entity+Providedf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Providedf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Providedf.Stringize() : System.String
 AngouriMath.Entity+Providedf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Providedf.ToString() : System.String
 AngouriMath.Entity+Providedf.ctor(AngouriMath.Entity, AngouriMath.Entity)
@@ -1642,11 +1550,9 @@ AngouriMath.Entity+Roundf.GetHashCode() : System.Int32
 AngouriMath.Entity+Roundf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Roundf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Roundf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Roundf.Latexize() : System.String
 AngouriMath.Entity+Roundf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Roundf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Roundf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Roundf.Stringize() : System.String
 AngouriMath.Entity+Roundf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Roundf.ToString() : System.String
 AngouriMath.Entity+Roundf.ctor(AngouriMath.Entity)
@@ -1664,11 +1570,9 @@ AngouriMath.Entity+Secantf.GetHashCode() : System.Int32
 AngouriMath.Entity+Secantf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Secantf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Secantf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Secantf.Latexize() : System.String
 AngouriMath.Entity+Secantf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Secantf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Secantf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Secantf.Stringize() : System.String
 AngouriMath.Entity+Secantf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Secantf.ToString() : System.String
 AngouriMath.Entity+Secantf.ctor(AngouriMath.Entity)
@@ -1687,11 +1591,9 @@ AngouriMath.Entity+Set+ConditionalSet.InitDirectChildren() : AngouriMath.Entity[
 AngouriMath.Entity+Set+ConditionalSet.InnerSimplify(System.Boolean) : AngouriMath.Entity
 AngouriMath.Entity+Set+ConditionalSet.IsSetEmpty { } : System.Boolean
 AngouriMath.Entity+Set+ConditionalSet.IsSetFinite { } : System.Boolean
-AngouriMath.Entity+Set+ConditionalSet.Latexize() : System.String
 AngouriMath.Entity+Set+ConditionalSet.Predicate { } : AngouriMath.Entity
 AngouriMath.Entity+Set+ConditionalSet.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Set+ConditionalSet.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Set+ConditionalSet.Stringize() : System.String
 AngouriMath.Entity+Set+ConditionalSet.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Set+ConditionalSet.ToString() : System.String
 AngouriMath.Entity+Set+ConditionalSet.TryContains(AngouriMath.Entity, System.Boolean&) : System.Boolean
@@ -1717,10 +1619,8 @@ AngouriMath.Entity+Set+FiniteSet.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Set+FiniteSet.InnerSimplify(System.Boolean) : AngouriMath.Entity
 AngouriMath.Entity+Set+FiniteSet.IsSetEmpty { } : System.Boolean
 AngouriMath.Entity+Set+FiniteSet.IsSetFinite { } : System.Boolean
-AngouriMath.Entity+Set+FiniteSet.Latexize() : System.String
 AngouriMath.Entity+Set+FiniteSet.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Set+FiniteSet.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Set+FiniteSet.Stringize() : System.String
 AngouriMath.Entity+Set+FiniteSet.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Set+FiniteSet.ToString() : System.String
 AngouriMath.Entity+Set+FiniteSet.TryContains(AngouriMath.Entity, System.Boolean&) : System.Boolean
@@ -1741,12 +1641,10 @@ AngouriMath.Entity+Set+Inf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Set+Inf.GetHashCode() : System.Int32
 AngouriMath.Entity+Set+Inf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Set+Inf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Set+Inf.Latexize() : System.String
 AngouriMath.Entity+Set+Inf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Set+Inf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Set+Inf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Set+Inf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Set+Inf.Stringize() : System.String
 AngouriMath.Entity+Set+Inf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Set+Inf.SupSet { } : AngouriMath.Entity
 AngouriMath.Entity+Set+Inf.ToString() : System.String
@@ -1766,12 +1664,10 @@ AngouriMath.Entity+Set+Intersectionf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Set+Intersectionf.InnerSimplify(System.Boolean) : AngouriMath.Entity
 AngouriMath.Entity+Set+Intersectionf.IsSetEmpty { } : System.Boolean
 AngouriMath.Entity+Set+Intersectionf.IsSetFinite { } : System.Boolean
-AngouriMath.Entity+Set+Intersectionf.Latexize() : System.String
 AngouriMath.Entity+Set+Intersectionf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Set+Intersectionf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Set+Intersectionf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Set+Intersectionf.Right { } : AngouriMath.Entity
-AngouriMath.Entity+Set+Intersectionf.Stringize() : System.String
 AngouriMath.Entity+Set+Intersectionf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Set+Intersectionf.ToString() : System.String
 AngouriMath.Entity+Set+Intersectionf.TryContains(AngouriMath.Entity, System.Boolean&) : System.Boolean
@@ -1792,14 +1688,12 @@ AngouriMath.Entity+Set+Interval.InnerSimplify(System.Boolean) : AngouriMath.Enti
 AngouriMath.Entity+Set+Interval.IsNumeric { } : System.Boolean
 AngouriMath.Entity+Set+Interval.IsSetEmpty { } : System.Boolean
 AngouriMath.Entity+Set+Interval.IsSetFinite { } : System.Boolean
-AngouriMath.Entity+Set+Interval.Latexize() : System.String
 AngouriMath.Entity+Set+Interval.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Set+Interval.LeftClosed { } : System.Boolean
 AngouriMath.Entity+Set+Interval.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Set+Interval.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Set+Interval.Right { } : AngouriMath.Entity
 AngouriMath.Entity+Set+Interval.RightClosed { } : System.Boolean
-AngouriMath.Entity+Set+Interval.Stringize() : System.String
 AngouriMath.Entity+Set+Interval.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Set+Interval.ToString() : System.String
 AngouriMath.Entity+Set+Interval.TryContains(AngouriMath.Entity, System.Boolean&) : System.Boolean
@@ -1819,12 +1713,10 @@ AngouriMath.Entity+Set+SetMinusf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Set+SetMinusf.InnerSimplify(System.Boolean) : AngouriMath.Entity
 AngouriMath.Entity+Set+SetMinusf.IsSetEmpty { } : System.Boolean
 AngouriMath.Entity+Set+SetMinusf.IsSetFinite { } : System.Boolean
-AngouriMath.Entity+Set+SetMinusf.Latexize() : System.String
 AngouriMath.Entity+Set+SetMinusf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Set+SetMinusf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Set+SetMinusf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Set+SetMinusf.Right { } : AngouriMath.Entity
-AngouriMath.Entity+Set+SetMinusf.Stringize() : System.String
 AngouriMath.Entity+Set+SetMinusf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Set+SetMinusf.ToString() : System.String
 AngouriMath.Entity+Set+SetMinusf.TryContains(AngouriMath.Entity, System.Boolean&) : System.Boolean
@@ -1839,7 +1731,6 @@ AngouriMath.Entity+Set+SpecialSet+Booleans.Equals(System.Object) : System.Boolea
 AngouriMath.Entity+Set+SpecialSet+Booleans.GetHashCode() : System.Int32
 AngouriMath.Entity+Set+SpecialSet+Booleans.MayContain(AngouriMath.Entity) : System.Boolean
 AngouriMath.Entity+Set+SpecialSet+Booleans.PrintMembers(System.Text.StringBuilder) : System.Boolean
-AngouriMath.Entity+Set+SpecialSet+Booleans.Stringize() : System.String
 AngouriMath.Entity+Set+SpecialSet+Booleans.ToString() : System.String
 AngouriMath.Entity+Set+SpecialSet+Booleans.ctor()
 AngouriMath.Entity+Set+SpecialSet+Booleans.op_Equality(AngouriMath.Entity+Set+SpecialSet+Booleans, AngouriMath.Entity+Set+SpecialSet+Booleans) : System.Boolean
@@ -1852,7 +1743,6 @@ AngouriMath.Entity+Set+SpecialSet+Complexes.Equals(System.Object) : System.Boole
 AngouriMath.Entity+Set+SpecialSet+Complexes.GetHashCode() : System.Int32
 AngouriMath.Entity+Set+SpecialSet+Complexes.MayContain(AngouriMath.Entity) : System.Boolean
 AngouriMath.Entity+Set+SpecialSet+Complexes.PrintMembers(System.Text.StringBuilder) : System.Boolean
-AngouriMath.Entity+Set+SpecialSet+Complexes.Stringize() : System.String
 AngouriMath.Entity+Set+SpecialSet+Complexes.ToString() : System.String
 AngouriMath.Entity+Set+SpecialSet+Complexes.ctor()
 AngouriMath.Entity+Set+SpecialSet+Complexes.op_Equality(AngouriMath.Entity+Set+SpecialSet+Complexes, AngouriMath.Entity+Set+SpecialSet+Complexes) : System.Boolean
@@ -1865,7 +1755,6 @@ AngouriMath.Entity+Set+SpecialSet+Integers.Equals(System.Object) : System.Boolea
 AngouriMath.Entity+Set+SpecialSet+Integers.GetHashCode() : System.Int32
 AngouriMath.Entity+Set+SpecialSet+Integers.MayContain(AngouriMath.Entity) : System.Boolean
 AngouriMath.Entity+Set+SpecialSet+Integers.PrintMembers(System.Text.StringBuilder) : System.Boolean
-AngouriMath.Entity+Set+SpecialSet+Integers.Stringize() : System.String
 AngouriMath.Entity+Set+SpecialSet+Integers.ToString() : System.String
 AngouriMath.Entity+Set+SpecialSet+Integers.ctor()
 AngouriMath.Entity+Set+SpecialSet+Integers.op_Equality(AngouriMath.Entity+Set+SpecialSet+Integers, AngouriMath.Entity+Set+SpecialSet+Integers) : System.Boolean
@@ -1878,7 +1767,6 @@ AngouriMath.Entity+Set+SpecialSet+Rationals.Equals(System.Object) : System.Boole
 AngouriMath.Entity+Set+SpecialSet+Rationals.GetHashCode() : System.Int32
 AngouriMath.Entity+Set+SpecialSet+Rationals.MayContain(AngouriMath.Entity) : System.Boolean
 AngouriMath.Entity+Set+SpecialSet+Rationals.PrintMembers(System.Text.StringBuilder) : System.Boolean
-AngouriMath.Entity+Set+SpecialSet+Rationals.Stringize() : System.String
 AngouriMath.Entity+Set+SpecialSet+Rationals.ToString() : System.String
 AngouriMath.Entity+Set+SpecialSet+Rationals.ctor()
 AngouriMath.Entity+Set+SpecialSet+Rationals.op_Equality(AngouriMath.Entity+Set+SpecialSet+Rationals, AngouriMath.Entity+Set+SpecialSet+Rationals) : System.Boolean
@@ -1891,7 +1779,6 @@ AngouriMath.Entity+Set+SpecialSet+Reals.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Set+SpecialSet+Reals.GetHashCode() : System.Int32
 AngouriMath.Entity+Set+SpecialSet+Reals.MayContain(AngouriMath.Entity) : System.Boolean
 AngouriMath.Entity+Set+SpecialSet+Reals.PrintMembers(System.Text.StringBuilder) : System.Boolean
-AngouriMath.Entity+Set+SpecialSet+Reals.Stringize() : System.String
 AngouriMath.Entity+Set+SpecialSet+Reals.ToString() : System.String
 AngouriMath.Entity+Set+SpecialSet+Reals.ctor()
 AngouriMath.Entity+Set+SpecialSet+Reals.op_Equality(AngouriMath.Entity+Set+SpecialSet+Reals, AngouriMath.Entity+Set+SpecialSet+Reals) : System.Boolean
@@ -1910,7 +1797,6 @@ AngouriMath.Entity+Set+SpecialSet.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Set+SpecialSet.InnerSimplify(System.Boolean) : AngouriMath.Entity
 AngouriMath.Entity+Set+SpecialSet.IsSetEmpty { } : System.Boolean
 AngouriMath.Entity+Set+SpecialSet.IsSetFinite { } : System.Boolean
-AngouriMath.Entity+Set+SpecialSet.Latexize() : System.String
 AngouriMath.Entity+Set+SpecialSet.MayContain(AngouriMath.Entity) : System.Boolean
 AngouriMath.Entity+Set+SpecialSet.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Set+SpecialSet.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
@@ -1934,12 +1820,10 @@ AngouriMath.Entity+Set+Unionf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Set+Unionf.InnerSimplify(System.Boolean) : AngouriMath.Entity
 AngouriMath.Entity+Set+Unionf.IsSetEmpty { } : System.Boolean
 AngouriMath.Entity+Set+Unionf.IsSetFinite { } : System.Boolean
-AngouriMath.Entity+Set+Unionf.Latexize() : System.String
 AngouriMath.Entity+Set+Unionf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Set+Unionf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Set+Unionf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Set+Unionf.Right { } : AngouriMath.Entity
-AngouriMath.Entity+Set+Unionf.Stringize() : System.String
 AngouriMath.Entity+Set+Unionf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Set+Unionf.ToString() : System.String
 AngouriMath.Entity+Set+Unionf.TryContains(AngouriMath.Entity, System.Boolean&) : System.Boolean
@@ -1977,11 +1861,9 @@ AngouriMath.Entity+Signumf.GetHashCode() : System.Int32
 AngouriMath.Entity+Signumf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Signumf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Signumf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Signumf.Latexize() : System.String
 AngouriMath.Entity+Signumf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Signumf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Signumf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Signumf.Stringize() : System.String
 AngouriMath.Entity+Signumf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Signumf.ToString() : System.String
 AngouriMath.Entity+Signumf.ctor(AngouriMath.Entity)
@@ -1999,11 +1881,9 @@ AngouriMath.Entity+Sinf.GetHashCode() : System.Int32
 AngouriMath.Entity+Sinf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Sinf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Sinf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Sinf.Latexize() : System.String
 AngouriMath.Entity+Sinf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Sinf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Sinf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Sinf.Stringize() : System.String
 AngouriMath.Entity+Sinf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Sinf.ToString() : System.String
 AngouriMath.Entity+Sinf.ctor(AngouriMath.Entity)
@@ -2034,12 +1914,10 @@ AngouriMath.Entity+Sumf.GetHashCode() : System.Int32
 AngouriMath.Entity+Sumf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Sumf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Sumf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Sumf.Latexize() : System.String
 AngouriMath.Entity+Sumf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Sumf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Sumf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Sumf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Sumf.Stringize() : System.String
 AngouriMath.Entity+Sumf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Sumf.Sum(System.Collections.Generic.IEnumerable<AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Sumf.Sum(System.Collections.Generic.IReadOnlyList<AngouriMath.Entity>) : AngouriMath.Entity
@@ -2058,10 +1936,8 @@ AngouriMath.Entity+Summationf.From { } : AngouriMath.Entity
 AngouriMath.Entity+Summationf.GetHashCode() : System.Int32
 AngouriMath.Entity+Summationf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Summationf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Summationf.Latexize() : System.String
 AngouriMath.Entity+Summationf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Summationf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Summationf.Stringize() : System.String
 AngouriMath.Entity+Summationf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Summationf.To { } : AngouriMath.Entity
 AngouriMath.Entity+Summationf.ToString() : System.String
@@ -2080,11 +1956,9 @@ AngouriMath.Entity+Tanf.GetHashCode() : System.Int32
 AngouriMath.Entity+Tanf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Tanf.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Tanf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Tanf.Latexize() : System.String
 AngouriMath.Entity+Tanf.NodeChild { } : AngouriMath.Entity
 AngouriMath.Entity+Tanf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Tanf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Tanf.Stringize() : System.String
 AngouriMath.Entity+Tanf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Tanf.ToString() : System.String
 AngouriMath.Entity+Tanf.ctor(AngouriMath.Entity)
@@ -2113,11 +1987,9 @@ AngouriMath.Entity+Variable.GetHashCode() : System.Int32
 AngouriMath.Entity+Variable.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Variable.InnerDifferentiate(AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.Entity+Variable.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Variable.Latexize() : System.String
 AngouriMath.Entity+Variable.Name { } : System.String
 AngouriMath.Entity+Variable.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Variable.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
-AngouriMath.Entity+Variable.Stringize() : System.String
 AngouriMath.Entity+Variable.ToString() : System.String
 AngouriMath.Entity+Variable.ctor(AngouriMath.Entity+Variable)
 AngouriMath.Entity+Variable.op_Equality(AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : System.Boolean
@@ -2133,14 +2005,12 @@ AngouriMath.Entity+Xorf.Equals(System.Object) : System.Boolean
 AngouriMath.Entity+Xorf.GetHashCode() : System.Int32
 AngouriMath.Entity+Xorf.InitDirectChildren() : AngouriMath.Entity[]
 AngouriMath.Entity+Xorf.InnerSimplify(System.Boolean) : AngouriMath.Entity
-AngouriMath.Entity+Xorf.Latexize() : System.String
 AngouriMath.Entity+Xorf.Left { } : AngouriMath.Entity
 AngouriMath.Entity+Xorf.NodeFirstChild { } : AngouriMath.Entity
 AngouriMath.Entity+Xorf.NodeSecondChild { } : AngouriMath.Entity
 AngouriMath.Entity+Xorf.PrintMembers(System.Text.StringBuilder) : System.Boolean
 AngouriMath.Entity+Xorf.Replace(System.Func<AngouriMath.Entity,AngouriMath.Entity>) : AngouriMath.Entity
 AngouriMath.Entity+Xorf.Right { } : AngouriMath.Entity
-AngouriMath.Entity+Xorf.Stringize() : System.String
 AngouriMath.Entity+Xorf.Substitute(AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Entity+Xorf.ToString() : System.String
 AngouriMath.Entity+Xorf.ctor(AngouriMath.Entity, AngouriMath.Entity)

--- a/Sources/Tests/UnitTests/Convenience/StringizeRoundTripTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/StringizeRoundTripTest.cs
@@ -366,5 +366,26 @@ namespace AngouriMath.Tests.Common
         [InlineData("aNaN")]
         public void AWordContainingTheTokenIsStillAVariable(string source) =>
             Assert.IsType<Entity.Variable>(source.ToEntity());
+
+        /// <summary>
+        /// A narrowed codomain is part of the expression, so it is part of what has to come back.
+        /// Nothing printed it, so <c>domain(x, ZZ)</c> printed as <c>x</c> and the annotation was
+        /// gone -- silently, since <c>x</c> is a perfectly good expression.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1022">#1022</a>.
+        /// <see cref="AngouriMath.Tests.Common.CodomainSurvivesPrintingTest"/> takes it across
+        /// every node type; these are the shapes the issue names.
+        /// </summary>
+        [Theory]
+        [InlineData("domain(x, ZZ)")]
+        [InlineData("domain(x + 1, RR)")]
+        [InlineData("domain(sqrt(-1), RR)")]
+        [InlineData("domain([1, 2], RR)")]
+        [InlineData("domain(a and b, BB)")]
+        [InlineData("sin(domain(x, ZZ)) + domain(y, RR)")]
+        [InlineData("2 * domain(x + 1, RR)")]
+        [InlineData("domain(x, ZZ) ^ domain(y, RR)")]
+        [InlineData("integral(domain(x, ZZ), x)")]
+        [InlineData("{ domain(x, ZZ) : x > 0 }")]
+        public void ANarrowedCodomainRoundTrips(string source) => AssertRoundTrip(source);
     }
 }


### PR DESCRIPTION
Closes #1022.

`Stringize` printed no node's `Codomain`. Measured on a build of `master` (cd0b56b9) and a build of
this branch:

| | master | this branch |
|---|---|---|
| `"domain(x, ZZ)".ToEntity().Stringize()` | `x` | `domain(x, ZZ)` |
| ... read back, `.Codomain` | `Any` | `Integer` |
| ... `e == e.Stringize().ToEntity()` | `False` | `True` |
| `"domain(x + 1, RR)".ToEntity().Stringize()` | `x + 1` | `domain(x + 1, RR)` |
| `"domain(sqrt(-1), RR)".ToEntity().Stringize()` | `sqrt(-1)`, which reads back as `i` | `domain(sqrt(-1), RR)`, which reads back as `NaN` |
| `"domain([1, 2], RR)".ToEntity().Stringize()` | `[1, 2]` | `domain([1, 2], RR)` |
| `Sin(Var("x").WithCodomain(Integer)) + Var("y").WithCodomain(Real)` | `sin(x) + y` | `sin(domain(x, ZZ)) + domain(y, RR)` |
| `.Latexize()` of the first | `x` | `{\left(x\right)}_{\mathbb{Z}}` |
| `JsonSerializer.Serialize` of the first | `"x"` | `"domain(x, ZZ)"` |

This matters past the round trip because #746 rests on it: *"the printed form is contractually a
lie-free channel — parsing what `Stringize` prints gives back the expression printed."* That
sentence had to be qualified with this defect; it does not any more, bar the two corners below.

### The rule for when to print, and why it is a comparison

Print `domain(inner, SET)` exactly where the codomain is **not** the one parsing the bare text would
give back — that is, not the node type's default. Anything wider would put a wrapper on every
expression the library prints and move hundreds of expected outputs for nothing.

**That default is not uniform**, which is the interesting part of the task and why the rule cannot be
"is it `Complex`":

| default | node types |
|---|---|
| `Any` | `Variable` (hence `Constant`), `Matrix`, every `Set` but `Interval`, `Providedf`, `Piecewise`, `Application`, `Lambda` |
| `Real` | `Modf`, `Absf`, `Minf`, `Maxf`, `Interval` |
| `Boolean` | every boolean node, and `Inf` |
| `Integer` | `Number.Integer`, `Phif` |
| `Rational` / `Real` / `Complex` | the numeric literal of that type |
| `Complex` | the remaining 30-odd continuous nodes |

So `DefaultCodomain` is declared beside each `Codomain` in `Domains.Classes.cs`, **both abstract on
`Entity`**: a node that declares one and forgets the other does not compile, and a test asserts that
every freshly built node of every node type carries its own default.

### What moved besides the printer

- **`Latexize` had the same gap.** It renders as `{\left(x\right)}_{\mathbb{Z}}`. The parentheses are
  unconditional, because a variable renders its own index as a subscript and `x_{\mathbb{Z}}` would
  be indistinguishable from a variable spelled that way. New output for CSharpMath.Evaluation, which
  has no notion of a codomain — it only appears for an expression carrying a narrowed one (#822).
- **`EntityJsonConverter` needed no change**: it serialises what `Stringize` prints, so #1022's entry
  in its remarks and in `Docs/Contributing/Serialization.md` is now a description of a fixed thing.
- **`MathS.ToSympyCode` did need one.** It emitted `{v.Stringize()} = sympy.Symbol(...)` for each
  variable, which after this change is `domain(x, ZZ) = sympy.Symbol('domain(x, ZZ)')` — not a Python
  identifier. It uses `Name` now, and its output is byte-identical to master's on both sides.
- **A sum stops collecting two terms that are not the same term.** `Simplify`'s polynomial collection
  keys a monomial by its base's *printed form*:

  ```
  "x - domain(x, ZZ)".ToEntity().Simplify()      master: 0        now: x - domain(x, ZZ)
  "domain(x, ZZ) + x".ToEntity().Simplify()      master: 2 * x    now: domain(x, ZZ) + x
  ```

  `0` is the answer only where `x` is an integer, and the annotation is exactly what says it might
  not be. Confirmed as the cause rather than inferred: putting the collision back — keying on the
  base with its codomain erased — brings `0` and `2 * x` straight back.

### What this does not fix

Two annotations still do not read back, and both are the **grammar's** limit, not the printer's.
Each is pinned by a test that fails if it starts working, so neither can outlive itself.

- **`Domain.Any` cannot be written.** `domain(...)`'s second argument must be a `SpecialSet`, and
  there is none for "no restriction". A node *widened* to `Any` from a narrower default prints as
  though it had not been. Printing `CC` instead would be a different lie, and throwing from a printer
  would take out every diagnostic message that quotes an expression.
- **No input yields a `Rational` whose codomain is `Complex`.** The pass that reads `1/2` as a
  rational rather than a quotient (#873) uses `Complex` as its "nobody annotated this" sentinel,
  because that is what an un-annotated `Divf` carries. So `domain(1/2, CC)` parses to the same node
  `1/2` does. Worth its own issue; it is a parser gap and there is nothing the printer can emit
  instead.

### The public surface

Each node declared its own `public override string Stringize()` and `Latexize()`. The codomain
wrapper is one decision and now lives once on `Entity`, with the per-node rendering behind
`private protected abstract StringizeNode()` / `LatexizeNode()`. `PublicApi.txt` therefore loses 130
overrides and gains nothing. **Nothing a caller writes stops compiling** — `someSumf.Stringize()`
still resolves, inherited — but an assembly *compiled* against 2.3.0 binds to
`Entity+Sumf::Stringize()` wherever its static type is a concrete node, and has to be rebuilt.
`BREAKING-CHANGES.md` says so.

### Tests

`dotnet test Sources/Tests/UnitTests -c Release`, full run each time, build lines read:

| | before | after |
|---|--:|--:|
| passed | 8070 | 8516 |
| failed | 0 | 0 |
| skipped | 14 | 14 |
| total | 8084 | 8530 |

The F#, Interactive and Terminal suites are green too (134 / 18 / 7).

Exactly two expected outputs moved, both deliberately:

- `EntitySerializationTest.ACodomainDoesNotSurviveBecauseNothingPrintsIt`, written to fail when this
  is fixed (#1031), is now `ACodomainSurvivesBecauseThePrintedFormCarriesIt`, plus a subnode case.
- `PublicApi.txt`, regenerated with `AM_UPDATE_PUBLIC_API=1`: 130 deletions, 0 additions.

New: `CodomainSurvivesPrintingTest` — every node type there is × every writable domain, comparing
entities and reusing `EveryNodeSurvivesEveryPipelineTest.EveryNodeType`, so it cannot silently stop
covering a node; the default-agreement check; the two pinned residuals; the LaTeX shape. Ten more
cases in `StringizeRoundTripTest`, including the binder positions (`lambda`, `derivative`,
`integral`, set-builder), which all round trip.

No wiki or website sample uses `domain(` or `WithCodomain`, so `docsamples` is unaffected; the
corpus gate is in the suite above. `Docs/Usage/Syntax.md`, `Docs/Contributing/Serialization.md`,
`NodeContract.md`, `Packaging.md` and `AddingNode.cs` are corrected where they described the old
behaviour or counted the abstract members (eleven capabilities, now twelve).

Against #746: this is a standing-condition fix rather than a tier item — it removes the exception
that had to be written into the printed-form claim that machine-to-machine exchange, caches and
agent tool calls all rest on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd
