### PR TITLE
`x! = 0` carries the condition under which the factorial exists (#1081)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -21,6 +21,8 @@ read first.
 
 | Silent? | What | Was | Is |
 |---|---|---|---|
+| **Silent** | `"x! = 0".ToEntity().Simplify()` | `False`, including at `x = -1` where `x!` has a pole and the statement is `NaN` | `False provided x in RR and (x >= 0 or not x in ZZ)` |
+| **Silent** | `"x! / x!".ToEntity().Simplify()`, and the same for any factorial over itself | `1`, including at `x = -1` where the quotient is `NaN` | `1 provided not x! = 0` |
 | **Silent** | `"(y < x) or (x = y)".ToEntity().Simplify()`, and three more disjunctions of a comparison with an equality written the other way round | `x <= y` — False at `x = 3, y = 2` where the input is True | `x >= y` |
 | **Silent** | `"x6 + x y + 1 = 0".ToEntity().Solve("x")`, and every equation no solver settles | `{  }` — there are no roots | `{ x : 1 + x ^ 6 + x * y = 0 }` — these are the roots, whichever they are |
 | **Silent** | `"(x - 1) * (x6 + x y + 1) = 0".ToEntity().Solve("x")` | `{ 1 }` | `{ 1 } \/ { x : 1 + x ^ 6 + x * y = 0 }` |
@@ -309,6 +311,34 @@ the same precedences this grammar uses — so those needed the same brackets —
 bracketing for. The change only ever adds `\left(`/`\right)` groups, which CSharpMath already
 parses, so nothing downstream needs a matching change
 ([#822](https://github.com/asc-community/AngouriMath/issues/822)).
+
+### `x! = 0` carries the condition under which the factorial exists
+
+A factorial is never zero **where it is defined**, and at a negative integer it is not defined.
+`"x! = 0".ToEntity().Simplify()` was `False` for every `x`, so at `x = -1` it answered a question
+the original declines: `(-1)! = 0` evaluates to `NaN`.
+
+| | before | now |
+|---|---|---|
+| `"x! = 0".ToEntity().Simplify()` | `False` | `False provided x in RR and (x >= 0 or not x in ZZ)` |
+| the same, at `x = 3` | `False` | `False` |
+| the same, at `x = -1` | `False` | `NaN` |
+| `RewriteRules.InequalityEquality.ApplyOnce("x! = 0")` | `False` | `False provided x in RR and (x >= 0 or not x in ZZ)` |
+
+The rule read `Factorialf({ DomainCondition: var condition })`, which is a property pattern on the
+factorial's **argument** rather than on the factorial. For a bare variable that condition is `True`,
+and `Provided` drops a `True`, so the answer went out unconditioned. One character of pattern syntax
+between the two, and the wrong one reads as though it were about the factorial.
+
+Where the factorial exists the answer is still `False`, so the condition narrows the rule rather
+than withdrawing it. A factorial **over itself** moves with it: `a / a = 1 provided a != 0`
+produced `1 provided not x! = 0`, whose condition used to discharge itself because `x! = 0` was
+`False`, and now survives. `"x! / x!".ToEntity().Simplify()` was `1` at every point including the
+poles; it now agrees with the original at `x = 3`, `0`, `-1` and `-2`, where `1` disagreed at both
+negative integers. Found by transcribing the set into `MatchedRules` for
+[#746](https://github.com/asc-community/AngouriMath/issues/746) tier 1, as the single disagreement
+out of 3,485 generated expressions
+([#1081](https://github.com/asc-community/AngouriMath/issues/1081)).
 
 ### Four `or`-with-equality rules gave the opposite comparison
 

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -2159,17 +2159,15 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<LessOrEqualf>(MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any<Entity>("k", one => Functions.Patterns.IsRealAbove(one, 0) is false && Functions.Patterns.IsRealBelow(one, 0))), MatchPattern.Any<Entity>("zero", one => Functions.Patterns.IsZeroReal(one))),
                 bound => bound["a"] >= Integer.Zero,
                 Soundness.Sound),
-            // The condition carried is the **argument's**, which is what the `switch` reads --
-            // `Factorialf({ DomainCondition: var condition })` is a property pattern on the child,
-            // not on the factorial. Whether that is the right condition is a separate question and
-            // https://github.com/asc-community/AngouriMath/issues/1081 asks it; agreeing with the
-            // arms is this rule's job.
+            // The factorial's own condition, not its argument's: `(-1)!` is a pole, so
+            // `(-1)! = 0` is NaN rather than False.
+            // https://github.com/asc-community/AngouriMath/issues/1081
             new MatchedRule(
                 "a-factorial-is-never-zero",
                 MatchPattern.Node<Equalsf>(
-                    MatchPattern.Node<Factorialf>(MatchPattern.Any("arg")),
+                    MatchPattern.Any<Factorialf>("f"),
                     MatchPattern.Any<Entity>("zero", one => Functions.Patterns.IsZeroReal(one))),
-                bound => Entity.Boolean.False.Provided(bound["arg"].DomainCondition),
+                bound => Entity.Boolean.False.Provided(((Factorialf)bound["f"]).DomainCondition),
                 Soundness.SoundUnderAssumptions),
             // The `DomainCondition` is about singularities and says nothing about where the ordering is
             // defined, so both are needed: `x < x` is False on the real line and NaN at x = i.

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.EqualityInequality.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.EqualityInequality.cs
@@ -275,7 +275,17 @@ namespace AngouriMath.Functions
             LessOrEqualf   (Divf(var any1, var rePo), var zeroEnt) when IsRealNegative(rePo) && IsZero(zeroEnt) => any1 >= Integer.Zero,
 
             // a! = 0
-            Equalsf(Factorialf({ DomainCondition: var condition }), var zeroEnt) when IsZero(zeroEnt) => False.Provided(condition),
+            // A factorial is never zero *where it is defined*, and at a negative integer it is
+            // not: `(-1)!` is a pole, so `(-1)! = 0` is NaN rather than False. The condition owed
+            // is therefore the factorial's own -- `x in RR and (x >= 0 or not x in ZZ)`.
+            //
+            // What was written was `Factorialf({ DomainCondition: var condition })`, a property
+            // pattern on the factorial's *argument*. For a bare variable that condition is True,
+            // and `Provided` drops a True, so `x! = 0` went out as an unconditioned False and
+            // answered a question the original declines.
+            // https://github.com/asc-community/AngouriMath/issues/1081
+            Equalsf(Factorialf factorial, var zeroEnt) when IsZero(zeroEnt)
+                => False.Provided(factorial.DomainCondition),
 
             // The DomainCondition is about singularities and says nothing about where the
             // ordering is defined, so both conditions are needed: `x < x` is False on the real

--- a/Sources/Tests/UnitTests/PatternsTest/FactorialIsNeverZeroTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/FactorialIsNeverZeroTest.cs
@@ -1,0 +1,68 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Core.Transformations;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.PatternsTest
+{
+    /// <summary>
+    /// A factorial is never zero <b>where it is defined</b>, and at a negative integer it is not.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/1081">#1081</a>
+    /// </summary>
+    /// <remarks>
+    /// The rule attached its <i>argument's</i> domain condition rather than the factorial's, and
+    /// for a bare variable that condition is <c>True</c> — which <c>Provided</c> drops. So the
+    /// answer went out unconditioned and was <c>False</c> at the poles, where the statement has
+    /// no truth value at all.
+    /// </remarks>
+    [Trait("Area", "Patterns")]
+    public sealed class FactorialIsNeverZeroTest
+    {
+        /// <summary>
+        /// Where the factorial is defined the answer is still <see langword="false"/>, so the
+        /// condition narrowed the rule rather than withdrawing it.
+        /// </summary>
+        [Theory]
+        [InlineData("3")]
+        [InlineData("0")]
+        [InlineData("1/2")]
+        public void ItIsFalseWhereTheFactorialExists(string at)
+            => Assert.Equal(
+                $"({at})! = 0".ToEntity().EvalBoolean(),
+                "x! = 0".ToEntity().Simplify().Substitute("x", at.ToEntity()).EvalBoolean());
+
+        /// <summary>
+        /// At a pole the statement is <c>NaN</c>, and the simplified form has to be too — this is
+        /// the case the rule used to answer <see langword="false"/>.
+        /// </summary>
+        [Theory]
+        [InlineData("-1")]
+        [InlineData("-2")]
+        [InlineData("-3")]
+        public void ItIsUndecidedWhereTheFactorialHasAPole(string at)
+        {
+            var simplified = "x! = 0".ToEntity().Simplify().Substitute("x", at.ToEntity());
+            Assert.False(simplified.EvaluableBoolean);
+            Assert.Equal($"({at})! = 0".ToEntity().Evaled, simplified.Evaled);
+        }
+
+        /// <summary>
+        /// And the rule on its own, so that a change in what the candidate search happens to pick
+        /// cannot quietly stop this being about the rule.
+        /// </summary>
+        [Fact]
+        public void TheRuleCarriesTheFactorialsOwnCondition()
+        {
+            var rewritten = RewriteRules.InequalityEquality.ApplyOnce("x! = 0".ToEntity());
+            Assert.NotEqual("x! = 0".ToEntity(), rewritten);
+            Assert.IsType<Entity.Providedf>(rewritten);
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/PatternsTest/SimplifyTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/SimplifyTest.cs
@@ -74,19 +74,25 @@ namespace AngouriMath.Tests.PatternsTest
         [Fact] public void FactorialM1() => AssertSimplify(MathS.Factorial(-1), double.NaN);
         [Fact] public void FactorialM1_5() => AssertSimplify(MathS.Factorial(-1.5m), -2 * MathS.Sqrt(MathS.pi));
         [Fact] public void FactorialM2() => AssertSimplify(MathS.Factorial(-2), double.NaN);
-        [Fact] public void FactorialXP1OverFactorialXP1() => AssertSimplify(MathS.Factorial(x + 1) / MathS.Factorial(x + 1), 1);
+        // These three recorded `1`, and `1` is wrong wherever the factorial has a pole: at
+        // x = -1, `x! / x!` is NaN / NaN and not 1. The condition arrives now because `x! = 0` is
+        // no longer answered False unconditionally, so `a / a = 1 provided a != 0` no longer
+        // discharges itself. Checked at x = 3, 0, -1 and -2: the new form agrees with the
+        // original at all four, where `1` disagreed at every pole.
+        // https://github.com/asc-community/AngouriMath/issues/1081
+        [Fact] public void FactorialXP1OverFactorialXP1() => AssertSimplify(MathS.Factorial(x + 1) / MathS.Factorial(x + 1), "1 provided not (1 + x)! = 0");
         [Fact] public void FactorialXP1OverFactorialX() => AssertSimplify(MathS.Factorial(1 + x) / MathS.Factorial(x), 1 + x);
         [Fact] public void FactorialXP1OverFactorialXM2() => AssertSimplify(MathS.Factorial(1 + x) / MathS.Factorial(-2 + x), "x3 - x");
         [Fact] public void FactorialXP1OverFactorialXM1() => AssertSimplify(MathS.Factorial(1 + x) / MathS.Factorial(-1 + x), x * (1 + x));
         [Fact] public void FactorialXP1OverFactorialXM3() => AssertSimplifyIdentical(MathS.Factorial(x + 1) / MathS.Factorial(x - 3));
         [Fact] public void FactorialXOverFactorialXP1() => AssertSimplify(MathS.Factorial(x) / MathS.Factorial(x + 1), 1 / (1 + x));
-        [Fact] public void FactorialXOverFactorialX() => AssertSimplify(MathS.Factorial(x) / MathS.Factorial(x), 1);
+        [Fact] public void FactorialXOverFactorialX() => AssertSimplify(MathS.Factorial(x) / MathS.Factorial(x), "1 provided not x! = 0");
         [Fact] public void FactorialXOverFactorialXM1() => AssertSimplify(MathS.Factorial(0 + x) / MathS.Factorial(x - 1), x);
         [Fact] public void FactorialXOverFactorialXM2() => AssertSimplify(MathS.Factorial(x + 0) / MathS.Factorial(x - 2), x.Pow(2) - x);
         [Fact] public void FactorialXOverFactorialXM3() => AssertSimplifyIdentical(MathS.Factorial(x) / MathS.Factorial(x - 3));
         [Fact] public void FactorialXM1OverFactorialXP1() => AssertSimplify(MathS.Factorial(x - 1) / MathS.Factorial(x + 1), 1 / (x * (x + 1)));
         [Fact] public void FactorialXM1OverFactorialX() => AssertSimplify(MathS.Factorial(-1 + x) / MathS.Factorial(x), 1 / x);
-        [Fact] public void FactorialXM1OverFactorialXM1() => AssertSimplify(MathS.Factorial(x - 1) / MathS.Factorial(x - 1), 1);
+        [Fact] public void FactorialXM1OverFactorialXM1() => AssertSimplify(MathS.Factorial(x - 1) / MathS.Factorial(x - 1), "1 provided not (-1 + x)! = 0");
         [Fact] public void FactorialXM1OverFactorialXM2() => AssertSimplify(MathS.Factorial(-1 + x) / MathS.Factorial(-2 + x), x - 1);
         // Same two factors, now in ascending order: the polynomial factorer offers
         // (x - 1) * (x - 2) and the complexity metric cannot tell the two orders apart.


### PR DESCRIPTION
Closes #1081.

A factorial is never zero **where it is defined**, and at a negative integer it is not.

```csharp
"x! = 0".ToEntity().Simplify()   // was False, now False provided x in RR and (x >= 0 or not x in ZZ)
```

| x | `x! = 0` | old `False` | now |
|---|---|---|---|
| 3 | False | False | False |
| 0 | False | False | False |
| −1 | **NaN** | False | NaN |
| −2 | **NaN** | False | NaN |

Both columns measured on a build of each side.

## Where it came from

```csharp
Equalsf(Factorialf({ DomainCondition: var condition }), var zeroEnt) when IsZero(zeroEnt)
    => False.Provided(condition),
```

`Factorialf({ DomainCondition: var condition })` is a property pattern on the factorial's
**argument**, not on the factorial. For a bare variable that condition is `True`, `Provided`
drops a `True`, and the answer went out unconditioned. One character of pattern syntax
between the two, and the wrong one reads as though it were about the factorial.

Where the factorial exists the answer is still `False` — this narrows the rule rather than
withdrawing it.

## A factorial over itself moves with it, and was wrong too

`a / a = 1 provided a != 0` produces `1 provided not x! = 0`. That condition used to
**discharge itself**, because `x! = 0` was `False`. So:

```csharp
"x! / x!".ToEntity().Simplify()   // was 1, now 1 provided not x! = 0
```

and `1` is wrong at every pole — `(-1)! / (-1)!` is `NaN / NaN`. Three recorded verdicts in
`SimplifyTest` said `1`. They now say the conditioned form, and the comment there records
that it agrees with the original at x = 3, 0, −1 and −2 where `1` disagreed at both negative
integers. A test that records a wrong answer is how a wrong answer survives a suite.

## Both forms change together

The `switch` and `MatchedRules.InequalityEquality` are edited in one commit, because
`InequalityEqualityAsDataMatchesTheSwitch` requires them to agree — which is what found this.
It was the single disagreement out of 3,485 generated expressions when the set was
transcribed for #746 tier 1, the data form having been written to read the node's own
condition.

`FactorialIsNeverZeroTest` fails 4 of its 7 cases without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd