### PR TITLE
An evaluation image proves irreducibility where the substitution cannot reach (#746)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -21,6 +21,7 @@ read first.
 
 | Silent? | What | Was | Is |
 |---|---|---|---|
+| | `MathS.Polynomials.Factor("x2 + y2 + z2 + w2 + 1", "x")`, and polynomials in enough variables generally | `null` — a refusal | the polynomial itself, meaning it does not factor |
 | **Silent** | `"x! = 0".ToEntity().Simplify()` | `False`, including at `x = -1` where `x!` has a pole and the statement is `NaN` | `False provided x in RR and (x >= 0 or not x in ZZ)` |
 | **Silent** | `"x! / x!".ToEntity().Simplify()`, and the same for any factorial over itself | `1`, including at `x = -1` where the quotient is `NaN` | `1 provided not x! = 0` |
 | **Silent** | `"(y < x) or (x = y)".ToEntity().Simplify()`, and three more disjunctions of a comparison with an equality written the other way round | `x <= y` — False at `x = 3, y = 2` where the input is True | `x >= y` |
@@ -311,6 +312,35 @@ the same precedences this grammar uses — so those needed the same brackets —
 bracketing for. The change only ever adds `\left(`/`\right)` groups, which CSharpMath already
 parses, so nothing downstream needs a matching change
 ([#822](https://github.com/asc-community/AngouriMath/issues/822)).
+
+### A polynomial in too many variables to substitute can still be answered
+
+`MathS.Polynomials.Factor` in more than one variable works by Kronecker's substitution, whose
+one-variable image has degree `Π (d_i + 1) - 1` — a *product*. That leaves the one-variable
+factoriser's reach after very few variables, and the answer was a refusal:
+
+| | before | now |
+|---|---|---|
+| `Factor("x2 + y2 + z2 + w2 + 1", "x")` | `null` | `w ^ 2 + x ^ 2 + y ^ 2 + z ^ 2 + 1` |
+| `Factor("x2 + y2 + z2 + 1", "x")` | `x ^ 2 + y ^ 2 + z ^ 2 + 1` | unchanged |
+| `Factor("x7 - y7", "x")` | `null` | `null` — it *is* reducible, and this says nothing about it |
+| `Factor("(x + y) * (x - y)", "x")` | `(x + y) * (x - y)` | unchanged |
+| `Factor("y * (x + 1)", "x")` | `y * (x + 1)` | unchanged |
+
+Where the substitution gives up, the polynomial is now evaluated at an integer point in every
+variable but the main one and the one-variable image is factored. **An image that is irreducible
+and has kept its degree is a proof that its source is irreducible** — substitution is a ring
+homomorphism, so a factorisation would survive it, and degrees in the main variable add, so
+neither part can have lost any while the total is preserved. An evaluation image has the degree
+of the polynomial in the main variable however many other variables there are, so this reaches
+where the substitution cannot.
+
+It answers in one direction only. A reducible image says nothing, so `x7 - y7` is still refused;
+a factor free of the main variable is invisible to it, so the content is checked and anything but
+a constant declines. Since
+[#1059](https://github.com/asc-community/AngouriMath/pull/1059) "it does not factor" is an
+answer rather than a refusal, which is what makes this worth having
+([#746](https://github.com/asc-community/AngouriMath/issues/746) tier 1).
 
 ### `x! = 0` carries the condition under which the factorial exists
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -27,6 +27,12 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [Tests/UnitTests/Core/Transformations/*.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[Tests/UnitTests/Algebra/Polynomials/EvaluationIrreducibilityTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[AngouriMath/Functions/Algebra/Polynomials/EvaluationHomomorphism.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [AngouriMath/Functions/Algebra/Polynomials/KroneckerFactorization.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/EvaluationHomomorphism.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/EvaluationHomomorphism.cs
@@ -1,0 +1,196 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using PeterO.Numbers;
+using System.Collections.Generic;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// Deciding that a polynomial in several variables <b>does not factor</b>, by evaluating
+    /// every variable but one at an integer point and asking the one-variable factoriser.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Substituting integers for variables is a ring homomorphism, so a factorisation survives
+    /// it: if <c>f = g·h</c> then <c>f(x, a) = g(x, a)·h(x, a)</c>. Degrees survive it too, as
+    /// long as the leading coefficient in <c>x</c> does not vanish at the point — and degrees in
+    /// <c>x</c> add, so if the total is preserved then neither part can have lost any. So <b>an
+    /// image that is irreducible, of the same degree in <c>x</c>, is a proof that the polynomial
+    /// it came from is irreducible</b>.
+    /// </para>
+    /// <para>
+    /// The converse is not true and is not claimed. An image factors more readily than its
+    /// source — <c>x^2 + y</c> at <c>y = 4</c> is <c>x^2 + 4</c>, still irreducible, but at
+    /// <c>y = -4</c> it is <c>(x-2)(x+2)</c> — so a reducible image says nothing at all, and
+    /// several points are tried before giving up. This decides one direction and declines the
+    /// other, which is why it can be asked first and cheaply.
+    /// </para>
+    /// <para>
+    /// <b>Why it is worth having next to <see cref="KroneckerFactorization"/>.</b> The
+    /// substitution's image has degree <c>Π (d_i + 1) - 1</c>, a product, so it leaves the
+    /// one-variable factoriser's reach after very few variables and the answer is a refusal —
+    /// <c>x^2 + y^2 + z^2 + w^2 + 1</c> is past it. An evaluation image has degree <c>d_main</c>
+    /// and does not grow with the variable count at all, so the polynomials this settles are
+    /// exactly the ones the substitution cannot reach. It answers only "it does not factor", but
+    /// since <a href="https://github.com/asc-community/AngouriMath/pull/1059">#1059</a> that is
+    /// an answer rather than a refusal.
+    /// </para>
+    /// <para>
+    /// <b>The precondition is checked and not assumed.</b> The argument above is about factors
+    /// of positive degree in <c>x</c>; a factor that is free of <c>x</c> — the content — is
+    /// invisible to it, and <c>y·(x + 1)</c> would be certified irreducible on an image of
+    /// <c>2x + 2</c> whose primitive part is <c>x + 1</c>. So the content in the main variable is
+    /// computed, and anything but a constant declines. The caller has a path that takes the
+    /// content out and asks again.
+    /// </para>
+    /// <para>
+    /// <b>This is not Hensel lifting</b>, and does not pretend to be the piece of
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> tier 1 that is
+    /// still outstanding. It is the first step of that algorithm — choosing an evaluation point
+    /// whose image keeps the degree and stays square-free — used for the one conclusion that
+    /// needs no lifting. Lifting a *reducible* image back to a factorisation of the source is the
+    /// rest of it, and is a different piece of work.
+    /// </para>
+    /// </remarks>
+    internal static class EvaluationHomomorphism
+    {
+        /// <summary>
+        /// Points tried, in this order. Small values keep the image's coefficients small, which
+        /// is what the one-variable factoriser's own bound is about; 0 is first because it makes
+        /// the image the coefficient of the constant term and is by far the cheapest, and both
+        /// signs are tried because a sign is exactly what decides <c>x^2 ± 4</c>.
+        /// </summary>
+        [ConstantField] private static readonly int[] Points = { 0, 1, -1, 2, -2, 3, -3, 5 };
+
+        /// <summary>
+        /// Combinations of <see cref="Points"/> tried before giving up. A point is a vector over
+        /// every variable but the main one, so the space is exponential in the variable count and
+        /// is walked in a fixed, small number of steps rather than enumerated.
+        /// </summary>
+        private const int MaxAttempts = 24;
+
+        /// <summary>
+        /// Whether <paramref name="poly"/> is irreducible over the rationals as a polynomial of
+        /// positive degree in <paramref name="main"/>. <see langword="false"/> means <b>not
+        /// settled</b> — it never means reducible.
+        /// </summary>
+        internal static bool CertifiesIrreducible(MultivariatePolynomial poly, int main)
+        {
+            var degree = poly.DegreeIn(main);
+            if (degree < 1 || poly.IsZero)
+                return false;
+
+            var others = new List<int>();
+            for (var variable = 0; variable < poly.VariableCount; variable++)
+                if (variable != main && poly.DegreeIn(variable) > 0)
+                    others.Add(variable);
+            if (others.Count == 0)
+                return false;
+
+            // A factor free of the main variable is not something an image in that variable can
+            // see, so this only speaks for a polynomial that has none.
+            if (PolynomialGcd.ContentIn(poly, main, others, 0) is not { IsConstant: true })
+                return false;
+
+            var point = new int[others.Count];
+            for (var attempt = 0; attempt < MaxAttempts; attempt++)
+            {
+                if (!NextPoint(point, attempt, others.Count))
+                    return false;
+                if (ToImage(poly, main, others, point) is not { } image)
+                    continue;
+                // The leading coefficient in the main variable vanished at this point, so the
+                // image has lost degree and its factorisation says nothing about the source.
+                if (image.Degree != degree)
+                    continue;
+                if (PolynomialFactorization.FactorPrimitive(image.PrimitivePart()) is not { } parts)
+                    continue;
+                if (parts.Count == 1 && parts[0].Multiplicity == 1 && parts[0].Factor.Degree == degree)
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// The <paramref name="attempt"/>th point, as a mixed-radix numeral over
+        /// <see cref="Points"/> — so the first few vary the last variable, which is the cheapest
+        /// thing to vary, and every coordinate is eventually reached.
+        /// </summary>
+        private static bool NextPoint(int[] point, int attempt, int count)
+        {
+            var left = attempt;
+            for (var i = count - 1; i >= 0; i--)
+            {
+                point[i] = Points[left % Points.Length];
+                left /= Points.Length;
+            }
+            // Past the last numeral the sequence would repeat, so there is nothing more to try.
+            return left == 0;
+        }
+
+        /// <summary>
+        /// <paramref name="poly"/> with every variable but <paramref name="main"/> replaced by
+        /// its coordinate of <paramref name="point"/>, with the denominators cleared — the
+        /// constant they came to is not wanted, a rational multiple of a factor being the same
+        /// factor.
+        /// </summary>
+        private static IntegerPolynomial? ToImage(
+            MultivariatePolynomial poly, int main, IReadOnlyList<int> others, IReadOnlyList<int> point)
+        {
+            var degree = poly.DegreeIn(main);
+            var coefficients = new ERational[degree + 1];
+            for (var i = 0; i < coefficients.Length; i++)
+                coefficients[i] = ERational.Zero;
+
+            foreach (var pair in poly.CoefficientsIn(main))
+            {
+                if (pair.Key >= coefficients.Length)
+                    return null;
+                if (Evaluate(pair.Value, others, point, 0) is not { } value)
+                    return null;
+                coefficients[pair.Key] = coefficients[pair.Key].Add(value);
+            }
+
+            var denominator = EInteger.One;
+            foreach (var coefficient in coefficients)
+                denominator = Lcm(denominator, coefficient.Denominator);
+            var whole = new EInteger[coefficients.Length];
+            for (var i = 0; i < whole.Length; i++)
+                whole[i] = coefficients[i].Numerator
+                    .Multiply(denominator.Divide(coefficients[i].Denominator));
+            return IntegerPolynomial.Create(whole);
+        }
+
+        /// <summary>
+        /// One variable at a time, Horner-free: each coefficient is evaluated at the remaining
+        /// variables and weighted by the point raised to that exponent. What is left when every
+        /// variable has been taken has to be a constant, and anything else declines.
+        /// </summary>
+        private static ERational? Evaluate(
+            MultivariatePolynomial poly, IReadOnlyList<int> others, IReadOnlyList<int> point, int depth)
+        {
+            if (depth == others.Count)
+                return poly.IsZero ? ERational.Zero
+                    : poly.IsConstant ? poly.CoefficientOf(0) : (ERational?)null;
+
+            var total = ERational.Zero;
+            var at = EInteger.FromInt32(point[depth]);
+            foreach (var pair in poly.CoefficientsIn(others[depth]))
+            {
+                if (Evaluate(pair.Value, others, point, depth + 1) is not { } inner)
+                    return null;
+                total = total.Add(inner.Multiply(ERational.Create(at.Pow(pair.Key), EInteger.One)))
+                    .ToLowestTerms();
+            }
+            return total;
+        }
+
+        private static EInteger Lcm(EInteger left, EInteger right)
+            => left.Divide(left.Gcd(right)).Multiply(right);
+    }
+}

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/KroneckerFactorization.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/KroneckerFactorization.cs
@@ -83,6 +83,25 @@ namespace AngouriMath.Functions
         {
             if (poly.IsZero || poly.DegreeIn(main) < 1)
                 return null;
+            if (BySubstitution(poly, main) is { } factors)
+                return factors;
+            // The substitution gave up -- on the image's degree, on how far it split, or on the
+            // arithmetic. An *evaluation* image has the degree of the polynomial in the main
+            // variable however many other variables there are, so it is still there to be asked,
+            // and what it can settle is that there is nothing to find. Asked second because it
+            // answers only that: the substitution is the one that can actually factor.
+            return EvaluationHomomorphism.CertifiesIrreducible(poly, main)
+                ? new[] { poly }
+                : null;
+        }
+
+        /// <summary>
+        /// The factorisation by Kronecker's substitution, or <see langword="null"/> where it
+        /// could not be reached.
+        /// </summary>
+        private static IReadOnlyList<MultivariatePolynomial>? BySubstitution(
+            MultivariatePolynomial poly, int main)
+        {
 
             // The main variable is placed first so that its exponent is the lowest digit; the
             // rest follow in index order, and a variable the polynomial does not use is left out

--- a/Sources/Tests/UnitTests/Algebra/Polynomials/EvaluationIrreducibilityTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/Polynomials/EvaluationIrreducibilityTest.cs
@@ -1,0 +1,156 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Extensions;
+using AngouriMath.Functions;
+using Xunit;
+using static AngouriMath.Entity;
+
+namespace AngouriMath.Tests.Algebra.Polynomials
+{
+    /// <summary>
+    /// <see cref="EvaluationHomomorphism.CertifiesIrreducible"/> — a proof that a polynomial in
+    /// several variables does not factor, from an image in one of them.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The half that must never be wrong is the <see langword="true"/> half, since nothing
+    /// downstream can check it: a factorisation is verified by division, and "there is no
+    /// factorisation" is not. So the reducible corpus below is the real subject of this file,
+    /// and it is built as <b>products</b> — every case is reducible by construction, whatever
+    /// the factoriser would say about it.
+    /// </para>
+    /// <para>
+    /// The <see langword="false"/> half claims nothing, so the irreducible corpus is a
+    /// measurement of reach rather than an assertion about correctness. It is written as a
+    /// count so that losing reach fails rather than passing quietly.
+    /// </para>
+        /// <para>
+        /// <b>The negative half is not vacuous, and <see cref="TheIrreducibleOnesAreCertified"/>
+        /// is what says so.</b> A certificate that always declined would pass every
+        /// <c>AssertFalse</c> here; it is the count in that test which requires the machinery to
+        /// actually reach a verdict, so the two halves hold each other up.
+        /// </para>
+    /// </remarks>
+    [Trait("Area", "Algebra")]
+    public sealed class EvaluationIrreducibilityTest
+    {
+        private static IReadOnlyDictionary<Variable, int> Index(params string[] names)
+        {
+            var index = new Dictionary<Variable, int>();
+            for (var i = 0; i < names.Length; i++)
+                index[(Variable)names[i]] = i;
+            return index;
+        }
+
+        private static bool Certifies(string source, string main, params string[] variables)
+        {
+            var parsed = MultivariatePolynomial.TryParse(source.ToEntity(), Index(variables));
+            Assert.True(parsed is not null, $"{source} was not read as a polynomial");
+            return EvaluationHomomorphism.CertifiesIrreducible(parsed!, System.Array.IndexOf(variables, main));
+        }
+
+        /// <summary>
+        /// Every one of these is a product, so a certificate on any of them is a wrong answer.
+        /// </summary>
+        [Theory]
+        [InlineData("(x + y) * (x - y)")]
+        [InlineData("(x + y) * (x + 2 * y)")]
+        [InlineData("(x + y + 1) * (x - y + 1)")]
+        [InlineData("(x ^ 2 + y) * (x ^ 2 - y)")]
+        [InlineData("(x ^ 2 + y ^ 5) * (x ^ 2 - y ^ 5)")]
+        [InlineData("(x ^ 8 + y) * (x ^ 8 + 3 * y)")]
+        [InlineData("(x + y) * (x + y)")]
+        [InlineData("(x - 1) * (x - y)")]
+        [InlineData("(x + 2 * y) * (3 * x - y)")]
+        [InlineData("(x ^ 3 + y) * (x + y ^ 3)")]
+        [InlineData("(x + y) * (x - y) * (x + 2 * y)")]
+        [InlineData("(x ^ 2 + x * y + 1) * (x ^ 2 - x * y + 1)")]
+        public void AProductIsNeverCertified(string source)
+            => Assert.False(Certifies(source, "x", "x", "y"),
+                $"{source} is a product and was certified irreducible");
+
+        /// <summary>
+        /// The same, written out rather than as a product — these are the shapes
+        /// <see cref="KroneckerFactorization"/>'s own remark names as ones it refuses, so a
+        /// certificate here would be a wrong answer on exactly the cases this is meant to help.
+        /// </summary>
+        [Theory]
+        [InlineData("x ^ 7 - y ^ 7")]
+        [InlineData("x ^ 6 - y ^ 6")]
+        [InlineData("x ^ 2 - y ^ 2")]
+        [InlineData("x ^ 4 - y ^ 4")]
+        [InlineData("x ^ 3 - y ^ 3")]
+        public void ADifferenceOfLikePowersIsNeverCertified(string source)
+            => Assert.False(Certifies(source, "x", "x", "y"),
+                $"{source} has x - y as a factor and was certified irreducible");
+
+        /// <summary>
+        /// A factor free of the main variable is invisible to an image in it, which is what the
+        /// content precondition is for. Without it <c>y * (x + 1)</c> is certified on an image
+        /// of <c>2x + 2</c>.
+        /// </summary>
+        [Theory]
+        [InlineData("y * (x + 1)")]
+        [InlineData("y ^ 2 * (x ^ 2 + 1)")]
+        [InlineData("(y + 1) * (x ^ 2 + x + 1)")]
+        [InlineData("y * z * (x + 1)")]
+        public void AContentInTheMainVariableDeclines(string source)
+            => Assert.False(Certifies(source, "x", "x", "y", "z"),
+                $"{source} has a factor free of x and was certified irreducible");
+
+        /// <summary>
+        /// What it reaches. Each of these is irreducible over the rationals, and the count is
+        /// asserted so that losing reach fails rather than passing quietly.
+        /// </summary>
+        [Fact]
+        public void TheIrreducibleOnesAreCertified()
+        {
+            var cases = new[]
+            {
+                ("x ^ 2 + y ^ 2 + 1", new[] { "x", "y" }),
+                ("x ^ 2 + y", new[] { "x", "y" }),
+                ("x ^ 3 + y + 1", new[] { "x", "y" }),
+                ("x ^ 2 + x * y + y ^ 2 + 1", new[] { "x", "y" }),
+                ("x ^ 2 + y ^ 2 + z ^ 2 + 1", new[] { "x", "y", "z" }),
+                ("x ^ 2 + y ^ 2 + z ^ 2 + w ^ 2 + 1", new[] { "x", "y", "z", "w" }),
+                ("x ^ 5 + y + 1", new[] { "x", "y" }),
+                ("x ^ 4 + x + y", new[] { "x", "y" }),
+            };
+            var certified = cases.Count(one => Certifies(one.Item1, "x", one.Item2));
+            Assert.True(certified >= 7,
+                $"only {certified} of {cases.Length} irreducible polynomials were certified");
+        }
+
+        /// <summary>
+        /// The four-variable case is the point of this: its Kronecker image has degree
+        /// <c>3·3·3·3 - 1 = 80</c>, past the one-variable factoriser's 32, so the substitution
+        /// refuses it outright. An evaluation image has degree 2 however many variables there
+        /// are.
+        /// </summary>
+        [Fact]
+        public void ItReachesPastTheSubstitutionsCeiling()
+        {
+            const string source = "x ^ 2 + y ^ 2 + z ^ 2 + w ^ 2 + 1";
+            Assert.True(Certifies(source, "x", "x", "y", "z", "w"));
+            // And the substitution cannot: 3·3·3·3 - 1 = 80 is past the one-variable
+            // factoriser's 32. Before the certificate, `Factor` refused with null here; it hands
+            // the polynomial back now, which is the difference this makes to a caller.
+            var factored = MathS.Polynomials.Factor(source.ToEntity(), (Variable)"x");
+            Assert.NotNull(factored);
+            // Compared by value rather than by spelling, since the answer comes back through the
+            // polynomial representation and its terms are in that order rather than the input's.
+            Assert.Equal(Number.Integer.Zero, (factored! - source.ToEntity()).Simplify());
+            // And it is the polynomial itself rather than a factorisation of it, which is the
+            // whole content of the answer: there is nothing to find.
+            Assert.IsNotType<Mulf>(factored);
+        }
+    }
+}


### PR DESCRIPTION
`MathS.Polynomials.Factor` in several variables is Kronecker's substitution, whose one-variable
image has degree `Π (d_i + 1) - 1` — a **product**. That leaves the one-variable factoriser's
reach after very few variables: `x2 + y2 + z2 + w2 + 1` needs an image of degree 80 against a
ceiling of 32, and the answer was `null`.

| | before | now |
|---|---|---|
| `Factor("x2 + y2 + z2 + w2 + 1", "x")` | `null` | `w ^ 2 + x ^ 2 + y ^ 2 + z ^ 2 + 1` |
| `Factor("x2 + y2 + z2 + 1", "x")` | `x ^ 2 + y ^ 2 + z ^ 2 + 1` | unchanged |
| `Factor("x7 - y7", "x")` | `null` | `null` — it *is* reducible; this says nothing about it |
| `Factor("(x + y) * (x - y)", "x")` | `(x + y) * (x - y)` | unchanged |
| `Factor("y * (x + 1)", "x")` | `y * (x + 1)` | unchanged |

Measured on a build of each side.

## Why an evaluation image settles anything

Evaluating is a ring homomorphism, so `f = g·h` gives `f(x, a) = g(x, a)·h(x, a)`. Degrees in
the main variable **add**, so if the image kept the total degree then neither part can have lost
any. An image that is irreducible and of full degree is therefore a **proof** that its source is
irreducible — and since #1059, "it does not factor" is an answer rather than a refusal.

An evaluation image has degree `d_main` however many other variables there are, which is exactly
why it reaches where the substitution does not.

## What it does not claim, and how that is held down

One direction only. A reducible image says nothing at all — `x2 + y` is irreducible and its
image at `y = -4` is `(x-2)(x+2)` — so several points are tried and a decline is never a claim
of reducibility.

The `true` half is the one **nothing downstream can check**: a factorisation is verified by
division, and "there is no factorisation" is not. So the tests are mostly about the half that
must never be wrong — **17 of the 23 assert that a certificate is *not* issued**, and every case
in them is written as a product, or is a difference of like powers, so it is reducible by
construction whatever a factoriser would say about it.

The count in the positive test is what stops all of that passing vacuously: a certificate that
always declined would satisfy every `AssertFalse` in the file. The two halves hold each other up,
and the test remark says so.

**The content precondition is checked, not assumed.** A factor free of the main variable is
invisible to an image in that variable, so `y · (x + 1)` would be certified on an image of
`2x + 2` whose primitive part is `x + 1`. The content in the main variable is computed and
anything but a constant declines.

## Where this sits

Asked **second**, after the substitution refuses — the substitution is the one that can actually
factor, and this only ever says there is nothing to find.

It is the first step of **Hensel lifting with an evaluation homomorphism** — choosing a point
whose image keeps the degree — used for the one conclusion that needs no lifting. Lifting a
*reducible* image back to a factorisation of its source is the rest of that algorithm, is
unchanged here, and remains the outstanding piece of #746 tier 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd