### PR TITLE
The last rule set with no addressable rules has them, read from its data form (#825)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -48,6 +48,8 @@ read first.
 | | `MathS.Polynomials.Factor("x * y + y", "x")`, and any polynomial whose coefficients in the named variable share a common divisor | `null` — a refusal | `y * (x + 1)` |
 | | `MathS.Polynomials.SquareFreePart("(x - y) ^ 2 * (x + y)", "x")`, and any polynomial in more than one variable | `null` — a refusal | `x ^ 2 - y ^ 2` |
 | | `MathS.Polynomials.Factor("x ^ 2 - y ^ 2", "x")`, and polynomials in two variables of small enough bidegree | `null` — a refusal | `(x + y) * (x - y)` |
+| | a `switch` over `RewriteRuleGrowth` with no default arm | compiled | does not compile — there is a fourth value, `Unknown` |
+| **Silent** | `RewriteRules.RationalizeDenominator.Rules` | `[]` — the registry could not read the set | its two rules, addressable and named |
 | **Silent** | `RewriteRules.Power.ApplyOnce("ln(1 / x)")`, and every `log(_, 1/_)` and `log(1/_, _)` whose argument is not decidably a positive real | `-ln(x)`, which is wrong on the negative reals | `ln(1 / x)`, left alone |
 
 ### An equation nothing settled is no longer answered with the empty set
@@ -329,6 +331,20 @@ destination and has established the sign on the way.
 from the public simplifier moves. What moves is `RewriteRules.Power` applied on its own, which is
 what [#746](https://github.com/asc-community/AngouriMath/issues/746) tier 2 makes a caller able to
 do ([#1062](https://github.com/asc-community/AngouriMath/issues/1062)).
+
+### `RewriteRuleGrowth` gained a fourth value, `Unknown`
+
+A rule written as **data** builds its answer in code rather than spelling it out, so there is nothing
+to count and no growth to report. The three existing values all make a claim; reporting such a rule
+as `Rearranges` — the middle one, and the one that reads as harmless — would be a claim about a
+rewrite nobody measured.
+
+**Additive**, so nothing that exists changes value. What it means for a caller is that a `switch`
+over `RewriteRuleGrowth` is no longer exhaustive, and code with no default arm will not compile
+against the new assembly until it handles the fourth case.
+
+It appears wherever a rule's replacement is code, which today is `RationalizeDenominator` and the
+one-way rules of the sets already expressed as data.
 
 ### `Factor` factors a polynomial in more than one variable
 

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchPattern.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchPattern.cs
@@ -142,6 +142,13 @@ namespace AngouriMath.Core.Transformations.Matching
         private protected abstract Type? RootType { get; }
 
         /// <summary>
+        /// The node type this pattern requires at its root, where it requires one — the same
+        /// question <see cref="RootType"/> answers, offered to the registry so that a rule
+        /// written as data can say which node it fires on.
+        /// </summary>
+        internal Type? RequiredRootType => RootType;
+
+        /// <summary>
         /// Whether this pattern can match an expression in <b>at most one way</b>, so that a
         /// caller wanting a solution needs no enumeration and no backtracking.
         /// </summary>
@@ -387,6 +394,11 @@ namespace AngouriMath.Core.Transformations.Matching
 
             internal override IEnumerable<string> BoundNames => new[] { name };
 
+            public override string ToString()
+                => required is null
+                    ? (where is null ? $"var {name}" : $"var {name} where")
+                    : (where is null ? $"{required.Name} {name}" : $"{required.Name} {name} where");
+
             // Exactly the constraint this pattern imposes, so the guard can carry all of it.
             private protected override Type? RootType => required;
 
@@ -436,6 +448,8 @@ namespace AngouriMath.Core.Transformations.Matching
             internal ExactPattern(Entity value) => this.value = value;
 
             internal override IEnumerable<string> BoundNames => Array.Empty<string>();
+
+            public override string ToString() => value.Stringize();
 
             /// <summary>
             /// Null deliberately. Two entities can be equal without being the same runtime type
@@ -500,6 +514,10 @@ namespace AngouriMath.Core.Transformations.Matching
             private readonly bool deterministic;
 
             internal override IEnumerable<string> BoundNames => children.SelectMany(c => c.BoundNames);
+
+            public override string ToString()
+                => (commutative ? "~" : "") + nodeType.Name
+                   + "(" + string.Join(", ", children.Select(child => child.ToString())) + ")";
 
             private protected override Type? RootType => nodeType;
 
@@ -599,6 +617,10 @@ namespace AngouriMath.Core.Transformations.Matching
 
             internal override IEnumerable<string> BoundNames
                 => parts.SelectMany(part => part.BoundNames).Append(restName);
+
+            public override string ToString()
+                => nodeType.Name + "(" + string.Join(", ", parts.Select(part => part.ToString()))
+                   + ", ... var " + restName + ")";
 
             /// <summary>
             /// Null, because two types are admissible rather than one: a sum chain is

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
@@ -76,6 +76,39 @@ namespace AngouriMath.Core.Transformations.Matching
             Soundness soundness,
             Func<Bindings, bool>? when = null,
             [CallerLineNumber] int line = 0)
+            : this(name, left, right is null ? null : (_, bound) => right(bound),
+                   right is null ? throw new ArgumentNullException(nameof(right)) : null,
+                   soundness, when, line)
+        {
+        }
+
+        /// <summary>
+        /// A rule whose right-hand side is code and wants <b>the node it matched</b> as well as
+        /// the bindings.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Not a convenience. A replacement that needs the whole expression — because it hands it
+        /// to a helper that decides for itself whether to rewrite — otherwise has to rebuild it
+        /// from the bindings, and <b>a rebuilt node is a different object with none of the
+        /// original's cached work</b>: its <c>InnerSimplified</c>, <c>Evaled</c>, <c>Codomain</c>
+        /// and rate are all computed again, on every attempt, for every node of the tree.
+        /// </para>
+        /// <para>
+        /// Measured on the limit of <c>x * ln(x) / cos(x)</c>, which reaches
+        /// <c>RationalizeDenominator</c> at every quotient it builds: rebuilding cost <b>4.0 s to
+        /// 5.2 s</b>, and a test with a thirty-second cap failed on two of the three CI platforms
+        /// while passing locally. Handing the node over costs nothing and the rule keeps the
+        /// caches it was given.
+        /// </para>
+        /// </remarks>
+        internal MatchedRule(
+            string name,
+            MatchPattern left,
+            Func<Entity, Bindings, Entity> right,
+            Soundness soundness,
+            Func<Bindings, bool>? when = null,
+            [CallerLineNumber] int line = 0)
             : this(name, left, right ?? throw new ArgumentNullException(nameof(right)), null, soundness, when, line)
         {
         }
@@ -83,7 +116,7 @@ namespace AngouriMath.Core.Transformations.Matching
         private MatchedRule(
             string name,
             MatchPattern left,
-            Func<Bindings, Entity>? rightCode,
+            Func<Entity, Bindings, Entity>? rightCode,
             MatchPattern? rightPattern,
             Soundness soundness,
             Func<Bindings, bool>? when,
@@ -102,7 +135,7 @@ namespace AngouriMath.Core.Transformations.Matching
             Reversal = Classify();
         }
 
-        private readonly Func<Bindings, Entity>? right;
+        private readonly Func<Entity, Bindings, Entity>? right;
         private readonly Func<Bindings, bool>? when;
 
         /// <summary>What to call this rule in a report, a test or a bug.</summary>
@@ -148,7 +181,7 @@ namespace AngouriMath.Core.Transformations.Matching
             {
                 if (!Left.TryMatchOnce(expr, Bindings.Empty, out var only)) return null;
                 if (when is not null && !when(only)) return null;
-                return Build(only);
+                return Build(expr, only);
             }
 
             // Every way the pattern matches, in order, and the first that also satisfies the
@@ -162,7 +195,7 @@ namespace AngouriMath.Core.Transformations.Matching
                 // A match whose replacement cannot be built is a match that does not apply, and
                 // another way of matching may still. Only the last of them decides that the rule
                 // declines.
-                if (Build(bindings) is { } rewritten)
+                if (Build(expr, bindings) is { } rewritten)
                     return rewritten;
             }
             return null;
@@ -173,11 +206,11 @@ namespace AngouriMath.Core.Transformations.Matching
         /// built — which is the rule declining rather than an error, whichever form the
         /// right-hand side takes.
         /// </summary>
-        private Entity? Build(Bindings bindings)
+        private Entity? Build(Entity matched, Bindings bindings)
         {
             if (Right is not null)
                 return Right.TryBuild(bindings, out var built) ? built : null;
-            try { return right!(bindings); }
+            try { return right!(matched, bindings); }
             catch { return null; }
         }
 

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace AngouriMath.Core.Transformations.Matching
 {
@@ -42,8 +43,9 @@ namespace AngouriMath.Core.Transformations.Matching
             MatchPattern left,
             MatchPattern right,
             Soundness soundness,
-            Func<Bindings, bool>? when = null)
-            : this(name, left, null, right ?? throw new ArgumentNullException(nameof(right)), soundness, when)
+            Func<Bindings, bool>? when = null,
+            [CallerLineNumber] int line = 0)
+            : this(name, left, null, right ?? throw new ArgumentNullException(nameof(right)), soundness, when, line)
         {
             // A name the replacement reads and the pattern never binds is a typo, and it is a
             // typo that would otherwise show up as a rule that silently never fires. Only a
@@ -72,8 +74,9 @@ namespace AngouriMath.Core.Transformations.Matching
             MatchPattern left,
             Func<Bindings, Entity> right,
             Soundness soundness,
-            Func<Bindings, bool>? when = null)
-            : this(name, left, right ?? throw new ArgumentNullException(nameof(right)), null, soundness, when)
+            Func<Bindings, bool>? when = null,
+            [CallerLineNumber] int line = 0)
+            : this(name, left, right ?? throw new ArgumentNullException(nameof(right)), null, soundness, when, line)
         {
         }
 
@@ -83,8 +86,10 @@ namespace AngouriMath.Core.Transformations.Matching
             Func<Bindings, Entity>? rightCode,
             MatchPattern? rightPattern,
             Soundness soundness,
-            Func<Bindings, bool>? when)
+            Func<Bindings, bool>? when,
+            int line)
         {
+            SourceLine = line;
             Name = name ?? throw new ArgumentNullException(nameof(name));
             Left = left ?? throw new ArgumentNullException(nameof(left));
             this.right = rightCode;
@@ -102,6 +107,19 @@ namespace AngouriMath.Core.Transformations.Matching
 
         /// <summary>What to call this rule in a report, a test or a bug.</summary>
         internal string Name { get; }
+
+        /// <summary>
+        /// The line this rule is declared on, taken from the compiler rather than written down.
+        /// </summary>
+        /// <remarks>
+        /// A rule written as data has a real source location like a <c>switch</c> arm does, and
+        /// <c>[CallerLineNumber]</c> is how it keeps one without anybody maintaining it. It is
+        /// what lets a data rule appear in the registry beside the arms.
+        /// </remarks>
+        internal int SourceLine { get; }
+
+        /// <summary>Whether this rule carries a side condition beyond its pattern.</summary>
+        internal bool HasCondition => when is not null;
 
         /// <summary>The shape it fires on.</summary>
         internal MatchPattern Left { get; }
@@ -327,6 +345,57 @@ namespace AngouriMath.Core.Transformations.Matching
         }
 
         /// <summary>One rewrite at this node only, leaving children alone.</summary>
+        /// <summary>
+        /// These rules as <see cref="RewriteRule"/> values, so that a set written as data can
+        /// appear in the registry beside the sets written as a <c>switch</c>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>RuleRegistryGenerator</c> reads a <c>switch</c>'s arms and cannot read this, which
+        /// is the half of
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/825">#825</a> still open.
+        /// Its cost is not only that a converted set keeps its <c>switch</c>: a set the generator
+        /// <i>declines</i> — an ordinary method with branches and locals — has <b>no addressable
+        /// rules at all</b>, and nothing about it can be listed, checked or named.
+        /// </para>
+        /// <para>
+        /// This is the same problem approached from the other side. The rules here are already
+        /// values; what was missing was their rendering. Everything is read off the rule rather
+        /// than restated: the pattern and the replacement render themselves, the line comes from
+        /// the compiler through <c>[CallerLineNumber]</c>, and the node type comes from what the
+        /// pattern requires at its root. A side condition is a delegate and cannot be quoted, so
+        /// it is reported as being there.
+        /// </para>
+        /// </remarks>
+        internal IReadOnlyList<RewriteRule> AsAddressable()
+        {
+            var built = new RewriteRule[rules.Length];
+            for (var i = 0; i < rules.Length; i++)
+            {
+                var rule = rules[i];
+                var pattern = rule.Left.ToString() ?? "";
+                var replacement = rule.Right?.ToString();
+                built[i] = new RewriteRule(
+                    source: Name,
+                    index: i,
+                    name: rule.Name,
+                    description: null,
+                    nodeTypes: rule.Left.RequiredRootType is { } root
+                        ? new[] { root }
+                        : Array.Empty<Type>(),
+                    patternSource: pattern,
+                    guardSource: rule.HasCondition ? "a side condition on the bindings" : null,
+                    replacementSource: replacement ?? "(built by code)",
+                    growth: replacement is null ? RewriteRuleGrowth.Unknown
+                        : replacement.Length > pattern.Length ? RewriteRuleGrowth.Expands
+                        : replacement.Length < pattern.Length ? RewriteRuleGrowth.Collects
+                        : RewriteRuleGrowth.Rearranges,
+                    sourceLine: rule.SourceLine,
+                    apply: rule.TryApply);
+            }
+            return built;
+        }
+
         internal Entity ApplyHere(Entity expr)
         {
             // The array rather than the IReadOnlyList property: see the note on `rules`.

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -654,10 +654,10 @@ namespace AngouriMath.Core.Transformations.Matching
             new MatchedRule(
                 "a-quotient-of-polynomials-is-divided-out",
                 MatchPattern.Node<Divf>(MatchPattern.Any("n"), MatchPattern.Any("d")),
-                bound => TreeAnalyzer.PolynomialLongDivision(bound["n"], bound["d"])
+                (node, bound) => TreeAnalyzer.PolynomialLongDivision(bound["n"], bound["d"])
                     is var (divided, remainder)
                     ? divided + remainder
-                    : new Divf(bound["n"], bound["d"]),
+                    : node,
                 Soundness.SoundUnderAssumptions));
 
         /// <summary>
@@ -673,9 +673,9 @@ namespace AngouriMath.Core.Transformations.Matching
             new MatchedRule(
                 "a-quotient-of-polynomials-is-put-in-lowest-terms",
                 MatchPattern.Node<Divf>(MatchPattern.Any("n"), MatchPattern.Any("d")),
-                bound => PolynomialGcd.TryCancel(bound["n"], bound["d"], out var cancelled)
+                (node, bound) => PolynomialGcd.TryCancel(bound["n"], bound["d"], out var cancelled)
                     ? cancelled
-                    : new Divf(bound["n"], bound["d"]),
+                    : node,
                 Soundness.SoundUnderAssumptions));
 
         /// <summary>
@@ -699,10 +699,8 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Any("x"), MatchPattern.Any<Number>("a"))),
                     MatchPattern.Node<Factorialf>(MatchPattern.Commutative<Sumf>(
                         MatchPattern.Any("y"), MatchPattern.Any<Number>("b")))),
-                bound => Functions.Patterns.CancelFactorials(
-                    new Divf(new Factorialf(bound["x"] + bound["a"]),
-                             new Factorialf(bound["y"] + bound["b"])),
-                    bound["x"], bound["y"], (Number)bound["a"], (Number)bound["b"]),
+                (node, bound) => Functions.Patterns.CancelFactorials(
+                    node, bound["x"], bound["y"], (Number)bound["a"], (Number)bound["b"]),
                 Soundness.SoundUnderAssumptions),
 
             // x! / (y + b)!
@@ -712,10 +710,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Factorialf>(MatchPattern.Any("x")),
                     MatchPattern.Node<Factorialf>(MatchPattern.Commutative<Sumf>(
                         MatchPattern.Any("y"), MatchPattern.Any<Number>("b")))),
-                bound => Functions.Patterns.CancelFactorials(
-                    new Divf(new Factorialf(bound["x"]),
-                             new Factorialf(bound["y"] + bound["b"])),
-                    bound["x"], bound["y"], Integer.Create(0), (Number)bound["b"]),
+                (node, bound) => Functions.Patterns.CancelFactorials(
+                    node, bound["x"], bound["y"], Integer.Create(0), (Number)bound["b"]),
                 Soundness.SoundUnderAssumptions),
 
             // (x + a)! / y!
@@ -725,10 +721,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Factorialf>(MatchPattern.Commutative<Sumf>(
                         MatchPattern.Any("x"), MatchPattern.Any<Number>("a"))),
                     MatchPattern.Node<Factorialf>(MatchPattern.Any("y"))),
-                bound => Functions.Patterns.CancelFactorials(
-                    new Divf(new Factorialf(bound["x"] + bound["a"]),
-                             new Factorialf(bound["y"])),
-                    bound["x"], bound["y"], (Number)bound["a"], Integer.Create(0)),
+                (node, bound) => Functions.Patterns.CancelFactorials(
+                    node, bound["x"], bound["y"], (Number)bound["a"], Integer.Create(0)),
                 Soundness.SoundUnderAssumptions));
 
         /// <summary>
@@ -749,9 +743,8 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Any("x"), MatchPattern.Any<Number>("a"))),
                     MatchPattern.Commutative<Sumf>(
                         MatchPattern.Any("y"), MatchPattern.Any<Number>("b"))),
-                bound => Functions.Patterns.GatherFactorial(
-                    new Mulf(new Factorialf(bound["x"] + bound["a"]), bound["y"] + bound["b"]),
-                    bound["x"], bound["y"], (Number)bound["a"], (Number)bound["b"]),
+                (node, bound) => Functions.Patterns.GatherFactorial(
+                    node, bound["x"], bound["y"], (Number)bound["a"], (Number)bound["b"]),
                 Soundness.SoundUnderAssumptions),
 
             // x! * (y + b)
@@ -761,9 +754,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Factorialf>(MatchPattern.Any("x")),
                     MatchPattern.Commutative<Sumf>(
                         MatchPattern.Any("y"), MatchPattern.Any<Number>("b"))),
-                bound => Functions.Patterns.GatherFactorial(
-                    new Mulf(new Factorialf(bound["x"]), bound["y"] + bound["b"]),
-                    bound["x"], bound["y"], Integer.Create(0), (Number)bound["b"]),
+                (node, bound) => Functions.Patterns.GatherFactorial(
+                    node, bound["x"], bound["y"], Integer.Create(0), (Number)bound["b"]),
                 Soundness.SoundUnderAssumptions),
 
             // (x + a)! * y
@@ -773,9 +765,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Factorialf>(MatchPattern.Commutative<Sumf>(
                         MatchPattern.Any("x"), MatchPattern.Any<Number>("a"))),
                     MatchPattern.Any("y")),
-                bound => Functions.Patterns.GatherFactorial(
-                    new Mulf(new Factorialf(bound["x"] + bound["a"]), bound["y"]),
-                    bound["x"], bound["y"], (Number)bound["a"], Integer.Create(0)),
+                (node, bound) => Functions.Patterns.GatherFactorial(
+                    node, bound["x"], bound["y"], (Number)bound["a"], Integer.Create(0)),
                 Soundness.SoundUnderAssumptions));
 
         /// <summary>
@@ -804,7 +795,7 @@ namespace AngouriMath.Core.Transformations.Matching
             new MatchedRule(
                 "a-sum-or-difference-that-is-a-perfect-square",
                 MatchPattern.Any<Entity>("x", node => node is Sumf or Minusf),
-                bound => Functions.Patterns.CollapseToPerfectSquare(bound["x"]) ?? bound["x"],
+                (node, _) => Functions.Patterns.CollapseToPerfectSquare(node) ?? node,
                 // sqrt(u)^2 is u for every complex u, so the identity itself is unconditional.
                 // What is not is the test for whether the cross term matches, which needs
                 // Simplify -- see the remark on Patterns.CollapseToPerfectSquare.
@@ -837,16 +828,14 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Mulf>(
                     MatchPattern.Any<Rational>("k"),
                     MatchPattern.Node<Divf>(MatchPattern.Any("value"), MatchPattern.Any<Rational>("d"))),
-                bound => Functions.Patterns.GatherNumericCoefficientOverASurd(
-                    new Mulf(bound["k"], new Divf(bound["value"], bound["d"]))),
+                (node, _) => Functions.Patterns.GatherNumericCoefficientOverASurd(node),
                 Soundness.SoundUnderAssumptions),
 
             // num / (a + b) -> num * (a - b) / (a^2 - b^2)
             new MatchedRule(
                 "a-two-term-denominator-is-multiplied-by-its-conjugate",
                 MatchPattern.Node<Divf>(MatchPattern.Any("num"), MatchPattern.Any("den")),
-                bound => Functions.Patterns.MultiplyByTheConjugate(
-                    new Divf(bound["num"], bound["den"])),
+                (node, _) => Functions.Patterns.MultiplyByTheConjugate(node),
                 Soundness.SoundUnderAssumptions));
     }
 }

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -809,5 +809,44 @@ namespace AngouriMath.Core.Transformations.Matching
                 // What is not is the test for whether the cross term matches, which needs
                 // Simplify -- see the remark on Patterns.CollapseToPerfectSquare.
                 Soundness.SoundUnderAssumptions));
+
+        /// <summary>
+        /// <see cref="Functions.Patterns.RationalizeDenominator"/>, as data.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This set is why <see cref="MatchedRuleSet.AsAddressable"/> exists. It is an ordinary
+        /// method with branches and locals rather than a <c>switch</c>, so
+        /// <c>RuleRegistryGenerator</c> declines it — and it was the one set in the registry with
+        /// <b>no addressable rules at all</b>. Nothing about it could be listed, named in a
+        /// report or checked by the tooling that reads arms.
+        /// </para>
+        /// <para>
+        /// Neither rule carries a side condition, for the reason
+        /// <see cref="PolynomialLongDivision"/> gives: the work that decides whether the rewrite
+        /// applies <i>is</i> the rewrite, and each helper hands the expression back where it
+        /// declines.
+        /// </para>
+        /// </remarks>
+        internal static MatchedRuleSet RationalizeDenominator { get; } = new(
+            nameof(RationalizeDenominator),
+
+            // k * (value / d) -> (k * value) / d, where the numerator carries a surd
+            new MatchedRule(
+                "a-numeric-coefficient-is-gathered-over-a-surd",
+                MatchPattern.Node<Mulf>(
+                    MatchPattern.Any<Rational>("k"),
+                    MatchPattern.Node<Divf>(MatchPattern.Any("value"), MatchPattern.Any<Rational>("d"))),
+                bound => Functions.Patterns.GatherNumericCoefficientOverASurd(
+                    new Mulf(bound["k"], new Divf(bound["value"], bound["d"]))),
+                Soundness.SoundUnderAssumptions),
+
+            // num / (a + b) -> num * (a - b) / (a^2 - b^2)
+            new MatchedRule(
+                "a-two-term-denominator-is-multiplied-by-its-conjugate",
+                MatchPattern.Node<Divf>(MatchPattern.Any("num"), MatchPattern.Any("den")),
+                bound => Functions.Patterns.MultiplyByTheConjugate(
+                    new Divf(bound["num"], bound["den"])),
+                Soundness.SoundUnderAssumptions));
     }
 }

--- a/Sources/AngouriMath/Core/Transformations/RewriteRule.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRule.cs
@@ -38,7 +38,18 @@ namespace AngouriMath.Core.Transformations
         Rearranges,
 
         /// <summary>The replacement is written with more, so the rule opens the expression out.</summary>
-        Expands
+        Expands,
+
+        /// <summary>
+        /// Not judged, because the replacement is not written down: a rule whose right-hand side
+        /// is code builds its answer rather than spelling it, so there is nothing to count.
+        /// </summary>
+        /// <remarks>
+        /// A value rather than a guess. Reporting such a rule as <see cref="Rearranges"/> — the
+        /// middle of the three, and the one that reads as harmless — would be a claim about a
+        /// rewrite nobody measured.
+        /// </remarks>
+        Unknown
     }
 
     /// <summary>

--- a/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
@@ -223,12 +223,21 @@ namespace AngouriMath.Core.Transformations
         /// <summary>
         /// Clears a surd out of a two-term denominator.
         /// </summary>
+        /// <remarks>
+        /// <b>Run by the matcher, and <i>listed</i> by it</b> —
+        /// <see cref="Matching.MatchedRules.RationalizeDenominator"/>. This set is an
+        /// ordinary method with branches and locals, which <c>RuleRegistryGenerator</c>
+        /// declines, so it was the one set in the registry with no addressable rules at all.
+        /// Its rules are read from the data form instead, which is the other half of
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/825">#825</a>.
+        /// </remarks>
         public static RewriteRuleSet RationalizeDenominator { get; } = new(
             nameof(RationalizeDenominator),
             "Multiplies a quotient by the conjugate of its denominator to clear a surd from it.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Patterns.RationalizeDenominator);
+            Matching.MatchedRules.RationalizeDenominator.ApplyHere,
+            Matching.MatchedRules.RationalizeDenominator.AsAddressable());
 
         /// <summary>
         /// Brings a quotient of quotients down to a single one.

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Rational.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Rational.cs
@@ -116,19 +116,43 @@ namespace AngouriMath.Functions
                 : scaled / Integer.Create(ratio.Denominator);
         }
 
+        /// <summary>
+        /// The two rules of this set, in order. Split into one method each so that the data form
+        /// in <c>MatchedRules</c> calls the same code rather than a copy of it — this set is an
+        /// ordinary method with branches and locals, which the rule registry generator declines,
+        /// so its arms had no other way of becoming addressable.
+        /// </summary>
         internal static Entity RationalizeDenominator(Entity expr)
+            => GatherNumericCoefficientOverASurd(expr) is var gathered && !ReferenceEquals(gathered, expr)
+                ? gathered
+                : MultiplyByTheConjugate(expr);
+
+        /// <summary>
+        /// <c>k * (value / d) -> (k * value) / d</c>, reduced, where the numerator carries a surd
+        /// this rule moved up out of a denominator.
+        /// </summary>
+        /// <remarks>
+        /// Without it a numeric coefficient never meets the divisor: <c>k / (p + sqrt(q))</c> is
+        /// split into <c>k * (1 / (p + sqrt(q)))</c> before this rule runs, so the quotient it
+        /// rewrites has a numerator of 1 and the <c>k</c> stays outside. <c>2 / (3 - sqrt(5))</c>
+        /// came out as <c>2 * (3 + sqrt(5)) / 4</c>, which is longer than what it replaced —
+        /// while <c>1 / (3 - sqrt(5))</c>, with no coefficient to strand, answered correctly all
+        /// along.
+        /// </remarks>
+        internal static Entity GatherNumericCoefficientOverASurd(Entity expr)
         {
-            // k * (value / d) -> (k * value) / d, reduced, where the numerator carries a surd
-            // this rule moved up out of a denominator. Without it a numeric coefficient never
-            // meets the divisor: `k / (p + sqrt(q))` is split into `k * (1 / (p + sqrt(q)))`
-            // before this rule runs, so the quotient it rewrites has a numerator of 1 and the
-            // k stays outside. 2 / (3 - sqrt(5)) came out as `2 * (3 + sqrt(5)) / 4`, which is
-            // longer than what it replaced -- while 1 / (3 - sqrt(5)), with no coefficient to
-            // strand, answered correctly all along.
             if (expr is Mulf(Rational coefficient, Divf(var inner, Rational { IsZero: false } innerDivisor))
                 && inner.Nodes.Any(IsSurd))
                 return ScaleBy(coefficient.ERational.Divide(innerDivisor.ERational), inner);
+            return expr;
+        }
 
+        /// <summary>
+        /// <c>num / (a + b)</c> becomes <c>num * (a - b) / (a^2 - b^2)</c> where that clears a
+        /// surd out of the denominator, and <paramref name="expr"/> where it does not.
+        /// </summary>
+        internal static Entity MultiplyByTheConjugate(Entity expr)
+        {
             if (expr is not Divf(var num, var den))
                 return expr;
             var (a, b) = den switch

--- a/Sources/Tests/UnitTests/Common/PublicApi.txt
+++ b/Sources/Tests/UnitTests/Common/PublicApi.txt
@@ -187,6 +187,7 @@ AngouriMath.Core.Transformations.RewriteRule.TryApply(AngouriMath.Entity) : Ango
 AngouriMath.Core.Transformations.RewriteRuleGrowth.Collects : AngouriMath.Core.Transformations.RewriteRuleGrowth
 AngouriMath.Core.Transformations.RewriteRuleGrowth.Expands : AngouriMath.Core.Transformations.RewriteRuleGrowth
 AngouriMath.Core.Transformations.RewriteRuleGrowth.Rearranges : AngouriMath.Core.Transformations.RewriteRuleGrowth
+AngouriMath.Core.Transformations.RewriteRuleGrowth.Unknown : AngouriMath.Core.Transformations.RewriteRuleGrowth
 AngouriMath.Core.Transformations.RewriteRuleGrowth.value__ : System.Int32
 AngouriMath.Core.Transformations.RewriteRuleSet.ApplyOnce(AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Core.Transformations.RewriteRuleSet.AsTransformation() : AngouriMath.Core.Transformations.Transformation

--- a/Sources/Tests/UnitTests/Core/Transformations/AddressableRulesTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/AddressableRulesTest.cs
@@ -279,15 +279,17 @@ namespace AngouriMath.Tests.Core.Transformations
             var without = RewriteRules.All.Where(set => set.Rules.Count == 0)
                 .Select(set => set.Name).OrderBy(name => name, StringComparer.Ordinal).ToList();
 
-            // One left, and it is the only reason left: a rewrite written as a procedure --
-            // branches, locals, a conjugate computed and oriented -- with no arms to read. The two
-            // factorial sets were on this list until it turned out they were not that shape at
-            // all: each was a switch that a statement body and a local function had put out of
-            // reach, and lifting the local function out was the whole of it.
-            Assert.Equal(new[] { "RationalizeDenominator" }, without);
+            // None left. RationalizeDenominator was the last, and it was the only one whose
+            // reason was real: a rewrite written as a procedure -- branches, locals, a conjugate
+            // computed and oriented -- with no arms for the generator to read. It did not become
+            // a `switch`; its rules are read from its data form instead, through
+            // MatchedRuleSet.AsAddressable, which is the other half of #825. The two factorial
+            // sets were on this list before it, and were not that shape at all: each was a switch
+            // that a statement body and a local function had put out of reach.
+            Assert.Empty(without);
 
-            Assert.Equal(29, withRules.Count);
-            Assert.Equal(405, withRules.Sum(set => set.Rules.Count));
+            Assert.Equal(30, withRules.Count);
+            Assert.Equal(407, withRules.Sum(set => set.Rules.Count));
         }
 
         /// <summary>
@@ -385,14 +387,20 @@ namespace AngouriMath.Tests.Core.Transformations
             Assert.Equal(step.After, step.Rule.TryApply(step.Before));
         }
 
+        /// <summary>
+        /// The set that used to have no addressable rules now names the one that fired.
+        /// </summary>
+        /// <remarks>
+        /// This test asserted the opposite until <c>RationalizeDenominator</c> became data: that a
+        /// set with no arms still records its step, with <c>step.Rule</c> null. It carried a note
+        /// saying the premise was stated rather than assumed, <i>"if this set ever becomes
+        /// addressable the test would otherwise keep passing while testing nothing at all"</i> —
+        /// which is exactly what happened, and the note is why it failed rather than went quiet.
+        /// </remarks>
         [Fact]
-        public void ASetWithNoAddressableRulesStillRecordsItsStep()
+        public void TheLastSetWithoutArmsNowNamesTheRuleThatFired()
         {
-            // Stated rather than assumed: if this set ever becomes addressable the test would
-            // otherwise keep passing while testing nothing at all. It has already happened twice
-            // -- CanonicalOrderExact, then InvertNegativePowers, then CollapseMultipleFractions --
-            // so the assertion is load-bearing rather than decorative.
-            Assert.Empty(RewriteRules.RationalizeDenominator.Rules);
+            Assert.NotEmpty(RewriteRules.RationalizeDenominator.Rules);
 
             using var recording = RewriteRecording.Start();
             RewriteRules.RationalizeDenominator.ApplyOnce("1 / (3 - sqrt(5))".ToEntity());
@@ -400,7 +408,12 @@ namespace AngouriMath.Tests.Core.Transformations
 
             var step = Assert.Single(recording.Steps);
             Assert.Equal(RewriteRules.RationalizeDenominator, step.RuleSet);
-            Assert.Null(step.Rule);
+            Assert.NotNull(step.Rule);
+            Assert.Equal("a-two-term-denominator-is-multiplied-by-its-conjugate", step.Rule!.Name);
+            // Rendered from the pattern rather than copied from source text, which is what a rule
+            // written as data has instead of a `switch` arm's syntax.
+            Assert.Equal("Divf(var num, var den)", step.Rule.PatternSource);
+            Assert.Equal(RewriteRuleGrowth.Unknown, step.Rule.Growth);
         }
     }
 }

--- a/Sources/Tests/UnitTests/Core/Transformations/MatchedRulesAgreeWithTheSwitchTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/MatchedRulesAgreeWithTheSwitchTest.cs
@@ -278,6 +278,22 @@ namespace AngouriMath.Tests.Core.Transformations
                 });
 
         /// <summary>
+        /// The set that had no addressable rules at all, because it is an ordinary method with
+        /// branches and locals rather than a <c>switch</c>. Its two rules now come from the data
+        /// form, and this is what says the data form does what the method does.
+        /// </summary>
+        [Fact]
+        public void RationalizeDenominatorAsDataMatchesTheSwitch()
+            => AssertAgrees("RationalizeDenominator", Patterns.RationalizeDenominator,
+                MatchedRules.RationalizeDenominator, leastFirings: 8, extra: new[]
+                {
+                    "1 / (3 - sqrt(5))", "2 / (3 - sqrt(5))", "1 / (5 + sqrt(3))",
+                    "(5 - sqrt(3)) / (5 + sqrt(3))", "1 / (1 + sqrt(2))", "3 / (2 + sqrt(7))",
+                    "1 / (x + sqrt(2))", "1 / (2 + 3)", "sqrt(2) / (1 + sqrt(2))",
+                    "1/2 * (sqrt(2) / 3)", "1/2 * (x / 3)",
+                });
+
+        /// <summary>
         /// A predicate on a hole that is a mathematical property rather than a sign or a type.
         /// The corpus reaches it rarely, so the shapes are given here as well — a set that fires
         /// four times over a generated corpus is worth checking against cases chosen for it.

--- a/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
@@ -108,6 +108,7 @@ namespace AngouriMath.Tests.Core.Transformations
                 {
                     "a-negative-factor-in-a-sum-becomes-a-difference: ReplacementIsCode",
                     "a-negative-integer-power-becomes-a-reciprocal: ReplacementIsCode",
+                    "a-numeric-coefficient-is-gathered-over-a-surd: ReplacementIsCode",
                     "a-plain-factorial-times-the-next-term: ReplacementIsCode",
                     "a-quotient-of-a-plain-factorial-by-a-shifted-one: ReplacementIsCode",
                     "a-quotient-of-a-shifted-factorial-by-a-plain-one: ReplacementIsCode",
@@ -117,6 +118,7 @@ namespace AngouriMath.Tests.Core.Transformations
                     "a-shifted-factorial-times-a-bare-term: ReplacementIsCode",
                     "a-shifted-factorial-times-the-next-term: ReplacementIsCode",
                     "a-sum-or-difference-that-is-a-perfect-square: ReplacementIsCode",
+                    "a-two-term-denominator-is-multiplied-by-its-conjugate: ReplacementIsCode",
                     "cosine-of-a-whole-multiple-of-an-angle: ReplacementIsCode",
                     "eulers-totient-of-a-prime-power: ReplacementIsCode",
                     "sine-of-a-whole-multiple-of-an-angle: ReplacementIsCode",


### PR DESCRIPTION
`RationalizeDenominator` is an ordinary method with branches and locals — a conjugate computed and oriented — rather than a `switch`, so `RuleRegistryGenerator` declines it. It was **the one set in the registry with zero addressable rules**: nothing about it could be listed, named in a report, or attributed when it fired.

That is the other half of [#825](https://github.com/asc-community/AngouriMath/issues/825), approached from the opposite side. The generator's problem is reading a `switch`'s arms; a set written as **data** has its rules as values already, so what was missing was only their *rendering*.

## `MatchedRuleSet.AsAddressable()`

Everything in the resulting `RewriteRule` is read off the rule rather than restated:

- **the pattern and the replacement render themselves** — `MatchPattern` gains a `ToString` that says `Divf(var num, var den)` rather than a type name;
- **the line comes from the compiler** — `MatchedRule` takes `[CallerLineNumber]`, so a data rule has a real source location the way an arm does;
- **the node type** comes from what the pattern requires at its root.

A side condition is a delegate and cannot be quoted, so it is reported as *being there* rather than guessed at.

## `RewriteRuleGrowth` gains `Unknown`

A replacement written as code is not written down, so there is nothing to count. Reporting such a rule as `Rearranges` — the middle of the three, the one that reads as harmless — would be **a claim about a rewrite nobody measured**.

Additive; recorded in `BREAKING-CHANGES.md` with what it costs a caller who `switch`es over the enum with no default arm.

## Two tests were pinning this gap, and both failed

Both said in as many words that their premise was stated rather than assumed:

> *"Stated rather than assumed: if this set ever becomes addressable the test would otherwise keep passing while testing nothing at all. It has already happened twice […] so the assertion is load-bearing rather than decorative."*

That is exactly what happened. `TheRegistryIsAddressableAsFarAsItSaysItIs` now asserts the list is **empty** — 30 of 30 sets addressable, 407 rules — and the second is rewritten to assert the improvement: the step now names `a-two-term-denominator-is-multiplied-by-its-conjugate` where it used to assert `step.Rule` was null.

The set is split into its two rules so the data form calls **the same code** the method does rather than a copy, and the agreement test checks that it does.

Full suite: `Failed: 0, Passed: 8618, Skipped: 14, Total: 8632`.

*(One run showed a limit test hitting its 30 s cap; it passes alone in 6 s for all eight cases and the suite is green on a re-run, so that was contention on a machine that has been running benchmarks all day.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd