### PR TITLE
An equation between two powers of numeric bases is answered exactly (#1007)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -24,6 +24,7 @@ read first.
 | **Silent** | `"limit(t * b, t, 0)".ToEntity().FreeVariables`, and every limit | `{ t, b }` — the variable it approaches along counted as free | `{ b }` |
 | **Silent** | `MathS.Polynomials.Factor("4 * x2 - 4 * y2", "x")`, and every multivariate polynomial whose content is a bare constant | `(x + y) * (x - y)` — **not equal to what it factored** | `4 * (x + y) * (x - y)` |
 | | `"2 * x3 - 2".ToEntity().Factorize()`, and every polynomial whose content the rules take out | `2 * (x ^ 3 - 1)` — the remainder left whole | `2 * (x - 1) * (x ^ 2 + x + 1)` |
+| | `"3^(x+1) - 2^(x-1)".ToEntity().SolveEquation("x")`, and every equation between two powers of numeric bases | `{ ln(0.04674569822628630438865471319331845734268426895141601562 ^ (1 / ln(2))) }` — a `double` promoted to a decimal | `{ -(ln(3) + ln(2)) / (ln(3) + -ln(2)) }` |
 | | `new Entity[0].SumAll()`, and `Sumf.Sum` on an empty list | `AngouriBugException: At least 1 child required` | `0` |
 | | `new Entity[0].MultiplyAll()`, and `Mulf.Multiply` on an empty list | `AngouriBugException` | `1` |
 | | `MathS.Vector()` and `new Entity[0].ToVector()` | `IndexOutOfRangeException` — outside the documented hierarchy | `InvalidMatrixOperationException` |
@@ -418,6 +419,28 @@ every factor the rules found survives and only the ones they could not split are
 asking the property [#1092](https://github.com/asc-community/AngouriMath/issues/1092) is about —
 that the answer multiplies back to its input — of a row that satisfied it and was still less
 factored than it should be.
+### An equation between two powers of numeric bases is answered exactly
+
+`3 ^ (x+1) = 2 ^ (x-1)` has the exact root `-ln(6) / ln(3/2)`. The multiplicative solver reached it
+by dividing one exponent by the other; for two different integer bases that ratio is
+`ln(3)/ln(2)` — irrational — so `InnerSimplified` settled it to a decimal and everything after was
+numeric. The answer agreed with the exact one to seventeen significant figures and diverged, which
+is the signature of a `double` promoted to a decimal rather than a number that was computed.
+
+| | before | now |
+|---|---|---|
+| `"3^(x+1) - 2^(x-1)".SolveEquation("x")` | `{ ln(0.0467456982262863043886547131933184573426842689514160156250 ^ (1 / ln(2))) }` | `{ -(ln(3) + ln(2)) / (ln(3) + -ln(2)) }` |
+| `"3^(x+1) - 2^x".SolveEquation("x")` | a decimal | `{ -ln(3) / (ln(3) + -ln(2)) }` |
+| `"5^(2x) - 7^(x+3)".SolveEquation("x")` | `{ }` — **no answer at all** | `{ 3 * ln(7) / (2 * ln(5) + -ln(7)) }` |
+| `"3^x - 2^x".SolveEquation("x")` | `{ 0 }` | unchanged |
+| `"2^(2x) - 5·2^x + 4".SolveEquation("x")` | `{ 0, 2 }` | unchanged |
+
+Taking logarithms has no such step: `a ^ p = b ^ q` is `p ln a = q ln b` for positive real `a` and
+`b`, which the analytical solver answers exactly. Both bases must be **decidably positive reals**,
+which is what makes the step an equivalence rather than a branch choice; anything else declines and
+the multiplicative path still gets its turn, so this only ever adds answers
+([#1007](https://github.com/asc-community/AngouriMath/issues/1007)).
+
 ### A fold over an empty sequence answers instead of throwing
 
 A fold over a monoid has an identity, so the empty sum is `0` and the empty product is `1` — which

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -30,6 +30,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [Tests/UnitTests/Convenience/EmptySequenceFoldTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[Tests/UnitTests/Algebra/ExponentialTwoBasesTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [Tests/UnitTests/Core/Transformations/*.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/AnalyticalEquationSolver.cs
@@ -307,6 +307,14 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
 
             MultithreadingFunctional.ExitIfCancelled();
 
+            // Two powers of numeric bases, by logarithms -- before the multiplicative solver,
+            // which reaches the same equations by a substitution that goes through a decimal.
+            // https://github.com/asc-community/AngouriMath/issues/1007
+            if (ExponentialSolver.SolveTwoPowersOfNumericBases(expr, x) is { } expTwo
+                && expTwo is FiniteSet elsExpTwo && elsExpTwo.Any())
+                return (Set)elsExpTwo.Select(ent => TryDowncast(expr, x, ent)).ToSet().InnerSimplified;
+            // // //
+
             // if no trigonometric rules helped, try exponential-multiplicative solver
             if (ExponentialSolver.SolveMultiplicative(expr, x) is { } expMul && expMul is FiniteSet elsExpMul)
                 return (Set)elsExpMul.Select(ent => TryDowncast(expr, x, ent)).ToSet().InnerSimplified;

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/ExponentialSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/ExponentialSolver.cs
@@ -66,6 +66,84 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
                 _ => expr
             };
 
+        /// <summary>
+        /// <c>a ^ p(x) = b ^ q(x)</c> for numeric <c>a</c> and <c>b</c>, solved by taking
+        /// logarithms, which keeps the answer exact.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <see cref="SolveMultiplicative"/> reaches these by substitution: it divides one
+        /// exponent by the other and simplifies, and for two different integer bases that ratio
+        /// is <c>ln(3)/ln(2)</c> — irrational — so <c>InnerSimplified</c> settles it to a decimal
+        /// and everything downstream is numeric. The answer then agrees with the exact one to
+        /// about seventeen figures and diverges after, which is a <c>double</c> promoted to a
+        /// decimal rather than a number that was computed.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1007">#1007</a>
+        /// </para>
+        /// <para>
+        /// Taking logarithms has no such step: <c>a ^ p = b ^ q</c> is <c>p ln a = q ln b</c>
+        /// for positive real <c>a</c> and <c>b</c>, and that is an ordinary equation the
+        /// analytical solver answers exactly — <c>3 ^ (x+1) = 2 ^ (x-1)</c> becomes
+        /// <c>-ln(6) / ln(3/2)</c>.
+        /// </para>
+        /// <para>
+        /// Both bases must be <b>decidably positive reals</b>, which is what makes <c>ln</c> of
+        /// them real and the step an equivalence rather than a branch choice. Anything else
+        /// declines and the substitution path still gets its turn, so this only ever adds
+        /// answers.
+        /// </para>
+        /// </remarks>
+        internal static Set? SolveTwoPowersOfNumericBases(Entity expr, Variable x)
+        {
+            // a ^ p - b ^ q, however the subtraction is spelled: `a - b` and `a + (-1) * b` are
+            // the same tree to the solver by the time it gets here.
+            // Zero terms are dropped first: the solver is handed `lhs - rhs - 0`, and the
+            // trailing zero makes a two-power equation look like a three-term one.
+            var terms = Entity.Sumf.LinearChildren(expr)
+                .Where(term => term.Evaled is not Number number || number != 0)
+                .ToList();
+            if (terms.Count != 2)
+                return null;
+
+            var (leftBase, leftPower, leftSign) = AsPower(terms[0]);
+            var (rightBase, rightPower, rightSign) = AsPower(terms[1]);
+            if (leftBase is null || rightBase is null)
+                return null;
+            // One of each sign, or the equation is a sum of two powers and has no such root.
+            if (leftSign == rightSign)
+                return null;
+            // Different bases only: one base is what SolveMultiplicative already does exactly.
+            if (leftBase == rightBase)
+                return null;
+
+            var logarithmic = (leftPower! * MathS.Ln(leftBase) - rightPower! * MathS.Ln(rightBase))
+                .InnerSimplified;
+            if (!logarithmic.ContainsNode(x))
+                return null;
+            return AnalyticalEquationSolver.Solve(logarithmic, x) as FiniteSet;
+        }
+
+        /// <summary>
+        /// <paramref name="term"/> read as a signed power of a decidably positive real base, or
+        /// a null base where it is not one.
+        /// </summary>
+        private static (Entity? Base, Entity? Power, bool Negated) AsPower(Entity term)
+        {
+            var negated = false;
+            if (term is Mulf(Real { IsNegative: true } coefficient, var rest)
+                && coefficient == -1)
+            {
+                negated = true;
+                term = rest;
+            }
+            if (term is not Powf(var @base, var power))
+                return (null, null, negated);
+            // Decidably positive so that ln is real and `a ^ p = b ^ q` iff `p ln a = q ln b`.
+            if (@base.Evaled is not Real { EDecimal.IsFinite: true } value || !value.IsPositive)
+                return (null, null, negated);
+            return (@base, power, negated);
+        }
+
         internal static Set? SolveMultiplicative(Entity expr, Variable x)
         {
             Entity? substitution = null;

--- a/Sources/Tests/UnitTests/Algebra/ExponentialTwoBasesTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/ExponentialTwoBasesTest.cs
@@ -1,0 +1,81 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Linq;
+using System.Text.RegularExpressions;
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+using static AngouriMath.Entity;
+
+namespace AngouriMath.Tests.Algebra
+{
+    /// <summary>
+    /// An equation between two powers of numeric bases is answered exactly.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/1007">#1007</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The multiplicative solver reaches these by dividing one exponent by the other, and for two
+    /// different integer bases that ratio is <c>ln(3)/ln(2)</c> — irrational — so it settles to a
+    /// decimal and everything after it is numeric. The answer then agreed with the exact one to
+    /// about seventeen figures and diverged, which is a <c>double</c> promoted to a decimal.
+    /// </para>
+    /// <para>
+    /// Asserted by <b>substituting the root back</b> rather than by comparing printed text, which
+    /// is what the issue asks for: a decimal that is right to seventeen figures passes any test
+    /// that reads the answer and fails the equation.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Algebra")]
+    public sealed class ExponentialTwoBasesTest
+    {
+        [Theory]
+        [InlineData("3^(x+1) - 2^(x-1)")]
+        [InlineData("3^(x+1) - 2^x")]
+        [InlineData("5^(2*x) - 7^(x+3)")]
+        [InlineData("2^(3*x) - 5^(x+1)")]
+        public void ARootOfTwoNumericPowersSatisfiesItsEquation(string equation)
+        {
+            var roots = equation.ToEntity().SolveEquation("x");
+            var finite = Assert.IsType<Set.FiniteSet>(roots);
+            Assert.NotEmpty(finite);
+            foreach (var root in finite)
+            {
+                var residual = equation.ToEntity().Substitute("x", root).EvalNumerical();
+                Assert.True(residual.Abs().RealPart.EDecimal.ToDouble() < 1e-8,
+                    $"{equation} at {root.Stringize()} is {residual.Stringize()}, not 0");
+            }
+        }
+
+        /// <summary>
+        /// And no decimal literal in the printed form — the exactness is the point, and a root
+        /// that satisfies the equation to eight figures would pass the check above either way.
+        /// </summary>
+        [Theory]
+        [InlineData("3^(x+1) - 2^(x-1)")]
+        [InlineData("3^(x+1) - 2^x")]
+        [InlineData("5^(2*x) - 7^(x+3)")]
+        public void TheAnswerCarriesNoDecimal(string equation)
+            => Assert.DoesNotMatch(@"\d\.\d{6,}",
+                equation.ToEntity().SolveEquation("x").Stringize());
+
+        /// <summary>
+        /// The cases that were exact before stay exact — this branch is asked before the
+        /// multiplicative solver, so it must not take equations that one already answers.
+        /// </summary>
+        [Theory]
+        [InlineData("3^x - 2^x", "{ 0 }")]
+        [InlineData("3^x - 2", "{ log(3, 2) }")]
+        [InlineData("2^x - 8", "{ 3 }")]
+        [InlineData("2^(2*x) - 5*2^x + 4", "{ 0, 2 }")]
+        [InlineData("ln(x)^2 - 3*ln(x) + 2", "{ e, e ^ 2 }")]
+        [InlineData("6^x - 2", "{ log(6, 2) }")]
+        public void WhatWasExactStaysExact(string equation, string expected)
+            => Assert.Equal(expected, equation.ToEntity().SolveEquation("x").Stringize());
+    }
+}


### PR DESCRIPTION
Closes #1007.

`3 ^ (x+1) = 2 ^ (x-1)` has the exact root `-ln(6) / ln(3/2)`.

| | before | now |
|---|---|---|
| `"3^(x+1) - 2^(x-1)".SolveEquation("x")` | `{ ln(0.04674569822628630438865471319331845734268426895141… ^ (1 / ln(2))) }` | `{ -(ln(3) + ln(2)) / (ln(3) + -ln(2)) }` |
| `"3^(x+1) - 2^x".SolveEquation("x")` | a decimal | `{ -ln(3) / (ln(3) + -ln(2)) }` |
| `"5^(2x) - 7^(x+3)".SolveEquation("x")` | `{ }` — **no answer at all** | `{ 3 * ln(7) / (2 * ln(5) + -ln(7)) }` |
| `"3^x - 2^x"`, `"2^(2x) - 5·2^x + 4"`, `"ln(x)² - 3ln(x) + 2"`, … | exact | **unchanged** |

## Why the decimal appeared

The multiplicative solver divides one exponent by the other. For two different integer bases that
ratio is `ln(3)/ln(2)` — irrational — so `InnerSimplified` settles it to a decimal and everything
downstream is numeric. The answer then agrees with the exact one to seventeen significant figures
and diverges, which is the signature of a `double` promoted to a decimal rather than a number that
was computed.

Taking logarithms has no such step: `a ^ p = b ^ q` is `p ln a = q ln b`, an ordinary equation the
analytical solver answers exactly. It is tried **before** the multiplicative solver, because that
is where the exactness is lost.

Both bases must be **decidably positive reals** — that is what makes `ln` of them real and the
step an equivalence rather than a branch choice. Anything else declines and the multiplicative
path still gets its turn, so this only ever adds answers.

## Two notes on getting there

**A trace found in one run what reading the code had not.** The first version did not fire at all:
the solver is handed `lhs - rhs - 0`, so a two-power equation arrives with **three** terms and the
count guard rejected it. Terms evaluating to zero are dropped before counting.

**The test substitutes each root back** rather than comparing printed text, as the issue asks — a
decimal right to seventeen figures passes any test that reads the answer and fails the equation.
It also pins that the six equations exact before are unchanged, since this branch runs ahead of
the one that answers them.

Fails 4 of its 13 cases without the change. Full suite: 8775 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd