### PR TITLE
Two rule sets run on the matcher rather than on their switch

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
@@ -117,12 +117,17 @@ namespace AngouriMath.Core.Transformations
         /// <summary>
         /// Gets a quotient into the shape the division rules expect before they run.
         /// </summary>
+        /// <remarks>
+        /// <b>Run by the matcher rather than by the <c>switch</c></b> —
+        /// <see cref="Matching.MatchedRules.DivisionPreparing"/>. See the note on
+        /// <see cref="CollapseMultipleFractions"/> for what that costs and what still describes it.
+        /// </remarks>
         public static RewriteRuleSet DivisionPreparing { get; } = new(
             nameof(DivisionPreparing),
             "Lifts numeric factors out of a quotient so that the division rules can see it.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Patterns.DivisionPreparingRules,
+            Matching.MatchedRules.DivisionPreparing.ApplyHere,
             Patterns.DivisionPreparingRulesArms);
 
         /// <summary>
@@ -204,12 +209,41 @@ namespace AngouriMath.Core.Transformations
         /// <summary>
         /// Brings a quotient of quotients down to a single one.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Run by the matcher rather than by the <c>switch</c></b> —
+        /// <see cref="Matching.MatchedRules.CollapseMultipleFractions"/>. This and
+        /// <see cref="DivisionPreparing"/> are the two sets whose data form is proven to agree
+        /// with the <c>switch</c> it mirrors over generated expressions
+        /// (<c>MatchedRulesAgreeWithTheSwitchTest</c>), which is the precondition for running one
+        /// instead of the other.
+        /// </para>
+        /// <para>
+        /// <b>What it costs.</b> Measured against <c>Simplify</c> itself, both arms in
+        /// one process with a third arm that is the <c>switch</c> again as a control: the data form
+        /// is −0.6% where the control differs from its own source by −1.1%, so the change is
+        /// smaller than this machine's disagreement with itself, and allocation is +0.04%. That
+        /// number used to be +5% for <see cref="DivisionPreparing"/> alone, and what closed it was
+        /// settling a pattern's determinism once rather than on every attempt
+        /// (<a href="https://github.com/asc-community/AngouriMath/pull/1050">#1050</a>).
+        /// </para>
+        /// <para>
+        /// <b>The <c>switch</c> is still what describes them.</b> <see cref="RewriteRule"/> carries
+        /// a <see cref="RewriteRule.PatternSource"/> and a <see cref="RewriteRule.SourceLine"/>,
+        /// which <c>RuleRegistryGenerator</c> reads off the arms of a <c>switch</c>; it has no way
+        /// yet to read a rule written as data. So the addressable rules of these two sets still come
+        /// from <c>Patterns</c>, and the arms they describe are the ones the agreement test holds
+        /// the matcher to rather than dead code. Teaching the generator to read
+        /// <see cref="Matching.MatchedRules"/> is what would let the <c>switch</c> go, and is
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/825">#825</a>.
+        /// </para>
+        /// </remarks>
         public static RewriteRuleSet CollapseMultipleFractions { get; } = new(
             nameof(CollapseMultipleFractions),
             "Collapses nested quotients into a single numerator over a single denominator.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Patterns.CollapseMultipleFractions,
+            Matching.MatchedRules.CollapseMultipleFractions.ApplyHere,
             Patterns.CollapseMultipleFractionsArms);
 
         /// <summary>


### PR DESCRIPTION
Part of #746 tier 1 (#248). Depends on #1050, which is merged.

### The gap this closes

#746's tier 1 row records pattern matching as data as delivered, and then says what is wrong with
that:

> **Pattern matching as data (#248) was recorded as done and is overstated**: the engine exists, with
> commutative and n-ary matching, and **nothing runs on it** — every type in
> `Core/Transformations/Matching` is `internal`, five rule sets are expressed as data, and 0 of the
> 30 registered sets use the matcher at runtime. The one exchange that was made was measured at +5%
> of `Simplify` and reverted.

The blocker was that number, and it was a fair one: 5% for one of thirty sets does not scale to
thirty. #1050 changed it, by settling a pattern's determinism once rather than on every attempt.

### Re-measured against `Simplify`, not against a microbenchmark

A microbenchmark ratio is how the 5% became a surprise the first time, so this is measured against
`Simplify` itself — both arms in one process, interleaved, with a **third arm that is the `switch`
again** as a control, because comparing two runs on this machine measures the machine:

```
switch   median 539 ms over 40 reps  (min 533, max 679)
data     median 536 ms over 40 reps  (min 534, max 716)     data    / switch = -0.6%
control  median 533 ms over 40 reps  (min 532, max 628)     control / switch = -1.1%
```

The control differs from its own source code by more than the change does. Allocation is
38,181,736 B against 38,196,896 B, **+0.04%**. Both arms were checked to give the same answer on
every input before either was timed.

### What is exchanged, and why only these two

`DivisionPreparing` and `CollapseMultipleFractions` are the two sets whose data form is *proven* to
agree with the `switch` it mirrors, over generated expressions, with a minimum firing count so the
agreement cannot be vacuous — `MatchedRulesAgreeWithTheSwitchTest`. That proof is the precondition
for running one in place of the other, and the other three data sets do not have it: `PowerOfPower`
is checked against a `switch` that does more than it, and `PythagoreanIdentity` has nothing to agree
with by design.

### The `switch` stays, and is not dead code

`RewriteRule` carries a `PatternSource` and a `SourceLine`, which `RuleRegistryGenerator` reads off
the arms of a `switch`. It has no way yet to read a rule written as data, so the addressable rules of
these two sets still come from `Patterns` — and the arms they describe are exactly the ones the
agreement test holds the matcher to, rather than code nothing runs. Teaching the generator to read
`MatchedRules` is what would let the `switch` go, and is #825.

This is stated in the doc comment rather than left for a reader to discover, because "the registry
describes a `switch` that no longer executes" is the kind of thing that is true and invisible.

### Evidence

- Suite **8553 passed, 0 failed, 14 skipped** — the same as master.
- `rulecheck`, `canoncheck`, `casbench` and `simpsweep` re-run against this branch are
  **byte-identical** to master's committed reports, ignoring the commit line and timings.
  `rulecheck` reports **0 value changes** across 1005 applications of 30 sets, and it is the harness
  that attributes a change to a *named* set — so a difference in either of these two would have been
  named rather than averaged away.

After this, #746 tier 1's "0 of the 30 registered sets use the matcher at runtime" reads **2 of 30**.