### PR TITLE
`Factorize` reaches inside a product the rules already made

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -23,6 +23,7 @@ read first.
 |---|---|---|---|
 | **Silent** | `"limit(t * b, t, 0)".ToEntity().FreeVariables`, and every limit | `{ t, b }` — the variable it approaches along counted as free | `{ b }` |
 | **Silent** | `MathS.Polynomials.Factor("4 * x2 - 4 * y2", "x")`, and every multivariate polynomial whose content is a bare constant | `(x + y) * (x - y)` — **not equal to what it factored** | `4 * (x + y) * (x - y)` |
+| | `"2 * x3 - 2".ToEntity().Factorize()`, and every polynomial whose content the rules take out | `2 * (x ^ 3 - 1)` — the remainder left whole | `2 * (x - 1) * (x ^ 2 + x + 1)` |
 | | `"x3 - 1".ToEntity().Factorize()`, and every polynomial no rewrite rule has a rule for | `x ^ 3 - 1` — handed back whole | `(x - 1) * (x ^ 2 + x + 1)` |
 | | `Entity.DomainConditionIn(Domain)` | did not exist | the domain of definition for a **stated** reading, through the whole tree |
 | | `MathS.Polynomials.Factor("(y * x3 + 1) * (x4 - y3)", "x")`, and bivariate polynomials whose leading coefficient in the main variable is a polynomial | `null` — a refusal | `(x ^ 4 - y ^ 3) * (x ^ 3 * y + 1)` |
@@ -393,6 +394,28 @@ constant means the product does not account for the polynomial, and then there i
 give. Everything here was already checked by exact division, but that check is on the individual
 *factors*; nothing compared the assembled product against the input
 ([#1092](https://github.com/asc-community/AngouriMath/issues/1092)).
+### `Factorize` reaches inside a product the rules already made
+
+The change below asks the polynomial layer only where the rewrite rules said nothing, so that an
+answer the rules already gave is never replaced. Declining a **product** outright was too broad:
+the rules take a numeric content out and hand back `2 * (x ^ 3 - 1)`, and the remainder is exactly
+the shape that change is about.
+
+| | before | now |
+|---|---|---|
+| `"2 * x3 - 2".Factorize()` | `2 * (x ^ 3 - 1)` | `2 * (x - 1) * (x ^ 2 + x + 1)` |
+| `"3 * x6 - 3".Factorize()` | `3 * (x ^ 6 - 1)` | five factors |
+| `"5 * x7 - 5".Factorize()` | `5 * (x ^ 7 - 1)` | `5 * (x - 1) * (x ^ 6 + … + 1)` |
+| `"y * (x3 - 1)".Factorize()` | `y * (x ^ 3 - 1)` | `y * (x - 1) * (x ^ 2 + x + 1)` |
+| `"2 * x4 - 10 * x2 + 8".Factorize()` | `2 * (x + 1) * (x + 2) * (x - 2) * (x - 1)` | unchanged |
+| `"x * y + x".Factorize()` | `x * (1 + y)` | unchanged |
+
+Each factor of the product is asked separately instead of the product being handed over whole, so
+every factor the rules found survives and only the ones they could not split are split. Found by
+asking the property [#1092](https://github.com/asc-community/AngouriMath/issues/1092) is about —
+that the answer multiplies back to its input — of a row that satisfied it and was still less
+factored than it should be.
+
 ### `Factorize` uses the polynomial layer where no rule reaches
 
 `Entity.Factorize` was composed entirely out of `RewriteRules`, so it factored what someone had

--- a/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
+++ b/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
@@ -369,18 +369,47 @@ namespace AngouriMath.Core.Transformations
             // factor" is the input handed back, not a refusal.
             protected override Entity? ApplyCore(Entity input)
             {
-                // Only where the rules found nothing. A product means they already factored it,
-                // and their answer is kept rather than replaced -- the two orders the factors
-                // can come out in are equally correct and the rules' one is the one on record,
-                // so replacing it would change answers that were never the complaint. What #1018
-                // is about is the expressions that come back whole.
+                // A product is taken apart and each factor asked separately, rather than being
+                // handed over whole. Replacing the rules' product would change answers that were
+                // never the complaint -- the order two factors come out in is arbitrary and
+                // theirs is the one on record -- but *declining* it leaves a real gap: the rules
+                // take a numeric content out and hand back `2 * (x ^ 3 - 1)`, and the remainder
+                // is exactly the shape #1018 is about. Asking each factor keeps every factor the
+                // rules found and splits the ones they could not.
+                if (input is Entity.Mulf)
+                {
+                    Entity? rebuilt = null;
+                    var moved = false;
+                    foreach (var factor in Entity.Mulf.LinearChildren(input))
+                    {
+                        var piece = Factored(factor) ?? factor;
+                        moved |= !ReferenceEquals(piece, factor);
+                        rebuilt = rebuilt is null ? piece : rebuilt * piece;
+                    }
+                    return moved && rebuilt is not null ? rebuilt : input;
+                }
+                return Factored(input) ?? input;
+            }
+
+            /// <summary>
+            /// <paramref name="input"/> factored by the polynomial layer, or <see langword="null"/>
+            /// where it does not factor.
+            /// </summary>
+            /// <remarks>
+            /// Each of its variables is tried in turn and the first that yields a genuine product
+            /// wins, which is deterministic because <see cref="Entity.Vars"/> is. Trying them all
+            /// rather than guessing a main one is what makes <c>x ^ 4 - y ^ 4</c> come out whole
+            /// however the caller wrote it.
+            /// </remarks>
+            private static Entity? Factored(Entity input)
+            {
                 if (input is Entity.Mulf or Entity.Powf)
-                    return input;
+                    return null;
                 foreach (var variable in input.Vars)
                     if (MathS.Polynomials.Factor(input, variable) is { } factored
                         && factored is Entity.Mulf or Entity.Powf)
                         return factored;
-                return input;
+                return null;
             }
         }
 

--- a/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialSurfaceTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/Polynomials/PolynomialSurfaceTest.cs
@@ -425,6 +425,31 @@ namespace AngouriMath.Tests.Algebra.Polynomials
             Assert.Equal(Integer.Zero, (factored! - original).Simplify());
         }
 
+        /// <summary>
+        /// <c>Factorize</c> reaches inside a product the rules already made, so a numeric content
+        /// taken out does not strand the remainder unfactored.
+        /// </summary>
+        /// <remarks>
+        /// The rules take the content out and hand back <c>2 * (x ^ 3 - 1)</c>; the polynomial
+        /// layer is what splits the remainder. Declining a product outright — which is how this
+        /// first shipped — keeps the rules' answers but leaves exactly the shape
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1018">#1018</a> is about
+        /// sitting inside one. Each factor is asked separately instead, so every factor the rules
+        /// found survives and the ones they could not split do.
+        /// </remarks>
+        [Theory]
+        [InlineData("2 * x^3 - 2", 3)]
+        [InlineData("3 * x^6 - 3", 5)]
+        [InlineData("5 * x^7 - 5", 3)]
+        [InlineData("y * (x^3 - 1)", 3)]
+        public void FactorizeReachesInsideAProductTheRulesMade(string input, int pieces)
+        {
+            var factored = input.ToEntity().Factorize();
+            Assert.Equal(pieces, Mulf.LinearChildren(factored).Count());
+            // And it is still the polynomial it factored, which is the property #1092 was about.
+            Assert.Equal(Integer.Zero, (factored - input.ToEntity()).Simplify());
+        }
+
         [Theory]
         [InlineData("(x + y + z + w) * (x - y)")]
         [InlineData("(x + y) * (x + z) * (x + w) * (x + v)")]


### PR DESCRIPTION
A follow-up to #1094, fixing an incompleteness that PR introduced.

#1094 asks the polynomial layer **only where the rewrite rules said nothing**, so that an answer
the rules already gave is never replaced — the order two factors come out in is arbitrary and
theirs is the one on record. Declining a **product** outright was too broad for that goal.

The rules take a numeric content out and hand back `2 * (x ^ 3 - 1)`. That is a product, so the
layer declined it — and the remainder is exactly the shape #1018 is about.

| | before | now |
|---|---|---|
| `"2 * x3 - 2".Factorize()` | `2 * (x ^ 3 - 1)` | `2 * (x - 1) * (x ^ 2 + x + 1)` |
| `"3 * x6 - 3".Factorize()` | `3 * (x ^ 6 - 1)` | five factors |
| `"5 * x7 - 5".Factorize()` | `5 * (x ^ 7 - 1)` | `5 * (x - 1) * (x ^ 6 + … + 1)` |
| `"y * (x3 - 1)".Factorize()` | `y * (x ^ 3 - 1)` | `y * (x - 1) * (x ^ 2 + x + 1)` |
| `"2 * x4 - 10 * x2 + 8".Factorize()` | four factors and a 2 | **unchanged** |
| `"x * y + x".Factorize()` | `x * (1 + y)` | **unchanged** |

Each factor is asked separately instead of the product being handed over whole. Every factor the
rules found survives; only the ones they could not split are split.

## How it was found, which is the part worth keeping

By asking of `Factorize` the property #1092 was about — that the answer multiplies back to what it
factored — and noticing a row that **satisfied it and was still wrong**.

`2 * (x ^ 3 - 1)` is perfectly equal to `2 * x ^ 3 - 2`. The value check says nothing. What was
wrong was not the value but the **stopping point**, and a property test does not ask about that
unless it is told to. The new test asserts the number of factors as well as the value, for exactly
that reason.

Full suite: 8751 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd