### PR TITLE
Hensel lifting along an evaluation homomorphism, in two variables (#746)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -21,6 +21,7 @@ read first.
 
 | Silent? | What | Was | Is |
 |---|---|---|---|
+| | `MathS.Polynomials.Factor("x7 - y7", "x")`, and bivariate polynomials whose substituted image over-factors | `null` — a refusal | `(x - y) * (x ^ 6 + x ^ 5 * y + … + y ^ 6)` |
 | | `MathS.Polynomials.Factor("x2 + y2 + z2 + w2 + 1", "x")`, and polynomials in enough variables generally | `null` — a refusal | the polynomial itself, meaning it does not factor |
 | **Silent** | `"x! = 0".ToEntity().Simplify()` | `False`, including at `x = -1` where `x!` has a pole and the statement is `NaN` | `False provided x in RR and (x >= 0 or not x in ZZ)` |
 | **Silent** | `"x! / x!".ToEntity().Simplify()`, and the same for any factorial over itself | `1`, including at `x = -1` where the quotient is `NaN` | `1 provided not x! = 0` |
@@ -312,6 +313,42 @@ the same precedences this grammar uses — so those needed the same brackets —
 bracketing for. The change only ever adds `\left(`/`\right)` groups, which CSharpMath already
 parses, so nothing downstream needs a matching change
 ([#822](https://github.com/asc-community/AngouriMath/issues/822)).
+
+### A polynomial in two variables is factored by lifting rather than by substituting
+
+`MathS.Polynomials.Factor` in several variables was Kronecker's substitution alone, and its
+one-variable image **over-factors**: `x7 - y7` maps to `t^7 (1 - t^49)`, whose factors are
+cyclotomic, so a two-factor bivariate becomes a one-variable polynomial with many irreducibles
+and the recombination is exponential in a count the substitution inflated itself. Those were
+refusals.
+
+An *evaluation* image inflates nothing — `x7 - y7` at `y = 1` is `x7 - 1`, which has the two
+factors the answer has — and the factorisation of that image is lifted back one power of `y` at
+a time.
+
+| | before | now |
+|---|---|---|
+| `Factor("x7 - y7", "x")` | `null` | `(x - y) * (x ^ 6 + x ^ 5 * y + x ^ 4 * y ^ 2 + x ^ 3 * y ^ 3 + x ^ 2 * y ^ 4 + x * y ^ 5 + y ^ 6)` |
+| `Factor("x6 - y6", "x")` | `null` | `(x + y) * (x - y) * (x ^ 2 + x * y + y ^ 2) * (x ^ 2 - x * y + y ^ 2)` |
+| `Factor("x12 - y12", "x")` | `null` | six factors, the full cyclotomic split |
+| `Factor("x4 - y10", "x")` | `null` | `(x ^ 2 + y ^ 5) * (x ^ 2 - y ^ 5)` |
+| `Factor("x16 + 4 x8 y + 3 y2", "x")` | `null` | `(x ^ 8 + 3 * y) * (x ^ 8 + y)` |
+| `Factor("x ^ 3 - (y + z) ^ 3", "x")` | `null` | `null` — three variables, and the lift goes along one |
+| `Factor("(x + y) * (x - y)", "x")` | `(x + y) * (x - y)` | unchanged |
+
+**What it will not do.** The leading coefficient in the main variable has to be a constant.
+Where it is a polynomial in `y`, the lifted factors' leading coefficients must be known before
+the lift to keep them polynomials rather than power series — Wang's leading-coefficient problem
+— and that is a second algorithm on top of this one. It declines, and the substitution is still
+tried first. Three or more variables decline for the same reason: the lift goes along one
+evaluation at a time.
+
+**Nothing is trusted.** Every candidate is checked by exact division of the original, so a bad
+evaluation point, a lift that drifted, or a recombination that is not a factor costs a refusal
+and cannot cost a wrong answer.
+
+This is [#746](https://github.com/asc-community/AngouriMath/issues/746) tier 1's Hensel lifting
+item, in two variables.
 
 ### A polynomial in too many variables to substitute can still be answered
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -30,6 +30,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [Tests/UnitTests/Algebra/Polynomials/EvaluationIrreducibilityTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[AngouriMath/Functions/Algebra/Polynomials/BivariateHenselFactorization.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [AngouriMath/Functions/Algebra/Polynomials/EvaluationHomomorphism.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/BivariateHenselFactorization.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/BivariateHenselFactorization.cs
@@ -1,0 +1,484 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using PeterO.Numbers;
+using System.Collections.Generic;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// Factorisation in two variables by <b>Hensel lifting along an evaluation
+    /// homomorphism</b>: factor the polynomial at a point, then lift that factorisation back
+    /// one power of the auxiliary variable at a time.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="KroneckerFactorization"/> reaches the same answers by a different route and
+    /// leaves a gap this fills. Its one-variable image has degree <c>Π (d_i + 1) - 1</c>, and —
+    /// worse than the size — the image <i>over-factors</i>: <c>x^7 - y^7</c> maps to
+    /// <c>t^7 (1 - t^49)</c>, whose factors are cyclotomic, so the recombination is exponential
+    /// in a count the substitution itself inflated. An evaluation image does not inflate
+    /// anything: <c>x^7 - y^7</c> at <c>y = 1</c> is <c>x^7 - 1</c>, which has the two factors
+    /// the answer has.
+    /// </para>
+    /// <para>
+    /// <b>The lift.</b> Write <c>g(x, y) = f(x, y + a)</c> so that the point is the origin.
+    /// <c>g(x, 0)</c> factors over the integers as <c>u_1 · … · u_r</c>, and a factorisation
+    /// modulo <c>y^k</c> is pushed to <c>y^(k+1)</c> by solving <c>α·v + β·u = e</c> for the
+    /// error <c>e</c> — which the Bezout pair of <c>u</c> and <c>v</c> answers immediately,
+    /// since a square-free image makes them coprime. Reducing <c>α</c> below the degree of
+    /// <c>u</c> and pushing the quotient into <c>β</c> keeps each side at the degree it started
+    /// at. Lifted as far as the degree of <c>g</c> in <c>y</c>, a true factor is reached
+    /// exactly rather than approximately, because it has no higher power to hide in.
+    /// </para>
+    /// <para>
+    /// <b>What is restricted, and why it is the honest restriction rather than a convenient
+    /// one.</b> The leading coefficient in the main variable must be constant. Where it is a
+    /// polynomial in <c>y</c>, the lifted factors' leading coefficients have to be *known in
+    /// advance* to keep them polynomials rather than power series — Wang's leading-coefficient
+    /// problem — and the usual answer is to factor that coefficient and distribute it, which is
+    /// a second algorithm on top of this one. Declining is a refusal, and refusing is something
+    /// this layer already does.
+    /// </para>
+    /// <para>
+    /// <b>Nothing here is trusted.</b> Every candidate is checked by exact division of the
+    /// original, so a mistake anywhere above — a bad point, a lift that drifted, a recombination
+    /// that is not a factor — costs a refusal and cannot cost a wrong answer.
+    /// </para>
+    /// </remarks>
+    internal static class BivariateHenselFactorization
+    {
+        /// <summary>
+        /// Evaluation points tried, in order. Small keeps the image's coefficients small, which
+        /// is what the one-variable factoriser's own bound is about.
+        /// </summary>
+        [ConstantField] private static readonly int[] Points = { 0, 1, -1, 2, -2, 3, -3, 4, -4, 5 };
+
+        /// <summary>
+        /// Past this the recombination is refused rather than paid for: it is over subsets of
+        /// the image's irreducible factors. The evaluation image does not over-factor the way a
+        /// substituted one does, so this is reached far less often than
+        /// <c>KroneckerFactorization.MaxImageFactors</c> is.
+        /// </summary>
+        private const int MaxImageFactors = 10;
+
+        /// <summary>
+        /// The factors of <paramref name="poly"/> in <paramref name="main"/> and
+        /// <paramref name="other"/>, each of positive degree in <paramref name="main"/>, or
+        /// <see langword="null"/> where nothing could be settled. A single factor means it does
+        /// not factor, which is an answer.
+        /// </summary>
+        internal static IReadOnlyList<MultivariatePolynomial>? Factor(
+            MultivariatePolynomial poly, int main, int other)
+        {
+            var degreeInMain = poly.DegreeIn(main);
+            var degreeInOther = poly.DegreeIn(other);
+            if (degreeInMain < 1 || degreeInOther < 1)
+                return null;
+
+            // Wang's leading-coefficient problem is not solved here, so a leading coefficient
+            // that is not a constant declines rather than being guessed at.
+            if (!poly.LeadingCoefficientIn(main).IsConstant)
+                return null;
+
+            // A factor free of the main variable is not something this finds, and its presence
+            // would make the image's factorisation say the wrong thing about degrees.
+            if (PolynomialGcd.ContentIn(poly, main, new[] { other }, 0) is not { IsConstant: true })
+                return null;
+
+            if (ByYPower(poly, main, other, degreeInOther) is not { } coefficients)
+                return null;
+
+            foreach (var point in Points)
+            {
+                if (Shift(coefficients, point) is not { } shifted)
+                    continue;
+                if (Attempt(poly, shifted, main, other, point, degreeInMain, degreeInOther) is { } factors)
+                    return factors;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// One evaluation point: factor at it, lift, and recombine. <see langword="null"/> where
+        /// this point does not settle it, which is not a statement about the polynomial.
+        /// </summary>
+        private static IReadOnlyList<MultivariatePolynomial>? Attempt(
+            MultivariatePolynomial poly, RationalPolynomial[] shifted, int main, int other,
+            int point, int degreeInMain, int degreeInOther)
+        {
+            var image = shifted[0];
+            // The leading coefficient is a non-zero constant, so the degree cannot have fallen;
+            // this says so rather than assuming it.
+            if (image.Degree != degreeInMain)
+                return null;
+            // Square-free, so that the image's factors are pairwise coprime and the Bezout pair
+            // the lift needs exists. Coprimality with the derivative is exactly that, and
+            // TryBezout reports it as it computes the pair.
+            if (!RationalPolynomial.TryBezout(image, Derivative(image), out _, out _))
+                return null;
+
+            if (ToInteger(image) is not { } whole)
+                return null;
+            if (PolynomialFactorization.FactorPrimitive(whole.PrimitivePart()) is not { } parts)
+                return null;
+
+            var irreducibles = new List<RationalPolynomial>();
+            foreach (var part in parts)
+            {
+                // A square-free image has no repeated factor; anything else means the point was
+                // a bad one rather than that the polynomial has one.
+                if (part.Multiplicity != 1)
+                    return null;
+                if (irreducibles.Count == MaxImageFactors)
+                    return null;
+                irreducibles.Add(RationalPolynomial.FromInteger(part.Factor));
+            }
+            if (irreducibles.Count == 0)
+                return null;
+            if (irreducibles.Count == 1)
+                return new[] { poly };
+
+            // The image is the product of its primitive factors times its content, and the lift
+            // needs a product that is the image exactly -- so the constant goes on the first.
+            var product = irreducibles[0];
+            for (var i = 1; i < irreducibles.Count; i++)
+                product = product.Multiply(irreducibles[i]);
+            if (!image.TryDivide(product, out var constant, out var remainder)
+                || !remainder.IsZero || !constant.IsConstant)
+                return null;
+            irreducibles[0] = irreducibles[0].Multiply(constant);
+
+            var lifted = Lift(shifted, irreducibles, degreeInOther + 1);
+            if (lifted is null)
+                return null;
+            return Recombine(poly, lifted, main, other, point, degreeInOther + 1);
+        }
+
+        /// <summary>
+        /// The image's factors lifted to agree with <paramref name="g"/> modulo
+        /// <c>y^<paramref name="depth"/></c>, each a truncated series in <c>y</c> whose
+        /// coefficients are polynomials in the main variable.
+        /// </summary>
+        /// <remarks>
+        /// Several factors at once, by splitting off one at a time: lift the pair
+        /// <c>(u_1, u_2 · … · u_r)</c>, then lift the second half against the rest. The pair
+        /// step is where the work is.
+        /// </remarks>
+        private static List<RationalPolynomial[]>? Lift(
+            RationalPolynomial[] g, IReadOnlyList<RationalPolynomial> factors, int depth)
+        {
+            var result = new List<RationalPolynomial[]>();
+            var rest = g;
+            for (var i = 0; i < factors.Count - 1; i++)
+            {
+                var others = factors[i + 1];
+                for (var j = i + 2; j < factors.Count; j++)
+                    others = others.Multiply(factors[j]);
+                if (LiftPair(rest, factors[i], others, depth) is not { } pair)
+                    return null;
+                result.Add(pair.Left);
+                rest = pair.Right;
+            }
+            result.Add(Truncate(rest, depth));
+            return result;
+        }
+
+        /// <summary>
+        /// <c>g = A·B</c> modulo <c>y^<paramref name="depth"/></c>, from
+        /// <c>g(x, 0) = u·v</c>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Writing the next pair as <c>A + α y^k</c> and <c>B + β y^k</c> and asking that the
+        /// product agree one power further leaves <c>α·v + β·u = e</c>, where <c>e</c> is the
+        /// coefficient of <c>y^k</c> in the error so far. The Bezout pair <c>s·u + t·v = 1</c>
+        /// answers it at once — <c>α = e·t</c>, <c>β = e·s</c> — and reducing <c>α</c> below the
+        /// degree of <c>u</c>, pushing the quotient into <c>β</c>, is what keeps each side at
+        /// the degree it started at. It is the same step as the p-adic lift in
+        /// <c>PolynomialFactorization</c>, over <c>(y)</c> rather than over a prime.
+        /// </para>
+        /// <para>
+        /// The Bezout pair is computed once: neither side changes modulo <c>y</c> as it is
+        /// lifted, which is the whole reason the same pair keeps answering.
+        /// </para>
+        /// </remarks>
+        private static (RationalPolynomial[] Left, RationalPolynomial[] Right)? LiftPair(
+            RationalPolynomial[] g, RationalPolynomial u, RationalPolynomial v, int depth)
+        {
+            if (!RationalPolynomial.TryBezout(u, v, out var s, out var t))
+                return null;
+
+            var a = new RationalPolynomial[depth];
+            var b = new RationalPolynomial[depth];
+            for (var i = 0; i < depth; i++)
+                a[i] = b[i] = RationalPolynomial.Zero;
+            a[0] = u;
+            b[0] = v;
+
+            for (var k = 1; k < depth; k++)
+            {
+                // The coefficient of y^k in g - A·B, with A and B known below y^k.
+                var error = k < g.Length ? g[k] : RationalPolynomial.Zero;
+                for (var i = 0; i <= k; i++)
+                    error = error.Subtract(a[i].Multiply(b[k - i]));
+                if (error.IsZero)
+                    continue;
+
+                var alpha = error.Multiply(t);
+                var beta = error.Multiply(s);
+                if (!alpha.TryDivide(u, out var quotient, out var reduced))
+                    return null;
+                alpha = reduced;
+                beta = beta.Add(quotient.Multiply(v));
+                // Either side growing past the degree it started at means the lift has left the
+                // factorisation it was following, and going on would only bury that.
+                if (alpha.Degree >= u.Degree || beta.Degree >= v.Degree + 1)
+                    return null;
+                a[k] = alpha;
+                b[k] = beta;
+            }
+
+            return (a, b);
+        }
+
+        private static RationalPolynomial[] Truncate(RationalPolynomial[] series, int depth)
+        {
+            var result = new RationalPolynomial[depth];
+            for (var i = 0; i < depth; i++)
+                result[i] = i < series.Length ? series[i] : RationalPolynomial.Zero;
+            return result;
+        }
+
+        /// <summary>
+        /// Every subset of the lifted factors, tried as a divisor of the original — which is
+        /// what makes a mistake anywhere above cost a refusal rather than a wrong answer.
+        /// </summary>
+        /// <remarks>
+        /// A subset that corresponds to a true factor multiplies to it exactly, because the lift
+        /// went as far as the degree in <c>y</c> and a factor has no higher power to hide in.
+        /// Subsets are walked smallest first so that the factorisation comes out in pieces
+        /// rather than as the polynomial and a constant.
+        /// </remarks>
+        private static IReadOnlyList<MultivariatePolynomial>? Recombine(
+            MultivariatePolynomial poly, List<RationalPolynomial[]> lifted,
+            int main, int other, int point, int depth)
+        {
+            var found = new List<MultivariatePolynomial>();
+            var remaining = poly;
+            var used = 0;
+            var count = lifted.Count;
+
+            // Every subset as a bit pattern, smallest first, so that the factorisation comes out
+            // in pieces rather than as the polynomial itself and a constant. Half of them is
+            // enough: what is left over after a subset divides out is the complement.
+            var masks = new List<int>();
+            for (var mask = 1; mask < (1 << count) - 1; mask++)
+                masks.Add(mask);
+            masks.Sort((left, right) => PopCount(left).CompareTo(PopCount(right)));
+
+            foreach (var mask in masks)
+            {
+                if ((mask & used) != 0)
+                    continue;
+                if (PopCount(mask) > count - PopCount(used) - 1)
+                    continue;
+
+                var product = new RationalPolynomial[depth];
+                for (var i = 0; i < depth; i++)
+                    product[i] = i == 0 ? RationalPolynomial.One : RationalPolynomial.Zero;
+                for (var i = 0; i < count; i++)
+                    if ((mask & (1 << i)) != 0)
+                        product = MultiplySeries(product, lifted[i], depth);
+
+                if (ToPolynomial(product, main, other, point, poly.VariableCount) is not { } candidate)
+                    continue;
+                if (candidate.IsConstant || candidate.DegreeIn(main) < 1)
+                    continue;
+                if (remaining.DivideExact(candidate) is not { } quotient)
+                    continue;
+
+                found.Add(candidate.Normalized());
+                remaining = quotient;
+                used |= mask;
+            }
+
+            if (found.Count == 0)
+                return null;
+            if (!remaining.IsConstant)
+                found.Add(remaining.Normalized());
+            return found.Count < 2 ? new[] { poly } : found;
+        }
+
+        private static int PopCount(int value)
+        {
+            var count = 0;
+            while (value != 0)
+            {
+                count += value & 1;
+                value >>= 1;
+            }
+            return count;
+        }
+
+        private static RationalPolynomial[] MultiplySeries(
+            RationalPolynomial[] left, RationalPolynomial[] right, int depth)
+        {
+            var result = new RationalPolynomial[depth];
+            for (var i = 0; i < depth; i++)
+                result[i] = RationalPolynomial.Zero;
+            for (var i = 0; i < depth; i++)
+            {
+                if (left[i].IsZero)
+                    continue;
+                for (var j = 0; i + j < depth; j++)
+                    if (!right[j].IsZero)
+                        result[i + j] = result[i + j].Add(left[i].Multiply(right[j]));
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// A lifted series back to a polynomial in the two variables, with the evaluation point
+        /// undone — the lift worked in <c>y + point</c>, so the answer is in <c>y - point</c>.
+        /// </summary>
+        private static MultivariatePolynomial? ToPolynomial(
+            RationalPolynomial[] series, int main, int other, int point, int variableCount)
+        {
+            if (Shift(series, -point) is not { } unshifted)
+                return null;
+            var result = MultivariatePolynomial.Zero(variableCount);
+            for (var k = 0; k < unshifted.Length; k++)
+            {
+                if (unshifted[k].IsZero)
+                    continue;
+                for (var i = 0; i <= unshifted[k].Degree; i++)
+                {
+                    var coefficient = unshifted[k][i];
+                    if (coefficient.IsZero)
+                        continue;
+                    var term = MultivariatePolynomial.Constant(variableCount, coefficient);
+                    if (i > 0)
+                    {
+                        if (term.ShiftedBy(main, i) is not { } withMain)
+                            return null;
+                        term = withMain;
+                    }
+                    if (k > 0)
+                    {
+                        if (term.ShiftedBy(other, k) is not { } withOther)
+                            return null;
+                        term = withOther;
+                    }
+                    result = result.Add(term);
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// <paramref name="poly"/> as coefficients of powers of <paramref name="other"/>, each a
+        /// polynomial in <paramref name="main"/> alone.
+        /// </summary>
+        private static RationalPolynomial[]? ByYPower(
+            MultivariatePolynomial poly, int main, int other, int degreeInOther)
+        {
+            var result = new RationalPolynomial[degreeInOther + 1];
+            for (var i = 0; i < result.Length; i++)
+                result[i] = RationalPolynomial.Zero;
+            foreach (var pair in poly.CoefficientsIn(other))
+            {
+                if (pair.Key >= result.Length)
+                    return null;
+                if (ToUnivariate(pair.Value, main) is not { } coefficient)
+                    return null;
+                result[pair.Key] = coefficient;
+            }
+            return result;
+        }
+
+        /// <summary>A polynomial in one variable only, as a one-variable polynomial.</summary>
+        private static RationalPolynomial? ToUnivariate(MultivariatePolynomial poly, int main)
+        {
+            var degree = poly.DegreeIn(main);
+            var coefficients = new ERational[degree + 1];
+            for (var i = 0; i < coefficients.Length; i++)
+                coefficients[i] = ERational.Zero;
+            foreach (var pair in poly.CoefficientsIn(main))
+            {
+                if (pair.Key >= coefficients.Length)
+                    return null;
+                if (pair.Value.IsZero)
+                    continue;
+                if (!pair.Value.IsConstant)
+                    return null;   // a variable other than the two this works in
+                coefficients[pair.Key] = pair.Value.CoefficientOf(0);
+            }
+            return RationalPolynomial.Create(coefficients);
+        }
+
+        /// <summary>
+        /// The same polynomial written in <c>y + point</c> — so that the evaluation point
+        /// becomes the origin and the ideal to lift along is <c>(y)</c>.
+        /// </summary>
+        private static RationalPolynomial[]? Shift(RationalPolynomial[] coefficients, int point)
+        {
+            if (point == 0)
+                return (RationalPolynomial[])coefficients.Clone();
+            var result = new RationalPolynomial[coefficients.Length];
+            for (var i = 0; i < result.Length; i++)
+                result[i] = RationalPolynomial.Zero;
+            var at = EInteger.FromInt32(point);
+            for (var j = 0; j < coefficients.Length; j++)
+            {
+                if (coefficients[j].IsZero)
+                    continue;
+                // (y + a)^j expanded, so the coefficient of y^j moves to every y^k below it
+                // weighted by C(j, k) a^(j-k).
+                for (var k = 0; k <= j; k++)
+                {
+                    var weight = ERational.Create(Binomial(j, k).Multiply(at.Pow(j - k)), EInteger.One);
+                    result[k] = result[k].Add(coefficients[j].ScaleBy(weight));
+                }
+            }
+            return result;
+        }
+
+        private static EInteger Binomial(int n, int k)
+        {
+            var result = EInteger.One;
+            for (var i = 0; i < k; i++)
+                result = result.Multiply(EInteger.FromInt32(n - i)).Divide(EInteger.FromInt32(i + 1));
+            return result;
+        }
+
+        private static RationalPolynomial Derivative(RationalPolynomial poly)
+        {
+            if (poly.Degree < 1)
+                return RationalPolynomial.Zero;
+            var coefficients = new ERational[poly.Degree];
+            for (var i = 1; i <= poly.Degree; i++)
+                coefficients[i - 1] = poly[i].Multiply(ERational.FromInt32(i));
+            return RationalPolynomial.Create(coefficients);
+        }
+
+        private static IntegerPolynomial? ToInteger(RationalPolynomial poly)
+        {
+            var denominator = EInteger.One;
+            for (var i = 0; i <= poly.Degree; i++)
+                denominator = Lcm(denominator, poly[i].Denominator);
+            var whole = new EInteger[poly.Degree + 1];
+            for (var i = 0; i < whole.Length; i++)
+                whole[i] = poly[i].Numerator.Multiply(denominator.Divide(poly[i].Denominator));
+            return IntegerPolynomial.Create(whole);
+        }
+
+        private static EInteger Lcm(EInteger left, EInteger right)
+            => left.IsZero || right.IsZero ? EInteger.One
+                : left.Divide(left.Gcd(right)).Multiply(right);
+    }
+}

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/KroneckerFactorization.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/KroneckerFactorization.cs
@@ -85,6 +85,13 @@ namespace AngouriMath.Functions
                 return null;
             if (BySubstitution(poly, main) is { } factors)
                 return factors;
+            // The substitution's image over-factors -- `x^7 - y^7` maps to `t^7 (1 - t^49)`,
+            // whose factors are cyclotomic -- so its recombination is exponential in a count it
+            // inflated itself. Lifting an *evaluation* image inflates nothing, and reaches the
+            // shapes the remark above names as refused.
+            if (OnlyOther(poly, main) is { } other
+                && BivariateHenselFactorization.Factor(poly, main, other) is { } lifted)
+                return lifted;
             // The substitution gave up -- on the image's degree, on how far it split, or on the
             // arithmetic. An *evaluation* image has the degree of the polynomial in the main
             // variable however many other variables there are, so it is still there to be asked,
@@ -93,6 +100,25 @@ namespace AngouriMath.Functions
             return EvaluationHomomorphism.CertifiesIrreducible(poly, main)
                 ? new[] { poly }
                 : null;
+        }
+
+        /// <summary>
+        /// The one variable other than <paramref name="main"/> that <paramref name="poly"/>
+        /// actually uses, or <see langword="null"/> where it uses none or several — the lift
+        /// works along one evaluation at a time.
+        /// </summary>
+        private static int? OnlyOther(MultivariatePolynomial poly, int main)
+        {
+            int? only = null;
+            for (var variable = 0; variable < poly.VariableCount; variable++)
+            {
+                if (variable == main || poly.DegreeIn(variable) == 0)
+                    continue;
+                if (only is not null)
+                    return null;
+                only = variable;
+            }
+            return only;
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialSurfaceTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialSurfaceTest.cs
@@ -305,18 +305,51 @@ namespace AngouriMath.Tests.Algebra.Polynomials
         /// </para>
         /// </remarks>
         [Theory]
-        [InlineData("x ^ 7 - y ^ 7")]
-        [InlineData("x ^ 6 - y ^ 6")]
         [InlineData("x ^ 3 - (y + z) ^ 3")]
-        [InlineData("(x ^ 8 + y) * (x ^ 8 + 3 * y)")]
-        [InlineData("(x ^ 2 + y ^ 5) * (x ^ 2 - y ^ 5)")]
         public void AnImageThatOverFactorsIsRefused(string input)
             => Assert.Null(MathS.Polynomials.Factor(input.ToEntity(), "x"));
+
+        /// <summary>
+        /// The rows that used to sit above, moved here because they factor now — which is what
+        /// that test's remark asked for when it said it pins the refusal and not the limit.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Hensel lifting along an evaluation homomorphism, in two variables. The substitution's
+        /// image over-factors — <c>x ^ 7 - y ^ 7</c> becomes <c>t ^ 7 (1 - t ^ 49)</c>, whose
+        /// factors are cyclotomic — and an evaluation image does not: at <c>y = 1</c> it is
+        /// <c>x ^ 7 - 1</c>, which has the two factors the answer has.
+        /// </para>
+        /// <para>
+        /// Checked by <b>value</b> rather than by spelling. What matters is that the product is
+        /// the polynomial and that it is a product at all; which arrangement of terms comes back
+        /// is the polynomial representation's business, and asserting on it would make this fail
+        /// for a reason that is not about factoring.
+        /// </para>
+        /// </remarks>
+        [Theory]
+        [InlineData("x ^ 7 - y ^ 7", 2)]
+        [InlineData("x ^ 6 - y ^ 6", 4)]
+        [InlineData("(x ^ 8 + y) * (x ^ 8 + 3 * y)", 2)]
+        [InlineData("(x ^ 2 + y ^ 5) * (x ^ 2 - y ^ 5)", 2)]
+        [InlineData("x ^ 12 - y ^ 12", 6)]
+        [InlineData("x ^ 2 - y ^ 2", 2)]
+        [InlineData("x ^ 3 - y ^ 3", 2)]
+        public void AnEvaluationImageIsLiftedBackToAFactorisation(string input, int pieces)
+        {
+            var factored = MathS.Polynomials.Factor(input.ToEntity(), "x");
+            Assert.NotNull(factored);
+            // It is a product, so something was actually found.
+            Assert.IsType<Mulf>(factored);
+            // And the product is the polynomial it came from -- which the factoriser itself
+            // checks by exact division, so this is the same claim made a second way.
+            Assert.Equal(Integer.Zero, (factored! - input.ToEntity()).Simplify());
+            Assert.Equal(pieces, Mulf.LinearChildren(factored!).Count());
+        }
 
         [Theory]
         [InlineData("(x + y + z + w) * (x - y)")]
         [InlineData("(x + y) * (x + z) * (x + w) * (x + v)")]
-        [InlineData("x ^ 12 - y ^ 12")]
         public void PastTheSubstitutionsCeilingItRefuses(string input)
             => Assert.Null(MathS.Polynomials.Factor(input.ToEntity(), "x"));
 


### PR DESCRIPTION
The remaining item on #746 tier 1's polynomial line — the one that row calls *a project rather
than a change*. `x ^ 12 - y ^ 12`, which it names as past the substitution's reach, factors.

| | before | now |
|---|---|---|
| `Factor("x7 - y7", "x")` | `null` | `(x - y) * (x ^ 6 + x ^ 5 y + x ^ 4 y ^ 2 + x ^ 3 y ^ 3 + x ^ 2 y ^ 4 + x y ^ 5 + y ^ 6)` |
| `Factor("x6 - y6", "x")` | `null` | `(x + y) (x - y) (x ^ 2 + x y + y ^ 2) (x ^ 2 - x y + y ^ 2)` |
| `Factor("x12 - y12", "x")` | `null` | six factors, the full cyclotomic split |
| `Factor("x4 - y10", "x")` | `null` | `(x ^ 2 + y ^ 5) * (x ^ 2 - y ^ 5)` |
| `Factor("x16 + 4 x8 y + 3 y2", "x")` | `null` | `(x ^ 8 + 3 y) * (x ^ 8 + y)` |
| `Factor("x ^ 3 - (y + z) ^ 3", "x")` | `null` | `null` — three variables |
| `Factor("(x + y) * (x - y)", "x")` | `(x + y) * (x - y)` | unchanged |

## Why the substitution could not

Not size — **over-factoring**. `x^7 - y^7` maps to `t^7 (1 - t^49)`, whose factors are
cyclotomic, so a two-factor bivariate becomes a one-variable polynomial with many irreducibles
and the recombination is exponential in a count the substitution inflated itself. #1064 measured
that doubling the degree bound changes none of these, which is exactly why this had to be a
different algorithm rather than a larger number.

An evaluation image inflates nothing: `x^7 - y^7` at `y = 1` is `x^7 - 1`, which has the two
factors the answer has.

## The lift

Write `g(x, y) = f(x, y + a)` so the point is the origin; factor `g(x, 0)` over the integers;
lift one power of `y` at a time. Asking the product to agree one power further leaves
`α·v + β·u = e` for the error `e`, which the Bezout pair of `u` and `v` answers at once — a
**square-free image is exactly what makes them coprime**. Reducing `α` below the degree of `u`
and pushing the quotient into `β` keeps each side at the degree it started at.

It is the same step as the p-adic lift already in `PolynomialFactorization.LiftPair`, over the
ideal `(y)` rather than over a prime. Lifted as far as the degree in `y`, a true factor is
reached **exactly** — it has no higher power to hide in.

## What it will not do, and why that is the honest boundary

**The leading coefficient in the main variable must be constant.** Where it is a polynomial in
`y`, the lifted factors' leading coefficients must be known *before* the lift to keep them
polynomials rather than power series — Wang's leading-coefficient problem — and that is a second
algorithm on top of this one. Three or more variables decline too: the lift goes along one
evaluation at a time. Both are refusals, and the substitution is still tried first, so nothing
that worked stops working.

**Nothing is trusted.** Every candidate is checked by exact division of the original, so a bad
evaluation point, a lift that drifted, or a recombination that is not a factor costs a refusal
and cannot cost a wrong answer. That is what made this safe to write.

## The tests that moved

Five rows leave `AnImageThatOverFactorsIsRefused` and one leaves
`PastTheSubstitutionsCeilingItRefuses` for a test that asserts the factorisation. That is what
those tests asked for — the first says in its own remark that it pins *the refusal, not the
limit*, and that a row which starts factoring belongs elsewhere. The new test checks by value,
not by spelling: that the result is a product, that the product **is** the polynomial, and how
many pieces it came out in.

Full suite: 8714 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd