### PR TITLE
`Factorize` uses the polynomial layer where no rule reaches (#1018)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -23,6 +23,7 @@ read first.
 |---|---|---|---|
 | **Silent** | `"limit(t * b, t, 0)".ToEntity().FreeVariables`, and every limit | `{ t, b }` — the variable it approaches along counted as free | `{ b }` |
 | **Silent** | `MathS.Polynomials.Factor("4 * x2 - 4 * y2", "x")`, and every multivariate polynomial whose content is a bare constant | `(x + y) * (x - y)` — **not equal to what it factored** | `4 * (x + y) * (x - y)` |
+| | `"x3 - 1".ToEntity().Factorize()`, and every polynomial no rewrite rule has a rule for | `x ^ 3 - 1` — handed back whole | `(x - 1) * (x ^ 2 + x + 1)` |
 | | `Entity.DomainConditionIn(Domain)` | did not exist | the domain of definition for a **stated** reading, through the whole tree |
 | | `MathS.Polynomials.Factor("(y * x3 + 1) * (x4 - y3)", "x")`, and bivariate polynomials whose leading coefficient in the main variable is a polynomial | `null` — a refusal | `(x ^ 4 - y ^ 3) * (x ^ 3 * y + 1)` |
 | | `MathS.Polynomials.Factor("x7 - y7", "x")`, and bivariate polynomials whose substituted image over-factors | `null` — a refusal | `(x - y) * (x ^ 6 + x ^ 5 * y + … + y ^ 6)` |
@@ -392,6 +393,37 @@ constant means the product does not account for the polynomial, and then there i
 give. Everything here was already checked by exact division, but that check is on the individual
 *factors*; nothing compared the assembled product against the input
 ([#1092](https://github.com/asc-community/AngouriMath/issues/1092)).
+### `Factorize` uses the polynomial layer where no rule reaches
+
+`Entity.Factorize` was composed entirely out of `RewriteRules`, so it factored what someone had
+written a rule for and handed everything else back whole — while square-free decomposition,
+Zassenhaus over `Q`, Kronecker's substitution and Hensel lifting all sat in the tree unused by it.
+
+| | before | now |
+|---|---|---|
+| `"x3 - 1".Factorize()` | `x ^ 3 - 1` | `(x - 1) * (x ^ 2 + x + 1)` |
+| `"x4 - 5x2 + 4".Factorize()` | `x ^ 4 - 5 * x ^ 2 + 4` | `(x + 1) * (x + 2) * (x - 2) * (x - 1)` |
+| `"x6 - 1".Factorize()` | `x ^ 6 - 1` | `(x + 1) * (x - 1) * (x ^ 2 + x + 1) * (x ^ 2 - x + 1)` |
+| `"x7 - 1".Factorize()` | `x ^ 7 - 1` | `(x - 1) * (x ^ 6 + x ^ 5 + x ^ 4 + x ^ 3 + x ^ 2 + x + 1)` |
+| `"x2 + 2x + 1".Factorize()` | `x ^ 2 + 2 * x + 1` | `(x + 1) ^ 2` |
+| `"a2 - b2".Factorize()` | `(a - b) * (a + b)` | unchanged |
+| `"x4 - y4".Factorize()` | `(x - y) * (x + y) * (x ^ 2 + y ^ 2)` | unchanged |
+| `"x * y + x".Factorize()` | `x * (1 + y)` | unchanged |
+| `"sin(x) + 1".Factorize()` | `sin(x) + 1` | unchanged |
+
+**The layer speaks only where the rules said nothing.** An expression the rules already turned
+into a product keeps their answer exactly — the order two factors come out in is arbitrary and
+theirs is the one on record, so replacing it would change answers that were never the complaint.
+What moves is only what came back whole.
+
+**`Simplify` is unchanged**, and that took a second seam. It offers a factorisation as a
+*candidate* and its cost model decides; the metric prefers the expanded form, so a factored
+candidate wins only where the two are closest — and those are the places a factored answer is
+least wanted (`x ^ 3 / 3 + x ^ 2 / 2` became `(3 + 2 * x) * x ^ 2 / 6`, an antiderivative in a
+form nobody writes). `Transformation.RuleBasedFactorizationAtLevel` is what that candidate site
+uses now. Offering the layer to that search is
+[#746](https://github.com/asc-community/AngouriMath/issues/746) tier 2's pluggable cost model
+rather than this ([#1018](https://github.com/asc-community/AngouriMath/issues/1018)).
 
 ### A polynomial in two variables is factored by lifting rather than by substituting
 

--- a/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
+++ b/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
@@ -70,11 +70,82 @@ namespace AngouriMath.Core.Transformations
         /// </remarks>
         public static Transformation FactorizationAtLevel(int level)
             => LevelledCache.Factorization.For(level, static l =>
+                RuleBasedFactorizationAtLevel(l)
+                    // And then the polynomial layer, which factors what no rule set has a rule
+                    // for. Last, so that the rules keep every answer they already gave and this
+                    // only ever adds one. See PolynomialFactorization.
+                    .Then(PolynomialFactorization));
+
+        /// <summary>
+        /// The rule-based half of <see cref="FactorizationAtLevel"/>, without the polynomial
+        /// layer.
+        /// </summary>
+        /// <remarks>
+        /// Separate because <c>Simplify</c> offers a factorisation as a <b>candidate</b> and its
+        /// cost model decides. The metric prefers the expanded form — <c>x ^ 6 - 1</c> rates 12
+        /// expanded against 58 factored — so a factored candidate wins only where the two are
+        /// closest, and those turn out to be the places a factored answer is least wanted:
+        /// <c>x ^ 3 / 3 + x ^ 2 / 2</c> becomes <c>(3 + 2 * x) * x ^ 2 / 6</c>, an antiderivative
+        /// in a form nobody writes. Offering the layer to that search is
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> tier 2's
+        /// pluggable cost model rather than
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1018">#1018</a>.
+        /// </remarks>
+        public static Transformation RuleBasedFactorizationAtLevel(int level)
+            => LevelledCache.RuleBasedFactorization.For(level, static l =>
                 Rewriting(RewriteRules.PerfectSquare)
                     .Then(Rewriting(RewriteRules.Factorization))
                     .Then(InnerSimplification)
                     // Entity.Factorize has always run at least one pass, whatever it was asked for.
                     .Repeat(Math.Max(l, 1)));
+
+        /// <summary>
+        /// Factors a polynomial by the polynomial layer — square-free decomposition, Zassenhaus
+        /// over <c>Q</c>, Kronecker's substitution and Hensel lifting — rather than by a rule.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// A rule set factors what someone wrote a rule for. <c>x ^ 2 - 1</c> has one and
+        /// <c>x ^ 3 - 1</c> does not, which is why <see cref="Entity.Factorize(int)"/> — the
+        /// operation whose entire job is factorisation — was worse at it than the machinery that
+        /// exists for it. <a href="https://github.com/asc-community/AngouriMath/issues/1018">#1018</a>
+        /// </para>
+        /// <para>
+        /// <b>This is not the cost-model question.</b> The reason the polynomial layer is not
+        /// wired into <c>Simplify</c> is that <c>SimplifiedRate</c> prefers the expanded
+        /// form — <c>x ^ 6 - 1</c> rates 12 expanded against 58 factored — so a factored candidate
+        /// could never win a search. There is no search here: <c>Factorize</c> is asked for the
+        /// factored form and returns it.
+        /// </para>
+        /// <para>
+        /// <b>Which variable.</b> The layer factors with respect to one, and an expression has
+        /// several. Each of its variables is tried in turn and the first that yields a genuine
+        /// product wins, which is deterministic because <see cref="Entity.Vars"/> is. Trying them
+        /// all rather than guessing a main one is what makes <c>x ^ 4 - y ^ 4</c> come out whole
+        /// however the caller wrote it.
+        /// </para>
+        /// <para>
+        /// <b>What it declines.</b> Anything that is not a polynomial, anything the layer refuses,
+        /// and anything whose answer is not a product — a refusal leaves the expression exactly as
+        /// the rules left it, so nothing that factored before can stop factoring.
+        /// </para>
+        /// </remarks>
+        /// <remarks>
+        /// Held in a nested class rather than in a static field of this one. Static field
+        /// initialisers run in declaration order, and <see cref="Factorization"/> — declared
+        /// above — is eager, so a field here would still be <see langword="null"/> when its
+        /// pipeline is built. That surfaces as <c>ArgumentNullException(nameof(next))</c> from a
+        /// combinator rather than as anything naming the real cause, and this file has had that
+        /// failure before. A nested type is initialised on first touch, whatever order this
+        /// one's members are written in.
+        /// </remarks>
+        public static Transformation PolynomialFactorization => PolynomialFactorizationHolder.Instance;
+
+        private static class PolynomialFactorizationHolder
+        {
+            [ConstantField]
+            internal static readonly Transformation Instance = new PolynomialFactorizationTransformation();
+        }
 
         /// <summary>
         /// Puts commutative chains into a canonical order, so that expressions which differ
@@ -261,6 +332,9 @@ namespace AngouriMath.Core.Transformations
             [ConcurrentField]
             internal static readonly LevelledCache Factorization = new();
 
+            [ConstantField]
+            internal static readonly LevelledCache RuleBasedFactorization = new();
+
             private readonly Transformation?[] cached = new Transformation?[Highest - Lowest + 1];
 
             internal Transformation For(int level, Func<int, Transformation> make)
@@ -279,6 +353,35 @@ namespace AngouriMath.Core.Transformations
 
             protected override Entity? ApplyCore(Entity input)
                 => RationalFunction.TryCanonicalize(input, out var canonical) ? canonical : null;
+        }
+
+        private sealed class PolynomialFactorizationTransformation : Transformation
+        {
+            public override string Name => "polynomial-factorization";
+
+            public override TransformationRelation Relation => TransformationRelation.Equivalence;
+
+            public override Soundness Soundness => Soundness.Sound;
+
+            // Total rather than declining, because a step that returns null makes the whole
+            // chain decline -- `Then` has no notion of an optional part, and `Factorization` is
+            // a chain. `InnerSimplification` is total for the same reason. So "nothing to
+            // factor" is the input handed back, not a refusal.
+            protected override Entity? ApplyCore(Entity input)
+            {
+                // Only where the rules found nothing. A product means they already factored it,
+                // and their answer is kept rather than replaced -- the two orders the factors
+                // can come out in are equally correct and the rules' one is the one on record,
+                // so replacing it would change answers that were never the complaint. What #1018
+                // is about is the expressions that come back whole.
+                if (input is Entity.Mulf or Entity.Powf)
+                    return input;
+                foreach (var variable in input.Vars)
+                    if (MathS.Polynomials.Factor(input, variable) is { } factored
+                        && factored is Entity.Mulf or Entity.Powf)
+                        return factored;
+                return input;
+            }
         }
 
         private sealed class InnerSimplificationTransformation : Transformation

--- a/Sources/AngouriMath/Functions/Simplification/Simplificator.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Simplificator.cs
@@ -302,7 +302,17 @@ namespace AngouriMath.Functions
                 var expandMark = recording?.Mark() ?? 0;
                 AddHistory(Noted(recording, res, res.Expand(), nameof(Entity.Expand), expandMark).Simplify(-level));
                 var factorizeMark = recording?.Mark() ?? 0;
-                AddHistory(Noted(recording, res, res.Factorize(), nameof(Entity.Factorize), factorizeMark).Simplify(-level));
+                // The **rule-based** factorisation, not `Entity.Factorize` -- which now also asks
+                // the polynomial layer, and whose answers must not become candidates here. The
+                // cost model prefers the expanded form (`x ^ 6 - 1` rates 12 expanded against 58
+                // factored), so a factored candidate wins only where the metric is closest, and
+                // those are exactly the places a factored answer is least wanted: `x^3/3 + x^2/2`
+                // becomes `(3 + 2 * x) * x ^ 2 / 6`, an antiderivative in a form no one writes.
+                // Offering the layer here is #746 tier 2's pluggable cost model, not this.
+                // https://github.com/asc-community/AngouriMath/issues/1018
+                AddHistory(Noted(recording, res,
+                    Transformation.RuleBasedFactorizationAtLevel(2).ApplyOrKeep(res),
+                    nameof(Entity.Factorize), factorizeMark).Simplify(-level));
 
                 // A multiple angle written out is worth having only where the pieces then
                 // cancel, so it has to be simplified in full before the metric can be

--- a/Sources/Tests/UnitTests/Common/PublicApi.txt
+++ b/Sources/Tests/UnitTests/Common/PublicApi.txt
@@ -255,11 +255,13 @@ AngouriMath.Core.Transformations.Transformation.Integration(AngouriMath.Entity+V
 AngouriMath.Core.Transformations.Transformation.LimitAt(AngouriMath.Entity+Variable, AngouriMath.Entity, AngouriMath.Core.ApproachFrom) : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Name { } : System.String
 AngouriMath.Core.Transformations.Transformation.Normalization { } : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.PolynomialFactorization { } : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.RationalCanonicalization { } : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Rationalization { } : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Relation { } : AngouriMath.Core.Transformations.TransformationRelation
 AngouriMath.Core.Transformations.Transformation.Repeat(System.Int32) : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Rewriting(AngouriMath.Core.Transformations.RewriteRuleSet) : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.RuleBasedFactorizationAtLevel(System.Int32) : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Simplification { } : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.SimplificationAtLevel(System.Int32) : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Soundness { } : AngouriMath.Core.Transformations.Soundness

--- a/Sources/Tests/UnitTests/Convenience/ExtensionsExampleTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/ExtensionsExampleTest.cs
@@ -155,7 +155,9 @@ namespace AngouriMath.Tests.Convenience
         [Fact] public void FactorizeString()
         {
             Printed("(a - b) * (a + b)", "a2 - b2".Factorize());
-            Printed("x ^ 2 + 2 * x + 1", "x2 + 2x + 1".Factorize());
+            // Was `x ^ 2 + 2 * x + 1` -- Factorize had no rule for it and handed it back whole.
+            // The polynomial layer does. https://github.com/asc-community/AngouriMath/issues/1018
+            Printed("(x + 1) ^ 2", "x2 + 2x + 1".Factorize());
         }
 
         [Fact] public void SubstituteOne()

--- a/Sources/Tests/UnitTests/Core/Transformations/TransformationTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/TransformationTest.cs
@@ -103,8 +103,8 @@ namespace AngouriMath.Tests.Core.Transformations
             var factorThenExpand = Transformation.Factorization.Then(Transformation.Expansion);
 
             // Not an inverse pair, and the names say which way round each one is.
-            Assert.Equal("expand[2] then factorize", Shorten(expandThenFactor.Name));
-            Assert.Equal("factorize then expand[2]", Shorten(factorThenExpand.Name));
+            Assert.Equal("expand[2] then factorize then polynomial-factorization", Shorten(expandThenFactor.Name));
+            Assert.Equal("factorize then polynomial-factorization then expand[2]", Shorten(factorThenExpand.Name));
 
             static string Shorten(string name)
                 => name.Replace("rewrite[PerfectSquare] then rewrite[Factorization] then inner-simplify x2", "factorize");


### PR DESCRIPTION
Closes #1018.

`Entity.Factorize` was composed entirely out of `RewriteRules`, so it factored what someone had
written a rule for and handed everything else back whole — while square-free decomposition,
Zassenhaus over `Q`, Kronecker's substitution and Hensel lifting all sat in the tree, unused by
the operation whose entire job is factorisation.

| | before | now |
|---|---|---|
| `"x3 - 1".Factorize()` | `x ^ 3 - 1` | `(x - 1) * (x ^ 2 + x + 1)` |
| `"x4 - 5x2 + 4".Factorize()` | `x ^ 4 - 5 * x ^ 2 + 4` | `(x + 1) * (x + 2) * (x - 2) * (x - 1)` |
| `"x6 - 1".Factorize()` | `x ^ 6 - 1` | four factors |
| `"x7 - 1".Factorize()` | `x ^ 7 - 1` | `(x - 1) * (x ^ 6 + x ^ 5 + … + 1)` |
| `"x2 + 2x + 1".Factorize()` | `x ^ 2 + 2 * x + 1` | `(x + 1) ^ 2` |
| `"a2 - b2".Factorize()` | `(a - b) * (a + b)` | **unchanged** |
| `"x4 - y4".Factorize()` | `(x - y) * (x + y) * (x ^ 2 + y ^ 2)` | **unchanged** |
| `"x * y + x".Factorize()` | `x * (1 + y)` | **unchanged** |
| `"sin(x) + 1".Factorize()` | `sin(x) + 1` | **unchanged** |

Measured on a build of each side.

## The layer speaks only where the rules said nothing

My first version replaced the rules' answers too, and that is wrong for a reason worth stating:
the order two factors come out in is arbitrary, the rules' order is the one on record, and
changing it changes answers that were **never the complaint**. A product coming out of the rules
is kept exactly as it is. That took the fallout from 9 changed expectations down to 1 — and the
one that remains is an improvement, not a reordering.

## `Simplify` is unchanged, and that took a second seam

`Simplificator` offers a factorisation as a **candidate** and the cost model decides. The metric
prefers the expanded form — `x ^ 6 - 1` rates 12 expanded against 58 factored — so a factored
candidate wins only where the two are closest, and those turn out to be exactly the places a
factored answer is least wanted:

```
"x^3/3 + x^2/2".Simplify()   →   (3 + 2 * x) * x ^ 2 / 6      // an antiderivative nobody writes
```

That candidate site now asks `RuleBasedFactorizationAtLevel` for the rule-based half only.

**The issue says the cost-model objection does not apply to `Factorize`. That is incomplete** —
`Factorize`'s output *feeds* the search — and 37 failing tests were the evidence. Offering the
layer to that search is #746 tier 2's pluggable cost model, still open, and not this.

## Two mechanical notes

The transformation is **total** rather than declining: `Then` has no notion of an optional part,
so a step returning `null` makes the whole chain decline and `Transformation.Factorization.Apply`
returned nothing at all.

`PolynomialFactorization` lives in a nested class. Static field initialisers run in declaration
order and `Factorization` is eager, so a plain field would still be `null` when its pipeline is
built — which surfaces as `ArgumentNullException(nameof(next))` from a combinator and names
nothing about the real cause. This file has had that failure before.

## One recorded verdict updated

`ExtensionsExampleTest.FactorizeString` recorded `x ^ 2 + 2 * x + 1` as `Factorize`'s answer to
itself. It is `(x + 1) ^ 2` now — and that example is user-facing documentation.

Depends on #1093, which fixes a wrong answer this change would otherwise have surfaced to a much
more used API.

Full suite: 8740 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd