### PR TITLE
Two more rule sets are data, and a corpus that fires nothing proves nothing

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -386,5 +386,89 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Minusf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
                 MatchPattern.Node<Minusf>(MatchPattern.Any("b"), MatchPattern.Any("a")),
                 Soundness.Sound));
+
+        /// <summary>
+        /// <see cref="Functions.Patterns.NormalTrigonometricForm"/>, as data.
+        /// </summary>
+        /// <remarks>
+        /// Four rules, and <b>the first set here where every rule reverses</b>: each writes one
+        /// of the four derived trigonometric functions in terms of sine and cosine, and both
+        /// sides are patterns, so reading a rule backwards recognises the quotient and puts the
+        /// name back. That direction is not run by anything today — it is the e-graph's
+        /// inverse-pair table that would — but it is now a property of the rules rather than a
+        /// second set someone has to write.
+        /// </remarks>
+        internal static MatchedRuleSet NormalTrigonometricForm { get; } = new(
+            nameof(NormalTrigonometricForm),
+
+            // tan(a) -> sin(a) / cos(a)
+            new MatchedRule(
+                "tangent-is-sine-over-cosine",
+                MatchPattern.Node<Tanf>(MatchPattern.Any("a")),
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Sinf>(MatchPattern.Any("a")),
+                    MatchPattern.Node<Cosf>(MatchPattern.Any("a"))),
+                // The quotient is undefined exactly where the tangent is -- at a zero of the
+                // cosine -- so the domain neither widens nor narrows. Left at the conservative
+                // tier with its three neighbours until the audit reaches them together.
+                Soundness.SoundUnderAssumptions),
+
+            // cotan(a) -> cos(a) / sin(a)
+            new MatchedRule(
+                "cotangent-is-cosine-over-sine",
+                MatchPattern.Node<Cotanf>(MatchPattern.Any("a")),
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Cosf>(MatchPattern.Any("a")),
+                    MatchPattern.Node<Sinf>(MatchPattern.Any("a"))),
+                Soundness.SoundUnderAssumptions),
+
+            // sec(a) -> 1 / cos(a)
+            new MatchedRule(
+                "secant-is-one-over-cosine",
+                MatchPattern.Node<Secantf>(MatchPattern.Any("a")),
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Exact(Integer.Create(1)),
+                    MatchPattern.Node<Cosf>(MatchPattern.Any("a"))),
+                Soundness.SoundUnderAssumptions),
+
+            // cosec(a) -> 1 / sin(a)
+            new MatchedRule(
+                "cosecant-is-one-over-sine",
+                MatchPattern.Node<Cosecantf>(MatchPattern.Any("a")),
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Exact(Integer.Create(1)),
+                    MatchPattern.Node<Sinf>(MatchPattern.Any("a"))),
+                Soundness.SoundUnderAssumptions));
+
+        /// <summary>
+        /// <see cref="Functions.Patterns.PhiFunctionRules"/>, as data.
+        /// </summary>
+        /// <remarks>
+        /// One rule, and the first whose <b>predicate on a hole is a mathematical property</b>
+        /// rather than a sign or a type: <c>phi(p ^ k) = p ^ (k - 1) * (p - 1)</c> holds for a
+        /// prime <c>p</c> and for no other integer, so primality is the condition and the hole
+        /// carries it. The replacement is arithmetic on the bound prime, so it is code and the
+        /// rule does not reverse.
+        /// </remarks>
+        internal static MatchedRuleSet PhiFunction { get; } = new(
+            nameof(PhiFunction),
+
+            // phi(p ^ k) -> p ^ (k - 1) * (p - 1), for a prime p
+            new MatchedRule(
+                "eulers-totient-of-a-prime-power",
+                MatchPattern.Node<Phif>(
+                    MatchPattern.Node<Powf>(
+                        MatchPattern.Any<Integer>("p", p => p.IsPrime),
+                        MatchPattern.Any("k"))),
+                // (Integer) on the prime and not on the exponent, and the difference is the
+                // point: p - 1 is arithmetic that folds to a number, k - 1 is a tree because k
+                // is whatever was bound. Written without the cast the rule builds 2 ^ (5 - 1) *
+                // (2 - 1) where the switch builds 2 ^ (5 - 1) * 1, which is what the agreement
+                // test caught.
+                bound => new Powf(bound["p"], bound["k"] - 1) * ((Integer)bound["p"] - 1),
+                // Euler's product formula, which is a theorem and not an assumption: for a prime
+                // p the integers below p^k sharing a factor with it are exactly the multiples of
+                // p, of which there are p^(k-1).
+                Soundness.Sound));
     }
 }

--- a/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
@@ -334,12 +334,19 @@ namespace AngouriMath.Core.Transformations
         /// <summary>
         /// Rewrites the derived trigonometric functions in terms of sine and cosine.
         /// </summary>
+        /// <remarks>
+        /// <b>Run by the matcher rather than by the <c>switch</c></b> —
+        /// <see cref="Matching.MatchedRules.NormalTrigonometricForm"/>, whose four rules are the
+        /// first here that all read backwards. See the note on
+        /// <see cref="CollapseMultipleFractions"/> for what that costs and why the <c>switch</c>
+        /// stays.
+        /// </remarks>
         public static RewriteRuleSet NormalTrigonometricForm { get; } = new(
             nameof(NormalTrigonometricForm),
             "Writes tangents, cotangents, secants and cosecants as sines and cosines.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Patterns.NormalTrigonometricForm,
+            Matching.MatchedRules.NormalTrigonometricForm.ApplyHere,
             Patterns.NormalTrigonometricFormArms);
 
         /// <summary>
@@ -441,12 +448,19 @@ namespace AngouriMath.Core.Transformations
         /// <summary>
         /// Rules about Euler's totient function.
         /// </summary>
+        /// <remarks>
+        /// <b>Run by the matcher rather than by the <c>switch</c></b> —
+        /// <see cref="Matching.MatchedRules.PhiFunction"/>, whose single rule carries primality
+        /// as a predicate on the hole it binds. See the note on
+        /// <see cref="CollapseMultipleFractions"/> for what that costs and why the <c>switch</c>
+        /// stays.
+        /// </remarks>
         public static RewriteRuleSet PhiFunction { get; } = new(
             nameof(PhiFunction),
             "Applies the multiplicative identities of Euler's totient function.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Patterns.PhiFunctionRules,
+            Matching.MatchedRules.PhiFunction.ApplyHere,
             Patterns.PhiFunctionRulesArms);
 
         #endregion

--- a/Sources/Tests/UnitTests/Core/Transformations/MatchedRulesAgreeWithTheSwitchTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/MatchedRulesAgreeWithTheSwitchTest.cs
@@ -74,10 +74,17 @@ namespace AngouriMath.Tests.Core.Transformations
         }
 
         private static void AssertAgrees(
-            string what, System.Func<Entity, Entity> bySwitch, MatchedRuleSet byData, int leastFirings)
+            string what, System.Func<Entity, Entity> bySwitch, MatchedRuleSet byData, int leastFirings,
+            string[]? extra = null)
         {
             var corpus = Corpus();
             Assert.True(corpus.Count > 500, $"the corpus is only {corpus.Count} expressions");
+            // A shape the grammar does not generate is still worth comparing on, where a set keys
+            // on a function the corpus has no leaf for. It is added to the generated corpus and
+            // never in place of it: a hand-written list only proves the cases someone thought of.
+            if (extra is not null)
+                foreach (var source in extra)
+                    corpus.Add(source.ToEntity());
 
             var disagreements = new List<string>();
             var fired = 0;
@@ -137,6 +144,40 @@ namespace AngouriMath.Tests.Core.Transformations
         public void InvertNegativeMultipliersAsDataMatchesTheSwitch()
             => AssertAgrees("InvertNegativeMultipliers", Patterns.InvertNegativeMultipliers,
                 MatchedRules.InvertNegativeMultipliers, leastFirings: 40);
+
+        /// <summary>
+        /// Four rules whose sides are all patterns, so this set reverses whole. Nothing runs the
+        /// reverse direction today, which is why agreement forward is what is asserted.
+        /// </summary>
+        /// <remarks>
+        /// The generated corpus has no <c>tan</c>, <c>cotan</c>, <c>sec</c> or <c>cosec</c> leaf
+        /// and so fired this set <b>zero</b> times — agreement between two things neither of
+        /// which ran. The shapes are supplied on top of the corpus rather than instead of it.
+        /// </remarks>
+        [Fact]
+        public void NormalTrigonometricFormAsDataMatchesTheSwitch()
+            => AssertAgrees("NormalTrigonometricForm", Patterns.NormalTrigonometricForm,
+                MatchedRules.NormalTrigonometricForm, leastFirings: 12, extra: new[]
+                {
+                    "tan(x)", "cotan(x)", "sec(x)", "cosec(x)",
+                    "tan(x + y)", "cotan(2 * x)", "sec(sqrt(x))", "cosec(-x)",
+                    "tan(1/2)", "cotan(0)", "sec(2)", "cosec(-1)",
+                    "tan(x) + cotan(x)", "sec(x) * cosec(x)", "1 / tan(x)", "sin(tan(x))",
+                });
+
+        /// <summary>
+        /// A predicate on a hole that is a mathematical property rather than a sign or a type.
+        /// The corpus reaches it rarely, so the shapes are given here as well — a set that fires
+        /// four times over a generated corpus is worth checking against cases chosen for it.
+        /// </summary>
+        [Fact]
+        public void PhiFunctionAsDataMatchesTheSwitch()
+            => AssertAgrees("PhiFunction", Patterns.PhiFunctionRules,
+                MatchedRules.PhiFunction, leastFirings: 1, extra: new[]
+                {
+                    "phi(2 ^ 5)", "phi(3 ^ 2)", "phi(7 ^ 1)", "phi(13 ^ x)",
+                    "phi(4 ^ 3)", "phi(6 ^ 2)", "phi(9 ^ 2)", "phi(x ^ 2)",
+                });
 
         /// <summary>
         /// A predicate on a hole refuses what fails it, which is the C# property pattern


### PR DESCRIPTION
`NormalTrigonometricForm` and `PhiFunction` run on the matcher. **Six of thirty sets.**

`NormalTrigonometricForm` is four rules writing `tan`, `cotan`, `sec` and `cosec` as sines and cosines, and it is **the first set here where every rule reverses** — both sides of each are patterns, so reading one backwards recognises the quotient and puts the name back. Nothing runs that direction today (the consumer is the e-graph's inverse-pair table), but it is now a property of the rules rather than a second set someone has to write.

`PhiFunction` is one rule whose predicate on a hole is a **mathematical property** rather than a sign or a type: `phi(p ^ k) = p ^ (k - 1) * (p - 1)` holds for a prime `p` and for no other integer, so primality is the condition and the hole carries it.

## A corpus that fires nothing proves nothing

The generated corpus has no `tan`, `cotan`, `sec`, `cosec` or `phi` leaf. So the trigonometric set fired on **0 of 3,417** expressions and the totient set on **0** — agreement between two things neither of which ran. That is exactly what the firing threshold in `AssertAgrees` is for, and it caught it.

Named shapes are now supplied **on top of** the corpus and never in place of it: a hand-written list only proves the cases someone thought of, and it is the generated shapes that find what nobody pictured.

## And it caught a real transcription error

`phi`'s replacement written as `bound["p"] - 1` builds a **subtraction node**, because a binding is an `Entity`. The `switch` binds `Integer prime`, so `prime - 1` is arithmetic that folds:

```
phi(2 ^ 5):  switch gave 2 ^ (5 - 1) * 1     data gave 2 ^ (5 - 1) * (2 - 1)
phi(13 ^ x): switch gave 13 ^ (x - 1) * 12   data gave 13 ^ (x - 1) * (13 - 1)
```

The cast belongs on the prime and **not** on the exponent — `k - 1` must stay a tree, because `k` is whatever was bound — and the reason is now written where the cast is.

## Cost

Measured against `Simplify` with three arms in one process, the third a second copy of the first:

- **allocation +0.0094%** — 6,510 bytes in 69.2 MB, where the *same* assembly loaded in a different slot differs by 0.60%
- **time**: medians +1.52%, same-binary spread **4.89%**, and the two ranges overlap (master's slowest sample is slower than the branch's fastest)

Full suite: `Failed: 0, Passed: 8595, Skipped: 14, Total: 8609`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd