### PR TITLE
The square-free part is taken where the coefficients are polynomials

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -46,6 +46,7 @@ read first.
 | | every node type's own `Stringize()` and `Latexize()` overrides — `Entity.Sumf.Stringize()` and 129 more | declared on each node | declared once on `Entity`; still callable on every node, and an assembly compiled against 2.3.0 keeps working without a rebuild |
 | | `"x + 1 // done".ToEntity()`, and any input whose last line ends in a `//` comment | `UnhandledParseException: extraneous input '/'` | `x + 1` — the comment is skipped, as the block form already was |
 | | `MathS.Polynomials.Factor("x * y + y", "x")`, and any polynomial whose coefficients in the named variable share a common divisor | `null` — a refusal | `y * (x + 1)` |
+| | `MathS.Polynomials.SquareFreePart("(x - y) ^ 2 * (x + y)", "x")`, and any polynomial in more than one variable | `null` — a refusal | `x ^ 2 - y ^ 2` |
 
 ### An equation nothing settled is no longer answered with the empty set
 
@@ -302,6 +303,32 @@ the same precedences this grammar uses — so those needed the same brackets —
 bracketing for. The change only ever adds `\left(`/`\right)` groups, which CSharpMath already
 parses, so nothing downstream needs a matching change
 ([#822](https://github.com/asc-community/AngouriMath/issues/822)).
+
+### The square-free part is taken where the coefficients are polynomials
+
+`MathS.Polynomials.SquareFreePart` refused every polynomial in more than one variable, for the same
+reason `Factor` did: it was written against a representation with rational coefficients.
+
+`p / gcd(p, dp/dx)` is the square-free part whatever ring the coefficients live in — a repeated
+factor appears in the derivative one time fewer than in the polynomial, so dividing by the common
+part leaves each distinct factor exactly once. The multivariate representation has all three
+operations already: `DerivativeIn`, the recursive greatest common divisor that
+`MathS.Polynomials.Gcd` is built from, and exact division.
+
+| | 2.3.0 | now |
+|---|---|---|
+| `SquareFreePart("(x - y) ^ 2 * (x + y)", "x")` | `null` | `x ^ 2 - y ^ 2` |
+| `SquareFreePart("(x - y) ^ 3", "x")` | `null` | `x - y` |
+| `SquareFreePart("(x + a) ^ 2 * (x + b)", "x")` | `null` | `a * b + a * x + b * x + x ^ 2` |
+| `SquareFreePart("x ^ 2 * y ^ 2", "x")` | `null` | `x` |
+| `SquareFreePart("y", "x")` | `null` | `null` |
+
+**The content is dropped, as it always was.** `SquareFreePart("4 * x ^ 2", "x")` is `x` rather than
+`4 * x`, because the univariate path takes the primitive part first. `x ^ 2 * y ^ 2` is `x` for
+exactly that reason, with `y ^ 2` as the content — the existing convention applied to a wider ring,
+not a new one.
+
+Reached only where the rational path declined, so nothing that already answered can change.
 
 ### `Factor` takes out the content instead of refusing
 

--- a/Sources/AngouriMath/Convenience/MathS.Polynomials.cs
+++ b/Sources/AngouriMath/Convenience/MathS.Polynomials.cs
@@ -345,7 +345,7 @@ namespace AngouriMath
                 if (!PolynomialFactoring.TryGetRationalCoefficients(
                         expr, variable, leastTerms: 1, leastDegree: 1,
                         IntegerPolynomial.MaxDegree, out var rational))
-                    return null;
+                    return MultivariateSquareFreePart(expr, variable);
                 var denominator = EInteger.One;
                 foreach (var coefficient in rational)
                     denominator = coefficient.Denominator
@@ -358,6 +358,50 @@ namespace AngouriMath
                 if (primitive.DivideExact(repeated) is not { } distinct)
                     return null;
                 return distinct.PrimitivePart().ToEntity(variable);
+            }
+
+            /// <summary>
+            /// The same, where the coefficients in <paramref name="variable"/> are polynomials
+            /// themselves rather than rational numbers.
+            /// </summary>
+            /// <remarks>
+            /// <para>
+            /// <c>p / gcd(p, dp/dx)</c> is the square-free part whatever ring the coefficients
+            /// live in — a repeated factor appears in the derivative one time fewer than in the
+            /// polynomial, so dividing by the common part leaves each distinct factor exactly
+            /// once. The univariate path above says exactly that over ℤ. Nothing about it is
+            /// univariate except the representation it was written against, and the multivariate
+            /// one has all three operations: <c>DerivativeIn</c>, the recursive
+            /// <see cref="PolynomialGcd"/> that <see cref="Gcd"/> is already built from, and
+            /// exact division.
+            /// </para>
+            /// <para>
+            /// Reached only where the rational path declined, so nothing that already answered
+            /// can change.
+            /// </para>
+            /// </remarks>
+            private static Entity? MultivariateSquareFreePart(Entity expr, Variable variable)
+            {
+                if (Index(expr, expr, variable) is not var (variables, index))
+                    return null;
+                if (MultivariatePolynomial.TryParse(expr, index) is not { } poly)
+                    return null;
+                var main = index[variable];
+                // A polynomial constant in the variable has no square-free part in it to speak
+                // of, and the univariate path refuses that case too.
+                if (poly.DegreeIn(main) < 1)
+                    return null;
+                var derivative = poly.DerivativeIn(main);
+                if (derivative.IsZero)
+                    return null;
+                var order = new int[variables.Count];
+                for (var i = 0; i < order.Length; i++)
+                    order[i] = i;
+                if (PolynomialGcd.Gcd(poly, derivative, order, 0) is not { } repeated)
+                    return null;
+                if (poly.DivideExact(repeated) is not { } distinct)
+                    return null;
+                return distinct.Normalized().ToEntity(variables);
             }
 
             /// <summary>

--- a/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialSurfaceTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialSurfaceTest.cs
@@ -157,6 +157,59 @@ namespace AngouriMath.Tests.Algebra.Polynomials
         }
 
         /// <summary>
+        /// The square-free part is <c>p / gcd(p, dp/dx)</c> whatever ring the coefficients live
+        /// in, so it is not univariate for any reason but the representation it used to be
+        /// written against. Each case here is built from known factors, and the answer has to be
+        /// their product with every multiplicity dropped to one.
+        /// </summary>
+        /// <remarks>
+        /// Compared numerically rather than as a string, and up to the content: the univariate
+        /// path drops it — <c>SquareFreePart("4 * x ^ 2", "x")</c> is <c>x</c>, not <c>4 * x</c> —
+        /// so <c>x ^ 2 * y ^ 2</c> is <c>x</c> for the same reason, with <c>y ^ 2</c> as the
+        /// content. That is the existing convention rather than a new one.
+        /// </remarks>
+        [Theory]
+        [InlineData("(x - y) ^ 2 * (x + y)", "(x - y) * (x + y)")]
+        [InlineData("(x - y) ^ 3", "x - y")]
+        [InlineData("(x + a) ^ 2 * (x + b)", "(x + a) * (x + b)")]
+        [InlineData("x ^ 2 * y ^ 2", "x")]
+        [InlineData("y ^ 2 * x ^ 2 * (x + 1)", "x * (x + 1)")]
+        public void TheSquareFreePartIsTakenWhereTheCoefficientsArePolynomials(
+            string input, string expected)
+        {
+            var part = MathS.Polynomials.SquareFreePart(input, "x");
+            Assert.NotNull(part);
+            var wanted = expected.ToEntity();
+            var variables = wanted.Vars.Concat(part!.Vars).Distinct().ToArray();
+            var random = new Random(20260825);
+            for (var trial = 0; trial < 20; trial++)
+            {
+                Entity left = wanted, right = part;
+                foreach (var variable in variables)
+                {
+                    Entity value = Math.Round(random.NextDouble() * 6 - 3, 4);
+                    left = left.Substitute(variable, value);
+                    right = right.Substitute(variable, value);
+                }
+                Assert.Equal(
+                    left.EvalNumerical().RealPart.EDecimal.ToDouble(),
+                    right.EvalNumerical().RealPart.EDecimal.ToDouble(),
+                    9);
+            }
+        }
+
+        /// <summary>
+        /// Where the coefficients are polynomials and there is still nothing to say, the answer
+        /// is a refusal rather than a guess.
+        /// </summary>
+        [Theory]
+        [InlineData("y")]                            // constant in x
+        [InlineData("sin(x) + 1")]                   // not a polynomial
+        [InlineData("sin(y) * x ^ 2")]               // the coefficient is not a polynomial either
+        public void ASquareFreePartOutsideTheLayerIsRefused(string input)
+            => Assert.Null(MathS.Polynomials.SquareFreePart(input, "x"));
+
+        /// <summary>
         /// A request outside what the layer can do is refused with <see langword="null"/>, and
         /// never answered with the input as though it were the result. Handing
         /// <c>x * y + y</c> back from a factorisation would say that <c>y * (x + 1)</c> does


### PR DESCRIPTION
Part of #746 tier 1, item 43. Follows #1053, which did the same for `Factor`'s content.

### What was wrong

`MathS.Polynomials.SquareFreePart` refused every polynomial in more than one variable — not because
the mathematics is univariate, but because the code was written against a representation whose
coefficients are rational numbers.

`p / gcd(p, dp/dx)` is the square-free part whatever ring the coefficients live in: a repeated factor
appears in the derivative one time fewer than in the polynomial, so dividing by the common part
leaves each distinct factor exactly once. The multivariate representation already has all three
operations — `DerivativeIn`, the recursive `PolynomialGcd` that `MathS.Polynomials.Gcd` is built
from, and exact division.

| | 2.3.0 | now |
|---|---|---|
| `SquareFreePart("(x - y) ^ 2 * (x + y)", "x")` | `null` | `x ^ 2 - y ^ 2` |
| `SquareFreePart("(x - y) ^ 3", "x")` | `null` | `x - y` |
| `SquareFreePart("(x + a) ^ 2 * (x + b)", "x")` | `null` | `a * b + a * x + b * x + x ^ 2` |
| `SquareFreePart("y ^ 2 * x ^ 2 * (x + 1)", "x")` | `null` | `x ^ 2 + x` |
| `SquareFreePart("x ^ 2 * y ^ 2", "x")` | `null` | `x` |
| `SquareFreePart("y", "x")` | `null` | `null` |
| `SquareFreePart("sin(y) * x ^ 2", "x")` | `null` | `null` |

### The two that look wrong and are not

`x ^ 2 * y ^ 2` gives `x`, not `x * y ^ 2`. **The content has always been dropped**: the univariate
path takes the primitive part first, so `SquareFreePart("4 * x ^ 2", "x")` is `x` rather than
`4 * x`. `y ^ 2` is the content here for exactly the same reason. That is the existing convention
applied to a wider ring, not a new one — and it was checked against the univariate path rather than
assumed. The expectation I wrote first was the wrong one, which is why the test says so explicitly.

`y` is still refused: it is constant in `x`, and the univariate path refuses that too.

### Scope

The multivariate path is reached **only where the rational path declined**, so nothing that already
answered can change.

### Verification

Tests compare numerically at twenty random points per case rather than as strings, for the reason
recorded on #1053 — `Simplify` does not prove two arrangements of a product equal, and a string
comparison reports a defect that is not one.

Suite: **8569 passed, 0 failed, 14 skipped**.