### PR TITLE
A widened codomain is written out, so `Stringize` round-trips it (#1048)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -25,6 +25,7 @@ read first.
 | **Silent** | `MathS.Polynomials.Factor("4 * x2 - 4 * y2", "x")`, and every multivariate polynomial whose content is a bare constant | `(x + y) * (x - y)` — **not equal to what it factored** | `4 * (x + y) * (x - y)` |
 | | `"2 * x3 - 2".ToEntity().Factorize()`, and every polynomial whose content the rules take out | `2 * (x ^ 3 - 1)` — the remainder left whole | `2 * (x - 1) * (x ^ 2 + x + 1)` |
 | | `"3^(x+1) - 2^(x-1)".ToEntity().SolveEquation("x")`, and every equation between two powers of numeric bases | `{ ln(0.04674569822628630438865471319331845734268426895141601562 ^ (1 / ln(2))) }` — a `double` promoted to a decimal | `{ -(ln(3) + ln(2)) / (ln(3) + -ln(2)) }` |
+| **Silent** | `MathS.Abs("x").WithCodomain(Domain.Any).Stringize()`, and every node widened to `Any` from a narrower default | `abs(x)` — reads back as `Real`, losing the widening | `domain(abs(x), Any)` |
 | | `new Entity[0].SumAll()`, and `Sumf.Sum` on an empty list | `AngouriBugException: At least 1 child required` | `0` |
 | | `new Entity[0].MultiplyAll()`, and `Mulf.Multiply` on an empty list | `AngouriBugException` | `1` |
 | | `MathS.Vector()` and `new Entity[0].ToVector()` | `IndexOutOfRangeException` — outside the documented hierarchy | `InvalidMatrixOperationException` |
@@ -440,6 +441,31 @@ Taking logarithms has no such step: `a ^ p = b ^ q` is `p ln a = q ln b` for pos
 which is what makes the step an equivalence rather than a branch choice; anything else declines and
 the multiplicative path still gets its turn, so this only ever adds answers
 ([#1007](https://github.com/asc-community/AngouriMath/issues/1007)).
+### A widened codomain is written out, so `Stringize` round-trips it
+
+`Domain.Any` had no spelling: the second argument of `domain(...)` had to be one of the five
+special sets, and none of them means "no restriction". So a node **widened** to `Any` from a
+narrower default printed as though it had not been, and reading that back gave the default.
+
+| | before | now |
+|---|---|---|
+| `MathS.Abs("x").WithCodomain(Any).Stringize()` | `abs(x)` | `domain(abs(x), Any)` |
+| the same, reparsed | `Real` — the widening was lost | `Any` |
+| `MathS.Abs("x").WithCodomain(Integer).Stringize()` | `domain(abs(x), ZZ)` | unchanged |
+| `"Any + 1"` | parses, `Any` is a variable | unchanged |
+
+`Any` is **not** a set literal — there is still no node for "no restriction", and
+`SpecialSet.Create(Domain.Any)` still throws for it. It is read in the second argument of
+`domain(...)` and nowhere else, which commits to a spelling without deciding whether there is a
+universal *set*; that question is [#996](https://github.com/asc-community/AngouriMath/issues/996)
+and this does not answer it.
+
+Read rather than lexed, deliberately. A literal in a parser rule becomes a global lexer token, and
+making `Any` a keyword reserved the name everywhere — `Any + 1` stopped parsing. A test pins that
+it stays an ordinary variable.
+
+`Latexize` renders the subscript as `\mathrm{Any}` rather than a `\mathbb`, since there is no set
+to render ([#1048](https://github.com/asc-community/AngouriMath/issues/1048)).
 
 ### A fold over an empty sequence answers instead of throwing
 

--- a/Sources/AngouriMath/Core/Antlr/AngouriMath.g
+++ b/Sources/AngouriMath/Core/Antlr/AngouriMath.g
@@ -434,9 +434,19 @@ atom returns[Entity value]
     | 'domain(' args = function_arguments ')' 
         { 
             Assert("domain", 2, $args.list.Count); 
-            if ($args.list[1] is not SpecialSet ss)
+            // `Any` is the unrestricted codomain. It is read here rather than lexed as a
+            // keyword, because a literal in a parser rule becomes a global lexer token and
+            // would reserve the name everywhere -- `Any + 1` stopped parsing when that was
+            // tried. It is not a SpecialSet either: there is no node for "no restriction", see
+            // SpecialSet.Create(Domain). Reading it in this one position commits to a spelling
+            // without deciding whether there is a universal *set*, which is #996.
+            // https://github.com/asc-community/AngouriMath/issues/1048
+            if ($args.list[1] is Variable { Name: "Any" })
+                $value = $args.list[0].WithCodomain(AngouriMath.Core.Domain.Any);
+            else if ($args.list[1] is not SpecialSet ss)
                 throw new InvalidArgumentParseException($"Unrecognized special set {$args.list[1].Stringize()}");
-            $value = $args.list[0].WithCodomain(ss.ToDomain());
+            else
+                $value = $args.list[0].WithCodomain(ss.ToDomain());
         }
     | 'piecewise(' args = function_arguments ')'
         {

--- a/Sources/AngouriMath/Core/Antlr/AngouriMathParser.cs
+++ b/Sources/AngouriMath/Core/Antlr/AngouriMathParser.cs
@@ -3233,9 +3233,19 @@ internal partial class AngouriMathParser : Parser {
 				Match(T__40);
 				 
 				            Assert("domain", 2, _localctx.args.list.Count); 
-				            if (_localctx.args.list[1] is not SpecialSet ss)
+				            // `Any` is the unrestricted codomain. It is read here rather than lexed as a
+				            // keyword, because a literal in a parser rule becomes a global lexer token and
+				            // would reserve the name everywhere -- `Any + 1` stopped parsing when that was
+				            // tried. It is not a SpecialSet either: there is no node for "no restriction", see
+				            // SpecialSet.Create(Domain). Reading it in this one position commits to a spelling
+				            // without deciding whether there is a universal *set*, which is #996.
+				            // https://github.com/asc-community/AngouriMath/issues/1048
+				            if (_localctx.args.list[1] is Variable { Name: "Any" })
+				                _localctx.value =  _localctx.args.list[0].WithCodomain(AngouriMath.Core.Domain.Any);
+				            else if (_localctx.args.list[1] is not SpecialSet ss)
 				                throw new InvalidArgumentParseException($"Unrecognized special set {_localctx.args.list[1].Stringize()}");
-				            _localctx.value =  _localctx.args.list[0].WithCodomain(ss.ToDomain());
+				            else
+				                _localctx.value =  _localctx.args.list[0].WithCodomain(ss.ToDomain());
 				        
 				}
 				break;

--- a/Sources/AngouriMath/Core/Domains.Definition.cs
+++ b/Sources/AngouriMath/Core/Domains.Definition.cs
@@ -78,15 +78,18 @@ namespace AngouriMath
         /// </summary>
         /// <remarks>
         /// <para>
-        /// <see cref="Domain.Any"/> is excluded because the grammar has no way to write it: the
-        /// second argument of <c>domain(...)</c> must be a <see cref="Set.SpecialSet"/>, and there
-        /// is no node for "no restriction" — see <see cref="Set.SpecialSet.Create(Domain)"/>. So a
-        /// node widened to <see cref="Domain.Any"/> from a narrower default still prints as though
-        /// it had not been. Printing <c>CC</c> there would be a different lie, and throwing from a
-        /// printer would take out every diagnostic message that quotes an expression.
+        /// <see cref="Domain.Any"/> used to be excluded, because the grammar had no way to write
+        /// it — the second argument of <c>domain(...)</c> had to be a <see cref="Set.SpecialSet"/>
+        /// and there is no node for "no restriction", see
+        /// <see cref="Set.SpecialSet.Create(Domain)"/>. A node widened to it from a narrower
+        /// default therefore printed as though it had not been, and reading that back gave the
+        /// default: <c>abs(x)</c> widened to <c>Any</c> came back <c>Real</c>. The grammar takes
+        /// <c>domain(x, Any)</c> now, as a keyword in that one position rather than as a set
+        /// literal, so this no longer has to lie by omission.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1048">#1048</a>
         /// </para>
         /// </remarks>
-        internal bool PrintsItsCodomain => Codomain != DefaultCodomain && Codomain != Domain.Any;
+        internal bool PrintsItsCodomain => Codomain != DefaultCodomain;
 
         /// <summary>
         /// Returns this node with the specified codomain, 

--- a/Sources/AngouriMath/Functions/Output/Latex.Definition.cs
+++ b/Sources/AngouriMath/Functions/Output/Latex.Definition.cs
@@ -53,7 +53,10 @@ namespace AngouriMath
         /// </remarks>
         public string Latexize()
             => PrintsItsCodomain
-                ? $@"{{\left({LatexizeNode()}\right)}}_{{{Set.SpecialSet.Create(Codomain).Latexize()}}}"
+                // No \mathbb for "no restriction" -- there is no set to render. #1048
+                ? Codomain is Domain.Any
+                    ? $@"{{\left({LatexizeNode()}\right)}}_{{\mathrm{{Any}}}}"
+                    : $@"{{\left({LatexizeNode()}\right)}}_{{{Set.SpecialSet.Create(Codomain).Latexize()}}}"
                 : LatexizeNode();
 
         /// <summary>

--- a/Sources/AngouriMath/Functions/Output/ToString.Definition.cs
+++ b/Sources/AngouriMath/Functions/Output/ToString.Definition.cs
@@ -22,7 +22,11 @@ namespace AngouriMath
         /// </remarks>
         public string Stringize()
             => PrintsItsCodomain
-                ? $"domain({StringizeNode()}, {Set.SpecialSet.Create(Codomain).Stringize()})"
+                // `Any` is a keyword in that position rather than a set, since there is no node
+                // for "no restriction" to ask for a name. #1048
+                ? Codomain is Domain.Any
+                    ? $"domain({StringizeNode()}, Any)"
+                    : $"domain({StringizeNode()}, {Set.SpecialSet.Create(Codomain).Stringize()})"
                 : StringizeNode();
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Common/CodomainSurvivesPrintingTest.cs
+++ b/Sources/Tests/UnitTests/Common/CodomainSurvivesPrintingTest.cs
@@ -172,24 +172,50 @@ namespace AngouriMath.Tests.Common
         }
 
         /// <summary>
-        /// <see cref="Domain.Any"/> is the one codomain that cannot be printed, and this pins it
-        /// rather than leaving it a hole nobody measured.
+        /// <see cref="Domain.Any"/> is written too, so the printed form no longer loses a
+        /// widening. This test used to pin the opposite and is the record of it changing.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1048">#1048</a>
         /// </summary>
         /// <remarks>
-        /// The second argument of <c>domain(...)</c> has to be a
-        /// <see cref="Entity.Set.SpecialSet"/>, and there is no node for "no restriction" — see
-        /// <see cref="Entity.Set.SpecialSet.Create(Domain)"/>, which throws for it. So a node
-        /// <em>widened</em> to <see cref="Domain.Any"/> from a narrower default still prints as
-        /// though it had not been. Printing <c>CC</c> instead would be a different lie, since
-        /// <see cref="Domain.Complex"/> rejects a value <see cref="Domain.Any"/> admits.
+        /// <para>
+        /// There is still no node for "no restriction" — <see cref="Entity.Set.SpecialSet.Create(Domain)"/>
+        /// throws for it — so <c>Any</c> is not a set literal. It is read in the second argument
+        /// of <c>domain(...)</c> and nowhere else, which commits to a spelling without deciding
+        /// whether there is a universal <em>set</em>.
+        /// </para>
+        /// <para>
+        /// Read rather than lexed, deliberately: a literal in a parser rule becomes a global
+        /// lexer token, and making <c>Any</c> a keyword stopped <c>Any + 1</c> parsing at all.
+        /// <see cref="AVariableNamedAnyIsStillAVariable"/> is what keeps that from coming back.
+        /// </para>
         /// </remarks>
-        [Fact]
-        public void WideningToAnyIsTheOneThingThePrintedFormStillCannotSay()
+        [Theory]
+        [InlineData("x + 1")]
+        [InlineData("abs(x)")]
+        [InlineData("phi(x)")]
+        public void WideningToAnyIsWrittenOut(string source)
         {
-            Entity widened = ((Entity)"x + 1").WithCodomain(Domain.Any);
+            var widened = MathS.FromString(source).WithCodomain(Domain.Any);
             Assert.Equal(Domain.Any, widened.Codomain);
-            Assert.Equal("x + 1", widened.Stringize());
-            Assert.NotEqual(widened, MathS.FromString(widened.Stringize()));
+            var printed = widened.Stringize();
+            var read = MathS.FromString(printed);
+            Assert.Equal(Domain.Any, read.Codomain);
+            Assert.Equal(widened, read);
+        }
+
+        /// <summary>
+        /// And <c>Any</c> is not reserved: it is read as the unrestricted codomain in the one
+        /// position where a codomain is expected, and is an ordinary variable everywhere else.
+        /// </summary>
+        [Theory]
+        [InlineData("Any + 1")]
+        [InlineData("Any")]
+        [InlineData("sin(Any)")]
+        public void AVariableNamedAnyIsStillAVariable(string source)
+        {
+            var parsed = MathS.FromString(source);
+            Assert.Contains((Entity.Variable)"Any", parsed.Vars);
+            Assert.Equal(source, parsed.Stringize());
         }
 
         /// <summary>


### PR DESCRIPTION
Closes case 1 of #1048.

`Domain.Any` had no spelling — the second argument of `domain(...)` had to be one of the five
special sets, and none means "no restriction". So a node **widened** to `Any` from a narrower
default printed as though it had not been:

| | before | now |
|---|---|---|
| `MathS.Abs("x").WithCodomain(Any).Stringize()` | `abs(x)` | `domain(abs(x), Any)` |
| the same, reparsed | `Real` — **the widening was lost** | `Any` |
| `MathS.Abs("x").WithCodomain(Integer).Stringize()` | `domain(abs(x), ZZ)` | unchanged |
| `"Any + 1"` | parses, `Any` is a variable | unchanged |

#746's lie-free channel asks that what the library prints reads back as what it printed.

## `Any` is not a set literal, and that is the point

There is still no node for "no restriction" — `SpecialSet.Create(Domain.Any)` throws for it,
deliberately. So `Any` is read **in the second argument of `domain(...)` and nowhere else**.

That commits to a spelling without deciding whether there is a universal *set*. The issue offers
`domain(x, Any)` and a `UU`-style token as both plausible; the second is entangled with #996,
which is open, so this takes the one that does not prejudge it.

## Read rather than lexed — and the first attempt is why

Writing `'Any'` as a literal in the parser rule makes ANTLR mint a **global lexer token**, so the
name became reserved everywhere and `Any + 1` stopped parsing. Reading it in the action reserves
nothing, and `AVariableNamedAnyIsStillAVariable` keeps that from coming back.

Mechanical confirmation: only `AngouriMathParser.cs` changed — **not** the lexer or the token
files.

## The grammar regeneration

Followed the procedure in the codebase skill, including regenerating the **unmodified** grammar
first and confirming `git diff` was empty, so a toolchain difference could not be mistaken for a
change of mine.

## The test that was designed to fail

`WideningToAnyIsTheOneThingThePrintedFormStillCannotSay` pinned the limitation, and #1048 says
those pins exist so the gap "cannot rot silently". It failed the moment this started working,
which is exactly its job. It is now a theory over three shapes asserting the round-trip.

Case 2 of the issue — no input yields a rational literal whose codomain is `Complex` — is
untouched. It is a sentinel sharing a representation with a real value, and the issue says nothing
is currently lost by it.

Full suite: 8767 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd