### PR TITLE
A fold over an empty sequence answers instead of throwing (#1028)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -24,6 +24,9 @@ read first.
 | **Silent** | `"limit(t * b, t, 0)".ToEntity().FreeVariables`, and every limit | `{ t, b }` — the variable it approaches along counted as free | `{ b }` |
 | **Silent** | `MathS.Polynomials.Factor("4 * x2 - 4 * y2", "x")`, and every multivariate polynomial whose content is a bare constant | `(x + y) * (x - y)` — **not equal to what it factored** | `4 * (x + y) * (x - y)` |
 | | `"2 * x3 - 2".ToEntity().Factorize()`, and every polynomial whose content the rules take out | `2 * (x ^ 3 - 1)` — the remainder left whole | `2 * (x - 1) * (x ^ 2 + x + 1)` |
+| | `new Entity[0].SumAll()`, and `Sumf.Sum` on an empty list | `AngouriBugException: At least 1 child required` | `0` |
+| | `new Entity[0].MultiplyAll()`, and `Mulf.Multiply` on an empty list | `AngouriBugException` | `1` |
+| | `MathS.Vector()` and `new Entity[0].ToVector()` | `IndexOutOfRangeException` — outside the documented hierarchy | `InvalidMatrixOperationException` |
 | | `"x3 - 1".ToEntity().Factorize()`, and every polynomial no rewrite rule has a rule for | `x ^ 3 - 1` — handed back whole | `(x - 1) * (x ^ 2 + x + 1)` |
 | | `Entity.DomainConditionIn(Domain)` | did not exist | the domain of definition for a **stated** reading, through the whole tree |
 | | `MathS.Polynomials.Factor("(y * x3 + 1) * (x4 - y3)", "x")`, and bivariate polynomials whose leading coefficient in the main variable is a polynomial | `null` — a refusal | `(x ^ 4 - y ^ 3) * (x ^ 3 * y + 1)` |
@@ -415,6 +418,30 @@ every factor the rules found survives and only the ones they could not split are
 asking the property [#1092](https://github.com/asc-community/AngouriMath/issues/1092) is about —
 that the answer multiplies back to its input — of a row that satisfied it and was still less
 factored than it should be.
+### A fold over an empty sequence answers instead of throwing
+
+A fold over a monoid has an identity, so the empty sum is `0` and the empty product is `1` — which
+is what makes `xs.Concat(ys).SumAll() == xs.SumAll() + ys.SumAll()` hold for every pair, the empty
+one included. These threw instead, and threw the wrong *kind* of exception: `AngouriBugException`
+ends its message asking the caller to report a bug against this repository, for a list their own
+`Where` happened to filter to nothing.
+
+| | before | now |
+|---|---|---|
+| `new Entity[0].SumAll()` | `AngouriBugException` | `0` |
+| `new Entity[0].MultiplyAll()` | `AngouriBugException` | `1` |
+| `Sumf.Sum(new Entity[0])` | `AngouriBugException` | `0` |
+| `Mulf.Multiply(new Entity[0])` | `AngouriBugException` | `1` |
+| `MathS.Vector()` | `IndexOutOfRangeException` | `InvalidMatrixOperationException` |
+| `new Entity[0].ToVector()` | `IndexOutOfRangeException` | `InvalidMatrixOperationException` |
+
+`IndexOutOfRangeException` is not under `AngouriMathBaseException`, so a caller catching the
+hierarchy `Docs/Usage/Exceptions.md` documents did not catch it at all.
+
+`Sumf.Sum` and `Mulf.Multiply` are not named in the issue. The defect is *passing an unchecked
+caller collection into `MultiHangBinary`*, whose `>= 1` precondition is genuine, and those two are
+public and do exactly that. `MultiHangBinary` itself is unchanged
+([#1028](https://github.com/asc-community/AngouriMath/issues/1028)).
 
 ### `Factorize` uses the polynomial layer where no rule reaches
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -27,6 +27,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [Tests/UnitTests/Core/DomainConditionInAReadingTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[Tests/UnitTests/Convenience/EmptySequenceFoldTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [Tests/UnitTests/Core/Transformations/*.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 

--- a/Sources/AngouriMath/Convenience/AngouriMathExtensions.cs
+++ b/Sources/AngouriMath/Convenience/AngouriMathExtensions.cs
@@ -100,8 +100,19 @@ namespace AngouriMath.Extensions
         /// 10
         /// </code>
         /// </example>
+        /// <remarks>
+        /// The empty sum is <c>0</c>, which is what makes
+        /// <c>xs.Concat(ys).SumAll() == xs.SumAll() + ys.SumAll()</c> hold for every pair
+        /// including the empty one. It used to reach <c>MultiHangBinary</c>'s genuine
+        /// precondition and throw an <c>AngouriBugException</c> — whose message asks the caller
+        /// to report a bug against this repository, for a list their own <c>Where</c> happened
+        /// to filter to nothing.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1028">#1028</a>
+        /// </remarks>
         public static Entity SumAll(this IEnumerable<Entity> terms)
-            => TreeAnalyzer.MultiHangBinary(terms.ToArray(), (a, b) => a + b);
+            => terms.ToArray() is { Length: > 0 } array
+                ? TreeAnalyzer.MultiHangBinary(array, (a, b) => a + b)
+                : Entity.Number.Integer.Zero;
 
         /// <summary>
         /// Multiplies all the given terms and returns the resulting expression
@@ -119,8 +130,14 @@ namespace AngouriMath.Extensions
         /// 120
         /// </code>
         /// </example>
+        /// <remarks>
+        /// The empty product is <c>1</c>, for the reason the empty sum is <c>0</c> — see
+        /// <see cref="SumAll"/>.
+        /// </remarks>
         public static Entity MultiplyAll(this IEnumerable<Entity> terms)
-            => TreeAnalyzer.MultiHangBinary(terms.ToArray(), (a, b) => a * b);
+            => terms.ToArray() is { Length: > 0 } array
+                ? TreeAnalyzer.MultiHangBinary(array, (a, b) => a * b)
+                : Entity.Number.Integer.One;
 
         /// <summary>
         /// Converts an <see cref="IEnumerable"/> into a piecewise function

--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -4808,8 +4808,18 @@ namespace AngouriMath
         /// 4
         /// </code>
         /// </example>
+        /// <remarks>
+        /// A vector of no entries is refused rather than built. It used to leak a
+        /// <see cref="IndexOutOfRangeException"/>, which is outside the hierarchy
+        /// <c>Docs/Usage/Exceptions.md</c> documents — so a caller catching
+        /// <c>AngouriMathBaseException</c> did not catch it.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1028">#1028</a>
+        /// </remarks>
         public static Matrix Vector(params Entity[] values)
-            => new Matrix(GenTensor.CreateTensor(new(values.Length, 1), arr => values[arr[0]]));
+            => values.Length is 0
+                ? throw new InvalidMatrixOperationException(
+                    "a vector needs at least one entry; there is no 0x1 matrix here")
+                : new Matrix(GenTensor.CreateTensor(new(values.Length, 1), arr => values[arr[0]]));
 
         /// <summary>
         /// Creates a zero square matrix

--- a/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Operators.Classes.cs
+++ b/Sources/AngouriMath/Core/Entity/Continuous/Entity.Continuous.Operators.Classes.cs
@@ -19,8 +19,17 @@ namespace AngouriMath
             /// <summary>
             /// Sums all the terms.
             /// </summary>
+            /// <remarks>
+            /// The empty sum is <c>0</c>. This takes a list from the caller and used to hand it
+            /// to <c>MultiHangBinary</c> unchecked, whose precondition is genuine and whose
+            /// refusal is an <c>AngouriBugException</c> — so an empty list asked the caller to
+            /// report a bug against this repository.
+            /// <a href="https://github.com/asc-community/AngouriMath/issues/1028">#1028</a>
+            /// </remarks>
             public static Entity Sum(IReadOnlyList<Entity> terms)
-                => TreeAnalyzer.MultiHangBinary(terms, (a, b) => a + b);
+                => terms.Count > 0
+                    ? TreeAnalyzer.MultiHangBinary(terms, (a, b) => a + b)
+                    : Number.Integer.Zero;
 
             /// <summary>
             /// Sums all the terms.
@@ -88,8 +97,14 @@ namespace AngouriMath
             /// <summary>
             /// Multiplies all the terms.
             /// </summary>
+            /// <remarks>
+            /// The empty product is <c>1</c>, for the reason the empty sum is <c>0</c> — see
+            /// <see cref="Sumf.Sum(System.Collections.Generic.IReadOnlyList{Entity})"/>.
+            /// </remarks>
             public static Entity Multiply(IReadOnlyList<Entity> terms)
-                => TreeAnalyzer.MultiHangBinary(terms, (a, b) => a * b);
+                => terms.Count > 0
+                    ? TreeAnalyzer.MultiHangBinary(terms, (a, b) => a * b)
+                    : Number.Integer.One;
 
             /// <summary>
             /// Multiplies all the terms.

--- a/Sources/Tests/UnitTests/Convenience/EmptySequenceFoldTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/EmptySequenceFoldTest.cs
@@ -1,0 +1,87 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Core.Exceptions;
+using AngouriMath.Extensions;
+using Xunit;
+using static AngouriMath.Entity;
+
+namespace AngouriMath.Tests.Convenience
+{
+    /// <summary>
+    /// What a fold over an empty sequence answers.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/1028">#1028</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A fold over a monoid has an identity, so the empty sum is <c>0</c> and the empty product
+    /// is <c>1</c>. These threw <c>AngouriBugException</c> instead — an exception whose message
+    /// asks the caller to report a bug against this repository, for a list their own
+    /// <c>Where</c> happened to filter to nothing.
+    /// </para>
+    /// <para>
+    /// The law is what pins it rather than the two constants: concatenation has to distribute
+    /// over the fold, and it is the empty case that a wrong identity breaks.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Convenience")]
+    public sealed class EmptySequenceFoldTest
+    {
+        [Fact]
+        public void TheEmptySumIsZero()
+            => Assert.Equal((Entity)0, Array.Empty<Entity>().SumAll());
+
+        [Fact]
+        public void TheEmptyProductIsOne()
+            => Assert.Equal((Entity)1, Array.Empty<Entity>().MultiplyAll());
+
+        /// <summary>The same two, reached through the operator classes rather than the extensions.</summary>
+        [Fact]
+        public void TheOperatorEntryPointsAgree()
+        {
+            Assert.Equal((Entity)0, Sumf.Sum(Array.Empty<Entity>()));
+            Assert.Equal((Entity)1, Mulf.Multiply(Array.Empty<Entity>()));
+        }
+
+        /// <summary>
+        /// The law the identity is for: splitting a sequence anywhere, including at either end,
+        /// must not change what the fold gives.
+        /// </summary>
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(3)]
+        public void ConcatenationDistributesOverTheFold(int count)
+        {
+            var all = Enumerable.Range(1, count).Select(i => (Entity)i).ToArray();
+            for (var split = 0; split <= count; split++)
+            {
+                var left = all.Take(split).ToArray();
+                var right = all.Skip(split).ToArray();
+                Assert.Equal(all.SumAll().Evaled, (left.SumAll() + right.SumAll()).Evaled);
+                Assert.Equal(all.MultiplyAll().Evaled, (left.MultiplyAll() * right.MultiplyAll()).Evaled);
+            }
+        }
+
+        /// <summary>
+        /// A vector of no entries is refused, and refused from inside the documented hierarchy —
+        /// it used to leak <see cref="IndexOutOfRangeException"/>, which a caller catching
+        /// <c>AngouriMathBaseException</c> does not catch.
+        /// </summary>
+        [Fact]
+        public void AnEmptyVectorIsRefusedFromInsideTheHierarchy()
+        {
+            Assert.Throws<InvalidMatrixOperationException>(() => MathS.Vector());
+            Assert.Throws<InvalidMatrixOperationException>(() => Array.Empty<Entity>().ToVector());
+            Assert.IsAssignableFrom<AngouriMathBaseException>(
+                Record.Exception(() => MathS.Vector()));
+        }
+    }
+}


### PR DESCRIPTION
Closes #1028.

```csharp
new Entity[0].SumAll();   // AngouriBugException: At least 1 child required
                          // "...please report about it to the official repository"
```

An empty list — which a caller's own `Where` can easily produce — asked them to file a bug report
against this repository for their own data.

| | before | now |
|---|---|---|
| `new Entity[0].SumAll()` | `AngouriBugException` | `0` |
| `new Entity[0].MultiplyAll()` | `AngouriBugException` | `1` |
| `Sumf.Sum(new Entity[0])` | `AngouriBugException` | `0` |
| `Mulf.Multiply(new Entity[0])` | `AngouriBugException` | `1` |
| `MathS.Vector()` | `IndexOutOfRangeException` | `InvalidMatrixOperationException` |
| `new Entity[0].ToVector()` | `IndexOutOfRangeException` | `InvalidMatrixOperationException` |

## Why `0` and `1` rather than a better exception

A fold over a monoid has an identity. That is not a preference — it is what makes

```csharp
xs.Concat(ys).SumAll() == xs.SumAll() + ys.SumAll()
```

hold for **every** pair, the empty one included. The test pins that law across every split point
of a 0-, 1- and 3-element sequence rather than pinning the two constants.

`IndexOutOfRangeException` is a separate problem: it is not under `AngouriMathBaseException`, so a
caller catching the hierarchy `Docs/Usage/Exceptions.md` documents did not catch it at all.

## Two of the five entry points are not named in the issue

The defect is **passing an unchecked caller collection into `MultiHangBinary`**, whose `>= 1`
precondition is genuine. Grepping its callers turned up `Sumf.Sum(IReadOnlyList<Entity>)` and
`Mulf.Multiply(IReadOnlyList<Entity>)` doing exactly that — both public, neither mentioned in the
report.

`MultiHangBinary` itself is unchanged. The issue is right that the bug is at the boundary rather
than in the fold, and its internal callers do rely on the precondition.

Fails 7 of 7 without the change. Full suite: 8758 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd