### PR TITLE
The factorisation ceiling is not the degree bound, and that is measured now

### DIFF
--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/KroneckerFactorization.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/KroneckerFactorization.cs
@@ -39,9 +39,27 @@ namespace AngouriMath.Functions
     /// added. Two variables reach bidegrees like (2, 10), (3, 7) and (5, 4); three variables of
     /// degree 2 fit (27 ≤ 32) and four do not (81); and a quadratic in eight variables is far
     /// past it. The recombination is over subsets, so the number of irreducible factors of the
-    /// image is capped as well. Both limits are refusals, never wrong answers, and neither is the
-    /// algorithm one would write to lift them: that is Hensel lifting with an evaluation
-    /// homomorphism, and it is a different piece of work
+    /// image is capped as well. Both limits are refusals, never wrong answers.
+    /// </para>
+    /// <para>
+    /// <b>Raising the degree ceiling is not what would lift them, and that was measured rather
+    /// than assumed.</b> <see cref="IntegerPolynomial.MaxDegree"/> is 32 while the machinery
+    /// underneath affords 64 (<see cref="PrimeFieldFactorization.MaxDegree"/>), which looks like
+    /// a free doubling of the exponent budget — a whole variable's worth of reach, since the
+    /// budget is a product. Doubled, <b>nothing new factors</b>: <c>x^7 - y^7</c>,
+    /// <c>x^6 - y^6</c>, <c>x^3 - (y + z)^3</c>, <c>(x^8 + y)(x^8 + 3y)</c> and
+    /// <c>(x^2 + y^5)(x^2 - y^5)</c> all still refuse, at images of degree 34 to 56 that are
+    /// inside the raised ceiling.
+    /// </para>
+    /// <para>
+    /// The reason is the method rather than the bound: <b>the substitution's images over-factor
+    /// badly</b>. A two-factor bivariate maps to a one-variable polynomial that splits into many
+    /// irreducibles — <c>x^7 - y^7</c> becomes <c>t^7 (1 - t^49)</c>, whose factors are
+    /// cyclotomic — so the recombination is exponential in a factor count the substitution itself
+    /// inflates. That is exactly the cost <see cref="IntegerPolynomial.MaxDegree"/> is set to
+    /// bound, and moving it only moves where the refusal comes from. Lifting these limits means
+    /// not inflating the factor count in the first place, which is <b>Hensel lifting with an
+    /// evaluation homomorphism</b> — a different algorithm, not a larger number
     /// (<a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> item 43).
     /// </para>
     /// </remarks>

--- a/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialSurfaceTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialSurfaceTest.cs
@@ -281,6 +281,38 @@ namespace AngouriMath.Tests.Algebra.Polynomials
             }
         }
 
+        /// <summary>
+        /// The other reason a factorisation is declined, and it is not the degree ceiling: the
+        /// substitution's image <b>over-factors</b>, so the recombination is exponential in a
+        /// count the substitution itself inflates.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Every row here factors mathematically and has an image well inside the degree the
+        /// machinery affords — 34 to 56, against a <c>PrimeFieldFactorization.MaxDegree</c> of
+        /// 64. Raising <c>IntegerPolynomial.MaxDegree</c> from 32 to 64 was measured and changes
+        /// none of them, which is why that is not the lever.
+        /// </para>
+        /// <para>
+        /// <c>x ^ 7 - y ^ 7</c> maps to <c>t ^ 7 * (1 - t ^ 49)</c>, whose factors are
+        /// cyclotomic: a two-factor bivariate becomes a one-variable polynomial with many
+        /// irreducibles. Not inflating that count is Hensel lifting with an evaluation
+        /// homomorphism, a different algorithm rather than a larger bound.
+        /// </para>
+        /// <para>
+        /// This test pins the <i>refusal</i>, not the limit. If one of these starts factoring,
+        /// something got better and the row belongs in the theory above.
+        /// </para>
+        /// </remarks>
+        [Theory]
+        [InlineData("x ^ 7 - y ^ 7")]
+        [InlineData("x ^ 6 - y ^ 6")]
+        [InlineData("x ^ 3 - (y + z) ^ 3")]
+        [InlineData("(x ^ 8 + y) * (x ^ 8 + 3 * y)")]
+        [InlineData("(x ^ 2 + y ^ 5) * (x ^ 2 - y ^ 5)")]
+        public void AnImageThatOverFactorsIsRefused(string input)
+            => Assert.Null(MathS.Polynomials.Factor(input.ToEntity(), "x"));
+
         [Theory]
         [InlineData("(x + y + z + w) * (x - y)")]
         [InlineData("(x + y) * (x + z) * (x + w) * (x + v)")]


### PR DESCRIPTION
No behaviour changes. This turns an inherited assumption into a measurement, and pins the result.

`IntegerPolynomial.MaxDegree` is **32** while the machinery underneath affords **64** (`PrimeFieldFactorization.MaxDegree`, an `O(n³)`/`O(p·n³)` ceiling). That looks like a free doubling of Kronecker's exponent budget — and since the budget is a *product* of the radices, a factor of two in it is a whole variable's worth of reach. [#746](https://github.com/asc-community/AngouriMath/issues/746) item 43 says lifting this ceiling is Hensel lifting, "a project rather than a change", and that was worth testing before writing it down again.

## Doubled, nothing new factors

| | image degree | before | with the ceiling at 64 |
|---|--:|---|---|
| `x ^ 7 - y ^ 7` | 56 | `null` | `null` |
| `x ^ 6 - y ^ 6` | 42 | `null` | `null` |
| `x ^ 3 - (y + z) ^ 3` | 48 | `null` | `null` |
| `(x ^ 8 + y) * (x ^ 8 + 3 * y)` | 34 | `null` | `null` |
| `(x ^ 2 + y ^ 5) * (x ^ 2 - y ^ 5)` | 50 | `null` | `null` |

Every one is inside the raised ceiling. The refusal simply moves from the size check to `FactorPrimitive` — which is what **instrumenting each `return null` said**, not what reading the code suggested.

## The reason is the method, not the bound

**The substitution's images over-factor.** A two-factor bivariate becomes a one-variable polynomial with many irreducibles: `x ^ 7 - y ^ 7` maps to `t ^ 7 * (1 - t ^ 49)`, whose factors are cyclotomic. So the recombination is exponential in a factor count *the substitution itself inflates* — which is exactly the cost `MaxDegree`'s doc comment says it is set to bound. Moving it only moves where the refusal comes from.

Not inflating that count is Hensel lifting with an evaluation homomorphism: a different algorithm, not a larger number. So item 43's claim stands, and now for a reason that was checked.

## What lands

The code is unchanged. The class remark records the measurement, and a new theory pins the five refusals — saying in as many words that it pins the **refusal** rather than the limit, so if one of them starts factoring the row belongs in the theory above it rather than here.

Full suite: `Failed: 0, Passed: 8600, Skipped: 14, Total: 8614`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd