### PR TITLE
A factorisation multiplies back to what it factored (#1092)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -22,6 +22,7 @@ read first.
 | Silent? | What | Was | Is |
 |---|---|---|---|
 | **Silent** | `"limit(t * b, t, 0)".ToEntity().FreeVariables`, and every limit | `{ t, b }` — the variable it approaches along counted as free | `{ b }` |
+| **Silent** | `MathS.Polynomials.Factor("4 * x2 - 4 * y2", "x")`, and every multivariate polynomial whose content is a bare constant | `(x + y) * (x - y)` — **not equal to what it factored** | `4 * (x + y) * (x - y)` |
 | | `Entity.DomainConditionIn(Domain)` | did not exist | the domain of definition for a **stated** reading, through the whole tree |
 | | `MathS.Polynomials.Factor("(y * x3 + 1) * (x4 - y3)", "x")`, and bivariate polynomials whose leading coefficient in the main variable is a polynomial | `null` — a refusal | `(x ^ 4 - y ^ 3) * (x ^ 3 * y + 1)` |
 | | `MathS.Polynomials.Factor("x7 - y7", "x")`, and bivariate polynomials whose substituted image over-factors | `null` — a refusal | `(x - y) * (x ^ 6 + x ^ 5 * y + … + y ^ 6)` |
@@ -364,6 +365,33 @@ carries `L^(n-1-i)`, so its degree in the auxiliary variable exceeds the origina
 `(n-1)·deg L`. Measured: a growth of 6 costs 376 ms and a growth of 7 costs 1 ms, while a growth
 of 14 costs **63 seconds** — so growth past 12 is refused. A refusal is a legitimate answer and a
 sixty-three second one is not, which is the same judgement the recombination's own cap makes.
+
+### A factorisation multiplies back to what it factored
+
+`MathS.Polynomials.Factor` dropped a constant content when the polynomial had more than one
+variable, so the product it returned was **not equal to the polynomial it factored**.
+
+| | before | now |
+|---|---|---|
+| `Factor("4 * x2 - 4 * y2", "x")` | `(x + y) * (x - y)` | `4 * (x + y) * (x - y)` |
+| `Factor("2 * x2 - 2 * y2", "x")` | `(x + y) * (x - y)` | `2 * (x + y) * (x - y)` |
+| `Factor("6 * x4 - 6 * y4", "x")` | three factors, no `6` | `6 * (x + y) * (x ^ 2 + y ^ 2) * (x - y)` |
+| `Factor("3 * x * y + 3 * y", "x")` | `y * 3 * (x + 1)` | unchanged — the content is not a constant |
+| `Factor("2 * x2 - 2", "x")` | `2 * (x + 1) * (x - 1)` | unchanged — univariate |
+
+`KroneckerFactorization.Factor` documents its result as *"each of positive degree in the main
+variable"*, so a constant content is deliberately not among the factors it returns and the caller
+must reinstate it. `MathS.Polynomials.Kronecker` assembled the factors into a product and never
+did. Only "multivariate **and** the content is a pure number" landed in the gap; a content with a
+variable in it goes down a different path that reinstates it, and a univariate polynomial never
+reaches the substitution.
+
+The content is recovered by dividing the polynomial by the assembled product, which is what the
+rest of this layer does with a claim it could get wrong — a quotient that is missing or is not a
+constant means the product does not account for the polynomial, and then there is no answer to
+give. Everything here was already checked by exact division, but that check is on the individual
+*factors*; nothing compared the assembled product against the input
+([#1092](https://github.com/asc-community/AngouriMath/issues/1092)).
 
 ### A polynomial in two variables is factored by lifting rather than by substituting
 

--- a/Sources/AngouriMath/Convenience/MathS.Polynomials.cs
+++ b/Sources/AngouriMath/Convenience/MathS.Polynomials.cs
@@ -205,6 +205,26 @@ namespace AngouriMath
                     return null;
                 if (KroneckerFactorization.Factor(poly, index[variable]) is not { } factors)
                     return null;
+
+                // What the factors multiply to, so that whatever they do not account for can be
+                // put back. `KroneckerFactorization.Factor` returns factors "each of positive
+                // degree in main" -- a constant content is deliberately not among them, and it
+                // is this method's job to reinstate it. It was not, so `4 * x^2 - 4 * y^2` came
+                // back as `(x + y) * (x - y)`: a factorisation that is not equal to what it
+                // factored. https://github.com/asc-community/AngouriMath/issues/1092
+                //
+                // Recovered by exact division rather than by tracking the content separately,
+                // which is what the rest of this layer does with a claim it could get wrong: if
+                // the quotient is not there, or is not a constant, the assembled product does
+                // not account for the polynomial and there is no answer to give.
+                var assembled = MultivariatePolynomial.One(poly.VariableCount);
+                foreach (var factor in factors)
+                    if (assembled.Multiply(factor) is not { } grown)
+                        return null;
+                    else
+                        assembled = grown;
+                if (poly.DivideExact(assembled) is not { IsConstant: true } leftOver)
+                    return null;
                 // One factor is an answer and not a refusal: the substitution has established
                 // that the polynomial does not factor, and a caller that took the content out of
                 // it -- which is who calls this -- still has a factorisation to assemble. The
@@ -233,7 +253,13 @@ namespace AngouriMath
                     var piece = multiplicity > 1 ? pieces[i].Pow(multiplicity) : pieces[i];
                     product = product is null ? piece : product * piece;
                 }
-                return product;
+                if (product is null)
+                    return null;
+                // The content goes in front, where the one-variable path and
+                // FactorAfterTakingOutTheContent both put it, so the same polynomial reads the
+                // same way whichever path answered it.
+                var content = leftOver.ToEntity(variables);
+                return content == Integer.One ? product : content * product;
             }
 
             /// <summary>

--- a/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialSurfaceTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialSurfaceTest.cs
@@ -393,6 +393,38 @@ namespace AngouriMath.Tests.Algebra.Polynomials
         public void PastTheMonicisationsGrowthBoundItRefuses(string input)
             => Assert.Null(MathS.Polynomials.Factor(input.ToEntity(), "x"));
 
+        /// <summary>
+        /// The property a factorisation has: multiplying the factors gives back what was
+        /// factored. Nothing checked it, and a constant content was being dropped — `4x² - 4y²`
+        /// came back as `(x + y)(x - y)`.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1092">#1092</a>
+        /// </summary>
+        /// <remarks>
+        /// Everything else in this layer is checked by exact division, but that check is on the
+        /// individual <i>factors</i>; nothing compared the **assembled product** against the
+        /// input, so a constant lost during assembly was lost silently. This asserts on the
+        /// value rather than on the spelling, which is the only way to catch that.
+        /// </remarks>
+        [Theory]
+        [InlineData("4 * x^2 - 4 * y^2")]
+        [InlineData("2 * x^2 - 2 * y^2")]
+        [InlineData("6 * x^4 - 6 * y^4")]
+        [InlineData("2 * x^7 - 2 * y^7")]
+        [InlineData("3 * x * y + 3 * y")]
+        [InlineData("5 * x^2 * y - 5 * y")]
+        [InlineData("x^2 - y^2")]
+        [InlineData("x^12 - y^12")]
+        [InlineData("x^2 + y^2 + 1")]
+        [InlineData("-2 * x^2 + 2 * y^2")]
+        [InlineData("x^2/2 - y^2/2")]
+        public void AFactorisationMultipliesBackToWhatItFactored(string input)
+        {
+            var original = input.ToEntity();
+            var factored = MathS.Polynomials.Factor(original, "x");
+            Assert.NotNull(factored);
+            Assert.Equal(Integer.Zero, (factored! - original).Simplify());
+        }
+
         [Theory]
         [InlineData("(x + y + z + w) * (x - y)")]
         [InlineData("(x + y) * (x + z) * (x + w) * (x + v)")]


### PR DESCRIPTION
Closes #1092.

```csharp
MathS.Polynomials.Factor("4 * x2 - 4 * y2", "x")   // was (x + y) * (x - y)
```

The `4` is gone, and `(answer - input).Simplify()` is `-3 * x ^ 2 + 3 * y ^ 2`. That is a
factorisation which is **not equal to what it factored** — the one property a factorisation has.

| | before | now |
|---|---|---|
| `Factor("4 * x2 - 4 * y2", "x")` | `(x + y) * (x - y)` | `4 * (x + y) * (x - y)` |
| `Factor("2 * x2 - 2 * y2", "x")` | `(x + y) * (x - y)` | `2 * (x + y) * (x - y)` |
| `Factor("6 * x4 - 6 * y4", "x")` | three factors, no `6` | `6 * (x + y) * (x ^ 2 + y ^ 2) * (x - y)` |
| `Factor("3 * x * y + 3 * y", "x")` | `y * 3 * (x + 1)` | unchanged |
| `Factor("2 * x2 - 2", "x")` | `2 * (x + 1) * (x - 1)` | unchanged |

Measured on a build of each side.

## Where it came from

`KroneckerFactorization.Factor` documents its result as *"each of positive degree in `main`"* — a
constant content is **deliberately not among the factors it returns**, and the caller has to
reinstate it. `MathS.Polynomials.Kronecker` assembled them into a product and never did.

Only "multivariate **and** the content is a pure number" lands in the gap. A content with a
variable in it (`3 * x * y + 3 * y` → content `3 * y`) goes through
`FactorAfterTakingOutTheContent`, which reinstates it; a univariate polynomial never reaches the
substitution.

The content is recovered by dividing the polynomial by the assembled product — the same
discipline as the rest of this layer. A quotient that is missing or is not a constant means the
product does not account for the polynomial, and then there is no answer to give.

## Why nothing caught it

Every candidate here is checked by exact division, which is what makes a refusal the worst this
layer can do. **But that check is on the individual factors.** Nothing ever compared the
*assembled product* against the input, so a constant lost during assembly was lost silently.

`AFactorisationMultipliesBackToWhatItFactored` asserts exactly that property, on **value** rather
than on spelling — the only way to catch it. It fails 6 of its 11 cases without this change.

Found while wiring the polynomial layer into `Entity.Factorize` for #1018, where this wrong
answer would have reached a far more used API. That is why this is a separate PR and goes first.

Full suite: 8747 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd