### PR TITLE
Three sets at once, and the first set that should not be data

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -1680,5 +1680,150 @@ namespace AngouriMath.Core.Transformations.Matching
                                      && interval.Right == Real.PositiveInfinity),
                 bound => Set.SpecialSet.Create(((Set.Interval)bound["i"]).Codomain),
                 Soundness.Sound));
+
+        /// <summary>
+        /// <see cref="Functions.Patterns.SortRules"/>, as data — one set per sort level.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>The first set here that is parameterised by something other than the expression.</b>
+        /// A <c>switch</c> takes that as a second argument and closes over it; a set of rules
+        /// closes over it too, but the set itself then has to be built per value rather than
+        /// declared once.
+        /// </para>
+        /// <para>
+        /// <b>And it is not wired, because the exchange is not free here — measured.</b> The
+        /// three canonical orders are the <i>normalisation</i>: they run on every node of every
+        /// simplification pass, where every other set converted so far fires on a shape. Paying
+        /// matcher dispatch there costs <b>+48% of <c>SimplifyEasy</c></b> (0.128 → 0.190 ms over
+        /// five samples each), which the kernel performance gate reports as 4.14x on a shared
+        /// runner. <see cref="CommonDenominator"/>, exchanged in the same change, is
+        /// <b>−0.8%</b>; the attribution is that clean.
+        /// </para>
+        /// <para>
+        /// Giving each rule a concrete root type instead of a predicate over
+        /// <c>Any&lt;Entity&gt;</c> was tried first, on the reading that a hole typed
+        /// <c>Entity</c> matches every node before its predicate is consulted and so defeats the
+        /// root-type dispatch. It moved +52% to +48%, so that was not the cost either: what costs
+        /// is the per-node dispatch itself, and no arrangement of these seven rules avoids it.
+        /// </para>
+        /// <para>
+        /// So this stays here, proven to agree with the <c>switch</c> at every level, and the
+        /// <c>switch</c> keeps running. It is the first set where the answer to "should this be
+        /// data?" is no, and the reason is a number rather than a preference.
+        /// </para>
+        /// <para>
+        /// Every rule is a bare type test with the whole node bound, which is a typed hole — and
+        /// two of the seven test <i>two</i> types, a sum being either <c>Sumf</c> or
+        /// <c>Minusf</c> and a product either <c>Mulf</c> or <c>Divf</c>, which is the predicate
+        /// on a hole again. All seven replacements are code: sorting a chain is not a tree
+        /// written down.
+        /// </para>
+        /// </remarks>
+        internal static MatchedRuleSet Sort(TreeAnalyzer.SortLevel level) => new(
+            nameof(Sort) + "." + level,
+
+            // A sum chain is either spelling, and each is its own rule rather than one rule over
+            // `Sumf or Minusf`. A predicate on a hole of type Entity matches every node in the
+            // tree before the predicate is consulted, which defeats the root-type dispatch that
+            // makes a miss cheap -- and this set runs on every node of every pass, so that is
+            // the difference between an exchange that is free and one that is not.
+            new MatchedRule(
+                "a-sum-chain-is-sorted-and-grouped",
+                MatchPattern.Any<Sumf>("x"),
+                (node, _) => Functions.Patterns.SortAndGroup(
+                    node, Sumf.LinearChildren(node), level, (a, b) => a + b),
+                Soundness.SoundUnderAssumptions),
+
+            new MatchedRule(
+                "a-difference-chain-is-sorted-and-grouped",
+                MatchPattern.Any<Minusf>("x"),
+                (node, _) => Functions.Patterns.SortAndGroup(
+                    node, Sumf.LinearChildren(node), level, (a, b) => a + b),
+                Soundness.SoundUnderAssumptions),
+
+            new MatchedRule(
+                "a-product-chain-is-sorted-and-grouped",
+                MatchPattern.Any<Mulf>("x"),
+                (node, _) => Functions.Patterns.SortAndGroup(
+                    node, Mulf.LinearChildren(node), level, (a, b) => a * b),
+                // Regrouping reads a quotient as a product with a negative power, which is the
+                // same value wherever the divisor is not zero.
+                Soundness.SoundUnderAssumptions),
+
+            new MatchedRule(
+                "a-quotient-chain-is-sorted-and-grouped",
+                MatchPattern.Any<Divf>("x"),
+                (node, _) => Functions.Patterns.SortAndGroup(
+                    node, Mulf.LinearChildren(node), level, (a, b) => a * b),
+                Soundness.SoundUnderAssumptions),
+
+            new MatchedRule(
+                "a-conjunction-chain-is-sorted-and-grouped",
+                MatchPattern.Any<Andf>("x"),
+                (node, _) => Functions.Patterns.SortAndGroup(
+                    node, Andf.LinearChildren(node), level, (a, b) => a & b),
+                Soundness.Sound),
+
+            new MatchedRule(
+                "a-disjunction-chain-is-sorted-and-grouped",
+                MatchPattern.Any<Orf>("x"),
+                (node, _) => Functions.Patterns.SortAndGroup(
+                    node, Orf.LinearChildren(node), level, (a, b) => a | b),
+                Soundness.Sound),
+
+            new MatchedRule(
+                "a-union-chain-is-sorted-and-grouped",
+                MatchPattern.Any<Set.Unionf>("x"),
+                (node, _) => Functions.Patterns.SortAndGroup(
+                    node, Set.Unionf.LinearChildren(node), level, (a, b) => a.Unite(b)),
+                Soundness.Sound),
+
+            new MatchedRule(
+                "an-intersection-chain-is-sorted-and-grouped",
+                MatchPattern.Any<Set.Intersectionf>("x"),
+                (node, _) => Functions.Patterns.SortAndGroup(
+                    node, Set.Intersectionf.LinearChildren(node), level, (a, b) => a.Intersect(b)),
+                Soundness.Sound),
+
+            new MatchedRule(
+                "an-exclusive-disjunction-chain-is-sorted-and-grouped",
+                MatchPattern.Any<Xorf>("x"),
+                (node, _) => Functions.Patterns.SortAndGroup(
+                    node, Xorf.LinearChildren(node), level, (a, b) => a ^ b),
+                Soundness.Sound));
+
+        /// <summary>
+        /// <see cref="Functions.Patterns.FractionCommonDenominatorRules"/>, as data — again one
+        /// set per sort level.
+        /// </summary>
+        internal static MatchedRuleSet CommonDenominator(TreeAnalyzer.SortLevel level) => new(
+            nameof(CommonDenominator) + "." + level,
+
+            new MatchedRule(
+                "two-added-fractions-take-a-common-denominator",
+                MatchPattern.Node<Sumf>(
+                    MatchPattern.Node<Divf>(MatchPattern.Any("ln"), MatchPattern.Any("ld")),
+                    MatchPattern.Node<Divf>(MatchPattern.Any("rn"), MatchPattern.Any("rd"))),
+                (node, bound) => Functions.Patterns.SumOfFractions(
+                    node, bound["ln"], bound["ld"], bound["rn"], bound["rd"]),
+                Soundness.SoundUnderAssumptions),
+
+            new MatchedRule(
+                "two-subtracted-fractions-take-a-common-denominator",
+                MatchPattern.Node<Minusf>(
+                    MatchPattern.Node<Divf>(MatchPattern.Any("ln"), MatchPattern.Any("ld")),
+                    MatchPattern.Node<Divf>(MatchPattern.Any("rn"), MatchPattern.Any("rd"))),
+                (node, bound) => Functions.Patterns.SumOfFractions(
+                    node, bound["ln"], bound["ld"], -bound["rn"], bound["rd"]),
+                Soundness.SoundUnderAssumptions),
+
+            new MatchedRule(
+                "a-quotient-of-symbolic-parts-is-grouped-pairwise",
+                MatchPattern.Node<Divf>(MatchPattern.Any("num"), MatchPattern.Any("den")),
+                (node, bound) => Functions.Patterns.PairwiseGroupedQuotient(
+                    node, bound["num"], bound["den"], level),
+                Soundness.SoundUnderAssumptions,
+                when: bound => bound["num"].Vars.Any() && bound["den"].Vars.Any()));
     }
 }

--- a/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
@@ -300,7 +300,7 @@ namespace AngouriMath.Core.Transformations
             "Adds quotients by putting them over a common denominator.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            expr => Patterns.FractionCommonDenominatorRules(expr, TreeAnalyzer.SortLevel.HIGH_LEVEL),
+            Matching.MatchedRules.CommonDenominator(TreeAnalyzer.SortLevel.HIGH_LEVEL).ApplyHere,
             Patterns.FractionCommonDenominatorRulesArms(TreeAnalyzer.SortLevel.HIGH_LEVEL));
 
         /// <summary>
@@ -311,7 +311,7 @@ namespace AngouriMath.Core.Transformations
             "Adds quotients over a common denominator, distinguishing terms by their constants too.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            expr => Patterns.FractionCommonDenominatorRules(expr, TreeAnalyzer.SortLevel.MIDDLE_LEVEL),
+            Matching.MatchedRules.CommonDenominator(TreeAnalyzer.SortLevel.MIDDLE_LEVEL).ApplyHere,
             Patterns.FractionCommonDenominatorRulesArms(TreeAnalyzer.SortLevel.MIDDLE_LEVEL));
 
         /// <summary>
@@ -322,7 +322,7 @@ namespace AngouriMath.Core.Transformations
             "Adds quotients over a common denominator, grouping terms by the whole subtree.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            expr => Patterns.FractionCommonDenominatorRules(expr, TreeAnalyzer.SortLevel.LOW_LEVEL),
+            Matching.MatchedRules.CommonDenominator(TreeAnalyzer.SortLevel.LOW_LEVEL).ApplyHere,
             Patterns.FractionCommonDenominatorRulesArms(TreeAnalyzer.SortLevel.LOW_LEVEL));
 
         /// <summary>

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Rational.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Rational.cs
@@ -13,7 +13,8 @@ namespace AngouriMath.Functions
 {
     partial class Patterns
     {
-        private static Entity SumOfFractions(Entity expr,
+        /// <remarks>Internal so the data form of this set calls it rather than repeating it.</remarks>
+        internal static Entity SumOfFractions(Entity expr,
             Entity leftNum, Entity leftDen, Entity rightNum, Entity rightDen)
         {
             // a/d + b/d = (a + b)/d. Cross-multiplying instead builds d*d and leaves the
@@ -65,9 +66,19 @@ namespace AngouriMath.Functions
                 Minusf(Divf(var leftNum, var leftDen), Divf(var rightNum, var rightDen))
                     => SumOfFractions(expr, leftNum, leftDen, -rightNum, rightDen),
                 Divf(var num, var den) when num.Vars.Any() && den.Vars.Any()
-                    => PairwiseGrouping(num, den, level).Select(PowerRules).MultiplyAll().InnerSimplified.Replace(CollapseMultipleFractions),
+                    => PairwiseGroupedQuotient(expr, num, den, level),
                 _ => expr
             };
+
+        /// <summary>
+        /// The quotient regrouped pairwise, its factors put through the power rules and
+        /// multiplied back. A method of its own so that the data form of this set calls the same
+        /// code rather than a copy of it.
+        /// </summary>
+        internal static Entity PairwiseGroupedQuotient(
+            Entity whole, Entity num, Entity den, TreeAnalyzer.SortLevel level)
+            => PairwiseGrouping(num, den, level).Select(PowerRules).MultiplyAll()
+                .InnerSimplified.Replace(CollapseMultipleFractions);
 
         /// <summary>n^(p/q) for a q of 2 or more -- a root that is not a whole power.</summary>
         private static bool IsSurd(Entity node)

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.cs
@@ -13,7 +13,8 @@ namespace AngouriMath.Functions
 {
     internal static partial class Patterns
     {
-        private static Entity SortAndGroup(Entity original, IEnumerable<Entity> children, TreeAnalyzer.SortLevel level, Func<Entity, Entity, Entity> ctor)
+        /// <remarks>Internal so the data form of this set calls it rather than repeating it.</remarks>
+        internal static Entity SortAndGroup(Entity original, IEnumerable<Entity> children, TreeAnalyzer.SortLevel level, Func<Entity, Entity, Entity> ctor)
         {
             var groups = new Dictionary<string, List<Entity>>();
             foreach (var child in children)

--- a/Sources/Tests/UnitTests/Core/Transformations/MatchedRulesAgreeWithTheSwitchTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/MatchedRulesAgreeWithTheSwitchTest.cs
@@ -430,6 +430,42 @@ namespace AngouriMath.Tests.Core.Transformations
                 });
 
         /// <summary>
+        /// <b>The first sets parameterised by something other than the expression</b>, and the
+        /// pair that unblocks six registry entries between them: three canonical orders and three
+        /// common-denominator variants, one per sort level.
+        /// </summary>
+        /// <remarks>
+        /// Checked at every level, because the level is what the rules close over and a set built
+        /// for one is not evidence about another.
+        /// </remarks>
+        // The level is an internal enum, so the theory carries its ordinal: a public test method
+        // cannot take it as a parameter.
+        private static TreeAnalyzer.SortLevel Level(int ordinal) => (TreeAnalyzer.SortLevel)ordinal;
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void SortAsDataMatchesTheSwitch(int ordinal)
+        {
+            var level = Level(ordinal);
+            AssertAgrees($"Sort.{level}", Patterns.SortRules(level),
+                MatchedRules.Sort(level), leastFirings: 100);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void CommonDenominatorAsDataMatchesTheSwitch(int ordinal)
+        {
+            var level = Level(ordinal);
+            AssertAgrees($"CommonDenominator.{level}",
+                expr => Patterns.FractionCommonDenominatorRules(expr, level),
+                MatchedRules.CommonDenominator(level), leastFirings: 50);
+        }
+
+        /// <summary>
         /// A predicate on a hole that is a mathematical property rather than a sign or a type.
         /// The corpus reaches it rarely, so the shapes are given here as well — a set that fires
         /// four times over a generated corpus is worth checking against cases chosen for it.

--- a/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
@@ -12,6 +12,7 @@ using System.Reflection;
 using AngouriMath.Core.Transformations;
 using AngouriMath.Core.Transformations.Matching;
 using AngouriMath.Extensions;
+using AngouriMath.Functions;
 using Xunit;
 using static AngouriMath.Entity;
 using static AngouriMath.Entity.Number;
@@ -46,11 +47,28 @@ namespace AngouriMath.Tests.Core.Transformations
         /// at run time from a rule that did not apply.
         /// </remarks>
         private static IEnumerable<MatchedRuleSet> DataRuleSets()
-            => typeof(MatchedRules)
-                .GetProperties(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
+        {
+            const BindingFlags Any = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static;
+            var sets = typeof(MatchedRules)
+                .GetProperties(Any)
                 .Where(property => property.PropertyType == typeof(MatchedRuleSet))
-                .Select(property => (MatchedRuleSet)property.GetValue(null)!)
-                .OrderBy(set => set.Name, StringComparer.Ordinal);
+                .Select(property => (MatchedRuleSet)property.GetValue(null)!);
+
+            // A set parameterised by a sort level is a *method*, not a property, so enumerating
+            // properties alone stopped covering the file the moment the first one was written --
+            // the same failure as the hand-written list this replaced, one shape further along.
+            // Each is asked for at every level, because the level is what its rules close over.
+            var factories = typeof(MatchedRules)
+                .GetMethods(Any)
+                .Where(method => method.ReturnType == typeof(MatchedRuleSet)
+                                 && method.GetParameters() is { Length: 1 } only
+                                 && only[0].ParameterType == typeof(TreeAnalyzer.SortLevel));
+            foreach (var factory in factories)
+                foreach (var level in Enum.GetValues(typeof(TreeAnalyzer.SortLevel)))
+                    sets = sets.Append((MatchedRuleSet)factory.Invoke(null, new[] { level })!);
+
+            return sets.OrderBy(set => set.Name, StringComparer.Ordinal);
+        }
 
         private static readonly string[] Leaves = { "x", "y", "z", "2", "-1", "1/2", "1", "0" };
 
@@ -89,13 +107,20 @@ namespace AngouriMath.Tests.Core.Transformations
         [Fact]
         public void EveryDataRuleIsClassifiedAsWritten()
         {
+            // Not a dictionary keyed by name: a set parameterised by a sort level exists three
+            // times over, so one rule name appears three times with the same classification.
+            // Keying by name threw, which is the enumeration having grown a shape the assertion
+            // had not.
             var actual = DataRuleSets()
                 .SelectMany(set => set.Rules)
-                .ToDictionary(rule => rule.Name, rule => rule.Reversal);
+                .Select(rule => (rule.Name, rule.Reversal))
+                .Distinct()
+                .ToList();
 
-            var oneWay = actual.Where(pair => pair.Value is not RuleReversal.Reversible)
-                .OrderBy(pair => pair.Key, StringComparer.Ordinal)
-                .Select(pair => $"{pair.Key}: {pair.Value}")
+            var oneWay = actual.Where(pair => pair.Reversal is not RuleReversal.Reversible)
+                .Select(pair => $"{pair.Name}: {pair.Reversal}")
+                .Distinct()
+                .OrderBy(one => one, StringComparer.Ordinal)
                 .ToArray();
 
             // Named one by one and with the reason, so that a rule losing or gaining a direction
@@ -109,6 +134,7 @@ namespace AngouriMath.Tests.Core.Transformations
                     "a-common-factor-is-collected-out-of-a-whole-sum: ReplacementIsCode",
                     "a-conditional-set-whose-condition-is-its-own-membership-is-that-set: ReplacementIsCode",
                     "a-conjunction-absorbs-a-disjunction-it-shares-an-operand-with: ReplacementIsCode",
+                    "a-conjunction-chain-is-sorted-and-grouped: ReplacementIsCode",
                     "a-conjunction-drops-a-negated-copy-of-its-other-operand: ReplacementIsCode",
                     "a-conjunction-of-disjunctions-sharing-an-operand-distributes: ReplacementIsCode",
                     "a-conjunction-of-negations-is-a-negated-disjunction: ReplacementIsCode",
@@ -117,9 +143,11 @@ namespace AngouriMath.Tests.Core.Transformations
                     "a-cosecant-times-a-sine-of-one-angle-is-one: ReplacementIsCode",
                     "a-cosine-of-an-arccosine: PatternCannotBeBuilt",
                     "a-cotangent-of-an-arccotangent: PatternCannotBeBuilt",
+                    "a-difference-chain-is-sorted-and-grouped: ReplacementIsCode",
                     "a-difference-of-even-powers-splits: ReplacementIsCode",
                     "a-difference-of-two-negatives-turns-round: ReplacementIsCode",
                     "a-disjunction-absorbs-a-conjunction-it-shares-an-operand-with: ReplacementIsCode",
+                    "a-disjunction-chain-is-sorted-and-grouped: ReplacementIsCode",
                     "a-disjunction-drops-a-negated-copy-of-its-other-operand: ReplacementIsCode",
                     "a-disjunction-of-conjunctions-sharing-an-operand-distributes: ReplacementIsCode",
                     "a-disjunction-of-negations-is-a-negated-conjunction: ReplacementIsCode",
@@ -142,15 +170,18 @@ namespace AngouriMath.Tests.Core.Transformations
                     "a-negative-subtracted-is-added: ReplacementIsCode",
                     "a-numeric-coefficient-is-gathered-over-a-surd: ReplacementIsCode",
                     "a-plain-factorial-times-the-next-term: ReplacementIsCode",
+                    "a-product-chain-is-sorted-and-grouped: ReplacementIsCode",
                     "a-product-of-two-negatives-is-positive: ReplacementIsCode",
                     "a-product-subtracted-from-its-own-factor: ReplacementIsCode",
                     "a-quotient-by-a-cosecant-is-a-sine: ReplacementIsCode",
                     "a-quotient-by-a-secant-is-a-cosine: ReplacementIsCode",
+                    "a-quotient-chain-is-sorted-and-grouped: ReplacementIsCode",
                     "a-quotient-of-a-plain-factorial-by-a-shifted-one: ReplacementIsCode",
                     "a-quotient-of-a-shifted-factorial-by-a-plain-one: ReplacementIsCode",
                     "a-quotient-of-polynomials-is-divided-out: ReplacementIsCode",
                     "a-quotient-of-polynomials-is-put-in-lowest-terms: ReplacementIsCode",
                     "a-quotient-of-shifted-factorials: ReplacementIsCode",
+                    "a-quotient-of-symbolic-parts-is-grouped-pairwise: ReplacementIsCode",
                     "a-quotient-of-two-negatives-is-positive: ReplacementIsCode",
                     "a-secant-times-a-cosine-of-one-angle-is-one: ReplacementIsCode",
                     "a-set-less-itself-is-empty: ReplacementIsCode",
@@ -167,6 +198,7 @@ namespace AngouriMath.Tests.Core.Transformations
                     "a-statement-differs-from-itself-nowhere: ReplacementIsCode",
                     "a-statement-implies-itself: ReplacementIsCode",
                     "a-statement-or-its-negation-is-true-where-it-has-a-truth-value: ReplacementIsCode",
+                    "a-sum-chain-is-sorted-and-grouped: ReplacementIsCode",
                     "a-sum-of-two-negatives-is-a-negated-sum: ReplacementIsCode",
                     "a-sum-or-difference-that-is-a-perfect-square: ReplacementIsCode",
                     "a-tangent-of-an-arctangent: PatternCannotBeBuilt",
@@ -175,12 +207,15 @@ namespace AngouriMath.Tests.Core.Transformations
                     "a-term-shared-with-a-product-added-to-it-comes-out: ReplacementIsCode",
                     "a-term-subtracted-from-itself-vanishes: ReplacementIsCode",
                     "a-two-term-denominator-is-multiplied-by-its-conjugate: ReplacementIsCode",
+                    "a-union-chain-is-sorted-and-grouped: ReplacementIsCode",
                     "a-union-with-itself-is-itself: PatternCannotBeBuilt",
                     "an-arccosecant-of-a-numeric-reciprocal-is-an-arcsine: ReplacementIsCode",
                     "an-arccosine-of-a-numeric-reciprocal-is-an-arcsecant: ReplacementIsCode",
                     "an-arcsecant-of-a-numeric-reciprocal-is-an-arccosine: ReplacementIsCode",
                     "an-arcsine-of-a-numeric-reciprocal-is-an-arccosecant: ReplacementIsCode",
+                    "an-exclusive-disjunction-chain-is-sorted-and-grouped: ReplacementIsCode",
                     "an-implication-between-negations-turns-round: ReplacementIsCode",
+                    "an-intersection-chain-is-sorted-and-grouped: ReplacementIsCode",
                     "an-intersection-distributes-over-a-union-on-its-left: ReplacementIsCode",
                     "an-intersection-distributes-over-a-union-on-its-right: ReplacementIsCode",
                     "an-intersection-with-itself-is-itself: PatternCannotBeBuilt",
@@ -206,8 +241,10 @@ namespace AngouriMath.Tests.Core.Transformations
                     "the-arctangent-of-one-over-root-three: ReplacementIsCode",
                     "the-arctangent-of-root-three: ReplacementIsCode",
                     "the-two-truth-values-are-the-boolean-domain: ReplacementIsCode",
+                    "two-added-fractions-take-a-common-denominator: ReplacementIsCode",
                     "two-arctangents-of-numbers-add-by-the-tangent-formula: ReplacementIsCode",
                     "two-powers-of-one-exponent-share-a-base: ReplacementIsCode",
+                    "two-subtracted-fractions-take-a-common-denominator: ReplacementIsCode",
                 },
                 oneWay);
         }


### PR DESCRIPTION
`CommonDenominator`, `CommonDenominatorCountingConstants` and `CommonDenominatorExact` run on the matcher — one rule set asked at three sort levels, and the first set here **parameterised by something other than the expression**. A `switch` takes the level as a second argument and closes over it; a set of rules closes over it too, but *the set itself* must then be built per value, so `MatchedRules` gains factories where the rest are properties.

`Sort` — the three canonical orders — is expressed here too, **proven to agree with its `switch` at every level, and deliberately not wired.**

## The performance gate failed the first version of this, and it was right

It reported `SimplifyEasy` at **4.14x** on a shared runner. Everything else in that table was 1.4–1.8x, which reads like a slower machine — the runner had half the cores of the baseline's. So I measured locally, three arms in one process, five samples each:

| | `SimplifyEasy` | |
|---|--:|--:|
| master | 0.128 ms | |
| `Sort` + `CommonDenominator` | 0.190 ms | **+48%** |
| `CommonDenominator` alone | 0.127 ms | **−0.8%** |

**The whole of the cost is the canonical orders**, and the attribution is that clean. Which is what they are: the *normalisation* runs on every node of every pass, where every other set converted so far fires on a shape.

## The obvious fix was tried and was not the cost

Giving each sort rule a concrete root type rather than a predicate over `Any<Entity>` — on the reading that a hole typed `Entity` matches every node before its predicate is consulted, defeating the root-type dispatch. It moved **+52% to +48%**. Recorded as tried rather than quietly dropped: what costs is the per-node dispatch itself, and no arrangement of those seven rules avoids it.

So this is **the first set where the answer to "should this be data?" is no**, and the reason is a number rather than a preference. It stays in the file with the measurement written against it, because the next person to ask will otherwise ask by trying it again.

## Two tests had to grow, both because a factory is not a property

`DataRuleSets()` enumerated *properties* and silently stopped covering the file the moment the first factory existed — the same failure as the hand-written list of five it replaced. And the reversal classification was keyed by rule name, which threw once one name existed three times over.

Full suite: `Failed: 0, Passed: 8626, Skipped: 14, Total: 8640`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd