### PR TITLE
Factor was throwing the content away with an irreducibility proof

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -327,8 +327,28 @@ candidate.
 | `Factor("x ^ 2 - (y + z) ^ 2", "x")` | `null` | `(x + y + z) * (x - y - z)` |
 | `Factor("x ^ 2 + 2 * x * y + y ^ 2 - z ^ 2", "x")` | `null` | `(x + y + z) * (x + y - z)` |
 | `Factor("(x + y) * (x + z) * (x + w)", "x")` | `null` | `(x + y) * (w + x) * (x + z)` |
-| `Factor("x ^ 2 + y ^ 2", "x")` | `null` | `null` — irreducible over ℚ |
-| `Factor("x * y + z", "x")` | `null` | `null` — irreducible over ℚ |
+| `Factor("x * y + y * z", "x")` | `null` | `y * (x + z)` |
+| `Factor("a * x + a * y + a * z", "x")` | `null` | `a * (x + y + z)` |
+| `Factor("x ^ 2 * y - y ^ 3", "x")` | `null` | `y * (x + y) * (x - y)` |
+| `Factor("x ^ 2 + y ^ 2", "x")` | `null` | `x ^ 2 + y ^ 2` — irreducible over ℚ |
+| `Factor("x * y + z", "x")` | `null` | `x * y + z` — irreducible over ℚ |
+| `Factor("x ^ 2 - a", "x")` | `null` | `x ^ 2 - a` — irreducible over ℚ |
+| `Factor("x + y", "x")` | `null` | `x + y` — irreducible over ℚ |
+
+**"It does not factor" is an answer, and the input is how it is said.** The substitution does not
+merely fail to find a factorisation; it *proves* there is none. A splitting of the polynomial into
+two parts of positive degree in the main variable maps to a splitting of the one-variable image,
+because the substitution is a ring homomorphism on these monomials — and every splitting of the
+image is one of the subsets the recombination tries. So where nothing recombines, nothing exists.
+
+Reporting that proof as `null` threw away the content along with it: `x * y + y * z` was refused,
+although `y` had already been taken out and `y * (x + z)` is a factorisation. It also disagreed with
+the one-variable path, where `Factor("x ^ 2 + 1", "x")` has always been `x ^ 2 + 1`.
+
+The proof has one precondition and it is now checked. A trial division answers `null` both for "does
+not divide" and for "ran out of room", and only the first is evidence — so where a division was cut
+short by a term or degree budget, the irreducibility claim is withheld and the answer stays a
+refusal.
 
 **It cannot answer wrongly.** The substitution is injective on monomials but not on factorisations,
 so the image may factor further than the polynomial does and a candidate is a guess. Every one is
@@ -389,7 +409,6 @@ the other variables — is now taken out first, using the same multivariate mach
 | `Factor("x ^ 2 * y + x * y", "x")` | `null` | `y * x * (x + 1)` |
 | `Factor("a * x ^ 2 + a * x", "x")` | `null` | `a * x * (x + 1)` |
 | `Factor("x ^ 2 * y ^ 2 - y ^ 2", "x")` | `null` | `y ^ 2 * (x + 1) * (x - 1)` |
-| `Factor("x * y + z", "x")` | `null` | `null` |
 
 **Only a refusal becomes an answer.** Nothing that already factorised changes, because this path
 runs only where the old one returned `null`.

--- a/Sources/AngouriMath/Convenience/MathS.Polynomials.cs
+++ b/Sources/AngouriMath/Convenience/MathS.Polynomials.cs
@@ -57,21 +57,29 @@ namespace AngouriMath
             /// The factorisation; the input itself where it is irreducible over the
             /// rationals, which is an answer and not a refusal; or <see langword="null"/>
             /// where <paramref name="expr"/> is not a polynomial in
-            /// <paramref name="variable"/> alone with rational coefficients, where its degree
-            /// is above 32, or where the factoriser declined.
+            /// <paramref name="variable"/> with rational or polynomial coefficients, or where
+            /// the question is past what the factoriser will do.
             /// </returns>
             /// <remarks>
             /// <para>
-            /// Zassenhaus: square-free decomposition, Berlekamp's factorisation modulo a
-            /// prime, Hensel lifting to a power of it above Mignotte's bound, and
-            /// recombination — and the factors are multiplied back and compared with the
-            /// input before they are returned.
+            /// <b>In one variable, Zassenhaus:</b> square-free decomposition, Berlekamp's
+            /// factorisation modulo a prime, Hensel lifting to a power of it above Mignotte's
+            /// bound, and recombination — and the factors are multiplied back and compared with
+            /// the input before they are returned. The degree bound is 32.
             /// </para>
             /// <para>
-            /// <b>Univariate only.</b> A polynomial in more than one variable is refused
-            /// rather than answered: <c>Factor("x * y + y", "x")</c> is <see langword="null"/>
-            /// and not <c>x * y + y</c>, because handing back the input would say that
-            /// <c>y * (x + 1)</c> does not exist.
+            /// <b>In more than one, two things are tried in order.</b> First the content in
+            /// <paramref name="variable"/> — the common divisor of the coefficients, which is a
+            /// polynomial in the other variables — is taken out. Then whatever remains is
+            /// factored by <b>Kronecker's substitution</b>, which writes the exponent vector as a
+            /// numeral in mixed radix and reads a one-variable factorisation back. Its ceiling is
+            /// a degree budget rather than a variable count: the image has degree the product of
+            /// the radices less one, so three variables of degree 2 fit and four do not.
+            /// </para>
+            /// <para>
+            /// <b>A refusal is possible and a wrong answer is not.</b> Every candidate factor is
+            /// checked by exact division before it is kept, and the assembled factors are divided
+            /// back into the input.
             /// </para>
             /// </remarks>
             /// <example>
@@ -85,8 +93,14 @@ namespace AngouriMath
             /// Console.WriteLine(MathS.Polynomials.Factor("x ^ 2 + 1", "x"));
             /// // x ^ 2 + 1        -- irreducible over Q, which is an answer
             ///
-            /// Console.WriteLine(MathS.Polynomials.Factor("x * y + y", "x") is null);
-            /// // True             -- more than one variable, so it declines
+            /// Console.WriteLine(MathS.Polynomials.Factor("x * y + y", "x"));
+            /// // y * (x + 1)      -- the content in x is taken out first
+            ///
+            /// Console.WriteLine(MathS.Polynomials.Factor("x ^ 2 - y ^ 2", "x"));
+            /// // (x + y) * (x - y)
+            ///
+            /// Console.WriteLine(MathS.Polynomials.Factor("x ^ 12 - y ^ 12", "x") is null);
+            /// // True             -- past the substitution's degree budget
             /// </code>
             /// </example>
             public static Entity? Factor(Entity expr, Variable variable)
@@ -189,9 +203,13 @@ namespace AngouriMath
             {
                 if (variables.Count < 2)
                     return null;
-                if (KroneckerFactorization.Factor(poly, index[variable]) is not { } factors
-                    || factors.Count < 2)
+                if (KroneckerFactorization.Factor(poly, index[variable]) is not { } factors)
                     return null;
+                // One factor is an answer and not a refusal: the substitution has established
+                // that the polynomial does not factor, and a caller that took the content out of
+                // it -- which is who calls this -- still has a factorisation to assemble. The
+                // one-variable path says the same thing the same way, Factor("x ^ 2 + 1", "x")
+                // being x ^ 2 + 1.
                 // Repeated factors are collected into a power, as the one-variable path does:
                 // the recombination finds a square as the same factor twice, and printing it
                 // twice would be a different answer to the same question depending on which

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/KroneckerFactorization.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/KroneckerFactorization.cs
@@ -206,6 +206,7 @@ namespace AngouriMath.Functions
             var found = new List<MultivariatePolynomial>();
             var remaining = poly;
             var available = new List<IntegerPolynomial>(irreducibles);
+            var everyDivisionSettled = true;
 
             var progress = true;
             while (progress && available.Count > 0)
@@ -221,10 +222,20 @@ namespace AngouriMath.Functions
                             else
                                 return null;
                         if (FromImage(product, poly.VariableCount, order, places, radices)
-                                is not { } candidate
-                            || candidate.DegreeIn(main) < 1
-                            || remaining.DivideExact(candidate) is not { } quotient)
+                                is not { } candidate)
+                            return null;
+                        // A candidate of degree zero in the main variable would be content, and
+                        // the content is taken out before this runs -- so skipping it discards
+                        // nothing a factorisation could have used.
+                        if (candidate.DegreeIn(main) < 1)
                             continue;
+                        if (remaining.DivideExact(candidate, out var settled) is not { } quotient)
+                        {
+                            // "Does not divide" and "ran out of room" are the same null, and
+                            // only the first of them is evidence.
+                            everyDivisionSettled &= settled;
+                            continue;
+                        }
                         found.Add(candidate.Normalized());
                         remaining = quotient;
                         for (var i = subset.Count - 1; i >= 0; i--)
@@ -234,8 +245,15 @@ namespace AngouriMath.Functions
                     }
             }
 
+            // Nothing recombined. Every subset of the image's irreducible factors was tried, so
+            // a factorisation of the polynomial into two parts of positive degree in the main
+            // variable would have been found: the substitution is a ring homomorphism on these
+            // monomials, so such a factorisation maps to a splitting of the image, and every
+            // splitting of the image is one of the subsets. The polynomial is irreducible, and
+            // saying so is an answer -- but only where every division was settled, since a
+            // division that ran out of room is not a "does not divide".
             if (found.Count == 0)
-                return new[] { poly };
+                return everyDivisionSettled ? new[] { poly } : null;
             if (!remaining.IsConstant)
                 found.Add(remaining.Normalized());
             // Nothing is returned that does not multiply back to what was asked about.

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/MultivariatePolynomial.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/MultivariatePolynomial.cs
@@ -27,7 +27,7 @@ namespace AngouriMath.Functions
     /// <para>
     /// An exponent vector is packed into one <see cref="ulong"/>, a byte to a variable,
     /// the first variable in the most significant byte. Comparing packed monomials is then
-    /// exactly the lexicographic order on exponents that <see cref="DivideExact"/> needs,
+    /// exactly the lexicographic order on exponents that <see cref="DivideExact(MultivariatePolynomial, int)"/> needs,
     /// and looking a monomial up costs one hash.
     /// </para>
     /// <para>
@@ -314,7 +314,24 @@ namespace AngouriMath.Functions
         /// divided out and seen to leave nothing behind.
         /// </remarks>
         internal MultivariatePolynomial? DivideExact(MultivariatePolynomial divisor, int maxTerms = MaxTerms)
+            => DivideExact(divisor, out _, maxTerms);
+
+        /// <summary>
+        /// The same division, saying <b>why</b> there is no quotient. <paramref name="settled"/>
+        /// is <see langword="false"/> where the division ran out of room rather than finishing:
+        /// the term count grew past <paramref name="maxTerms"/>, a monomial went past
+        /// <see cref="MaxDegree"/>, or the loop reached its step limit.
+        /// </summary>
+        /// <remarks>
+        /// A caller that reads a <see langword="null"/> as "does not divide" is right only where
+        /// the division was settled. Where it was not, the same <see langword="null"/> means "no
+        /// answer", and a caller drawing a mathematical conclusion from it — that a polynomial is
+        /// irreducible, say — would be stating exhaustion as a fact.
+        /// </remarks>
+        internal MultivariatePolynomial? DivideExact(
+            MultivariatePolynomial divisor, out bool settled, int maxTerms = MaxTerms)
         {
+            settled = true;
             if (divisor.IsZero)
                 return null;
             if (IsZero)
@@ -331,16 +348,25 @@ namespace AngouriMath.Functions
                 if (rest.IsZero)
                     return new(VariableCount, quotient);
                 var lead = rest.LeadingMonomial();
+                // The leading monomial of what is left is not a multiple of the divisor's, and
+                // no later step can make it one -- so this is a "no" and not a "gave up".
                 if (!TryDivideMonomials(lead, divisorLead, VariableCount, out var monomial))
                     return null;
                 var value = rest.terms[lead].Divide(divisorValue).ToLowestTerms();
                 quotient[monomial] = value;
                 if (divisor.MultiplyByTerm(monomial, value) is not { } product)
+                {
+                    settled = false;
                     return null;
+                }
                 rest = rest.Subtract(product);
                 if (rest.TermCount > maxTerms)
+                {
+                    settled = false;
                     return null;
+                }
             }
+            settled = false;
             return null;
         }
 

--- a/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialSurfaceTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialSurfaceTest.cs
@@ -227,6 +227,60 @@ namespace AngouriMath.Tests.Algebra.Polynomials
         /// degree 35 and 79 against an <c>IntegerPolynomial.MaxDegree</c> of 32; the third is
         /// two variables and past it on its own.
         /// </remarks>
+        /// <summary>
+        /// A polynomial whose primitive part does not factor still has its content taken out, and
+        /// an irreducible one comes back as itself rather than as a refusal.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The substitution answers "this does not factor" by *proving* it: a factorisation into
+        /// two parts of positive degree in the main variable maps to a splitting of the
+        /// one-variable image, and every splitting of the image is one of the subsets the
+        /// recombination tries. Reporting that proof as <see langword="null"/> threw the content
+        /// away with it — <c>x * y + y * z</c> was refused although <c>y * (x + z)</c> is a
+        /// factorisation this path had already found half of.
+        /// </para>
+        /// <para>
+        /// It also disagreed with the one-variable path, which has always handed back
+        /// <c>Factor("x ^ 2 + 1", "x")</c> as <c>x ^ 2 + 1</c>.
+        /// </para>
+        /// </remarks>
+        [Theory]
+        [InlineData("x * y + y * z", "y * (x + z)")]
+        [InlineData("a * x + a * y + a * z", "a * (x + y + z)")]
+        [InlineData("x ^ 2 * y - y ^ 3", "y * (x + y) * (x - y)")]
+        [InlineData("x ^ 2 + y ^ 2", "x ^ 2 + y ^ 2")]
+        [InlineData("x + y", "x + y")]
+        [InlineData("y * (x ^ 2 + y ^ 2)", "y * (x ^ 2 + y ^ 2)")]
+        [InlineData("x ^ 2 - a", "x ^ 2 - a")]
+        [InlineData("x * y + z", "x * y + z")]
+        public void AnIrreducibleRestIsAnAnswerAndKeepsItsContent(string input, string expected)
+        {
+            var factored = MathS.Polynomials.Factor(input.ToEntity(), "x");
+            Assert.NotNull(factored);
+
+            // Numerically rather than as a string, for the reason the content test above gives:
+            // Simplify does not prove a factored form equal to its expansion.
+            var expr = input.ToEntity();
+            var wanted = expected.ToEntity();
+            var variables = expr.Vars.Concat(factored!.Vars).Concat(wanted.Vars).Distinct().ToArray();
+            var random = new Random(20260825);
+            for (var trial = 0; trial < 20; trial++)
+            {
+                Entity got = factored, want = wanted;
+                foreach (var variable in variables)
+                {
+                    Entity value = Math.Round(random.NextDouble() * 6 - 3, 4);
+                    got = got.Substitute(variable, value);
+                    want = want.Substitute(variable, value);
+                }
+                Assert.Equal(
+                    want.EvalNumerical().RealPart.EDecimal.ToDouble(),
+                    got.EvalNumerical().RealPart.EDecimal.ToDouble(),
+                    9);
+            }
+        }
+
         [Theory]
         [InlineData("(x + y + z + w) * (x - y)")]
         [InlineData("(x + y) * (x + z) * (x + w) * (x + v)")]
@@ -302,16 +356,23 @@ namespace AngouriMath.Tests.Algebra.Polynomials
             => Assert.Null(MathS.Polynomials.SquareFreePart(input, "x"));
 
         /// <summary>
-        /// A request outside what the layer can do is refused with <see langword="null"/>, and
-        /// never answered with the input as though it were the result. Handing
-        /// <c>x * y + y</c> back from a factorisation would say that <c>y * (x + 1)</c> does
-        /// not exist, which is a wrong answer and not a graceful failure.
+        /// A request the layer cannot settle is refused with <see langword="null"/>, and never
+        /// answered with the input as though it were the result. Handing <c>x * y + y</c> back
+        /// from a factorisation would say that <c>y * (x + 1)</c> does not exist, which is a
+        /// wrong answer and not a graceful failure.
         /// </summary>
+        /// <remarks>
+        /// The rows are the two ways of not being asked a question this layer can answer: it is
+        /// not a polynomial, or it is past the factoriser's degree bound. Returning the input
+        /// where the substitution has *proved* the polynomial does not factor is a different
+        /// thing and is asserted separately — see
+        /// <see cref="AnIrreducibleRestIsAnAnswerAndKeepsItsContent"/>. What must never happen is
+        /// the input coming back from a question that was never settled, which is what these
+        /// rows pin.
+        /// </remarks>
         [Theory]
-        [InlineData("x ^ 2 + y ^ 2")]                // irreducible over Q in both variables
-        [InlineData("x ^ 2 - a")]                    // a symbolic coefficient is not rational
-        [InlineData("x * y + z")]                    // three variables: the substitution is over two
         [InlineData("sin(x) + 1")]                   // not a polynomial
+        [InlineData("sin(y) * x ^ 2 + 1")]           // nor is a coefficient of one
         [InlineData("x ^ 33 - 1")]                   // past the degree bound of the factoriser
         public void FactorisationRefusesRatherThanReturningTheInput(string input)
             => Assert.Null(MathS.Polynomials.Factor(input, "x"));


### PR DESCRIPTION
Kronecker's substitution does not merely *fail to find* a factorisation — it **proves there is none**. A splitting of the polynomial into two parts of positive degree in the main variable maps to a splitting of the one-variable image, because the substitution is a ring homomorphism on the monomials that can appear; and every splitting of the image is one of the subsets the recombination tries. So where nothing recombines, nothing exists.

That proof was being reported as `null`, and the content went out with it.

| | before | now |
|---|---|---|
| `Factor("x * y + y * z", "x")` | `null` | `y * (x + z)` |
| `Factor("a * x + a * y + a * z", "x")` | `null` | `a * (x + y + z)` |
| `Factor("x ^ 2 * y - y ^ 3", "x")` | `null` | `y * (x + y) * (x - y)` |
| `Factor("x ^ 2 + y ^ 2", "x")` | `null` | `x ^ 2 + y ^ 2` |
| `Factor("x * y + z", "x")` | `null` | `x * y + z` |
| `Factor("x ^ 2 - a", "x")` | `null` | `x ^ 2 - a` |
| `Factor("x + y", "x")` | `null` | `x + y` |

The first three are the real loss: the content had already been taken out and the factorisation assembled, and then the single-factor rest threw the whole thing away. The rest are a contract that disagreed with itself — the one-variable path has always answered `Factor("x ^ 2 + 1", "x")` with `x ^ 2 + 1`.

## The proof has a precondition, and it is now checked

`DivideExact` answers `null` both for **"does not divide"** and for **"ran out of room"** — a term count past its budget, a monomial past the degree bound, the step limit — and only the first is evidence. Drawing "irreducible" from the second would be stating exhaustion as a mathematical fact.

So it says which, through a new overload, and the irreducibility claim is withheld where any trial division was cut short. Where `FromImage` cannot read a candidate back the recombination now **refuses** rather than skipping it, because a skipped candidate is a subset that was never tried and the proof is over all of them.

## The documentation was two PRs stale

The XML doc on `MathS.Polynomials.Factor` still read **"Univariate only. A polynomial in more than one variable is refused rather than answered"**, with a worked example asserting

```csharp
Console.WriteLine(MathS.Polynomials.Factor("x * y + y", "x") is null);
// True             -- more than one variable, so it declines
```

False since #1053, and it is *public API documentation* — nothing in the suite reads it, and the `docsamples` harness checks the wiki and the website rather than XML comments. Rewritten and every printed value in it re-measured.

The existing `FactorisationRefusesRatherThanReturningTheInput` theory kept three rows that are now proofs rather than refusals; those moved to the new theory, and the test keeps the rows where a refusal is still right — not a polynomial, and past the degree bound.

Full suite: `Failed: 0, Passed: 8591, Skipped: 14, Total: 8605`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd