### PR TITLE
A rule set asks only the rules the node's type can match: −36% of SimplifyEasy

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
@@ -451,11 +451,55 @@ namespace AngouriMath.Core.Transformations.Matching
 
         internal Entity ApplyHere(Entity expr)
         {
-            // The array rather than the IReadOnlyList property: see the note on `rules`.
-            foreach (var rule in rules)
+            // The rules this node's type can possibly match, rather than all of them. See the
+            // note on `applicable`.
+            foreach (var rule in ApplicableTo(expr.GetType()))
                 if (rule.TryApply(expr) is { } rewritten)
                     return rewritten;
             return expr;
         }
+
+        /// <summary>
+        /// The rules whose pattern requires a root type this one is, cached per runtime type.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// A rule that cannot match still costs a virtual call and a type test to say so, and a
+        /// rewrite pass asks every rule of a set at every node of the tree. For a set of three
+        /// that is nothing, which is why the note above records a per-type index as measured and
+        /// rejected — and it was rejected on a set of three.
+        /// </para>
+        /// <para>
+        /// Thirty sets are data now, so a pass asks several hundred rules at every node where it
+        /// used to ask a handful, and the arithmetic has changed. Indexing is <b>−36.0% of
+        /// <c>SimplifyEasy</c></b> — 148,223 ns to 94,904 ns — with allocation identical to the
+        /// byte and <c>ParseEasy</c>, <c>SolveEasy</c> and <c>SimplifyHard</c> unmoved, so what it
+        /// removes is dispatch and nothing else.
+        /// </para>
+        /// <para>
+        /// What was rejected before was a <i>cache</i> that allocated per node. This allocates
+        /// once per runtime type ever seen and then never again, so a pass over a tree of
+        /// products and sums touches two entries and allocates nothing. The dictionary is only
+        /// ever added to, and adding is done on a copy that replaces the field, so a reader
+        /// racing a writer sees either the old map or the new one and never a torn one.
+        /// </para>
+        /// </remarks>
+        private MatchedRule[] ApplicableTo(Type type)
+        {
+            var known = applicable;
+            if (known.TryGetValue(type, out var found))
+                return found;
+
+            var matching = new List<MatchedRule>(rules.Length);
+            foreach (var rule in rules)
+                if (rule.Left.RequiredRootType is not { } required || required.IsAssignableFrom(type))
+                    matching.Add(rule);
+            found = matching.Count == rules.Length ? rules : matching.ToArray();
+
+            applicable = new Dictionary<Type, MatchedRule[]>(known) { [type] = found };
+            return found;
+        }
+
+        private Dictionary<Type, MatchedRule[]> applicable = new();
     }
 }

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleIndexTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleIndexTest.cs
@@ -1,0 +1,133 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using AngouriMath;
+using AngouriMath.Core.Transformations;
+using AngouriMath.Core.Transformations.Matching;
+using AngouriMath.Extensions;
+using AngouriMath.Functions;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// <c>MatchedRuleSet.ApplyHere</c> asks only the rules whose pattern requires a root type the
+    /// node is. This is what says that skipping the rest skips nothing.
+    /// </summary>
+    /// <remarks>
+    /// The index is derived from <c>MatchPattern.RequiredRootType</c>, so it is only as sound as
+    /// that property is — a pattern that under-reports what it requires would have rules skipped
+    /// that could have fired, and the answer would silently stop changing. Comparing against a
+    /// linear scan over the whole set is the check that cannot be fooled by the same mistake.
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class RuleIndexTest
+    {
+        private static IEnumerable<MatchedRuleSet> AllSets
+        {
+            get
+            {
+                const BindingFlags Any = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static;
+                foreach (var property in typeof(MatchedRules).GetProperties(Any))
+                    if (property.PropertyType == typeof(MatchedRuleSet))
+                        yield return (MatchedRuleSet)property.GetValue(null)!;
+                foreach (var factory in typeof(MatchedRules).GetMethods(Any))
+                    if (factory.ReturnType == typeof(MatchedRuleSet)
+                        && factory.GetParameters() is { Length: 1 } parameters
+                        && parameters[0].ParameterType == typeof(TreeAnalyzer.SortLevel))
+                        foreach (var level in Enum.GetValues(typeof(TreeAnalyzer.SortLevel)))
+                            yield return (MatchedRuleSet)factory.Invoke(null, new[] { level })!;
+            }
+        }
+
+        private static readonly string[] Leaves = { "x", "y", "2", "-1", "-2", "1/2", "1", "0" };
+
+        private static readonly string[] Shapes =
+        {
+            "-({0})", "1 / ({0})", "({0}) ^ 2", "sqrt({0})", "sin({0})", "abs({0})", "sgn({0})",
+            "({0})!", "cos({0})", "tan({0})", "log(2, {0})", "not ({0} > 1)",
+        };
+
+        private static readonly string[] Pairs =
+        {
+            "({0}) + ({1})", "({0}) - ({1})", "({0}) * ({1})", "({0}) / ({1})", "({0}) ^ ({1})",
+            "({0}) = ({1})", "({0}) < ({1})", "({0}) >= ({1})",
+            "({0}) and ({1})", "({0}) or ({1})", "({0}) implies ({1})",
+        };
+
+        private static List<Entity> Corpus()
+        {
+            var sources = new List<string>(Leaves);
+            foreach (var shape in Shapes)
+                foreach (var inner in Leaves)
+                    sources.Add(string.Format(shape, inner));
+            foreach (var shape in Pairs)
+                foreach (var left in Leaves)
+                    foreach (var right in Leaves)
+                        sources.Add(string.Format(shape, left, right));
+            sources.AddRange(new[]
+            {
+                @"A /\ B", @"A \/ B", @"A \ B", "{ 1, 2 }", "[0; 1]", "(-oo; +oo)",
+                "{ x : x > 0 }", "x in [0; 1]", "1 provided x > 0",
+            });
+
+            var parsed = new List<Entity>();
+            foreach (var source in sources)
+            {
+                try { parsed.Add(source.ToEntity()); }
+                catch { /* the generator makes some strings the parser declines */ }
+            }
+            return parsed;
+        }
+
+        /// <summary>
+        /// The indexed answer against the answer a scan over every rule gives, for every set and
+        /// every expression — including the nodes inside each one, so a type the corpus only
+        /// produces as a child is covered too.
+        /// </summary>
+        [Fact]
+        public void TheIndexSkipsOnlyRulesThatCouldNotHaveFired()
+        {
+            var corpus = Corpus();
+            Assert.True(corpus.Count > 500, $"the corpus is only {corpus.Count} expressions");
+
+            var compared = 0;
+            var changed = 0;
+            foreach (var set in AllSets)
+                foreach (var expr in corpus.SelectMany(Everywhere))
+                {
+                    var indexed = set.ApplyHere(expr);
+
+                    var linear = expr;
+                    foreach (var rule in set.Rules)
+                        if (rule.TryApply(expr) is { } rewritten) { linear = rewritten; break; }
+
+                    Assert.True(linear.Equals(indexed),
+                        $"{set.Name} on '{expr.Stringize()}': a scan gave "
+                        + $"'{linear.Stringize()}', the index gave '{indexed.Stringize()}'");
+                    if (!indexed.Equals(expr)) changed++;
+                    compared++;
+                }
+
+            Assert.True(compared > 20000, $"only {compared} set/expression pairs compared");
+            // Agreement between two things that both did nothing is not agreement.
+            Assert.True(changed > 500, $"the rules only fired {changed} times");
+        }
+
+        private static IEnumerable<Entity> Everywhere(Entity expr)
+        {
+            yield return expr;
+            foreach (var child in expr.DirectChildren)
+                foreach (var inner in Everywhere(child))
+                    yield return inner;
+        }
+    }
+}


### PR DESCRIPTION
`MatchedRuleSet.ApplyHere` asked **every** rule of a set at **every** node of the tree. A rule
that cannot match still costs a virtual call and a type test to say so — and that is now the
dominant cost of a rewrite pass, because thirty sets run as data, so several hundred rules are
asked at each node where a `switch` made one jump.

Indexed by the root type each pattern requires — which `MatchPattern.RequiredRootType` already
reports, and `MatchedRuleSet.AsAddressable` already reads:

| | master (`2d6bcfca`) | with the index |
|---|---|---|
| `SimplifyEasy` | 148,223 ns | **94,904 ns — −36.0%** |
| `SimplifyEasy` allocated | 128,100 B | 128,100 B — identical |
| `ParseEasy` | 5,733 ns | 5,730 ns |
| `SolveEasy` | 4,798,880 ns | 4,795,827 ns |
| `SimplifyHard` | 1,542,491,599 ns | 1,525,152,589 ns |

Measured with the repo's own BenchmarkDotNet job on both sides. What it removes is dispatch and
nothing else.

## The note that said this was tried and rejected

`MatchedRuleSet` carries a comment recording a per-type index as measured and rejected — 24 B
per node, 912 B per pass, for a time win inside the machine's drift. That stays true of what was
measured, and **both halves of it have changed**:

- It was a *cache* that allocated per node. This allocates once per runtime type ever seen and
  then never again — a pass over a tree of products and sums touches two entries.
- It was tried on a set of **three** rules. `Common` is sixty-two, `InequalityEquality`
  sixty-five, and there are thirty sets.

The dictionary is only added to, and adding builds a copy that replaces the field, so a reader
racing a writer sees the old map or the new one and never a torn one.

## What says the skipping is safe

`RuleIndexTest`: for every set and every node of every expression its grammar builds, the
indexed answer against the answer a **linear scan over the whole set** gives. 20,000+ pairs, and
it asserts the rules actually fired rather than agreeing about nothing.

That comparison matters because the index is derived from `RequiredRootType`. A pattern that
under-reported what it requires would have rules skipped that could have fired, and the answer
would silently stop changing — an assertion written from the same property would be fooled by
the same mistake; a scan cannot be.

## Why now

This came out of #1083 (`Common` as data), which measured **+34.6%** on `SimplifyEasy` — sixty-two
rules against a `switch`'s single jump. With this in, that branch measures **92,221 ns**, which is
28.5% *below* master rather than 34.6% above it. It is split out here because it is a change to
the kernel that stands on its own measurement, not on that branch's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd