### PR TITLE
Six more rule sets are data, and a template that cannot be built is now an error

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchPattern.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchPattern.cs
@@ -252,6 +252,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     nodeType == typeof(Entity.Cosf) ? new Entity.Cosf(only) :
                     nodeType == typeof(Entity.Tanf) ? new Entity.Tanf(only) :
                     nodeType == typeof(Entity.Cotanf) ? new Entity.Cotanf(only) :
+                    nodeType == typeof(Entity.Secantf) ? new Entity.Secantf(only) :
+                    nodeType == typeof(Entity.Cosecantf) ? new Entity.Cosecantf(only) :
                     nodeType == typeof(Entity.Absf) ? new Entity.Absf(only) :
                     nodeType == typeof(Entity.Signumf) ? new Entity.Signumf(only) :
                     (Entity?)null;

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
@@ -52,6 +52,16 @@ namespace AngouriMath.Core.Transformations.Matching
                 if (!left.BoundNames.Contains(wanted))
                     throw new ArgumentException(
                         $"'{name}' builds '{wanted}', which its pattern does not bind", nameof(right));
+            // And the same failure mode from the other direction. A node type is matchable
+            // without being buildable -- see MatchPattern.Construct -- so a template naming one
+            // is a rule that matches, builds nothing, and is indistinguishable at run time from a
+            // rule that did not apply. It cost an afternoon and a twenty-eight-row agreement
+            // failure before this check existed, which is the argument for the check.
+            if (!right.IsBuildable)
+                throw new ArgumentException(
+                    $"'{name}' has a replacement this cannot build: some node type in it is "
+                    + "matchable but not constructible. Add it to MatchPattern.Construct, or "
+                    + "write the replacement as code.", nameof(right));
         }
 
         /// <summary>

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -470,5 +470,212 @@ namespace AngouriMath.Core.Transformations.Matching
                 // p the integers below p^k sharing a factor with it are exactly the multiples of
                 // p, of which there are p^(k-1).
                 Soundness.Sound));
+
+        /// <summary>
+        /// <see cref="Functions.Patterns.CollapseTrigonometricFunctions"/>, as data.
+        /// </summary>
+        /// <remarks>
+        /// The reverse of <see cref="NormalTrigonometricForm"/>, and the pair is worth having as
+        /// data together: they are each other read backwards, and the type says so instead of a
+        /// comment. Order is load-bearing — the two named quotients must be tried before the
+        /// general reciprocal rules, or <c>sin(x) / cos(x)</c> becomes <c>sin(x) * sec(x)</c>
+        /// rather than <c>tan(x)</c>.
+        /// </remarks>
+        internal static MatchedRuleSet CollapseTrigonometricFunctions { get; } = new(
+            nameof(CollapseTrigonometricFunctions),
+
+            // sin(a) / cos(a) -> tan(a). "a" is bound by the numerator and re-matched by the
+            // denominator, which is how the pattern says "of the same argument".
+            new MatchedRule(
+                "sine-over-cosine-is-the-tangent",
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Sinf>(MatchPattern.Any("a")),
+                    MatchPattern.Node<Cosf>(MatchPattern.Any("a"))),
+                MatchPattern.Node<Tanf>(MatchPattern.Any("a")),
+                Soundness.SoundUnderAssumptions),
+
+            // cos(a) / sin(a) -> cotan(a)
+            new MatchedRule(
+                "cosine-over-sine-is-the-cotangent",
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Cosf>(MatchPattern.Any("a")),
+                    MatchPattern.Node<Sinf>(MatchPattern.Any("a"))),
+                MatchPattern.Node<Cotanf>(MatchPattern.Any("a")),
+                Soundness.SoundUnderAssumptions),
+
+            // a / sin(b) -> a * cosec(b)
+            new MatchedRule(
+                "a-quotient-by-a-sine-is-a-cosecant",
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Any("a"),
+                    MatchPattern.Node<Sinf>(MatchPattern.Any("b"))),
+                MatchPattern.Node<Mulf>(
+                    MatchPattern.Any("a"),
+                    MatchPattern.Node<Cosecantf>(MatchPattern.Any("b"))),
+                Soundness.SoundUnderAssumptions),
+
+            // a / cos(b) -> a * sec(b)
+            new MatchedRule(
+                "a-quotient-by-a-cosine-is-a-secant",
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Any("a"),
+                    MatchPattern.Node<Cosf>(MatchPattern.Any("b"))),
+                MatchPattern.Node<Mulf>(
+                    MatchPattern.Any("a"),
+                    MatchPattern.Node<Secantf>(MatchPattern.Any("b"))),
+                Soundness.SoundUnderAssumptions));
+
+        /// <summary>
+        /// <see cref="Functions.Patterns.ExpandRules"/>, as data.
+        /// </summary>
+        /// <remarks>
+        /// The angle-sum identities, and both sides of each are patterns — so read backwards they
+        /// are the angle-<i>gathering</i> identities, which the <c>switch</c> would need a second
+        /// set to say.
+        /// </remarks>
+        internal static MatchedRuleSet Expansion { get; } = new(
+            nameof(Expansion),
+
+            // sin(a + b) -> sin(a)cos(b) + sin(b)cos(a)
+            new MatchedRule(
+                "sine-of-a-sum",
+                MatchPattern.Node<Sinf>(
+                    MatchPattern.Node<Sumf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
+                MatchPattern.Node<Sumf>(
+                    MatchPattern.Node<Mulf>(
+                        MatchPattern.Node<Sinf>(MatchPattern.Any("a")),
+                        MatchPattern.Node<Cosf>(MatchPattern.Any("b"))),
+                    MatchPattern.Node<Mulf>(
+                        MatchPattern.Node<Sinf>(MatchPattern.Any("b")),
+                        MatchPattern.Node<Cosf>(MatchPattern.Any("a")))),
+                // Holds for every complex a and b: the identity is the addition theorem, which
+                // has no branch to fall off.
+                Soundness.Sound),
+
+            // sin(a - b) -> sin(a)cos(b) - sin(b)cos(a)
+            new MatchedRule(
+                "sine-of-a-difference",
+                MatchPattern.Node<Sinf>(
+                    MatchPattern.Node<Minusf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
+                MatchPattern.Node<Minusf>(
+                    MatchPattern.Node<Mulf>(
+                        MatchPattern.Node<Sinf>(MatchPattern.Any("a")),
+                        MatchPattern.Node<Cosf>(MatchPattern.Any("b"))),
+                    MatchPattern.Node<Mulf>(
+                        MatchPattern.Node<Sinf>(MatchPattern.Any("b")),
+                        MatchPattern.Node<Cosf>(MatchPattern.Any("a")))),
+                Soundness.Sound));
+
+        /// <summary>
+        /// <see cref="Functions.Patterns.ExpandTrigonometricRules"/>, as data.
+        /// </summary>
+        internal static MatchedRuleSet ExpandTrigonometric { get; } = new(
+            nameof(ExpandTrigonometric),
+
+            // (1/2) * sin(2a) -> sin(a) * cos(a)
+            new MatchedRule(
+                "half-the-sine-of-a-doubled-angle",
+                MatchPattern.Node<Mulf>(
+                    MatchPattern.Exact(Rational.Create(1, 2)),
+                    MatchPattern.Node<Sinf>(
+                        MatchPattern.Node<Mulf>(
+                            MatchPattern.Exact(Integer.Create(2)),
+                            MatchPattern.Any("a")))),
+                MatchPattern.Node<Mulf>(
+                    MatchPattern.Node<Sinf>(MatchPattern.Any("a")),
+                    MatchPattern.Node<Cosf>(MatchPattern.Any("a"))),
+                Soundness.Sound),
+
+            // cos(2a) -> cos(a)^2 - sin(a)^2
+            new MatchedRule(
+                "cosine-of-a-doubled-angle",
+                MatchPattern.Node<Cosf>(
+                    MatchPattern.Node<Mulf>(
+                        MatchPattern.Exact(Integer.Create(2)),
+                        MatchPattern.Any("a"))),
+                MatchPattern.Node<Minusf>(
+                    MatchPattern.Node<Powf>(
+                        MatchPattern.Node<Cosf>(MatchPattern.Any("a")),
+                        MatchPattern.Exact(Integer.Create(2))),
+                    MatchPattern.Node<Powf>(
+                        MatchPattern.Node<Sinf>(MatchPattern.Any("a")),
+                        MatchPattern.Exact(Integer.Create(2)))),
+                Soundness.Sound));
+
+        /// <summary>
+        /// <see cref="Functions.Patterns.ExpandMultipleAngleRules"/>, as data.
+        /// </summary>
+        /// <remarks>
+        /// The replacement is a Chebyshev-style expansion computed from the multiplier, so it is
+        /// code and the rule does not reverse. The predicate on the hole asks
+        /// <see cref="Functions.Patterns.IsWorthExpanding"/> rather than repeating its bound,
+        /// which is how two copies of a constant start disagreeing.
+        /// </remarks>
+        internal static MatchedRuleSet ExpandMultipleAngle { get; } = new(
+            nameof(ExpandMultipleAngle),
+
+            // sin(n * a) -> the expansion, for a whole n worth expanding
+            new MatchedRule(
+                "sine-of-a-whole-multiple-of-an-angle",
+                MatchPattern.Node<Sinf>(
+                    MatchPattern.Node<Mulf>(
+                        MatchPattern.Any<Integer>("n", Functions.Patterns.IsWorthExpanding),
+                        MatchPattern.Any("a"))),
+                bound => TrigonometricAngleExpansion.ExpandSineArgumentMultiplied(
+                    new Sinf(bound["a"]), new Cosf(bound["a"]),
+                    ((Integer)bound["n"]).EInteger.ToInt32Checked()),
+                Soundness.Sound),
+
+            // cos(n * a) -> the expansion, for a whole n worth expanding
+            new MatchedRule(
+                "cosine-of-a-whole-multiple-of-an-angle",
+                MatchPattern.Node<Cosf>(
+                    MatchPattern.Node<Mulf>(
+                        MatchPattern.Any<Integer>("n", Functions.Patterns.IsWorthExpanding),
+                        MatchPattern.Any("a"))),
+                bound => TrigonometricAngleExpansion.ExpandCosineArgumentMultiplied(
+                    new Sinf(bound["a"]), new Cosf(bound["a"]),
+                    ((Integer)bound["n"]).EInteger.ToInt32Checked()),
+                Soundness.Sound));
+
+        /// <summary>
+        /// <see cref="Functions.Patterns.PolynomialLongDivision"/>, as data.
+        /// </summary>
+        /// <remarks>
+        /// One rule with <b>no side condition</b>, deliberately. The work that decides whether it
+        /// applies is the division itself, and asking it in a guard would run it twice on a path
+        /// the simplifier takes for every quotient; the helper hands back the expression
+        /// unchanged where it declines, which <see cref="MatchedRuleSet.ApplyHere"/> reads as no
+        /// rewrite exactly as the <c>switch</c>'s own fallthrough does.
+        /// </remarks>
+        internal static MatchedRuleSet PolynomialLongDivision { get; } = new(
+            nameof(PolynomialLongDivision),
+
+            new MatchedRule(
+                "a-quotient-of-polynomials-is-divided-out",
+                MatchPattern.Node<Divf>(MatchPattern.Any("n"), MatchPattern.Any("d")),
+                bound => TreeAnalyzer.PolynomialLongDivision(bound["n"], bound["d"])
+                    is var (divided, remainder)
+                    ? divided + remainder
+                    : new Divf(bound["n"], bound["d"]),
+                Soundness.SoundUnderAssumptions));
+
+        /// <summary>
+        /// <see cref="Functions.Patterns.PolynomialGcdCancellation"/>, as data.
+        /// </summary>
+        /// <remarks>
+        /// No side condition, for the reason <see cref="PolynomialLongDivision"/> gives: the
+        /// cancellation is the test.
+        /// </remarks>
+        internal static MatchedRuleSet PolynomialGcdCancellation { get; } = new(
+            nameof(PolynomialGcdCancellation),
+
+            new MatchedRule(
+                "a-quotient-of-polynomials-is-put-in-lowest-terms",
+                MatchPattern.Node<Divf>(MatchPattern.Any("n"), MatchPattern.Any("d")),
+                bound => PolynomialGcd.TryCancel(bound["n"], bound["d"], out var cancelled)
+                    ? cancelled
+                    : new Divf(bound["n"], bound["d"]),
+                Soundness.SoundUnderAssumptions));
     }
 }

--- a/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
@@ -173,12 +173,18 @@ namespace AngouriMath.Core.Transformations
         /// <summary>
         /// Multiplies products over sums out.
         /// </summary>
+        /// <remarks>
+        /// <b>Run by the matcher rather than by the <c>switch</c></b> —
+        /// <see cref="Matching.MatchedRules.Expansion"/>. See the note on
+        /// <see cref="CollapseMultipleFractions"/> for what that costs and why the <c>switch</c>
+        /// stays.
+        /// </remarks>
         public static RewriteRuleSet Expansion { get; } = new(
             nameof(Expansion),
             "Distributes products and powers over sums.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Patterns.ExpandRules,
+            Matching.MatchedRules.Expansion.ApplyHere,
             Patterns.ExpandRulesArms);
 
         /// <summary>
@@ -295,23 +301,35 @@ namespace AngouriMath.Core.Transformations
         /// <summary>
         /// Divides one polynomial by another, leaving a quotient plus a remainder.
         /// </summary>
+        /// <remarks>
+        /// <b>Run by the matcher rather than by the <c>switch</c></b> —
+        /// <see cref="Matching.MatchedRules.PolynomialLongDivision"/>. See the note on
+        /// <see cref="CollapseMultipleFractions"/> for what that costs and why the <c>switch</c>
+        /// stays.
+        /// </remarks>
         public static RewriteRuleSet PolynomialLongDivision { get; } = new(
             nameof(PolynomialLongDivision),
             "Divides a polynomial by a polynomial, giving the quotient plus the remainder.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Patterns.PolynomialLongDivision,
+            Matching.MatchedRules.PolynomialLongDivision.ApplyHere,
             Patterns.PolynomialLongDivisionArms);
 
         /// <summary>
         /// Puts a quotient of polynomials into lowest terms.
         /// </summary>
+        /// <remarks>
+        /// <b>Run by the matcher rather than by the <c>switch</c></b> —
+        /// <see cref="Matching.MatchedRules.PolynomialGcdCancellation"/>. See the note on
+        /// <see cref="CollapseMultipleFractions"/> for what that costs and why the <c>switch</c>
+        /// stays.
+        /// </remarks>
         public static RewriteRuleSet PolynomialGcdCancellation { get; } = new(
             nameof(PolynomialGcdCancellation),
             "Cancels the greatest common divisor of a polynomial quotient's numerator and denominator.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Patterns.PolynomialGcdCancellation,
+            Matching.MatchedRules.PolynomialGcdCancellation.ApplyHere,
             Patterns.PolynomialGcdCancellationArms);
 
         #endregion
@@ -352,23 +370,35 @@ namespace AngouriMath.Core.Transformations
         /// <summary>
         /// Gathers sines and cosines back into the derived functions where that is shorter.
         /// </summary>
+        /// <remarks>
+        /// <b>Run by the matcher rather than by the <c>switch</c></b> —
+        /// <see cref="Matching.MatchedRules.CollapseTrigonometricFunctions"/>. See the note on
+        /// <see cref="CollapseMultipleFractions"/> for what that costs and why the <c>switch</c>
+        /// stays.
+        /// </remarks>
         public static RewriteRuleSet CollapseTrigonometricFunctions { get; } = new(
             nameof(CollapseTrigonometricFunctions),
             "Recognises a quotient or reciprocal of sines and cosines as a tangent, cotangent, secant or cosecant.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Patterns.CollapseTrigonometricFunctions,
+            Matching.MatchedRules.CollapseTrigonometricFunctions.ApplyHere,
             Patterns.CollapseTrigonometricFunctionsArms);
 
         /// <summary>
         /// Opens a trigonometric function of a sum into functions of its terms.
         /// </summary>
+        /// <remarks>
+        /// <b>Run by the matcher rather than by the <c>switch</c></b> —
+        /// <see cref="Matching.MatchedRules.ExpandTrigonometric"/>. See the note on
+        /// <see cref="CollapseMultipleFractions"/> for what that costs and why the <c>switch</c>
+        /// stays.
+        /// </remarks>
         public static RewriteRuleSet ExpandTrigonometric { get; } = new(
             nameof(ExpandTrigonometric),
             "Expands a sine or cosine of a sum into products of sines and cosines of its terms.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Patterns.ExpandTrigonometricRules,
+            Matching.MatchedRules.ExpandTrigonometric.ApplyHere,
             Patterns.ExpandTrigonometricRulesArms);
 
         /// <summary>
@@ -378,12 +408,18 @@ namespace AngouriMath.Core.Transformations
         /// Written out, <c>sin(4x)</c> is far longer than it started, which is why the
         /// simplifier offers the result as a candidate rather than taking it.
         /// </remarks>
+        /// <remarks>
+        /// <b>Run by the matcher rather than by the <c>switch</c></b> —
+        /// <see cref="Matching.MatchedRules.ExpandMultipleAngle"/>. See the note on
+        /// <see cref="CollapseMultipleFractions"/> for what that costs and why the <c>switch</c>
+        /// stays.
+        /// </remarks>
         public static RewriteRuleSet ExpandMultipleAngle { get; } = new(
             nameof(ExpandMultipleAngle),
             "Expands a sine or cosine of an integer multiple of an angle.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Patterns.ExpandMultipleAngleRules,
+            Matching.MatchedRules.ExpandMultipleAngle.ApplyHere,
             Patterns.ExpandMultipleAngleRulesArms);
 
         #endregion

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Trigonometry.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Trigonometry.cs
@@ -263,7 +263,13 @@ namespace AngouriMath.Functions
             _ => x
         };
 
-        private static bool IsWorthExpanding(Integer n)
+        /// <summary>Whether opening up sin(n x) or cos(n x) is worth the length it costs.</summary>
+        /// <remarks>
+        /// Internal rather than private so that the data form of this set asks the same
+        /// question rather than repeating its bound, which is how two copies of a constant
+        /// start disagreeing.
+        /// </remarks>
+        internal static bool IsWorthExpanding(Integer n)
             => n.EInteger.Abs() >= 2 && n.EInteger.Abs() <= MaxAngleMultiplier;
 
         [AddressableRules]

--- a/Sources/Tests/UnitTests/Core/Transformations/MatchedRulesAgreeWithTheSwitchTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/MatchedRulesAgreeWithTheSwitchTest.cs
@@ -166,6 +166,71 @@ namespace AngouriMath.Tests.Core.Transformations
                 });
 
         /// <summary>
+        /// The reverse of <see cref="MatchedRules.NormalTrigonometricForm"/>, and the set where
+        /// order is most obviously load-bearing: the two named quotients have to be tried before
+        /// the general reciprocal rules, or <c>sin(x) / cos(x)</c> becomes <c>sin(x) * sec(x)</c>.
+        /// </summary>
+        [Fact]
+        public void CollapseTrigonometricFunctionsAsDataMatchesTheSwitch()
+            => AssertAgrees("CollapseTrigonometricFunctions", Patterns.CollapseTrigonometricFunctions,
+                MatchedRules.CollapseTrigonometricFunctions, leastFirings: 25);
+
+        /// <summary>
+        /// The angle-sum identities, both of whose sides are patterns. The corpus has no sum
+        /// inside a sine, so the shapes are given.
+        /// </summary>
+        [Fact]
+        public void ExpansionAsDataMatchesTheSwitch()
+            => AssertAgrees("Expansion", Patterns.ExpandRules,
+                MatchedRules.Expansion, leastFirings: 5, extra: new[]
+                {
+                    "sin(x + y)", "sin(x - y)", "sin(2 + x)", "sin(x - 1/2)",
+                    "sin(x + y) * cos(x - y)", "sin(sin(x) + cos(y))",
+                });
+
+        /// <summary>
+        /// The doubled-angle identities, keyed on literals — <c>1/2</c> and <c>2</c> — which the
+        /// corpus does build but never in this arrangement.
+        /// </summary>
+        [Fact]
+        public void ExpandTrigonometricAsDataMatchesTheSwitch()
+            => AssertAgrees("ExpandTrigonometric", Patterns.ExpandTrigonometricRules,
+                MatchedRules.ExpandTrigonometric, leastFirings: 5, extra: new[]
+                {
+                    "1/2 * sin(2 * x)", "cos(2 * x)", "cos(2 * y)", "1/2 * sin(2 * y)",
+                    "cos(2 * (x + y))", "1/2 * sin(2 * sin(x))", "cos(3 * x)", "1/3 * sin(2 * x)",
+                });
+
+        /// <summary>
+        /// A predicate on a hole asked through the <c>switch</c>'s own helper, so the two cannot
+        /// disagree about where the multiplier stops being worth expanding.
+        /// </summary>
+        [Fact]
+        public void ExpandMultipleAngleAsDataMatchesTheSwitch()
+            => AssertAgrees("ExpandMultipleAngle", Patterns.ExpandMultipleAngleRules,
+                MatchedRules.ExpandMultipleAngle, leastFirings: 6, extra: new[]
+                {
+                    "sin(2 * x)", "cos(2 * x)", "sin(3 * x)", "cos(5 * x)",
+                    "sin(8 * x)", "cos(9 * x)", "sin(1 * x)", "sin(-3 * x)",
+                    "cos(x * 2)", "sin(2 * (x + y))",
+                });
+
+        /// <summary>
+        /// The two sets whose rule has no side condition because the work that decides whether it
+        /// applies <i>is</i> the rewrite. Agreement here is what says that handing the expression
+        /// back unchanged reads the same as a <c>switch</c> arm falling through.
+        /// </summary>
+        [Fact]
+        public void PolynomialLongDivisionAsDataMatchesTheSwitch()
+            => AssertAgrees("PolynomialLongDivision", Patterns.PolynomialLongDivision,
+                MatchedRules.PolynomialLongDivision, leastFirings: 20);
+
+        [Fact]
+        public void PolynomialGcdCancellationAsDataMatchesTheSwitch()
+            => AssertAgrees("PolynomialGcdCancellation", Patterns.PolynomialGcdCancellation,
+                MatchedRules.PolynomialGcdCancellation, leastFirings: 10);
+
+        /// <summary>
         /// A predicate on a hole that is a mathematical property rather than a sign or a type.
         /// The corpus reaches it rarely, so the shapes are given here as well — a set that fires
         /// four times over a generated corpus is worth checking against cases chosen for it.

--- a/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using AngouriMath.Core.Transformations;
 using AngouriMath.Core.Transformations.Matching;
 using AngouriMath.Extensions;
@@ -33,14 +34,23 @@ namespace AngouriMath.Tests.Core.Transformations
     [Trait("Area", "Core")]
     public sealed class ReversibleRuleTest
     {
+        /// <summary>
+        /// Every set in <see cref="MatchedRules"/>, read off the type rather than listed here.
+        /// </summary>
+        /// <remarks>
+        /// This was a hand-written list of five, and it stopped covering the file the moment a
+        /// sixth set was added — so <c>EveryDataRuleIsBuildableOnBothSides</c>, whose whole
+        /// purpose is to catch a template naming a node type the matcher can match but not
+        /// build, was silently not looking at the new sets. It missed exactly that: a rule
+        /// building a <c>Cosecantf</c>, which matched, built nothing, and was indistinguishable
+        /// at run time from a rule that did not apply.
+        /// </remarks>
         private static IEnumerable<MatchedRuleSet> DataRuleSets()
-        {
-            yield return MatchedRules.DivisionPreparing;
-            yield return MatchedRules.CollapseMultipleFractions;
-            yield return MatchedRules.PowerOfPower;
-            yield return MatchedRules.SharedFactor;
-            yield return MatchedRules.PythagoreanIdentity;
-        }
+            => typeof(MatchedRules)
+                .GetProperties(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
+                .Where(property => property.PropertyType == typeof(MatchedRuleSet))
+                .Select(property => (MatchedRuleSet)property.GetValue(null)!)
+                .OrderBy(set => set.Name, StringComparer.Ordinal);
 
         private static readonly string[] Leaves = { "x", "y", "z", "2", "-1", "1/2", "1", "0" };
 
@@ -83,15 +93,29 @@ namespace AngouriMath.Tests.Core.Transformations
                 .SelectMany(set => set.Rules)
                 .ToDictionary(rule => rule.Name, rule => rule.Reversal);
 
-            var oneWay = actual.Where(pair => pair.Value is not RuleReversal.Reversible).ToList();
+            var oneWay = actual.Where(pair => pair.Value is not RuleReversal.Reversible)
+                .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+                .Select(pair => $"{pair.Key}: {pair.Value}")
+                .ToArray();
 
-            // The only rule here that cannot be read backwards, and the reason is the
-            // mathematics rather than the encoding: 1 does not say which angle it came from.
+            // Named one by one and with the reason, so that a rule losing or gaining a direction
+            // fails rather than moving a number. Almost all of these are one-way because their
+            // replacement is arithmetic on a binding rather than a tree built around it -- see
+            // RuleReversal.ReplacementIsCode -- and exactly one is one-way for a mathematical
+            // reason: 1 does not say which angle it came from.
             Assert.Equal(
-                new[] { "squared-sine-and-cosine-of-one-argument-sum-to-one" },
-                oneWay.Select(pair => pair.Key).ToArray());
-            Assert.Equal(RuleReversal.ReplacementDropsHoles, oneWay[0].Value);
-            Assert.Equal(13, actual.Count(pair => pair.Value is RuleReversal.Reversible));
+                new[]
+                {
+                    "a-negative-factor-in-a-sum-becomes-a-difference: ReplacementIsCode",
+                    "a-negative-integer-power-becomes-a-reciprocal: ReplacementIsCode",
+                    "a-quotient-of-polynomials-is-divided-out: ReplacementIsCode",
+                    "a-quotient-of-polynomials-is-put-in-lowest-terms: ReplacementIsCode",
+                    "cosine-of-a-whole-multiple-of-an-angle: ReplacementIsCode",
+                    "eulers-totient-of-a-prime-power: ReplacementIsCode",
+                    "sine-of-a-whole-multiple-of-an-angle: ReplacementIsCode",
+                    "squared-sine-and-cosine-of-one-argument-sum-to-one: ReplacementDropsHoles",
+                },
+                oneWay);
         }
 
         /// <summary>
@@ -232,22 +256,52 @@ namespace AngouriMath.Tests.Core.Transformations
 
         /// <summary>
         /// A pattern over a node this cannot construct is matchable and not writable, so a rule
-        /// using one is one-way — reported as its own reason rather than folded into the others,
-        /// because it is a gap in the mechanism where the rest are facts about the mathematics.
+        /// matching one is one-way — reported as its own reason rather than folded into the
+        /// others, because it is a gap in the mechanism where the rest are facts about the
+        /// mathematics.
         /// </summary>
+        /// <remarks>
+        /// The unbuildable node is on the <b>left</b>, which is the case this is about: the rule
+        /// fires, and only its reverse is impossible. An unbuildable node on the right is a
+        /// different thing entirely and is rejected outright — see
+        /// <see cref="AReplacementCannotNameANodeThisCannotBuild"/>.
+        /// </remarks>
         [Fact]
         public void APatternOverAnUnbuildableNodeIsMatchableAndNotReversible()
         {
             var overMod = new MatchedRule(
                 "modulus",
                 MatchPattern.Node<Modf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
-                MatchPattern.Node<Modf>(MatchPattern.Any("b"), MatchPattern.Any("a")),
+                MatchPattern.Node<Mulf>(MatchPattern.Any("b"), MatchPattern.Any("a")),
                 Soundness.Heuristic);
 
             // It still matches, which is what "matchable and not writable" means.
             Assert.True(overMod.Left.Matches("x mod y".ToEntity()));
+            Assert.Equal("y * x", overMod.TryApply("x mod y".ToEntity())!.Stringize());
             Assert.Equal(RuleReversal.PatternCannotBeBuilt, overMod.Reversal);
             Assert.Null(overMod.Reversed);
+        }
+
+        /// <summary>
+        /// A replacement naming a node type the matcher can match but not construct is not a
+        /// one-way rule — it is a rule that <b>never fires</b>, since the match succeeds and the
+        /// build then returns nothing, which <c>TryApply</c> reports as "did not apply".
+        /// </summary>
+        /// <remarks>
+        /// Indistinguishable at run time from a correct rule on an expression it declines, so
+        /// nothing downstream can catch it. It cost an afternoon and a twenty-eight-row agreement
+        /// failure — a set of four rules building a <c>Cosecantf</c>, which was not in
+        /// <c>MatchPattern.Construct</c> — before the constructor was made to say so.
+        /// </remarks>
+        [Fact]
+        public void AReplacementCannotNameANodeThisCannotBuild()
+        {
+            var thrown = Assert.Throws<ArgumentException>(() => new MatchedRule(
+                "unbuildable",
+                MatchPattern.Node<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
+                MatchPattern.Node<Modf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
+                Soundness.Heuristic));
+            Assert.Contains("cannot build", thrown.Message);
         }
 
         /// <summary>
@@ -278,9 +332,17 @@ namespace AngouriMath.Tests.Core.Transformations
             foreach (var set in DataRuleSets())
                 foreach (var rule in set.Rules)
                 {
-                    Assert.True(rule.Left.IsBuildable, $"{set.Name}/{rule.Name}: left");
-                    Assert.NotNull(rule.Right);
-                    Assert.True(rule.Right!.IsBuildable, $"{set.Name}/{rule.Name}: right");
+                    // A rule whose replacement is code has no right-hand pattern to check, and
+                    // its left need not be buildable either: it is one-way whatever the nodes.
+                    if (rule.Right is null)
+                    {
+                        Assert.Equal(RuleReversal.ReplacementIsCode, rule.Reversal);
+                        continue;
+                    }
+                    Assert.True(rule.Right.IsBuildable, $"{set.Name}/{rule.Name}: right");
+                    // The left decides only whether it reads backwards, and the type says which.
+                    Assert.Equal(rule.Left.IsBuildable,
+                        rule.Reversal is not RuleReversal.PatternCannotBeBuilt);
                 }
         }
 


### PR DESCRIPTION
`CollapseTrigonometricFunctions`, `Expansion`, `ExpandTrigonometric`, `ExpandMultipleAngle`, `PolynomialLongDivision` and `PolynomialGcdCancellation` run on the matcher. **Twelve of thirty sets.**

## What went wrong writing them is the valuable part

Four rules built a `Cosecantf` or a `Secantf`, which `MatchPattern.Construct` did not know. A node type is **matchable without being buildable** — so those rules matched, built nothing, and `TryApply` reported that as *"did not apply"*.

At run time that is indistinguishable from a correct rule declining an expression. It surfaced only as a twenty-eight-row agreement failure whose rows all read:

```
x / sin(y): switch gave x * csc(y), data gave x / sin(y)
```

Three changes come out of it.

**1. `Secantf` and `Cosecantf` are in `Construct`** — the immediate fix.

**2. `MatchedRule`'s constructor refuses a right-hand side it cannot build.** This is the same argument the constructor already makes for a replacement naming a hole the pattern does not bind: *"a typo that would otherwise show up as a rule that silently never fires"*. An unbuildable node on the **left** is a different thing and stays legal — the rule fires, only its reverse is impossible, which is what `RuleReversal.PatternCannotBeBuilt` is for — so the test covering that case now puts the unbuildable node where it belongs, and a new test pins the refusal.

**3. `EveryDataRuleIsBuildableOnBothSides` was reading a hand-written list of five sets, written before there were nine.** The test whose whole purpose is to catch this was not looking at the sets it needed to. It enumerates `MatchedRules` by reflection now, and the reversal classification is asserted the same way — naming every one-way rule and its reason rather than counting them.

## Two rules with no side condition, deliberately

The work that decides whether a polynomial division applies **is** the division. Asking it in a guard would run it twice on a path the simplifier takes for every quotient; the helper hands the expression back unchanged where it declines, which `ApplyHere` reads as no rewrite exactly as the `switch`'s fallthrough does.

## Cost, and allocation attributes it precisely

| | time (medians) | allocation |
|---|--:|--:|
| the four trigonometric sets | +1.19% | **−0.0025%** |
| all six | +1.35% | **+0.20%** |

So the whole of the allocation cost is the two polynomial sets — the ones that run at every quotient node, which is exactly where a per-node dispatch would show.

On time, the same-binary spread is **1.81%**, so +1.35% is at the edge of the noise rather than clear of it. Reported as such rather than as free: I cannot separate signal from drift at this resolution, and the honest thing is to say which column is clean.

Full suite: `Failed: 0, Passed: 8614, Skipped: 14, Total: 8628`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd