### PR TITLE
Two more rule sets run on the matcher (#746 tier 1, #248)

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -35,16 +35,23 @@ namespace AngouriMath.Core.Transformations.Matching
     /// the mathematics rather than about the encoding.
     /// </para>
     /// <para>
-    /// <b>What it costs to actually use one of these has been measured, once, end to end.</b>
-    /// <see cref="DivisionPreparing"/> was put in place of its <c>switch</c> in
-    /// <c>RewriteRules.DivisionPreparing</c> — which <c>Simplificator</c> runs twice per
-    /// iteration — and the whole suite passed, 7143 of 7143, so the exchange is a behavioural
-    /// non-event rather than merely an agreeing one. The cost was <b>no extra allocation</b>
-    /// (<c>Simplify</c> identical at 84,402 B, <c>SimplifyQuotient</c> +0.04%) and about
-    /// <b>5% of <c>Simplify</c>'s time</b> for that one set. The ten-times figure a single pass
-    /// shows does not reach the caller, because dispatch is a small part of what simplification
-    /// spends; but five percent for one of some thirty sets is not free either, so the exchange
-    /// is worth making where a set's rules need to be data and is not worth making wholesale.
+    /// <b>What it costs to use one of these has been measured end to end, and the first answer
+    /// was wrong about the reason.</b> The first exchange cost about <b>5% of
+    /// <c>Simplify</c>'s time</b> for one set, which was recorded here as the price of the idea
+    /// and as the argument against doing it wholesale. It was not the idea: <c>NodePattern</c>
+    /// recomputed <see cref="MatchPattern.IsDeterministic"/> on <i>every attempt</i>, walking the
+    /// whole pattern tree behind a delegate before any matching began, so the case that does the
+    /// least work — a rule that does not fire — paid the most for it. Settled once instead, a
+    /// miss goes 29.99 ns → 13.48 ns and a whole pass 1182.9 ns → 659.9 ns at identical
+    /// allocation.
+    /// </para>
+    /// <para>
+    /// Re-measured against <c>Simplify</c> itself, three arms in one process with the third a
+    /// second copy of the first, the exchange is <b>inside the noise floor on time</b> — six
+    /// samples each, medians +0.12% apart where the same binary spreads 1.90% — and
+    /// <b>+0.14% on allocation</b>, which is the one figure that reproduces: two copies of the
+    /// same assembly agree to 5 bytes in 45.6 MB. So a set is exchanged when its rules want to
+    /// be data, and the cost is no longer the reason not to.
     /// </para>
     /// </remarks>
     internal static class MatchedRules
@@ -318,6 +325,66 @@ namespace AngouriMath.Core.Transformations.Matching
                 // "x" is bound by the first part and re-matched by the second, so the two terms
                 // are required to be about the same argument rather than merely both squared.
                 MatchPattern.Node<Sumf>(MatchPattern.Exact(Integer.Create(1)), MatchPattern.Any("rest")),
+                Soundness.Sound));
+
+        /// <summary>
+        /// <see cref="Functions.Patterns.InvertNegativePowers"/>, as data.
+        /// </summary>
+        /// <remarks>
+        /// One rule, and the first here whose replacement is <b>code rather than a pattern</b>:
+        /// <c>-1 * n</c> is arithmetic on the bound integer and not a tree built around it, so
+        /// writing it as a pattern would produce <c>a ^ (-1 * -3)</c> where the <c>switch</c>
+        /// produces <c>a ^ 3</c>. That costs the reversal —
+        /// <see cref="RuleReversal.ReplacementIsCode"/> — which is the honest trade and is
+        /// recorded by the type rather than by a comment.
+        /// </remarks>
+        internal static MatchedRuleSet InvertNegativePowers { get; } = new(
+            nameof(InvertNegativePowers),
+
+            // a ^ n -> 1 / a ^ (-n), for a negative integer n
+            new MatchedRule(
+                "a-negative-integer-power-becomes-a-reciprocal",
+                MatchPattern.Node<Powf>(
+                    MatchPattern.Any("a"),
+                    MatchPattern.Any<Integer>("n", n => n.IsNegative)),
+                bound => 1 / MathS.Pow(bound["a"], -1 * (Integer)bound["n"]),
+                // Both sides are undefined at exactly one place, a = 0, and equal everywhere
+                // else in the complex plane: this is the definition of a negative power rather
+                // than an identity that needs one. Measured at 0 as well as away from it before
+                // the tier was written down.
+                Soundness.Sound));
+
+        /// <summary>
+        /// <see cref="Functions.Patterns.InvertNegativeMultipliers"/>, as data.
+        /// </summary>
+        /// <remarks>
+        /// Two rules that differ in the way that matters here. The first negates a bound real,
+        /// so its replacement is code and it has no reversal. The second only rearranges what it
+        /// bound — <c>-(a - b) = b - a</c> — so both of its sides are patterns and it reads
+        /// backwards, which is the distinction <see cref="MatchedRule.Reversal"/> exists to make
+        /// visible within one set.
+        /// </remarks>
+        internal static MatchedRuleSet InvertNegativeMultipliers { get; } = new(
+            nameof(InvertNegativeMultipliers),
+
+            // a + (c * b) -> a - (-c) * b, for a negative real c
+            new MatchedRule(
+                "a-negative-factor-in-a-sum-becomes-a-difference",
+                MatchPattern.Node<Sumf>(
+                    MatchPattern.Any("a"),
+                    MatchPattern.Node<Mulf>(
+                        MatchPattern.Any<Real>("c", c => c.IsNegative),
+                        MatchPattern.Any("b"))),
+                bound => bound["a"] - (-1 * (Real)bound["c"]) * bound["b"],
+                Soundness.Sound),
+
+            // (-1) * (a - b) -> b - a
+            new MatchedRule(
+                "a-negated-difference-is-the-difference-the-other-way",
+                MatchPattern.Node<Mulf>(
+                    MatchPattern.Exact(Integer.Create(-1)),
+                    MatchPattern.Node<Minusf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
+                MatchPattern.Node<Minusf>(MatchPattern.Any("b"), MatchPattern.Any("a")),
                 Soundness.Sound));
     }
 }

--- a/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
@@ -83,23 +83,35 @@ namespace AngouriMath.Core.Transformations
         /// <summary>
         /// Turns a negative power into a quotient: <c>a * b ^ (-1)</c> becomes <c>a / b</c>.
         /// </summary>
+        /// <remarks>
+        /// <b>Run by the matcher rather than by the <c>switch</c></b> —
+        /// <see cref="Matching.MatchedRules.InvertNegativePowers"/>. See the note on
+        /// <see cref="CollapseMultipleFractions"/> for what that costs and why the <c>switch</c>
+        /// stays.
+        /// </remarks>
         public static RewriteRuleSet InvertNegativePowers { get; } = new(
             nameof(InvertNegativePowers),
             "Rewrites negative powers as quotients.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Patterns.InvertNegativePowers,
+            Matching.MatchedRules.InvertNegativePowers.ApplyHere,
             Patterns.InvertNegativePowersArms);
 
         /// <summary>
         /// Brings a negative numeric factor out in front of the term it multiplies.
         /// </summary>
+        /// <remarks>
+        /// <b>Run by the matcher rather than by the <c>switch</c></b> —
+        /// <see cref="Matching.MatchedRules.InvertNegativeMultipliers"/>. See the note on
+        /// <see cref="CollapseMultipleFractions"/> for what that costs and why the <c>switch</c>
+        /// stays.
+        /// </remarks>
         public static RewriteRuleSet InvertNegativeMultipliers { get; } = new(
             nameof(InvertNegativeMultipliers),
             "Moves a negative numeric factor out of a product into the sign of the term.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Patterns.InvertNegativeMultipliers,
+            Matching.MatchedRules.InvertNegativeMultipliers.ApplyHere,
             Patterns.InvertNegativeMultipliersArms);
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Core/Transformations/MatchedRulesAgreeWithTheSwitchTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/MatchedRulesAgreeWithTheSwitchTest.cs
@@ -32,11 +32,14 @@ namespace AngouriMath.Tests.Core.Transformations
     [Trait("Area", "Core")]
     public sealed class MatchedRulesAgreeWithTheSwitchTest
     {
-        private static readonly string[] Leaves = { "x", "y", "2", "-1", "1/2", "1", "0" };
+        // -2 and -1/2 are here for the sets that key on a negative literal. With -1 as the only
+        // negative leaf a rule about negative powers fired on 7 of 1399 expressions, which is
+        // agreement between two things that barely ran.
+        private static readonly string[] Leaves = { "x", "y", "2", "-1", "-2", "1/2", "-1/2", "1", "0" };
 
         private static readonly string[] Unary =
         {
-            "-({0})", "1 / ({0})", "({0}) ^ 2", "sqrt({0})", "sin({0})", "abs({0})",
+            "-({0})", "1 / ({0})", "({0}) ^ 2", "({0}) ^ (-2)", "sqrt({0})", "sin({0})", "abs({0})",
         };
 
         private static readonly string[] Binary =
@@ -113,6 +116,27 @@ namespace AngouriMath.Tests.Core.Transformations
         public void CollapseMultipleFractionsAsDataMatchesTheSwitch()
             => AssertAgrees("CollapseMultipleFractions", Patterns.CollapseMultipleFractions,
                 MatchedRules.CollapseMultipleFractions, leastFirings: 50);
+
+        /// <summary>
+        /// The first set here whose replacement is <b>code</b>: <c>-1 * n</c> is arithmetic on
+        /// the bound integer, so the rule builds <c>a ^ 3</c> where a pattern would build
+        /// <c>a ^ (-1 * -3)</c>. Agreement over generated expressions is what says the arithmetic
+        /// was done the same way, and there is no other way to check it.
+        /// </summary>
+        [Fact]
+        public void InvertNegativePowersAsDataMatchesTheSwitch()
+            => AssertAgrees("InvertNegativePowers", Patterns.InvertNegativePowers,
+                MatchedRules.InvertNegativePowers, leastFirings: 20);
+
+        /// <summary>
+        /// Two rules, one with a code replacement and one whose sides are both patterns, so this
+        /// is the first set where <see cref="MatchedRule.Reversal"/> differs between the rules of
+        /// one set rather than between sets.
+        /// </summary>
+        [Fact]
+        public void InvertNegativeMultipliersAsDataMatchesTheSwitch()
+            => AssertAgrees("InvertNegativeMultipliers", Patterns.InvertNegativeMultipliers,
+                MatchedRules.InvertNegativeMultipliers, leastFirings: 40);
 
         /// <summary>
         /// A predicate on a hole refuses what fails it, which is the C# property pattern


### PR DESCRIPTION
`InvertNegativePowers` and `InvertNegativeMultipliers` are expressed as data and `RewriteRules` runs them from there. **Four of thirty sets, not two.**

Both agree with the `switch` they replace over every expression the generated corpus produces — 0 disagreements.

## The corpus had to grow first, and that is the finding

With `-1` as its only negative leaf, the negative-power rule fired on **7 of 1,399** expressions. That is agreement between two things that barely ran, and the threshold in `AssertAgrees` exists precisely to catch it — it did.

Adding `-2`, `-1/2` and a `^ (-2)` shape takes the two sets to **27 and 56 firings of 3,417**. The sets already checked still agree on the richer corpus, so nothing had been hiding behind the thin leaves.

## Three rules, covering both shapes a replacement can have

| rule | replacement | reversal |
|---|---|---|
| `a ^ n → 1 / a ^ (-n)`, negative integer `n` | code | none |
| `a + c*b → a - (-c)*b`, negative real `c` | code | none |
| `(-1) * (a - b) → b - a` | pattern | reads backwards |

The first two negate a bound number, which is *arithmetic* and not a tree built around a binding: a pattern right-hand side would produce `a ^ (-1 * -3)` where the `switch` produces `a ^ 3`. So the replacement is code and the rule has no reversal — and `RuleReversal.ReplacementIsCode` says so, rather than a comment. The third only rearranges what it bound, so both its sides are patterns.

**This is the first set here where reversal differs between the rules of one set** rather than between sets.

## The recorded reason not to do this was stale

`MatchedRules.cs` still said the exchange costs *"about 5% of `Simplify`'s time"* and is therefore *"not worth making wholesale"*. That number died with #1050 — which this same file records as its cause — but the paragraph naming the cost had not been rewritten.

Re-measured against `Simplify` itself, three arms in one process with the third a second copy of the first:

```
six samples each, same slot
master  15.772 15.833 15.946 16.001 16.054 16.072   median 15.974 ms
branch  15.873 15.950 15.992 15.993 16.067 16.532   median 15.992 ms
```

**Medians 0.12% apart where the same binary spreads 1.90%** — the distributions interleave, so time is inside the noise floor. **Allocation is +0.14%**, and that one reproduces: two copies of the same assembly agree to 5 bytes in 45.6 MB.

The arms had to be **permuted** before any of that could be said. The first assembly loaded is consistently about 8% faster than the same bytes loaded third, and the first reading — taken without permuting — showed the change 2.4% *faster* than master, which was the slot and not the code.

Full suite: `Failed: 0, Passed: 8593, Skipped: 14, Total: 8607`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd