### PR TITLE
Add the 1844th performance column, and what two runs of one commit say about the timings

### DIFF
--- a/Sources/AngouriMath/Docs/WhatsNew/version_performance_control.md
+++ b/Sources/AngouriMath/Docs/WhatsNew/version_performance_control.md
@@ -123,26 +123,26 @@ benchmark and the size of the move. A move nobody can explain is the finding, no
 
 ---
 
-|          Method |         [331st](https://github.com/asc-community/AngouriMath/commit/10e6e5a90e7270336b68dc5fd6aa36f3e0e65d2b) |          [380th](https://github.com/asc-community/AngouriMath/commit/73ae36488ddb863c1d6f35db5ed2f5dcf1484a26) |     [391st](https://github.com/asc-community/AngouriMath/commit/c7e08e6936bfdc2373377bec81ffd160e406244f)      |         [410th](https://github.com/asc-community/AngouriMath/commit/20814936bc740a9f410af4a4368e9895eab7aaf7) |           [483rd](https://github.com/asc-community/AngouriMath/commit/355963dcdf0ff9da568e9f1144ad2b7b68c19584) |         [520th](https://github.com/asc-community/AngouriMath/commit/70aa71acb73307c9f7df0aac006faae31b06058c) |         [690th](https://github.com/asc-community/AngouriMath/commit/5cc894939cb3657f0aa7ef5a25fd55011058929f) |         [826th](https://github.com/asc-community/AngouriMath/commit/87e33ec3590a95dd4ec59ff5c1f77064a64196d1) |         [914th](https://github.com/asc-community/AngouriMath/commit/6134338df083a908369b6bcfb69e70a4269ec51b) |         [920th](https://github.com/asc-community/AngouriMath/commit/501a0a3a9b2e07cddf92c4446b73ad6e2748253a) |        [1034th](https://github.com/asc-community/AngouriMath/commit/a3f48b47795b2dc2b3435152989a6e15639a65b4) |        [1066th](https://github.com/asc-community/AngouriMath/commit/a33746651f56a380b6c17913aa844f162f258d8c) |        [1090th](https://github.com/asc-community/AngouriMath/commit/9530c5b04484e98023941f7693bbeb1a3282cee6) |           [1446th](https://github.com/asc-community/AngouriMath/commit/2abb2b537c03977281f3fc2cab1da2c78c36a5f5) | [1620th](https://github.com/asc-community/AngouriMath/commit/e05d71797f53a9ac7dbdad6075cd7302a91036e7) | [1671st](https://github.com/asc-community/AngouriMath/commit/253b5a8d598a9a1d721b777340bd53ae3be12f99) | [1769th](https://github.com/asc-community/AngouriMath/commit/3ac24bc241e898509533bc980ec5dc91c5d79a07) |
-|---------------- |--------------:|---------------:|---------------:|--------------:|----------------:|--------------:|--------------:|--------------:|--------------:|--------------:|--------------:|--------------:|--------------:|-----------------:|--------------:|--------------:|--:|
-|       ParseEasy |        28,599 |         73,669 |        134,120 |        44,328 |          54,675 |        21,722 |        32,212 |        32,138 |        34,702 |        32,199 |        33,008 |        27,483 |        33,043 |        34,664 | 11,760 ns | 10,857 ns | 10,080 ns |
-|       ParseHard |        92,037 |        208,710 |        415,440 |       178,760 |         287,865 |       209,853 |       624,769 |       698,094 |     4,272,898 |     3,862,375 |     4,731,275 |     4,051,823 |     5,284,613 |     5,657,058 | 2,617,362 ns | 2,493,337 ns | 2,235,852 ns |
-|    SimplifyEasy |     6,225,707 |     16,387,374 |     41,081,822 |       397,973 |       2,594,367 |       168,462 |       225,393 |       281,626 |       122,809 |        79,184 |        94,505 |        86,478 |       102,600 |        87,759 | 153,704 ns | 152,631 ns | 136,841 ns |
-|    SimplifyHard | 3,245,613,128 |  8,120,319,273 |  9,715,629,251 | 7,477,089,153 |  13,529,147,530 | 3,015,302,746 | 3,162,675,550 | 3,826,831,860 | 4,024,002,060 | 2,633,113,653 | 3,262,112,233 | 4,540,783,876 | 4,639,170,780 | 4,880,264,786 | 2,848,037,261 ns | 2,916,127,943 ns | 2,489,408,789 ns |
-|        Derivate |         5,550 |         39,895 |        161,507 |        50,858 |          56,255 |        37,702 |        46,083 |        86,751 |        68,604 |        41,388 |        58,340 |        48,376 |        54,228 |        60,425 | 26,808 ns | 25,629 ns | 23,674 ns |
-|       SolveEasy |       677,259 |      4,066,049 |     33,760,616 |     7,556,902 |     124,888,489 |    38,935,084 |    42,101,926 |    43,102,578 |    43,778,486 |    42,818,770 |    42,230,213 |    35,415,096 |    45,032,006 |    45,587,157 | 21,829,186 ns | 21,322,368 ns | 8,530,148 ns |
-| SolveEasyMedium |       192,319 |        741,114 |      2,861,751 |       646,063 |         789,993 |       124,082 |       154,729 |       142,744 |       138,836 |        78,712 |       110,144 |        88,021 |       106,430 |       108,175 | 48,368 ns | 48,863 ns | 50,203 ns |
-|     SolveMedium |    22,487,990 |    126,650,858 |    690,232,457 |   178,691,349 |     350,752,882 |     2,961,363 |     2,174,299 |     2,108,050 |     2,248,458 |     2,449,733 |     2,996,001 |     2,661,744 |     3,272,498 |     4,409,082 | 783,737 ns | 796,814 ns | 696,969 ns |
-| SolveMediumHard |       > 1 h   |       > 1 h    | 12,033,099,074 | 2,754,157,261 |   5,779,298,835 |   240,930,082 |   258,560,720 |   309,944,856 |   346,532,318 |   258,799,676 |   305,404,083 |   354,286,153 |   409,437,694 |   453,280,166 | 124,316,631 ns | 129,750,583 ns | 117,103,179 ns |
-|       SolveHard |       > 1 h   |       > 1 h    | 21,565,808,100 | 5,636,112,783 | 100,663,275,757 | 1,862,768,773 | 2,532,972,635 | 3,000,655,673 | 3,606,412,386 | 2,425,286,433 | 2,918,112,980 | 3,162,162,893 | 3,353,403,193 | 3,494,150,836 | 1,134,532,585 ns | 1,365,230,469 ns | 1,144,927,429 ns |
-|        EvalEasy |        12,059 |        200,766 |      1,548,901 |       550,676 |       3,354,484 |            34 |            72 |            68 |            84 |            28 |            11 |            11 |            13 |             9 | 2 ns | 2 ns | 1 ns |
-|        EvalTrig |             -- |              -- |              -- |            -- |               -- |            -- |            -- |            -- |            -- |            -- |            -- |            -- |            -- |               -- |               -- | 1,344,115 ns | 1,280,227 ns |
-| EvalTrigPrecise |             -- |              -- |              -- |            -- |               -- |            -- |            -- |            -- |            -- |            -- |            -- |            -- |            -- |               -- |               -- | 43,285,515 ns | 37,048,158 ns |
-|     CompileEasy |        24,771 |         38,300 |         62,328 |        33,684 |          40,751 |         9,208 |        15,467 |         5,487 |         5,623 |         6,283 |         6,254 |         5,143 |       565,597 |       589,540 | 352,800 ns | 352,449 ns | 314,521 ns |
-|     CompileHard |        61,572 |         84,042 |        139,499 |        73,738 |          96,203 |        18,274 |        26,390 |        14,782 |        15,657 |        17,986 |        17,672 |        14,902 |     1,234,995 |     1,321,375 | 595,593 ns | 596,664 ns | 585,717 ns |
-|         RunEasy |           138 |            126 |            123 |           117 |             128 |           157 |           170 |           165 |           175 |           167 |           161 |           149 |            48 |            43 | 42 ns | 42 ns | 28 ns |
-|       RunMedium |           833 |            950 |            920 |           844 |             838 |         1,008 |         1,081 |         1,064 |         1,155 |         1,089 |           982 |           875 |           630 |           549 | 318 ns | 320 ns | 238 ns |
-|         RunHard |         1,403 |          1,644 |          1,558 |         1,427 |           1,391 |         1,974 |         2,102 |         2,037 |         2,046 |         2,044 |         1,855 |         1,655 |         1,041 |           928 | 586 ns | 582 ns | 433 ns |
+|          Method |         [331st](https://github.com/asc-community/AngouriMath/commit/10e6e5a90e7270336b68dc5fd6aa36f3e0e65d2b) |          [380th](https://github.com/asc-community/AngouriMath/commit/73ae36488ddb863c1d6f35db5ed2f5dcf1484a26) |     [391st](https://github.com/asc-community/AngouriMath/commit/c7e08e6936bfdc2373377bec81ffd160e406244f)      |         [410th](https://github.com/asc-community/AngouriMath/commit/20814936bc740a9f410af4a4368e9895eab7aaf7) |           [483rd](https://github.com/asc-community/AngouriMath/commit/355963dcdf0ff9da568e9f1144ad2b7b68c19584) |         [520th](https://github.com/asc-community/AngouriMath/commit/70aa71acb73307c9f7df0aac006faae31b06058c) |         [690th](https://github.com/asc-community/AngouriMath/commit/5cc894939cb3657f0aa7ef5a25fd55011058929f) |         [826th](https://github.com/asc-community/AngouriMath/commit/87e33ec3590a95dd4ec59ff5c1f77064a64196d1) |         [914th](https://github.com/asc-community/AngouriMath/commit/6134338df083a908369b6bcfb69e70a4269ec51b) |         [920th](https://github.com/asc-community/AngouriMath/commit/501a0a3a9b2e07cddf92c4446b73ad6e2748253a) |        [1034th](https://github.com/asc-community/AngouriMath/commit/a3f48b47795b2dc2b3435152989a6e15639a65b4) |        [1066th](https://github.com/asc-community/AngouriMath/commit/a33746651f56a380b6c17913aa844f162f258d8c) |        [1090th](https://github.com/asc-community/AngouriMath/commit/9530c5b04484e98023941f7693bbeb1a3282cee6) |           [1446th](https://github.com/asc-community/AngouriMath/commit/2abb2b537c03977281f3fc2cab1da2c78c36a5f5) | [1620th](https://github.com/asc-community/AngouriMath/commit/e05d71797f53a9ac7dbdad6075cd7302a91036e7) | [1671st](https://github.com/asc-community/AngouriMath/commit/253b5a8d598a9a1d721b777340bd53ae3be12f99) | [1769th](https://github.com/asc-community/AngouriMath/commit/3ac24bc241e898509533bc980ec5dc91c5d79a07) | [1844th](https://github.com/asc-community/AngouriMath/commit/55cd1a58) |
+|---------------- |--------------:|---------------:|---------------:|--------------:|----------------:|--------------:|--------------:|--------------:|--------------:|--------------:|--------------:|--------------:|--------------:|-----------------:|--------------:|--------------:|--:| --------------: |
+|       ParseEasy |        28,599 |         73,669 |        134,120 |        44,328 |          54,675 |        21,722 |        32,212 |        32,138 |        34,702 |        32,199 |        33,008 |        27,483 |        33,043 |        34,664 | 11,760 ns | 10,857 ns | 10,080 ns |           6,846 ns |
+|       ParseHard |        92,037 |        208,710 |        415,440 |       178,760 |         287,865 |       209,853 |       624,769 |       698,094 |     4,272,898 |     3,862,375 |     4,731,275 |     4,051,823 |     5,284,613 |     5,657,058 | 2,617,362 ns | 2,493,337 ns | 2,235,852 ns |       1,621,902 ns |
+|    SimplifyEasy |     6,225,707 |     16,387,374 |     41,081,822 |       397,973 |       2,594,367 |       168,462 |       225,393 |       281,626 |       122,809 |        79,184 |        94,505 |        86,478 |       102,600 |        87,759 | 153,704 ns | 152,631 ns | 136,841 ns |         111,852 ns |
+|    SimplifyHard | 3,245,613,128 |  8,120,319,273 |  9,715,629,251 | 7,477,089,153 |  13,529,147,530 | 3,015,302,746 | 3,162,675,550 | 3,826,831,860 | 4,024,002,060 | 2,633,113,653 | 3,262,112,233 | 4,540,783,876 | 4,639,170,780 | 4,880,264,786 | 2,848,037,261 ns | 2,916,127,943 ns | 2,489,408,789 ns |   1,762,805,433 ns |
+|        Derivate |         5,550 |         39,895 |        161,507 |        50,858 |          56,255 |        37,702 |        46,083 |        86,751 |        68,604 |        41,388 |        58,340 |        48,376 |        54,228 |        60,425 | 26,808 ns | 25,629 ns | 23,674 ns |          16,507 ns |
+|       SolveEasy |       677,259 |      4,066,049 |     33,760,616 |     7,556,902 |     124,888,489 |    38,935,084 |    42,101,926 |    43,102,578 |    43,778,486 |    42,818,770 |    42,230,213 |    35,415,096 |    45,032,006 |    45,587,157 | 21,829,186 ns | 21,322,368 ns | 8,530,148 ns |       6,240,038 ns |
+| SolveEasyMedium |       192,319 |        741,114 |      2,861,751 |       646,063 |         789,993 |       124,082 |       154,729 |       142,744 |       138,836 |        78,712 |       110,144 |        88,021 |       106,430 |       108,175 | 48,368 ns | 48,863 ns | 50,203 ns |          37,304 ns |
+|     SolveMedium |    22,487,990 |    126,650,858 |    690,232,457 |   178,691,349 |     350,752,882 |     2,961,363 |     2,174,299 |     2,108,050 |     2,248,458 |     2,449,733 |     2,996,001 |     2,661,744 |     3,272,498 |     4,409,082 | 783,737 ns | 796,814 ns | 696,969 ns |         510,664 ns |
+| SolveMediumHard |       > 1 h   |       > 1 h    | 12,033,099,074 | 2,754,157,261 |   5,779,298,835 |   240,930,082 |   258,560,720 |   309,944,856 |   346,532,318 |   258,799,676 |   305,404,083 |   354,286,153 |   409,437,694 |   453,280,166 | 124,316,631 ns | 129,750,583 ns | 117,103,179 ns |      94,087,468 ns |
+|       SolveHard |       > 1 h   |       > 1 h    | 21,565,808,100 | 5,636,112,783 | 100,663,275,757 | 1,862,768,773 | 2,532,972,635 | 3,000,655,673 | 3,606,412,386 | 2,425,286,433 | 2,918,112,980 | 3,162,162,893 | 3,353,403,193 | 3,494,150,836 | 1,134,532,585 ns | 1,365,230,469 ns | 1,144,927,429 ns |     887,253,553 ns |
+|        EvalEasy |        12,059 |        200,766 |      1,548,901 |       550,676 |       3,354,484 |            34 |            72 |            68 |            84 |            28 |            11 |            11 |            13 |             9 | 2 ns | 2 ns | 1 ns |               2 ns |
+|        EvalTrig |             -- |              -- |              -- |            -- |               -- |            -- |            -- |            -- |            -- |            -- |            -- |            -- |            -- |               -- |               -- | 1,344,115 ns | 1,280,227 ns |         977,789 ns |
+| EvalTrigPrecise |             -- |              -- |              -- |            -- |               -- |            -- |            -- |            -- |            -- |            -- |            -- |            -- |            -- |               -- |               -- | 43,285,515 ns | 37,048,158 ns |      29,174,367 ns |
+|     CompileEasy |        24,771 |         38,300 |         62,328 |        33,684 |          40,751 |         9,208 |        15,467 |         5,487 |         5,623 |         6,283 |         6,254 |         5,143 |       565,597 |       589,540 | 352,800 ns | 352,449 ns | 314,521 ns |         215,593 ns |
+|     CompileHard |        61,572 |         84,042 |        139,499 |        73,738 |          96,203 |        18,274 |        26,390 |        14,782 |        15,657 |        17,986 |        17,672 |        14,902 |     1,234,995 |     1,321,375 | 595,593 ns | 596,664 ns | 585,717 ns |         424,923 ns |
+|         RunEasy |           138 |            126 |            123 |           117 |             128 |           157 |           170 |           165 |           175 |           167 |           161 |           149 |            48 |            43 | 42 ns | 42 ns | 28 ns |              21 ns |
+|       RunMedium |           833 |            950 |            920 |           844 |             838 |         1,008 |         1,081 |         1,064 |         1,155 |         1,089 |           982 |           875 |           630 |           549 | 318 ns | 320 ns | 238 ns |             181 ns |
+|         RunHard |         1,403 |          1,644 |          1,558 |         1,427 |           1,391 |         1,974 |         2,102 |         2,037 |         2,046 |         2,044 |         1,855 |         1,655 |         1,041 |           928 | 586 ns | 582 ns | 433 ns |             318 ns |
 																													   
 
 
@@ -152,31 +152,93 @@ Bytes allocated per operation, measured in the same run as the timing column of 
 above. The 1671st is the first version measured for it, so the history is shorter than the
 timings'; later runs add to it the same way.
 
-| Method | [1671st](https://github.com/asc-community/AngouriMath/commit/253b5a8d598a9a1d721b777340bd53ae3be12f99) | [1769th](https://github.com/asc-community/AngouriMath/commit/3ac24bc241e898509533bc980ec5dc91c5d79a07) |
-|---|--:|--:|
-| ParseEasy | 18,052 B | 18,040 B |
-| ParseHard | 3,486,004 B | 3,522,411 B |
-| SimplifyEasy | 127,578 B | 128,096 B |
-| SimplifyHard | 3,710,538,008 B | 3,620,663,136 B |
-| Derivate | 52,821 B | 52,822 B |
-| SolveEasy | 20,213,448 B | 8,852,065 B |
-| SolveEasyMedium | 79,613 B | 95,788 B |
-| SolveMedium | 553,368 B | 658,051 B |
-| SolveMediumHard | 152,243,208 B | 162,301,856 B |
-| SolveHard | 1,341,716,112 B | 1,431,834,672 B |
-| EvalEasy | none | none |
-| EvalTrig | 1,341,378 B | 1,341,378 B |
-| EvalTrigPrecise | 12,743,208 B | 12,742,256 B |
-| CompileEasy | 16,200 B | 16,139 B |
-| CompileHard | 37,944 B | 37,793 B |
-| RunEasy | none | none |
-| RunMedium | none | none |
-| RunHard | none | none |
+| Method | [1671st](https://github.com/asc-community/AngouriMath/commit/253b5a8d598a9a1d721b777340bd53ae3be12f99) | [1769th](https://github.com/asc-community/AngouriMath/commit/3ac24bc241e898509533bc980ec5dc91c5d79a07) | [1844th](https://github.com/asc-community/AngouriMath/commit/55cd1a58) |
+|---|--:|--:| --: |
+| ParseEasy | 18,052 B | 18,040 B | 18,109 B |
+| ParseHard | 3,486,004 B | 3,522,411 B | 3,522,458 B |
+| SimplifyEasy | 127,578 B | 128,096 B | 128,096 B |
+| SimplifyHard | 3,710,538,008 B | 3,620,663,136 B | 3,632,010,176 B |
+| Derivate | 52,821 B | 52,822 B | 52,822 B |
+| SolveEasy | 20,213,448 B | 8,852,065 B | 8,853,472 B |
+| SolveEasyMedium | 79,613 B | 95,788 B | 97,192 B |
+| SolveMedium | 553,368 B | 658,051 B | 661,915 B |
+| SolveMediumHard | 152,243,208 B | 162,301,856 B | 164,544,992 B |
+| SolveHard | 1,341,716,112 B | 1,431,834,672 B | 1,446,779,520 B |
+| EvalEasy | none | none | none |
+| EvalTrig | 1,341,378 B | 1,341,378 B | 1,341,377 B |
+| EvalTrigPrecise | 12,743,208 B | 12,742,256 B | 12,742,216 B |
+| CompileEasy | 16,200 B | 16,139 B | 10,952 B |
+| CompileHard | 37,944 B | 37,793 B | 20,377 B |
+| RunEasy | none | none | none |
+| RunMedium | none | none | none |
+| RunHard | none | none | none |
 
 **`EvalEasy` allocating nothing is the proof of the caching note above**, rather than a further
 argument for it. Evaluating `1 + 2 + log(2, 3) + sqrt(4) - 4 ^ 7 + e * pi` cannot allocate zero
 bytes; a dictionary lookup can. `RunEasy`, `RunMedium` and `RunHard` allocate nothing for the
 honest reason -- a compiled delegate over `Complex` has nothing to put on the heap.
+
+---
+
+## The 1844th: what this file's timings can and cannot support
+
+The column for 2.4.0. Seventy-five commits from the 1769th, carrying the rule-set exchange --
+twenty-seven of thirty sets running as data -- Hensel lifting along an evaluation homomorphism,
+and four wrong answers found by writing rules out as data.
+
+**Read the allocation column and treat the timings as indicative.** That is not the usual caution;
+it was measured. The Kernel Benchmark was run **twice on this same commit**, nothing changed
+between them:
+
+| | run 1 | run 2 | apart |
+|---|--:|--:|--:|
+| ParseEasy | 12,593 ns | 6,846 ns | 46% |
+| SimplifyEasy | 197,016 ns | 111,852 ns | 43% |
+| SolveHard | 1,638,350,518 ns | 887,253,553 ns | 46% |
+| RunEasy | 50 ns | 21 ns | 57% |
+| *every one of eighteen* | | | **30-57%** |
+
+Allocation over the same pair of runs: `SimplifyEasy` 128,098 B against 128,096 B, `SolveHard`
+1,446,783,288 B against 1,446,779,520 B. **A thousandfold difference in reproducibility**, which
+is exactly the argument `PerformanceGate` makes for gating allocation and not time -- restated
+here because the columns above invite a comparison the numbers cannot carry.
+
+The table takes run 2. Run 1 is recorded here so the choice is visible rather than quiet.
+
+### What this means for the columns above
+
+A timing difference between two columns of this file is evidence only if it is larger than about
+50%. The 1769th's write-up reads `-7%`, `-10%`, `-15%` as improvements and concludes *"every row
+is faster or flat"*; on this measurement none of those figures is distinguishable from the runner,
+and only its `SolveEasy` row -- 21.3 ms to 8.5 ms, a 2.5x move with allocation dropping 2.3x
+alongside -- survives. The rule it states is the right one and it is the allocation half that
+carries it.
+
+### The exchange cost 13% of `SimplifyEasy`, measured somewhere this file cannot measure
+
+That is a real finding and it is **not** from the columns here. On one desktop, both arms built
+and run the same way, BenchmarkDotNet reporting a standard deviation under half a per cent:
+
+| | `SimplifyEasy` |
+|---|--:|
+| 1769th, before the rule sets became data | 82,676 ns |
+| after the exchange, before the node-type index | 148,223 ns |
+| after the index | 94,904 ns |
+| 1843rd | 93,732 ns |
+
+Every conversion was measured against the commit in front of it and every one came back free or
+better. **Nothing was measured against the start**, and the sum of a run of individually-free
+steps is +13%. The index recovered most of what the exchange spent; *most* is not *all*.
+
+Where it goes, from counting rather than guessing: the work shape is identical -- 4,914 rule-set
+invocations on this input at both commits -- so it is per-operation overhead, roughly 1.3 ns on
+each invocation and 14 ns on each rule attempt. `InequalityEquality` alone is 26% of it and
+`InvertNegativePowers`, a set with one rule, is 15%. Three attempts to make the dispatch cheaper
+-- caching the per-type rule list one slot, eight slots, and replacing the dictionary with an
+array index -- each measured, and none moved it. About 40% of the gap is still unattributed.
+
+The lever, if it is wanted, is the invocation count rather than the dispatch: 4,914 for one
+`Simplify`, of which 2,202 are the canonical order running on every node.
 
 ---
 


### PR DESCRIPTION
The performance column 2.4.0 needs, and a measurement that changes how the columns above should
be read.

## The Kernel Benchmark was run twice on this same commit

Nothing changed between them.

| | run 1 | run 2 | apart |
|---|--:|--:|--:|
| ParseEasy | 12,593 ns | 6,846 ns | 46% |
| SimplifyEasy | 197,016 ns | 111,852 ns | 43% |
| SolveHard | 1,638,350,518 ns | 887,253,553 ns | 46% |
| RunEasy | 50 ns | 21 ns | 57% |
| *all eighteen* | | | **30–57%** |

Allocation over the same pair: `SimplifyEasy` 128,098 B against 128,096 B, `SolveHard`
1,446,783,288 B against 1,446,779,520 B — **0.03%**. A thousandfold difference in
reproducibility, which is precisely the argument `PerformanceGate` already makes for gating
allocation and not time. It had not been measured on *this* workflow before.

**So a timing difference between two columns of this file is evidence only above ~50%.** The
1769th's write-up reads −7%, −10%, −15% as improvements and concludes "every row is faster or
flat"; none of those is distinguishable from the runner. Only its `SolveEasy` row survives —
2.5x with allocation moving 2.3x alongside — and it survives by the rule that write-up itself
states.

The table takes run 2; run 1 is in the prose so the choice is visible rather than quiet.

## The exchange cost 13% of `SimplifyEasy`

Real, and measured where this file cannot measure — one desktop, both arms built and run the
same way, BenchmarkDotNet StdDev under 0.5%:

| | `SimplifyEasy` |
|---|--:|
| 1769th, before the rule sets became data | 82,676 ns |
| after the exchange, before the node-type index | 148,223 ns |
| after the index | 94,904 ns |
| 1843rd | 93,732 ns |

Every conversion was measured against the commit in front of it and every one came back free or
better. **Nothing was measured against the start.** The index recovered most of what the exchange
spent; most is not all.

Counted rather than guessed: **4,914 rule-set invocations at both commits** — the work shape is
identical, so this is per-operation overhead, ~1.3 ns per invocation and ~14 ns per rule attempt.
`InequalityEquality` is 26% of it; `InvertNegativePowers`, a set with one rule, is 15%. Three
attempts at making dispatch cheaper (one-slot cache, eight-slot cache, array index instead of the
dictionary) were each measured and none moved it. **About 40% is still unattributed** and this
says so.

The lever, if wanted, is the invocation count rather than the dispatch — 4,914 for one
`Simplify`, of which 2,202 are the canonical order on every node.

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bjumi5K7fg8yx6UK1mZTQd