### PR TITLE
Thirty-five arms become thirty: Power is data (#746)

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -2193,5 +2193,355 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<LessOrEqualf>(MatchPattern.Any("a"), MatchPattern.Any("a")),
                 bound => Entity.Boolean.True.Provided(bound["a"].DomainCondition).Provided(Functions.Patterns.OrderedConditionFor(bound["a"])),
                 Soundness.SoundUnderAssumptions));
+
+        /// <summary>
+        /// <see cref="Functions.Patterns.PowerRules"/>, as data.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>The largest set converted so far, and the one whose rules are least alike.</b> It
+        /// carries the branch-cut guards that <a
+        /// href="https://github.com/asc-community/AngouriMath/issues/752">#752</a>, <a
+        /// href="https://github.com/asc-community/AngouriMath/issues/801">#801</a>, <a
+        /// href="https://github.com/asc-community/AngouriMath/issues/802">#802</a>, <a
+        /// href="https://github.com/asc-community/AngouriMath/issues/902">#902</a> and <a
+        /// href="https://github.com/asc-community/AngouriMath/issues/721">#721</a> each put on one
+        /// rewrite, and those guards are the reason nearly every rule here is
+        /// <see cref="Soundness.SoundUnderAssumptions"/> rather than
+        /// <see cref="Soundness.Sound"/>: the identity is true, and it is true on a region.
+        /// </para>
+        /// <para>
+        /// The conditions stay where they were — <c>Patterns.Power.cs</c> holds
+        /// <c>MayTakeLogOfPower</c>, <c>MayGatherLogarithms</c> and <c>ReduceRadical</c>, and the
+        /// rules here ask them. Copying a branch-cut condition into a second file is how the two
+        /// copies come to disagree, and one of them has already been wrong in both directions at
+        /// once.
+        /// </para>
+        /// <para>
+        /// <para>
+        /// <b>Two commutative rules stand for six arms here, and that is affordable only because
+        /// of <a href="https://github.com/asc-community/AngouriMath/issues/1079">#1079</a>.</b>
+        /// A commutative pattern is not <see cref="MatchPattern.IsDeterministic"/>, and before
+        /// bounded matching that meant enumerating its two candidates through an iterator state
+        /// machine per pattern node, at every node of every pass: 165.05 MB to 171.37 MB on
+        /// <c>SolveMediumHard</c>, +3.8%, past the kernel gate's 3% allocation band. Walked by
+        /// index instead, the same two rules cost +0.94% and the six arms need not be written out.
+        /// </para>
+        /// Two rules read something a <see cref="Bindings"/> cannot carry. <c>log_b(b) = 1</c>
+        /// needs the <i>node's</i> own <c>DomainCondition</c> rather than a condition written out
+        /// here, and takes the overload that is handed the matched node; and the radical reduction
+        /// asks <c>ReduceRadical</c> in both its <c>when</c> and its replacement, because whether
+        /// the rule applies and what it produces are the same computation.
+        /// </para>
+        /// </remarks>
+        internal static MatchedRuleSet Power { get; } = new(
+            nameof(Power),
+
+            new MatchedRule(
+                "a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero",
+                MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("a")),
+                bound => new Providedf(1, !bound["a"].EqualTo(0)),
+                Soundness.SoundUnderAssumptions),
+
+            new MatchedRule(
+                "a-power-whose-exponent-divides-by-a-logarithm-of-its-own-base-changes-base",
+                MatchPattern.Node<Powf>(
+                    MatchPattern.Any("a"),
+                    MatchPattern.Node<Divf>(
+                        MatchPattern.Any("n"),
+                        MatchPattern.Node<Logf>(MatchPattern.Any("c"), MatchPattern.Any("a")))),
+                bound => new Powf(bound["c"], bound["n"]),
+                Soundness.SoundUnderAssumptions),
+
+            // Both orientations are written out in the `switch`, so one commutative rule fires
+            // exactly where the pair did.
+            new MatchedRule(
+                "a-power-times-its-own-base-raises-the-exponent",
+                MatchPattern.Commutative<Mulf>(
+                    MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("n")),
+                    MatchPattern.Any("a")),
+                bound => new Powf(bound["a"], bound["n"] + 1),
+                Soundness.SoundUnderAssumptions),
+
+            new MatchedRule(
+                "two-powers-of-one-base-multiply-by-adding-exponents",
+                MatchPattern.Node<Mulf>(
+                    MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("n")),
+                    MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("m"))),
+                bound => new Powf(bound["a"], bound["n"] + bound["m"]),
+                Soundness.SoundUnderAssumptions),
+
+            new MatchedRule(
+                "two-powers-of-one-base-divide-by-subtracting-exponents",
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("n")),
+                    MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("m"))),
+                bound => new Powf(bound["a"], bound["n"] - bound["m"]),
+                Soundness.SoundUnderAssumptions),
+
+            // True for a positive base whatever the exponents, and for any base when the outer
+            // exponent is whole. Outside those two it moves the branch, which is what #752
+            // measured: sqrt(x^2) came back as x, and at -0.63 that is the negation.
+            // https://github.com/asc-community/AngouriMath/issues/752
+            new MatchedRule(
+                "a-power-of-a-power-multiplies-the-exponents",
+                MatchPattern.Node<Powf>(
+                    MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("n")),
+                    MatchPattern.Any("m")),
+                bound => new Powf(bound["a"], bound["n"] * bound["m"]),
+                Soundness.SoundUnderAssumptions,
+                when: bound => bound["m"] is Integer
+                               || bound["a"].Evaled is Real { IsPositive: true }),
+
+            // https://github.com/asc-community/AngouriMath/issues/801
+            new MatchedRule(
+                "two-powers-of-one-exponent-share-a-base",
+                MatchPattern.Node<Mulf>(
+                    MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("n")),
+                    MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("n"))),
+                bound => new Powf(bound["a"] * bound["b"], bound["n"]),
+                Soundness.SoundUnderAssumptions,
+                when: bound => bound["n"] is Integer
+                               || (bound["a"].Evaled is Real { IsPositive: true }
+                                   && bound["b"].Evaled is Real { IsPositive: true })),
+
+            // https://github.com/asc-community/AngouriMath/issues/802
+            new MatchedRule(
+                "two-powers-of-one-exponent-share-a-quotient-of-bases",
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("n")),
+                    MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("n"))),
+                bound => new Powf(bound["a"] / bound["b"], bound["n"]),
+                Soundness.SoundUnderAssumptions,
+                when: bound => bound["n"] is Integer
+                               || (bound["a"].Evaled is Real { IsPositive: true }
+                                   && bound["b"].Evaled is Real { IsPositive: true })),
+
+            // The pair the rule above loses whenever only one of the two bases is itself a power,
+            // read back. https://github.com/asc-community/AngouriMath/issues/740
+            new MatchedRule(
+                "a-quotient-of-powers-whose-exponents-differ-by-a-whole-factor-takes-it-into-the-divisor",
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("n")),
+                    MatchPattern.Node<Powf>(
+                        MatchPattern.Any("b"),
+                        MatchPattern.Node<Mulf>(
+                            MatchPattern.Any<Integer>("c", whole => whole.IsPositive),
+                            MatchPattern.Any("n")))),
+                bound => new Powf(bound["a"] / new Powf(bound["b"], bound["c"]), bound["n"]),
+                Soundness.SoundUnderAssumptions),
+
+            new MatchedRule(
+                "a-quotient-of-powers-whose-exponents-differ-by-a-whole-factor-takes-it-into-the-dividend",
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Powf>(
+                        MatchPattern.Any("a"),
+                        MatchPattern.Node<Mulf>(
+                            MatchPattern.Any<Integer>("c", whole => whole.IsPositive),
+                            MatchPattern.Any("n"))),
+                    MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("n"))),
+                bound => new Powf(new Powf(bound["a"], bound["c"]) / bound["b"], bound["n"]),
+                Soundness.SoundUnderAssumptions),
+
+            new MatchedRule(
+                "a-thing-over-a-power-of-itself-is-one-power",
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Any("a"),
+                    MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("n"))),
+                bound => new Powf(bound["a"], 1 - bound["n"]),
+                Soundness.SoundUnderAssumptions),
+
+            new MatchedRule(
+                "a-power-over-its-own-base-lowers-the-exponent",
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("n")),
+                    MatchPattern.Any("a")),
+                bound => new Powf(bound["a"], bound["n"] - 1),
+                Soundness.SoundUnderAssumptions),
+
+            new MatchedRule(
+                "a-number-raised-to-a-logarithm-of-itself-is-the-antilogarithm",
+                MatchPattern.Node<Powf>(
+                    MatchPattern.Any<Number>("c"),
+                    MatchPattern.Node<Logf>(MatchPattern.Any<Number>("c"), MatchPattern.Any("a"))),
+                bound => bound["a"],
+                Soundness.SoundUnderAssumptions),
+
+            // Four `switch` arms: the power on either side of a product, and the shared base in
+            // either position inside it. A commutative pattern says both halves at once.
+            new MatchedRule(
+                "a-power-times-a-product-containing-its-own-base-raises-the-exponent",
+                MatchPattern.Commutative<Mulf>(
+                    MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("n")),
+                    MatchPattern.Commutative<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("rest"))),
+                bound => new Powf(bound["a"], bound["n"] + 1) * bound["rest"],
+                Soundness.SoundUnderAssumptions),
+
+            // Taking a factor out from under a root needs that factor positive, or the root to be
+            // a whole power. https://github.com/asc-community/AngouriMath/issues/752
+            new MatchedRule(
+                "a-numeric-factor-comes-out-of-a-power-of-a-product",
+                MatchPattern.Node<Powf>(
+                    MatchPattern.Node<Mulf>(MatchPattern.Any<Number>("c"), MatchPattern.Any("a")),
+                    MatchPattern.Any<Number>("d")),
+                bound => new Powf(bound["c"], bound["d"]) * new Powf(bound["a"], bound["d"]),
+                Soundness.SoundUnderAssumptions,
+                when: bound => bound["d"] is Integer || bound["c"] is Real { IsPositive: true }),
+
+            new MatchedRule(
+                "a-reciprocal-power-is-a-quotient",
+                MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Exact(Integer.Create(-1))),
+                bound => 1 / bound["a"],
+                Soundness.Sound),
+
+            new MatchedRule(
+                "a-power-of-a-numeric-reciprocal-times-its-own-denominator-lowers-the-exponent",
+                MatchPattern.Node<Mulf>(
+                    MatchPattern.Node<Powf>(
+                        MatchPattern.Node<Divf>(MatchPattern.Any<Number>("c"), MatchPattern.Any("a")),
+                        MatchPattern.Any<Number>("d")),
+                    MatchPattern.Any("a")),
+                // `Number` arithmetic rather than `Entity` arithmetic: the `switch` binds these
+                // as numbers, so `1 - c` folds to a literal there and would build a `Minusf` here.
+                bound => new Powf(bound["c"], bound["d"])
+                    * new Powf(bound["a"], 1 - (Number)bound["d"]),
+                Soundness.SoundUnderAssumptions),
+
+            new MatchedRule(
+                "a-power-of-a-numeric-reciprocal-times-a-power-of-its-own-denominator-subtracts-the-exponents",
+                MatchPattern.Node<Mulf>(
+                    MatchPattern.Node<Powf>(
+                        MatchPattern.Node<Divf>(MatchPattern.Any<Number>("c"), MatchPattern.Any("a")),
+                        MatchPattern.Any<Number>("d")),
+                    MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any<Number>("e"))),
+                bound => new Powf(bound["c"], bound["d"])
+                    * new Powf(bound["a"], (Number)bound["e"] - (Number)bound["d"]),
+                Soundness.SoundUnderAssumptions),
+
+            new MatchedRule(
+                "dividing-twice-by-one-thing-squares-it",
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
+                    MatchPattern.Any("b")),
+                bound => bound["a"] / new Powf(bound["b"], 2),
+                Soundness.SoundUnderAssumptions),
+
+            new MatchedRule(
+                "dividing-by-a-power-and-then-by-its-base-raises-the-exponent",
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Divf>(
+                        MatchPattern.Any("a"),
+                        MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("n"))),
+                    MatchPattern.Any("b")),
+                bound => bound["a"] / new Powf(bound["b"], bound["n"] + 1),
+                Soundness.SoundUnderAssumptions),
+
+            new MatchedRule(
+                "dividing-by-a-thing-and-then-by-a-power-of-it-raises-the-exponent",
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
+                    MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("n"))),
+                bound => bound["a"] / new Powf(bound["b"], bound["n"] + 1),
+                Soundness.SoundUnderAssumptions),
+
+            new MatchedRule(
+                "dividing-by-two-powers-of-one-base-adds-the-exponents",
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Divf>(
+                        MatchPattern.Any("a"),
+                        MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("m"))),
+                    MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("n"))),
+                bound => bound["a"] / new Powf(bound["b"], bound["n"] + bound["m"]),
+                Soundness.SoundUnderAssumptions),
+
+            new MatchedRule(
+                "a-variable-times-a-power-puts-the-power-first",
+                MatchPattern.Node<Mulf>(
+                    MatchPattern.Any<Variable>("v"),
+                    MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("n"))),
+                bound => new Powf(bound["a"], bound["n"]) * bound["v"],
+                Soundness.Sound),
+
+            // https://github.com/asc-community/AngouriMath/issues/902
+            new MatchedRule(
+                "an-exponent-comes-out-of-a-logarithm",
+                MatchPattern.Node<Logf>(
+                    MatchPattern.Any("a"),
+                    MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("n"))),
+                bound => bound["n"] * MathS.Log(bound["a"], bound["b"]),
+                Soundness.SoundUnderAssumptions,
+                when: bound => Functions.Patterns.MayTakeLogOfPower(bound["b"], bound["n"])),
+
+            // The condition to carry is the node's own: log(-3, -3) is 1 where a written-out
+            // `a > 0` calls it undefined, and log(1, 1) is NaN where that guard calls it 1.
+            // https://github.com/asc-community/AngouriMath/issues/721
+            new MatchedRule(
+                "a-logarithm-of-its-own-base-is-one-where-it-is-defined",
+                MatchPattern.Node<Logf>(MatchPattern.Any("a"), MatchPattern.Any("a")),
+                (node, bound) => new Providedf(1, ((Logf)node).DomainCondition),
+                Soundness.SoundUnderAssumptions),
+
+            // ln(1/b) = -ln(b) is false on the negative reals: at b = -0.63 the two differ by the
+            // full turn of the argument the principal branch discards.
+            // https://github.com/asc-community/AngouriMath/issues/721
+            new MatchedRule(
+                "a-logarithm-of-a-reciprocal-in-a-reciprocal-base-turns-round-twice",
+                MatchPattern.Node<Logf>(
+                    MatchPattern.Node<Divf>(MatchPattern.Exact(Integer.Create(1)), MatchPattern.Any("a")),
+                    MatchPattern.Node<Divf>(MatchPattern.Exact(Integer.Create(1)), MatchPattern.Any("b"))),
+                bound => MathS.Log(bound["a"], bound["b"]),
+                Soundness.SoundUnderAssumptions,
+                when: bound => Functions.Patterns.MayGatherLogarithms(Integer.One, bound["a"], isDifference: true)
+                               && Functions.Patterns.MayGatherLogarithms(Integer.One, bound["b"], isDifference: true)),
+
+            new MatchedRule(
+                "a-logarithm-of-a-reciprocal-negates",
+                MatchPattern.Node<Logf>(
+                    MatchPattern.Any("a"),
+                    MatchPattern.Node<Divf>(MatchPattern.Exact(Integer.Create(1)), MatchPattern.Any("b"))),
+                bound => -MathS.Log(bound["a"], bound["b"]),
+                Soundness.SoundUnderAssumptions,
+                when: bound => Functions.Patterns.MayGatherLogarithms(Integer.One, bound["b"], isDifference: true)),
+
+            new MatchedRule(
+                "a-logarithm-in-a-reciprocal-base-negates",
+                MatchPattern.Node<Logf>(
+                    MatchPattern.Node<Divf>(MatchPattern.Exact(Integer.Create(1)), MatchPattern.Any("a")),
+                    MatchPattern.Any("b")),
+                bound => -MathS.Log(bound["a"], bound["b"]),
+                Soundness.SoundUnderAssumptions,
+                when: bound => Functions.Patterns.MayGatherLogarithms(Integer.One, bound["a"], isDifference: true)),
+
+            // https://github.com/asc-community/AngouriMath/issues/721
+            new MatchedRule(
+                "two-logarithms-of-one-base-add-by-multiplying-their-antilogarithms",
+                MatchPattern.Node<Sumf>(
+                    MatchPattern.Node<Logf>(MatchPattern.Any("c"), MatchPattern.Any("a")),
+                    MatchPattern.Node<Logf>(MatchPattern.Any("c"), MatchPattern.Any("b"))),
+                bound => bound["c"].Log(bound["a"] * bound["b"]),
+                Soundness.SoundUnderAssumptions,
+                when: bound => Functions.Patterns.MayGatherLogarithms(bound["a"], bound["b"], isDifference: false)),
+
+            new MatchedRule(
+                "two-logarithms-of-one-base-subtract-by-dividing-their-antilogarithms",
+                MatchPattern.Node<Minusf>(
+                    MatchPattern.Node<Logf>(MatchPattern.Any("c"), MatchPattern.Any("a")),
+                    MatchPattern.Node<Logf>(MatchPattern.Any("c"), MatchPattern.Any("b"))),
+                bound => bound["c"].Log(bound["a"] / bound["b"]),
+                Soundness.SoundUnderAssumptions,
+                when: bound => Functions.Patterns.MayGatherLogarithms(bound["a"], bound["b"], isDifference: true)),
+
+            // sqrt(8) = 2 * sqrt(2). Whether it applies and what it produces are one computation,
+            // so the `when` asks the same helper the replacement does.
+            new MatchedRule(
+                "a-whole-power-comes-out-from-under-a-radical",
+                MatchPattern.Node<Powf>(
+                    MatchPattern.Any<Integer>("radicand", whole => whole.IsPositive),
+                    MatchPattern.Any<Rational>("power", ratio => ratio is not Integer)),
+                bound => Functions.Patterns.ReduceRadical(
+                    (Integer)bound["radicand"], (Rational)bound["power"])!,
+                Soundness.Sound,
+                when: bound => Functions.Patterns.ReduceRadical(
+                    (Integer)bound["radicand"], (Rational)bound["power"]) is not null));
     }
 }

--- a/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
@@ -166,6 +166,14 @@ namespace AngouriMath.Core.Transformations
         /// <summary>
         /// Rules about powers, roots and logarithms.
         /// </summary>
+        /// <remarks>
+        /// <b>Run by the matcher rather than by the <c>switch</c></b> —
+        /// <see cref="Matching.MatchedRules.Power"/>, where its thirty-five arms are thirty
+        /// rules. The largest set converted, and the one whose branch-cut conditions are asked
+        /// of <c>Patterns.Power.cs</c> rather than restated: five issues put a guard on one
+        /// rewrite here, and a second copy of one of those guards is how the two come to
+        /// disagree.
+        /// </remarks>
         public static RewriteRuleSet Power { get; } = new(
             nameof(Power),
             "Gathers and splits powers, roots and logarithms.",
@@ -173,7 +181,7 @@ namespace AngouriMath.Core.Transformations
             // (a ^ b) ^ c is a ^ (b c) only on a branch; the rules guard for it, and the
             // guard is what the tier is stating.
             Soundness.SoundUnderAssumptions,
-            Patterns.PowerRules,
+            Matching.MatchedRules.Power.ApplyHere,
             Patterns.PowerRulesArms);
 
         /// <summary>

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Power.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Power.cs
@@ -350,7 +350,7 @@ namespace AngouriMath.Functions
         /// and the base holds a positive sign on the approach to its destination while the exponent
         /// is real along it.
         /// </summary>
-        private static bool MayTakeLogOfPower(Entity @base, Entity exponent)
+        internal static bool MayTakeLogOfPower(Entity @base, Entity exponent)
             => (IsPositiveReal(@base) && MayBeTakenAsReal(exponent))
                || Algebra.LimitFunctional.MayTakeLogOfPowerHere(@base, exponent);
 
@@ -359,7 +359,7 @@ namespace AngouriMath.Functions
         /// positive numbers, or because a limit is being read and they hold their sign on the
         /// approach to its destination.
         /// </summary>
-        private static bool MayGatherLogarithms(Entity left, Entity right, bool isDifference)
+        internal static bool MayGatherLogarithms(Entity left, Entity right, bool isDifference)
             => (IsPositiveReal(left) && IsPositiveReal(right))
                || Algebra.LimitFunctional.MayGatherLogarithmsHere(left, right, isDifference);
 
@@ -408,7 +408,7 @@ namespace AngouriMath.Functions
         /// <see langword="null"/> when nothing can be pulled out, so that the rule does
         /// not fire and rewriting terminates.
         /// </returns>
-        private static Entity? ReduceRadical(Integer radicand, Rational power)
+        internal static Entity? ReduceRadical(Integer radicand, Rational power)
         {
             var denominator = power.ERational.Denominator;
             if (denominator < 2 || denominator > 64)

--- a/Sources/Tests/UnitTests/Core/Transformations/MatchedRulesAgreeWithTheSwitchTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/MatchedRulesAgreeWithTheSwitchTest.cs
@@ -504,6 +504,33 @@ namespace AngouriMath.Tests.Core.Transformations
                 });
 
         /// <summary>
+        /// <b>The largest set, and the one carrying the most branch-cut conditions.</b> Five
+        /// separate issues put a guard on one rule here; the data form asks the same helpers in
+        /// <c>Patterns.Power.cs</c> rather than restating any of them, which is the only way two
+        /// copies of a branch cut cannot come to disagree.
+        /// </summary>
+        [Fact]
+        public void PowerAsDataMatchesTheSwitch()
+            => AssertAgrees("Power", Patterns.PowerRules,
+                MatchedRules.Power, leastFirings: 100, extra: new[]
+                {
+                    "x ^ (2 / log(3, x))", "2 ^ log(2, x)", "3 ^ log(3, x + 1)",
+                    "x ^ 2 * x ^ 3", "x ^ 2 / x ^ 3", "(x ^ 2) ^ 3", "sqrt(x ^ 2)",
+                    "x ^ y * z ^ y", "x ^ y / z ^ y", "2 ^ y * 3 ^ y", "2 ^ y / 3 ^ y",
+                    "x ^ y / z ^ (2 * y)", "x ^ (2 * y) / z ^ y",
+                    "x / x ^ 2", "x ^ 2 / x", "x ^ (-1)", "y ^ (-1)",
+                    "x ^ 2 * (x * y)", "(x * y) * x ^ 2", "x ^ 2 * (y * x)", "(y * x) * x ^ 2",
+                    "(2 * x) ^ 3", "(2 * x) ^ (1/2)", "(-2 * x) ^ (1/2)",
+                    "(2 / x) ^ 3 * x", "(2 / x) ^ 3 * x ^ 4",
+                    "x / y / y", "x / y ^ 2 / y", "x / y / y ^ 2", "x / y ^ 3 / y ^ 2",
+                    "x * y ^ 2", "log(2, x ^ 3)", "log(2, 3 ^ x)", "log(x, x)", "log(2, 2)",
+                    "log(1 / x, 1 / y)", "log(x, 1 / y)", "log(1 / x, y)",
+                    "log(2, 3) + log(2, 5)", "log(2, 3) - log(2, 5)",
+                    "log(2, x) + log(2, y)", "log(2, x) - log(2, y)",
+                    "8 ^ (1/2)", "54 ^ (1/3)", "12 ^ (1/2)", "7 ^ (1/2)", "8 ^ (3/2)",
+                });
+
+        /// <summary>
         /// A predicate on a hole that is a mathematical property rather than a sign or a type.
         /// The corpus reaches it rarely, so the shapes are given here as well — a set that fires
         /// four times over a generated corpus is worth checking against cases chosen for it.

--- a/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
@@ -108,14 +108,24 @@ namespace AngouriMath.Tests.Core.Transformations
         public void EveryDataRuleIsClassifiedAsWritten()
         {
             // Not a dictionary keyed by name: a set parameterised by a sort level exists three
-            // times over, so one rule name appears three times with the same classification.
-            // Keying by name threw, which is the enumeration having grown a shape the assertion
-            // had not.
+            // times over, and `Power` and `Factorization` deliberately carry the same guarded
+            // `a^b * c^b` -- so one name appears several times, with the same classification each
+            // time. Keying by name threw, which is the enumeration having grown a shape the
+            // assertion had not.
             var actual = DataRuleSets()
                 .SelectMany(set => set.Rules)
                 .Select(rule => (rule.Name, rule.Reversal))
                 .Distinct()
                 .ToList();
+
+            // What `Distinct` must not hide is one name standing for two classifications: that
+            // would list the rule twice below rather than fail, and a name meaning two things is
+            // the thing the exception used to be standing in for.
+            foreach (var byName in actual.GroupBy(pair => pair.Name))
+                Assert.True(byName.Count() == 1,
+                    $"'{byName.Key}' is classified "
+                    + string.Join(" and ", byName.Select(pair => pair.Reversal))
+                    + " in different sets, so the name means two things");
 
             var oneWay = actual.Where(pair => pair.Reversal is not RuleReversal.Reversible)
                 .Select(pair => $"{pair.Name}: {pair.Reversal}")
@@ -179,6 +189,10 @@ namespace AngouriMath.Tests.Core.Transformations
                     "a-lessorequal-of-a-thing-with-itself-is-decided: ReplacementIsCode",
                     "a-lessorequal-with-a-number-on-the-left-turns-round: ReplacementIsCode",
                     "a-lessorequal-with-zero-on-the-left-turns-round: ReplacementIsCode",
+                    "a-logarithm-in-a-reciprocal-base-negates: ReplacementIsCode",
+                    "a-logarithm-of-a-reciprocal-in-a-reciprocal-base-turns-round-twice: ReplacementIsCode",
+                    "a-logarithm-of-a-reciprocal-negates: ReplacementIsCode",
+                    "a-logarithm-of-its-own-base-is-one-where-it-is-defined: ReplacementIsCode",
                     "a-negated-conjunction-becomes-a-disjunction-of-negations: ReplacementIsCode",
                     "a-negated-disjunction-becomes-a-conjunction-of-negations: ReplacementIsCode",
                     "a-negation-or-something-is-an-implication: ReplacementIsCode",
@@ -206,7 +220,9 @@ namespace AngouriMath.Tests.Core.Transformations
                     "a-negative-integer-power-becomes-a-reciprocal: ReplacementIsCode",
                     "a-negative-minuend-comes-out-in-front: ReplacementIsCode",
                     "a-negative-subtracted-is-added: ReplacementIsCode",
+                    "a-number-raised-to-a-logarithm-of-itself-is-the-antilogarithm: ReplacementIsCode",
                     "a-numeric-coefficient-is-gathered-over-a-surd: ReplacementIsCode",
+                    "a-numeric-factor-comes-out-of-a-power-of-a-product: ReplacementIsCode",
                     "a-plain-factorial-times-the-next-term: ReplacementIsCode",
                     "a-positive-divisor-drops-out-of-a-equals-with-zero: ReplacementIsCode",
                     "a-positive-divisor-drops-out-of-a-greater-with-zero: ReplacementIsCode",
@@ -223,6 +239,13 @@ namespace AngouriMath.Tests.Core.Transformations
                     "a-positive-factor-second-drops-out-of-a-greaterorequal-with-zero: ReplacementIsCode",
                     "a-positive-factor-second-drops-out-of-a-less-with-zero: ReplacementIsCode",
                     "a-positive-factor-second-drops-out-of-a-lessorequal-with-zero: ReplacementIsCode",
+                    "a-power-of-a-numeric-reciprocal-times-a-power-of-its-own-denominator-subtracts-the-exponents: ReplacementIsCode",
+                    "a-power-of-a-numeric-reciprocal-times-its-own-denominator-lowers-the-exponent: ReplacementIsCode",
+                    "a-power-of-a-power-multiplies-the-exponents: ReplacementIsCode",
+                    "a-power-over-its-own-base-lowers-the-exponent: ReplacementIsCode",
+                    "a-power-times-a-product-containing-its-own-base-raises-the-exponent: ReplacementIsCode",
+                    "a-power-times-its-own-base-raises-the-exponent: ReplacementIsCode",
+                    "a-power-whose-exponent-divides-by-a-logarithm-of-its-own-base-changes-base: ReplacementIsCode",
                     "a-power-with-a-real-positive-exponent-is-zero-when-its-base-is: ReplacementIsCode",
                     "a-product-chain-is-sorted-and-grouped: ReplacementIsCode",
                     "a-product-of-two-negatives-is-positive: ReplacementIsCode",
@@ -232,12 +255,16 @@ namespace AngouriMath.Tests.Core.Transformations
                     "a-quotient-chain-is-sorted-and-grouped: ReplacementIsCode",
                     "a-quotient-of-a-plain-factorial-by-a-shifted-one: ReplacementIsCode",
                     "a-quotient-of-a-shifted-factorial-by-a-plain-one: ReplacementIsCode",
+                    "a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero: ReplacementIsCode",
                     "a-quotient-of-polynomials-is-divided-out: ReplacementIsCode",
                     "a-quotient-of-polynomials-is-put-in-lowest-terms: ReplacementIsCode",
+                    "a-quotient-of-powers-whose-exponents-differ-by-a-whole-factor-takes-it-into-the-dividend: ReplacementIsCode",
+                    "a-quotient-of-powers-whose-exponents-differ-by-a-whole-factor-takes-it-into-the-divisor: ReplacementIsCode",
                     "a-quotient-of-shifted-factorials: ReplacementIsCode",
                     "a-quotient-of-symbolic-parts-is-grouped-pairwise: ReplacementIsCode",
                     "a-quotient-of-two-negatives-is-positive: ReplacementIsCode",
                     "a-reciprocal-is-never-zero: ReplacementIsCode",
+                    "a-reciprocal-power-is-a-quotient: ReplacementIsCode",
                     "a-secant-times-a-cosine-of-one-angle-is-one: ReplacementIsCode",
                     "a-set-less-itself-is-empty: ReplacementIsCode",
                     "a-shifted-factorial-times-a-bare-term: ReplacementIsCode",
@@ -261,9 +288,12 @@ namespace AngouriMath.Tests.Core.Transformations
                     "a-term-added-to-itself-doubles: ReplacementIsCode",
                     "a-term-shared-with-a-product-added-to-it-comes-out: ReplacementIsCode",
                     "a-term-subtracted-from-itself-vanishes: ReplacementIsCode",
+                    "a-thing-over-a-power-of-itself-is-one-power: ReplacementIsCode",
                     "a-two-term-denominator-is-multiplied-by-its-conjugate: ReplacementIsCode",
                     "a-union-chain-is-sorted-and-grouped: ReplacementIsCode",
                     "a-union-with-itself-is-itself: PatternCannotBeBuilt",
+                    "a-variable-times-a-power-puts-the-power-first: ReplacementIsCode",
+                    "a-whole-power-comes-out-from-under-a-radical: ReplacementIsCode",
                     "an-arccosecant-of-a-numeric-reciprocal-is-an-arcsine: ReplacementIsCode",
                     "an-arccosine-of-a-numeric-reciprocal-is-an-arcsecant: ReplacementIsCode",
                     "an-arcsecant-of-a-numeric-reciprocal-is-an-arccosine: ReplacementIsCode",
@@ -273,6 +303,7 @@ namespace AngouriMath.Tests.Core.Transformations
                     "an-equality-or-a-less-than-as-written-is-at-most: ReplacementIsCode",
                     "an-equality-or-a-less-than-the-other-way-round-is-at-least: ReplacementIsCode",
                     "an-exclusive-disjunction-chain-is-sorted-and-grouped: ReplacementIsCode",
+                    "an-exponent-comes-out-of-a-logarithm: ReplacementIsCode",
                     "an-implication-between-negations-turns-round: ReplacementIsCode",
                     "an-intersection-chain-is-sorted-and-grouped: ReplacementIsCode",
                     "an-intersection-distributes-over-a-union-on-its-left: ReplacementIsCode",
@@ -287,6 +318,10 @@ namespace AngouriMath.Tests.Core.Transformations
                     "arctangent-of-a-tangent-inside-its-own-interval: ReplacementIsCode",
                     "arctangent-plus-arccotangent-is-a-right-angle-with-the-sign-of-the-argument: ReplacementIsCode",
                     "cosine-of-a-whole-multiple-of-an-angle: ReplacementIsCode",
+                    "dividing-by-a-power-and-then-by-its-base-raises-the-exponent: ReplacementIsCode",
+                    "dividing-by-a-thing-and-then-by-a-power-of-it-raises-the-exponent: ReplacementIsCode",
+                    "dividing-by-two-powers-of-one-base-adds-the-exponents: ReplacementIsCode",
+                    "dividing-twice-by-one-thing-squares-it: ReplacementIsCode",
                     "eulers-totient-of-a-prime-power: ReplacementIsCode",
                     "membership-of-a-singleton-is-an-equality: ReplacementIsCode",
                     "membership-of-an-interval-is-written-out: ReplacementIsCode",
@@ -308,7 +343,12 @@ namespace AngouriMath.Tests.Core.Transformations
                     "two-arctangents-of-numbers-add-by-the-tangent-formula: ReplacementIsCode",
                     "two-comparisons-of-one-pair-that-exclude-each-other-are-false: ReplacementIsCode",
                     "two-comparisons-of-one-pair-that-leave-no-case-are-true: ReplacementIsCode",
+                    "two-logarithms-of-one-base-add-by-multiplying-their-antilogarithms: ReplacementIsCode",
+                    "two-logarithms-of-one-base-subtract-by-dividing-their-antilogarithms: ReplacementIsCode",
+                    "two-powers-of-one-base-divide-by-subtracting-exponents: ReplacementIsCode",
+                    "two-powers-of-one-base-multiply-by-adding-exponents: ReplacementIsCode",
                     "two-powers-of-one-exponent-share-a-base: ReplacementIsCode",
+                    "two-powers-of-one-exponent-share-a-quotient-of-bases: ReplacementIsCode",
                     "two-subtracted-fractions-take-a-common-denominator: ReplacementIsCode",
                 },
                 oneWay);


### PR DESCRIPTION
The largest `switch` in the transformation layer, and the one carrying the most
conditions. `Patterns.PowerRules` has thirty-five arms; five separate issues — #752,
#801, #802, #902 and #721 — each put a branch-cut guard on one rewrite in it. As data
it is thirty rules.

**The guards are asked, not restated.** `MayTakeLogOfPower`, `MayGatherLogarithms` and
`ReduceRadical` stay in `Patterns.Power.cs` and the rules call them. Copying a branch-cut
condition into a second file is how the two copies come to disagree, and one of these has
already been wrong in both directions at once (`log(-3, -3)` is 1 where a written-out
`a > 0` calls it undefined; `log(1, 1)` is NaN where that guard calls it 1).

**Two rules read what a `Bindings` cannot carry.** `log_b(b) = 1` takes the overload
handed the matched node, so the condition it attaches is the node's own `DomainCondition`.
The radical reduction asks `ReduceRadical` in both its `when` and its replacement, because
whether it applies and what it produces are one computation.

**Six arms become two commutative patterns** — a power times its own base, and a power
times a product containing its base. They fire exactly where the pair and the quadruple
did, since the `switch` writes every orientation out; `firesWhereTheSwitchDoesNot` is empty.

## What this PR cost, and what it produced

The kernel gate **failed** the first version of this branch on allocation — `SolveHard`
+4.4%, `SolveMediumHard` +5.0%, past its 3% band. Not time, and not noise: allocation
reproduces to 0.033%.

The cause was the two commutative patterns. A commutative pattern is not
`IsDeterministic`, so `TryApply` enumerated its two candidates through an iterator state
machine per pattern node, at **every node of every pass**. My own pre-push measurement had
looked at `Simplify`, whose allocation is identical to the byte on every build here — so
the regression was invisible to it. The gate measures eighteen entry points because one of
them is not the others.

Writing the six arms out as node patterns fixed it, at the cost of the collapse. That was
a bad trade for a rule set language, so it became **#1079 → #1080**: a bounded pattern is
now walked by index rather than enumerated. With that in, the commutative form is the cheap
one:

| | `SolveMediumHard`, allocated |
|---|---|
| master (`2c082da4`) | 163,425,360 B |
| this branch, two commutative rules | 164,959,936 B — **+0.94%** |
| *the same, before #1080* | *171,367,976 B — +3.8%, gate red* |

`SimplifyEasy` is 129,648 B on both, to the byte.

**What the differential run caught.** Two arms bind their operands as `Number`, so `1 - c`
folds to a literal in the `switch` where `Entity` arithmetic builds a `Minusf`. Both
disagreed on the first run of `PowerAsDataMatchesTheSwitch` over 3,464 generated
expressions, and neither is a case anyone would have written down by hand.

**One test made stronger.** `EveryDataRuleIsClassifiedAsWritten` now asserts that a rule
name never stands for two classifications. `Power` and `Factorization` deliberately carry
the same guarded `a^b * c^b`; without the assertion, a name meaning two things would have
listed the rule twice rather than failed.

Part of #746 tier 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd