### PR TITLE
A predicate on a hole says everything the work-list called unsayable

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -777,5 +777,37 @@ namespace AngouriMath.Core.Transformations.Matching
                     new Mulf(new Factorialf(bound["x"] + bound["a"]), bound["y"]),
                     bound["x"], bound["y"], (Number)bound["a"], Integer.Create(0)),
                 Soundness.SoundUnderAssumptions));
+
+        /// <summary>
+        /// <see cref="Functions.Patterns.PerfectSquareRules"/>, as data.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// One rule, and it is here to settle a question rather than for its own sake. The
+        /// <c>switch</c> arm is <c>x is Sumf or Minusf</c> — an <b>alternation of node types</b>,
+        /// which <see cref="MatchPattern.Node{T}"/> cannot say and which was recorded as needing
+        /// an addition to the matcher.
+        /// </para>
+        /// <para>
+        /// <b>It does not.</b> A typed hole with a predicate says it:
+        /// <c>Any&lt;Entity&gt;(name, e =&gt; e is Sumf or Minusf)</c> matches either and binds the
+        /// whole node, which is exactly what the arm does. The same shape covers every other
+        /// construct on that list — <c>var x and not Integer(1)</c> is a predicate,
+        /// <c>Rational and not Integer</c> is a predicate on a typed hole, and
+        /// <c>not Set and not Matrix</c> is a predicate. So the matcher was never the thing
+        /// standing in the way of those sets.
+        /// </para>
+        /// </remarks>
+        internal static MatchedRuleSet PerfectSquare { get; } = new(
+            nameof(PerfectSquare),
+
+            new MatchedRule(
+                "a-sum-or-difference-that-is-a-perfect-square",
+                MatchPattern.Any<Entity>("x", node => node is Sumf or Minusf),
+                bound => Functions.Patterns.CollapseToPerfectSquare(bound["x"]) ?? bound["x"],
+                // sqrt(u)^2 is u for every complex u, so the identity itself is unconditional.
+                // What is not is the test for whether the cross term matches, which needs
+                // Simplify -- see the remark on Patterns.CollapseToPerfectSquare.
+                Soundness.SoundUnderAssumptions));
     }
 }

--- a/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
@@ -202,12 +202,18 @@ namespace AngouriMath.Core.Transformations
         /// Recognises a perfect square written out, so that factorisation has something to
         /// gather.
         /// </summary>
+        /// <remarks>
+        /// <b>Run by the matcher rather than by the <c>switch</c></b> —
+        /// <see cref="Matching.MatchedRules.PerfectSquare"/>, whose arm is the one that was
+        /// recorded as needing an alternation of node types the matcher does not have. It
+        /// needed a predicate on a hole, which it does.
+        /// </remarks>
         public static RewriteRuleSet PerfectSquare { get; } = new(
             nameof(PerfectSquare),
             "Collapses a written-out perfect square into a squared binomial.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Patterns.PerfectSquareRules,
+            Matching.MatchedRules.PerfectSquare.ApplyHere,
             Patterns.PerfectSquareRulesArms);
 
         #endregion

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.ExpandFactorize.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.ExpandFactorize.cs
@@ -131,7 +131,8 @@ namespace AngouriMath.Functions
         /// </para>
         /// </remarks>
         /// <returns><see langword="null"/> when the sum is not a square, so the rule does not fire.</returns>
-        private static Entity? CollapseToPerfectSquare(Entity expr)
+        /// <remarks>Internal so that the data form of this set calls it rather than repeating it.</remarks>
+        internal static Entity? CollapseToPerfectSquare(Entity expr)
         {
             if (!expr.Nodes.Any(node => node is Powf(_, Rational and not Integer)))
                 return null;

--- a/Sources/Tests/UnitTests/Core/Transformations/MatchedRulesAgreeWithTheSwitchTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/MatchedRulesAgreeWithTheSwitchTest.cs
@@ -262,6 +262,22 @@ namespace AngouriMath.Tests.Core.Transformations
                 });
 
         /// <summary>
+        /// <b>The alternation case.</b> The <c>switch</c> arm is <c>x is Sumf or Minusf</c>, which
+        /// <c>Node&lt;T&gt;</c> cannot say — and which the work-list in <c>work/rulecheck</c>
+        /// recorded as needing an addition to the matcher. A typed hole with a predicate says it,
+        /// and agreement over the corpus is what turns that from an argument into a fact.
+        /// </summary>
+        [Fact]
+        public void PerfectSquareAsDataMatchesTheSwitch()
+            => AssertAgrees("PerfectSquare", Patterns.PerfectSquareRules,
+                MatchedRules.PerfectSquare, leastFirings: 1, extra: new[]
+                {
+                    "1 + sqrt(2 * x) + x / 2", "x + 2 * sqrt(x) * sqrt(y) + y",
+                    "x - 2 * sqrt(x) * sqrt(y) + y", "4 + 4 * x + x ^ 2",
+                    "x + y", "x - y", "sin(x) + cos(x)",
+                });
+
+        /// <summary>
         /// A predicate on a hole that is a mathematical property rather than a sign or a type.
         /// The corpus reaches it rarely, so the shapes are given here as well — a set that fires
         /// four times over a generated corpus is worth checking against cases chosen for it.

--- a/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
@@ -116,6 +116,7 @@ namespace AngouriMath.Tests.Core.Transformations
                     "a-quotient-of-shifted-factorials: ReplacementIsCode",
                     "a-shifted-factorial-times-a-bare-term: ReplacementIsCode",
                     "a-shifted-factorial-times-the-next-term: ReplacementIsCode",
+                    "a-sum-or-difference-that-is-a-perfect-square: ReplacementIsCode",
                     "cosine-of-a-whole-multiple-of-an-angle: ReplacementIsCode",
                     "eulers-totient-of-a-prime-power: ReplacementIsCode",
                     "sine-of-a-whole-multiple-of-an-angle: ReplacementIsCode",


### PR DESCRIPTION
`PerfectSquare` runs on the matcher — **fifteen of thirty sets** — but the count is not why this is here.

`work/rulecheck`'s work-list named three constructs as needing an addition to the matcher, across **eight sets**: a negated pattern, an alternation of node types, a type conjunction. The reading behind that was that `Node<T>` matches one node type and cannot say "either".

## All three are a predicate on a hole

And `Any<T>(name, where)` has been there since the matcher was written.

| `switch` arm | as data |
|---|---|
| `x is Sumf or Minusf` | `Any<Entity>(n, e => e is Sumf or Minusf)` |
| `var x and not Integer(1)` | a predicate |
| `Rational and not Integer and var p` | a predicate on a typed hole |
| `not Set and not Matrix and var v` | a predicate |

`PerfectSquareRules` is the smallest of the eight — one arm, `x is Sumf or Minusf` — so it is converted here to **settle the question by measurement rather than by argument**. It agrees with the `switch` over the generated corpus and over shapes chosen for it.

## What it changes

Not *"eight sets need the matcher extended and fifteen do not"*, but: **every remaining set is writable today**, with the agreement proof the only thing in the way. [#746](https://github.com/asc-community/AngouriMath/issues/746) tier 1's rule-set line is now a single kind of work rather than two.

The question *"can the matcher say this?"* had been answered by reading the pattern language instead of by trying to express an arm in it. The workspace's `Blocker` classifier keeps its place and returns null for everything, with that reading written into it as the reason the column exists.

One set remains unlistable — `RationalizeDenominator`, whose arms the registry cannot read — and that is a **generator** gap ([#825](https://github.com/asc-community/AngouriMath/issues/825)) rather than a matcher one.

Full suite: `Failed: 0, Passed: 8617, Skipped: 14, Total: 8631`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd