### PR TITLE
A leading coefficient that is a polynomial no longer stops the lift (#746)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -21,6 +21,7 @@ read first.
 
 | Silent? | What | Was | Is |
 |---|---|---|---|
+| | `MathS.Polynomials.Factor("(y * x3 + 1) * (x4 - y3)", "x")`, and bivariate polynomials whose leading coefficient in the main variable is a polynomial | `null` — a refusal | `(x ^ 4 - y ^ 3) * (x ^ 3 * y + 1)` |
 | | `MathS.Polynomials.Factor("x7 - y7", "x")`, and bivariate polynomials whose substituted image over-factors | `null` — a refusal | `(x - y) * (x ^ 6 + x ^ 5 * y + … + y ^ 6)` |
 | | `MathS.Polynomials.Factor("x2 + y2 + z2 + w2 + 1", "x")`, and polynomials in enough variables generally | `null` — a refusal | the polynomial itself, meaning it does not factor |
 | **Silent** | `"x! = 0".ToEntity().Simplify()` | `False`, including at `x = -1` where `x!` has a pole and the statement is `NaN` | `False provided x in RR and (x >= 0 or not x in ZZ)` |
@@ -313,6 +314,31 @@ the same precedences this grammar uses — so those needed the same brackets —
 bracketing for. The change only ever adds `\left(`/`\right)` groups, which CSharpMath already
 parses, so nothing downstream needs a matching change
 ([#822](https://github.com/asc-community/AngouriMath/issues/822)).
+
+### A leading coefficient that is a polynomial no longer stops the lift
+
+The Hensel lift below declined when the leading coefficient in the main variable was not a
+constant: the lifted factors' leading coefficients have to be known before the lift to keep them
+polynomials rather than power series. That is Wang's leading-coefficient problem, and it is
+avoided here rather than solved — `L^(n-1) f(z/L, y) = Σ a_i L^(n-1-i) z^i` is a polynomial,
+because `n - 1 - i` is never negative below the leading term, and it is **monic** in `z`, because
+the leading term contributes `L · L^(-1)`. A monic polynomial has a constant leading coefficient,
+which is the case the lift already handled. A factor comes back as `h(L·x, y)` with the content
+that substitution introduced divided out.
+
+| | before | now |
+|---|---|---|
+| `Factor("(y * x3 + 1) * (x4 - y3)", "x")` | `null` | `(x ^ 4 - y ^ 3) * (x ^ 3 * y + 1)` |
+| `Factor("(y * x + 1) * (x7 - y7)", "x")` | `null` | three factors |
+| `Factor("(y * x2 + 1) * (x6 - y6)", "x")` | `null` | five factors |
+| `Factor("(y2 * x3 + 1) * (x5 - y2)", "x")` | `null` | `null` — past the growth bound below |
+| `Factor("(y * x + 1) * (x + y)", "x")` | `(x * y + 1) * (x + y)` | unchanged — the substitution already reached it |
+
+That last-but-one row is a **bound rather than a limitation of the method**. The monic form
+carries `L^(n-1-i)`, so its degree in the auxiliary variable exceeds the original's by up to
+`(n-1)·deg L`. Measured: a growth of 6 costs 376 ms and a growth of 7 costs 1 ms, while a growth
+of 14 costs **63 seconds** — so growth past 12 is refused. A refusal is a legitimate answer and a
+sixty-three second one is not, which is the same judgement the recombination's own cap makes.
 
 ### A polynomial in two variables is factored by lifting rather than by substituting
 

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/BivariateHenselFactorization.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/BivariateHenselFactorization.cs
@@ -67,6 +67,12 @@ namespace AngouriMath.Functions
         private const int MaxImageFactors = 10;
 
         /// <summary>
+        /// How much degree the monicisation may add before it is refused instead. See the note
+        /// where it is used: past this the cost is seconds rather than milliseconds.
+        /// </summary>
+        private const int MaxMonicGrowth = 12;
+
+        /// <summary>
         /// The factors of <paramref name="poly"/> in <paramref name="main"/> and
         /// <paramref name="other"/>, each of positive degree in <paramref name="main"/>, or
         /// <see langword="null"/> where nothing could be settled. A single factor means it does
@@ -80,10 +86,10 @@ namespace AngouriMath.Functions
             if (degreeInMain < 1 || degreeInOther < 1)
                 return null;
 
-            // Wang's leading-coefficient problem is not solved here, so a leading coefficient
-            // that is not a constant declines rather than being guessed at.
+            // A leading coefficient that is a polynomial is made into one that is not, and the
+            // factorisation of that is mapped back. See MonicIn.
             if (!poly.LeadingCoefficientIn(main).IsConstant)
-                return null;
+                return ByMonicisation(poly, main, other, degreeInMain);
 
             // A factor free of the main variable is not something this finds, and its presence
             // would make the image's factorisation say the wrong thing about degrees.
@@ -101,6 +107,149 @@ namespace AngouriMath.Functions
                     return factors;
             }
             return null;
+        }
+
+        /// <summary>
+        /// The factorisation of a polynomial whose leading coefficient in
+        /// <paramref name="main"/> is not a constant, by making it one.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is <b>Wang's leading-coefficient problem</b>, and the answer here is not Wang's.
+        /// His is to factor the leading coefficient and distribute its factors among the lifted
+        /// ones, which needs a way to tell which goes where. The older answer needs none:
+        /// <c>g(z, y) = L^(n-1) · f(z/L, y) = Σ a_i L^(n-1-i) z^i</c> is a polynomial, because
+        /// <c>n - 1 - i</c> is never negative below the leading term, and it is <b>monic</b> in
+        /// <c>z</c>, because the leading term contributes <c>L · L^(-1)</c>. A monic polynomial
+        /// has a constant leading coefficient, which is the case the lift already handles.
+        /// </para>
+        /// <para>
+        /// A factor <c>h(z, y)</c> of the monic form comes back as <c>h(L·x, y)</c> with its
+        /// content in <c>y</c> divided out — the substitution multiplies the coefficient of
+        /// <c>z^j</c> by <c>L^j</c>, and the content is what that puts in and the original never
+        /// had.
+        /// </para>
+        /// <para>
+        /// The cost is that <c>deg_y g</c> grows by up to <c>(n-1)·deg_y L</c>, so the lift is
+        /// deeper and the polynomial larger. Nothing is asserted about staying inside
+        /// <see cref="MultivariatePolynomial"/>'s bounds: the construction returns
+        /// <see langword="null"/> when it leaves them, which is a refusal.
+        /// </para>
+        /// </remarks>
+        private static IReadOnlyList<MultivariatePolynomial>? ByMonicisation(
+            MultivariatePolynomial poly, int main, int other, int degreeInMain)
+        {
+            var leading = poly.LeadingCoefficientIn(main);
+            if (leading.IsZero)
+                return null;
+
+            // The monic form carries L^(n-1-i), so its degree in the auxiliary variable exceeds
+            // the original's by up to (n-1)·deg L, and the lift is that much deeper. Measured on
+            // the cases this reaches: a growth of 6 costs 376 ms and a growth of 7 costs 1 ms,
+            // while a growth of 14 costs **63 seconds** -- so it is bounded rather than paid
+            // for, which is what the rest of this layer does with a cost it cannot predict.
+            var growth = (degreeInMain - 1) * leading.DegreeIn(other);
+            if (growth > MaxMonicGrowth)
+                return null;
+
+            if (MonicIn(poly, main, leading, degreeInMain) is not { } monic)
+                return null;
+            if (!monic.LeadingCoefficientIn(main).IsConstant)
+                return null;
+
+            // The monic form is a different polynomial, so it gets the whole treatment rather
+            // than a shortcut into the lift: its own content, its own evaluation point.
+            if (Factor(monic, main, other) is not { } factors || factors.Count < 2)
+                return null;
+
+            var found = new List<MultivariatePolynomial>();
+            var remaining = poly;
+            foreach (var factor in factors)
+            {
+                if (Substitute(factor, main, leading) is not { } mapped)
+                    return null;
+                if (PolynomialGcd.ContentIn(mapped, main, new[] { other }, 0) is not { } content)
+                    return null;
+                if (mapped.DivideExact(content) is not { } candidate)
+                    return null;
+                if (candidate.DegreeIn(main) < 1)
+                    continue;
+                if (remaining.DivideExact(candidate) is not { } quotient)
+                    return null;
+                found.Add(candidate.Normalized());
+                remaining = quotient;
+            }
+
+            if (found.Count < 2)
+                return null;
+            if (!remaining.IsConstant)
+                found.Add(remaining.Normalized());
+            return found;
+        }
+
+        /// <summary>
+        /// <c>Σ a_i · L^(n-1-i) · x^i</c> — the same polynomial with a leading coefficient of
+        /// one, in a variable that stands for <c>x·L</c>.
+        /// </summary>
+        private static MultivariatePolynomial? MonicIn(
+            MultivariatePolynomial poly, int main, MultivariatePolynomial leading, int degreeInMain)
+        {
+            var result = MultivariatePolynomial.Zero(poly.VariableCount);
+            foreach (var pair in poly.CoefficientsIn(main))
+            {
+                var power = degreeInMain - 1 - pair.Key;
+                var term = pair.Value;
+                if (power > 0)
+                {
+                    if (leading.Power(power) is not { } weight)
+                        return null;
+                    if (term.Multiply(weight) is not { } scaled)
+                        return null;
+                    term = scaled;
+                }
+                else if (power < 0)
+                {
+                    // Only the leading term, where L^(n-1-n) cancels the L the term carries.
+                    if (term.DivideExact(leading) is not { } divided)
+                        return null;
+                    term = divided;
+                }
+                if (pair.Key > 0)
+                {
+                    if (term.ShiftedBy(main, pair.Key) is not { } shifted)
+                        return null;
+                    term = shifted;
+                }
+                result = result.Add(term);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// <paramref name="poly"/> with <paramref name="main"/> replaced by
+        /// <c><paramref name="main"/> · <paramref name="by"/></c> — so the coefficient of
+        /// <c>x^j</c> is multiplied by <c>by^j</c>.
+        /// </summary>
+        private static MultivariatePolynomial? Substitute(
+            MultivariatePolynomial poly, int main, MultivariatePolynomial by)
+        {
+            var result = MultivariatePolynomial.Zero(poly.VariableCount);
+            foreach (var pair in poly.CoefficientsIn(main))
+            {
+                var term = pair.Value;
+                if (pair.Key > 0)
+                {
+                    if (by.Power(pair.Key) is not { } weight)
+                        return null;
+                    if (term.Multiply(weight) is not { } scaled)
+                        return null;
+                    if (scaled.ShiftedBy(main, pair.Key) is not { } shifted)
+                        return null;
+                    term = shifted;
+                }
+                result = result.Add(term);
+            }
+            return result;
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialSurfaceTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialSurfaceTest.cs
@@ -347,6 +347,52 @@ namespace AngouriMath.Tests.Algebra.Polynomials
             Assert.Equal(pieces, Mulf.LinearChildren(factored!).Count());
         }
 
+        /// <summary>
+        /// A leading coefficient in <c>x</c> that is a polynomial in <c>y</c> — Wang's
+        /// leading-coefficient problem, which the lift declined until it was made not to arise.
+        /// </summary>
+        /// <remarks>
+        /// <c>L^(n-1) f(z/L, y)</c> is a polynomial and is monic in <c>z</c>, so it has a
+        /// constant leading coefficient and the lift already handles it; a factor comes back as
+        /// <c>h(L·x, y)</c> with the content that substitution introduced divided out. Checked
+        /// by value: the product has to be the polynomial, whatever spelling comes back.
+        /// </para>
+        /// <para>
+        /// <b>Every row is past the substitution's reach as well as having a leading coefficient
+        /// that is a polynomial</b>, and both conditions are needed for the row to be about this.
+        /// A small one like <c>(y x + 1)(x + y)</c> has the leading coefficient but Kronecker
+        /// already factors it, so it would pass without any of this code — which is what the
+        /// first version of this test was made of.
+        /// </remarks>
+        [Theory]
+        [InlineData("(y * x3 + 1) * (x4 - y3)", 2)]
+        [InlineData("(y * x + 1) * (x7 - y7)", 3)]
+        [InlineData("(y * x2 + 1) * (x6 - y6)", 5)]
+        public void ALeadingCoefficientThatIsAPolynomialIsMadeMonic(string input, int pieces)
+        {
+            var factored = MathS.Polynomials.Factor(input.ToEntity(), "x");
+            Assert.NotNull(factored);
+            Assert.IsType<Mulf>(factored);
+            Assert.Equal(Integer.Zero, (factored! - input.ToEntity()).Simplify());
+            Assert.Equal(pieces, Mulf.LinearChildren(factored!).Count());
+        }
+
+        /// <summary>
+        /// The monicisation's own bound. It multiplies by <c>L^(n-1-i)</c>, so the degree it
+        /// adds is <c>(n-1)·deg L</c>, and past twelve the cost stops being milliseconds:
+        /// this row factors correctly in <b>63 seconds</b> unbounded and refuses in three.
+        /// </summary>
+        /// <remarks>
+        /// A refusal is a legitimate answer and a sixty-three second one is not, which is the
+        /// same judgement <c>MaxImageFactors</c> makes about the recombination. The row is here
+        /// rather than deleted so that a bound which stops being needed fails rather than
+        /// quietly costing reach.
+        /// </remarks>
+        [Theory]
+        [InlineData("(y2 * x3 + 1) * (x5 - y2)")]
+        public void PastTheMonicisationsGrowthBoundItRefuses(string input)
+            => Assert.Null(MathS.Polynomials.Factor(input.ToEntity(), "x"));
+
         [Theory]
         [InlineData("(x + y + z + w) * (x - y)")]
         [InlineData("(x + y) * (x + z) * (x + w) * (x + v)")]


### PR DESCRIPTION
#1088's lift declined when the leading coefficient in the main variable was not a constant, and
said why: the lifted factors' leading coefficients must be known **before** the lift to keep
them polynomials rather than power series. That is Wang's leading-coefficient problem, and its
usual answer — factor the leading coefficient and distribute its factors among the lifted ones —
needs a way to tell which goes where.

**The older answer needs none.** `L^(n-1) f(z/L, y) = Σ aᵢ L^(n-1-i) zⁱ` is a polynomial, since
`n - 1 - i` is never negative below the leading term, and it is **monic** in `z`, since the
leading term contributes `L · L⁻¹`. A monic polynomial has a constant leading coefficient — the
case the lift already handled. So the problem is *avoided* rather than solved. A factor returns
as `h(L·x, y)` with the content that substitution introduced divided out, and is checked by
exact division like every other candidate.

| | before | now |
|---|---|---|
| `Factor("(y * x3 + 1) * (x4 - y3)", "x")` | `null` | `(x ^ 4 - y ^ 3) * (x ^ 3 * y + 1)` |
| `Factor("(y * x + 1) * (x7 - y7)", "x")` | `null` | three factors |
| `Factor("(y * x2 + 1) * (x6 - y6)", "x")` | `null` | five factors |
| `Factor("(y2 * x3 + 1) * (x5 - y2)", "x")` | `null` | `null` — past the growth bound |
| `Factor("(y * x + 1) * (x + y)", "x")` | `(x * y + 1) * (x + y)` | unchanged |

Measured on a build of each side.

## The first version of this test proved nothing

Its rows all had a leading coefficient that was a polynomial — but were small enough that
Kronecker's substitution **already factored them**, so they passed without reaching any of this
code. I only noticed because I measured the "before" against the wrong build and got a suspicious
answer.

Every row now has to be past the substitution's reach *as well as* having a polynomial leading
coefficient. Both conditions are needed for a row to be about this change, and the test remark
says so, because the mistake is an easy one to repeat.

## A growth bound, from measuring rather than from taste

The monic form carries `L^(n-1-i)`, so its degree in the auxiliary variable grows by up to
`(n-1)·deg L`:

| growth | cost |
|---|---|
| 6 | 376 ms |
| 7 | 1 ms |
| **14** | **63 seconds** |

Sixty-three seconds is a hang as far as a caller is concerned, so growth past 12 is refused — the
same judgement `MaxImageFactors` already makes about the recombination. The row that trips it is
kept as a test rather than deleted, so a bound that stops being needed fails rather than quietly
costing reach.

Full suite: 8718 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd