### PR TITLE
Close twelve of the thirteen recorded e-graph review findings

### DIFF
--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -5745,8 +5745,8 @@ namespace AngouriMath
             ///     expr => expr.Nodes.Count(node => node is Entity.Divf)
             /// );
             /// 
-            /// Console.WriteLine(FromString("a / b + b / c", useCache: false).SimplifiedRate);
-            /// Console.WriteLine(FromString("a / b + b / c", useCache: false).Simplify().SimplifiedRate);
+            /// Console.WriteLine("a / b + b / c".ToEntity().SimplifiedRate);
+            /// Console.WriteLine("a / b + b / c".ToEntity().Simplify().SimplifiedRate);
             /// </code>
             /// Prints
             /// <code>
@@ -5756,14 +5756,25 @@ namespace AngouriMath
             /// 1
             /// </code>
             /// By default criteria it cannot simplify it further, however, the custom one
-            /// it simplified from 2 to 1. 
+            /// it simplified from 2 to 1.
             /// </example>
             /// <remarks>
+            /// <para>
             /// The function itself lives on <see cref="CostModel.Default"/>, with the named
             /// alternatives beside it — <see cref="CostModel.SmallestTree"/>,
             /// <see cref="CostModel.FewestDivisions"/>, <see cref="CostModel.FewestRadicals"/>.
             /// It is referenced rather than repeated so the setting's default and the model
             /// cannot drift apart.
+            /// </para>
+            /// <para>
+            /// The second half of the example above used to need
+            /// <c>FromString(expr, useCache: false)</c>, because a parsed expression is cached by
+            /// its text and <see cref="Entity.SimplifiedRate"/> cached one rate per instance —
+            /// so the number computed under the default criteria was handed back under this one.
+            /// That is fixed: a rate is cached only while nobody has scoped this setting, and a
+            /// scoped criteria is computed afresh. Reading a rate under a criteria of your own no
+            /// longer needs the parser cache defeated to be right.
+            /// </para>
             /// </remarks>
             public static Setting<Func<Entity, double>> ComplexityCriteria { get; } =
                 new Func<Entity, double>(CostModel.DefaultCost);

--- a/Sources/AngouriMath/Core/Entity/Entity.Definition.cs
+++ b/Sources/AngouriMath/Core/Entity/Entity.Definition.cs
@@ -702,7 +702,38 @@ namespace AngouriMath
         /// <see cref="MathS.Settings.ComplexityCriteria"/> which can be changed by user.
         /// See <see cref="MathS.Settings.ComplexityCriteria"/> for more details.
         /// </summary>
-        public double SimplifiedRate => simplifiedRate.GetValue(MathS.Settings.ComplexityCriteria.Value, this);
+        /// <remarks>
+        /// <para>
+        /// <b>Cached for the default criteria only, and computed afresh for any other.</b> The
+        /// cache is one slot per <see cref="Entity"/> instance and the criteria is an ambient
+        /// setting, so the two do not agree about what the cached number is a rate <i>of</i>: a
+        /// rate computed under one cost model was answered with under the next, and
+        /// <c>Simplificator.PickSimplest</c> compares candidates by this property — so it would
+        /// weigh one model's cached rate against another's freshly computed one and choose on the
+        /// strength of it, with nothing anywhere to say the comparison was meaningless.
+        /// </para>
+        /// <para>
+        /// The unset path keeps the cache, which is what nearly every call takes and what the
+        /// slot was there for. A criteria anybody has scoped computes without caching, so it can
+        /// neither be answered with somebody else's number nor leave one behind for them. The
+        /// test is <c>IsOverriden</c> — the setting's own "nobody expressed an opinion", which is
+        /// what <c>BudgetLedger.For</c> already asks of <see cref="MathS.Settings.Budget"/> — and
+        /// not an equality against the default function: it is one ambient read rather than a
+        /// read plus a delegate comparison, on a property <c>Simplificator.PickSimplest</c> reads
+        /// once per candidate. A caller who scopes the default function explicitly gets the same
+        /// number by the uncached route.
+        /// </para>
+        /// </remarks>
+        public double SimplifiedRate
+        {
+            get
+            {
+                var criteria = MathS.Settings.ComplexityCriteria;
+                return criteria.IsOverriden
+                    ? criteria.Value(this)
+                    : simplifiedRate.GetValue(criteria.Default, this);
+            }
+        }
         private LazyPropertyA<double> simplifiedRate;
 
         /// <summary>Checks whether the given expression contains variable</summary>

--- a/Sources/AngouriMath/Core/Transformations/EGraph.cs
+++ b/Sources/AngouriMath/Core/Transformations/EGraph.cs
@@ -338,21 +338,14 @@ namespace AngouriMath.Core.Transformations
 
         /// <summary>
         /// <see cref="MatchPattern.ConstructNode"/> takes the runtime <see cref="Type"/> a
-        /// <see cref="Key"/> string names -- this is the one place that resolves the name back,
-        /// so it is the one place that would need to change if two node types ever printed the
-        /// same <c>GetType().Name</c>.
+        /// <see cref="Key"/> string names, and <see cref="MatchPattern.BuildableNodeTypes"/> is
+        /// where those types are named -- once, beside the <c>Construct</c> that builds them.
+        /// This used to hold a second copy of that list, which nothing kept in step: a type added
+        /// to one and not the other silently stopped being reachable from here, with no compiler
+        /// error to say so.
         /// </summary>
-        [ConstantField]
-        private static readonly Dictionary<string, Type> OperatorTypes = new Type[]
-        {
-            typeof(Entity.Sumf), typeof(Entity.Minusf), typeof(Entity.Mulf), typeof(Entity.Divf),
-            typeof(Entity.Powf), typeof(Entity.Logf), typeof(Entity.Sinf), typeof(Entity.Cosf),
-            typeof(Entity.Tanf), typeof(Entity.Cotanf), typeof(Entity.Secantf),
-            typeof(Entity.Cosecantf), typeof(Entity.Absf), typeof(Entity.Signumf),
-        }.ToDictionary(t => t.Name);
-
         private static Type OperatorType(string op)
-            => OperatorTypes.TryGetValue(op, out var type) ? type : typeof(void);
+            => MatchPattern.NodeTypeNamed(op) ?? typeof(void);
 
         /// <summary>
         /// Whether the e-class <paramref name="id"/> already contains a leaf equal to

--- a/Sources/AngouriMath/Core/Transformations/EGraph.cs
+++ b/Sources/AngouriMath/Core/Transformations/EGraph.cs
@@ -16,7 +16,7 @@ namespace AngouriMath.Core.Transformations
     /// <summary>
     /// One e-node: an operator, and the e-classes of its children.
     /// </summary>
-    internal readonly struct ENode : IEquatable<ENode>
+    internal readonly struct ENode : IEquatable<ENode>, IComparable<ENode>
     {
         internal ENode(string op, int[] children)
         {
@@ -36,6 +36,27 @@ namespace AngouriMath.Core.Transformations
         }
 
         public override bool Equals(object? obj) => obj is ENode node && Equals(node);
+
+        /// <summary>
+        /// A total order on e-nodes, so that the members of one e-class can be visited in a
+        /// defined sequence. <see cref="HashSet{T}"/> enumeration order is an unspecified
+        /// implementation detail and a string's hash code is randomised per process, so a cost
+        /// tie between two members would otherwise be settled differently from one run to the
+        /// next -- against the premise that a bounded computation is reproducible given a defined
+        /// algorithm order. Ordinal on <see cref="Op"/>, so it does not move with the culture
+        /// either.
+        /// </summary>
+        public int CompareTo(ENode other)
+        {
+            var byOp = string.CompareOrdinal(Op, other.Op);
+            if (byOp != 0) return byOp;
+            if (Children.Length != other.Children.Length)
+                return Children.Length.CompareTo(other.Children.Length);
+            for (var i = 0; i < Children.Length; i++)
+                if (Children[i] != other.Children[i])
+                    return Children[i].CompareTo(other.Children[i]);
+            return 0;
+        }
 
         public override int GetHashCode()
         {
@@ -57,6 +78,14 @@ namespace AngouriMath.Core.Transformations
     /// </remarks>
     internal sealed class EGraph
     {
+        /// <summary>
+        /// How deep <see cref="Extract(int, Func{Entity, double})"/> will chain through child
+        /// classes before declining to build. A crash guard rather than a quality knob: textbook
+        /// input nests nowhere near this far, so the cap is only reached where the alternative is
+        /// an uncatchable stack overflow.
+        /// </summary>
+        private const int MaxExtractionDepth = 256;
+
         private readonly List<int> parent = new();
         private readonly Dictionary<ENode, int> hashcons = new();
         private readonly Dictionary<int, HashSet<ENode>> classes = new();
@@ -256,10 +285,19 @@ namespace AngouriMath.Core.Transformations
         {
             id = Find(id);
             if (memo.TryGetValue(id, out var done)) return done;
+            // visiting is the chain currently being expanded, so its size is this call's depth.
+            // The cycle guard below bounds that chain only by the number of distinct classes,
+            // which unions grow past the input expression's own syntactic depth -- and a
+            // StackOverflowException cannot be caught, so exhausting the stack takes the process
+            // down rather than failing one call. Declining to build is the answer the cycle case
+            // already gives, and the same shape as Gruntz's own MaxDepth.
+            if (visiting.Count >= MaxExtractionDepth) return null;
             if (!visiting.Add(id)) return null;              // a cycle; the other node will do
             Entity? best = null;
             var bestCost = double.MaxValue;
-            foreach (var node in NodesOf(id))
+            // Ordered, not as the set enumerates: a tie on cost is settled by whichever candidate
+            // is reached first, and set order is neither specified nor stable across processes.
+            foreach (var node in NodesOf(id).OrderBy(node => node))
             {
                 var parts = new Entity[node.Children.Length];
                 var ok = true;
@@ -277,6 +315,12 @@ namespace AngouriMath.Core.Transformations
                 if (codomains.TryGetValue(node, out var domain)) built = built.WithCodomain(domain);
                 double here;
                 try { here = cost(built); } catch { continue; }
+                // A model that answers NaN has not ranked this candidate, which is what a model
+                // that throws is already saying, so both decline it the same way. Without this,
+                // the comparison below is false for NaN on either side (IEEE-754), so NaN becomes
+                // the incumbent cheapest and every later candidate then beats it unconditionally
+                // -- the answer stops being the cheapest and becomes whichever member came last.
+                if (double.IsNaN(here)) continue;
                 if (here >= bestCost) continue;
                 best = built;
                 bestCost = here;

--- a/Sources/AngouriMath/Core/Transformations/EGraph.cs
+++ b/Sources/AngouriMath/Core/Transformations/EGraph.cs
@@ -161,33 +161,90 @@ namespace AngouriMath.Core.Transformations
                && set.Any(n => n.Children.Length == 0 && n.Op == leaf);
 
         /// <summary>
+        /// The leaves worth trying as an identity. The additive and multiplicative identities,
+        /// which is what the arithmetic operators have; a fold that needed some other constant
+        /// would be a fact about that operator rather than about neutrality.
+        /// </summary>
+        [ConstantField]
+        private static readonly string[] NeutralLeaves = { "0", "1" };
+
+        /// <summary>
+        /// Which operator folds away which leaf on which side, asked of
+        /// <see cref="Entity.InnerSimplified"/> rather than written out a second time.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This used to be a hand-written table over <c>Sumf</c>, <c>Minusf</c>, <c>Mulf</c>,
+        /// <c>Divf</c> and <c>Powf</c>, restating identities each of those types already
+        /// implements and tests in its own <c>InnerSimplify</c>. Nothing kept the two in step, and
+        /// the divergence would have been silent in the worst direction: the e-graph would go on
+        /// asserting an equivalence the rest of the library had stopped believing, merging two
+        /// classes that are no longer equal.
+        /// </para>
+        /// <para>
+        /// Asking instead of restating also settles the cases that make a hand-written table
+        /// fragile, without anybody having to remember them. <c>0 - x</c> is a negation and
+        /// <c>1 / x</c> a reciprocal, so neither folds to its other operand; <c>1 ^ x</c> is the
+        /// constant 1 rather than <c>x</c>. And if an arm ever answers with a condition attached
+        /// — <c>Powf</c>'s <c>1 ^ x</c> already carries a <c>Providedf</c> domain condition — the
+        /// answer is not the bare operand, so no fold is claimed for it. A hand-written table has
+        /// no way to learn any of that.
+        /// </para>
+        /// </remarks>
+        [ConstantField]
+        private static readonly HashSet<(string Op, string Leaf, int LeafSide)> neutralFolds
+            = BuildNeutralFolds();
+
+        private static HashSet<(string Op, string Leaf, int LeafSide)> BuildNeutralFolds()
+        {
+            var folds = new HashSet<(string, string, int)>();
+            Entity operand = MathS.Var("x");
+            foreach (var type in MatchPattern.BuildableNodeTypes)
+                foreach (var leafText in NeutralLeaves)
+                    for (var side = 0; side < 2; side++)
+                    {
+                        var leaf = leafText.ToEntity();
+                        var children = side == 0
+                            ? new[] { leaf, operand }
+                            : new[] { operand, leaf };
+                        // A node this cannot build, or an arm that throws on a shape it did not
+                        // expect, simply contributes no fold -- the table is what was observed.
+                        try
+                        {
+                            if (MatchPattern.ConstructNode(type, children) is not { } built) continue;
+                            if (built.InnerSimplified.Equals(operand))
+                                folds.Add((type.Name, leafText, side));
+                        }
+                        catch { /* not a fold, and not this table's business why */ }
+                    }
+            return folds;
+        }
+
+        /// <summary>
+        /// The folds this graph performs on insertion, as <c>Op(first, second)</c> — for the test
+        /// that names them, so that a change in <c>InnerSimplify</c> shows up as a changed list
+        /// rather than as e-graph folding quietly gaining or losing a case.
+        /// </summary>
+        internal static IEnumerable<string> NeutralFolds
+            => neutralFolds.Select(fold => fold.LeafSide == 0
+                ? $"{fold.Op}({fold.Leaf}, x)"
+                : $"{fold.Op}(x, {fold.Leaf})");
+
+        /// <summary>
         /// If <paramref name="node"/> is a neutral element applied to something, the class that
         /// already denotes its value -- <see langword="null"/> otherwise.
         /// </summary>
-        /// <remarks>
-        /// <c>Sumf</c> and <c>Mulf</c> are commutative, so the identity folds from either side:
-        /// <c>x + 0</c> and <c>0 + x</c> both denote <c>x</c>. <c>Minusf</c> and <c>Divf</c> are
-        /// not: <c>x - 0</c> and <c>x / 1</c> denote <c>x</c>, but <c>0 - x</c> and <c>1 / x</c>
-        /// do not -- they negate or invert it, a different value from either operand, and not
-        /// something this method may fold away. <c>1 ^ x</c> is likewise not <c>x</c> -- it is
-        /// the constant 1 -- so <c>Powf</c> only checks the exponent.
-        /// </remarks>
         private int? NeutralClass(ENode node)
         {
             if (node.Children.Length != 2) return null;
-            return node.Op switch
+            foreach (var leaf in NeutralLeaves)
             {
-                "Sumf" => Holds(node.Children[1], "0") ? Find(node.Children[0])
-                    : Holds(node.Children[0], "0") ? Find(node.Children[1])
-                    : (int?)null,
-                "Minusf" => Holds(node.Children[1], "0") ? Find(node.Children[0]) : (int?)null,
-                "Mulf" => Holds(node.Children[1], "1") ? Find(node.Children[0])
-                    : Holds(node.Children[0], "1") ? Find(node.Children[1])
-                    : (int?)null,
-                "Divf" => Holds(node.Children[1], "1") ? Find(node.Children[0]) : (int?)null,
-                "Powf" => Holds(node.Children[1], "1") ? Find(node.Children[0]) : (int?)null,
-                _ => null
-            };
+                if (neutralFolds.Contains((node.Op, leaf, 1)) && Holds(node.Children[1], leaf))
+                    return Find(node.Children[0]);
+                if (neutralFolds.Contains((node.Op, leaf, 0)) && Holds(node.Children[0], leaf))
+                    return Find(node.Children[1]);
+            }
+            return null;
         }
 
         /// <summary>Every e-class currently in the graph.</summary>

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchPattern.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchPattern.cs
@@ -376,8 +376,82 @@ namespace AngouriMath.Core.Transformations.Matching
         internal static Entity? ConstructNode(Type nodeType, Entity[] children) => Construct(nodeType, children);
 
         /// <summary>
+        /// Every node type this builds, with its arity and the constructor call that builds it.
+        /// One table, and the only place any of these three facts is written.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Constructor calls written out rather than reflected, for the reason
+        /// <see cref="Construct"/> gives. A table rather than a chain of
+        /// <c>nodeType == typeof(T)</c> tests because the chain was walked on every node built
+        /// during matching and grew linearly with this list: at fourteen types that was cheap,
+        /// and this list is longer than that. The lambdas are non-capturing, so each is a single
+        /// cached delegate rather than an allocation per call.
+        /// </para>
+        /// <para>
+        /// <see cref="BuildableNodeTypes"/> and <see cref="NodeTypeNamed"/> are both derived from
+        /// this table's keys, so there is no second list to drift from it — <see cref="EGraph"/>
+        /// used to keep one, and a type added here and not there silently stopped being reachable
+        /// from the e-graph with no compiler error.
+        /// </para>
+        /// </remarks>
+        [ConstantField]
+        private static readonly Dictionary<Type, (int Arity, Func<Entity[], Entity> Build)> constructors = new()
+        {
+            // Trigonometric, and their inverses.
+            [typeof(Entity.Sinf)] = (1, static c => new Entity.Sinf(c[0])),
+            [typeof(Entity.Cosf)] = (1, static c => new Entity.Cosf(c[0])),
+            [typeof(Entity.Tanf)] = (1, static c => new Entity.Tanf(c[0])),
+            [typeof(Entity.Cotanf)] = (1, static c => new Entity.Cotanf(c[0])),
+            [typeof(Entity.Secantf)] = (1, static c => new Entity.Secantf(c[0])),
+            [typeof(Entity.Cosecantf)] = (1, static c => new Entity.Cosecantf(c[0])),
+            [typeof(Entity.Arcsinf)] = (1, static c => new Entity.Arcsinf(c[0])),
+            [typeof(Entity.Arccosf)] = (1, static c => new Entity.Arccosf(c[0])),
+            [typeof(Entity.Arctanf)] = (1, static c => new Entity.Arctanf(c[0])),
+            [typeof(Entity.Arccotanf)] = (1, static c => new Entity.Arccotanf(c[0])),
+            [typeof(Entity.Arcsecantf)] = (1, static c => new Entity.Arcsecantf(c[0])),
+            [typeof(Entity.Arccosecantf)] = (1, static c => new Entity.Arccosecantf(c[0])),
+            // Other unary functions.
+            [typeof(Entity.Absf)] = (1, static c => new Entity.Absf(c[0])),
+            [typeof(Entity.Signumf)] = (1, static c => new Entity.Signumf(c[0])),
+            [typeof(Entity.Floorf)] = (1, static c => new Entity.Floorf(c[0])),
+            [typeof(Entity.Ceilf)] = (1, static c => new Entity.Ceilf(c[0])),
+            [typeof(Entity.Roundf)] = (1, static c => new Entity.Roundf(c[0])),
+            [typeof(Entity.Factorialf)] = (1, static c => new Entity.Factorialf(c[0])),
+            [typeof(Entity.Phif)] = (1, static c => new Entity.Phif(c[0])),
+            [typeof(Entity.Notf)] = (1, static c => new Entity.Notf(c[0])),
+            // Arithmetic.
+            [typeof(Entity.Sumf)] = (2, static c => new Entity.Sumf(c[0], c[1])),
+            [typeof(Entity.Minusf)] = (2, static c => new Entity.Minusf(c[0], c[1])),
+            [typeof(Entity.Mulf)] = (2, static c => new Entity.Mulf(c[0], c[1])),
+            [typeof(Entity.Divf)] = (2, static c => new Entity.Divf(c[0], c[1])),
+            [typeof(Entity.Powf)] = (2, static c => new Entity.Powf(c[0], c[1])),
+            [typeof(Entity.Logf)] = (2, static c => new Entity.Logf(c[0], c[1])),
+            [typeof(Entity.Modf)] = (2, static c => new Entity.Modf(c[0], c[1])),
+            [typeof(Entity.Gcdf)] = (2, static c => new Entity.Gcdf(c[0], c[1])),
+            [typeof(Entity.Minf)] = (2, static c => new Entity.Minf(c[0], c[1])),
+            [typeof(Entity.Maxf)] = (2, static c => new Entity.Maxf(c[0], c[1])),
+            // Comparisons and connectives.
+            [typeof(Entity.Equalsf)] = (2, static c => new Entity.Equalsf(c[0], c[1])),
+            [typeof(Entity.Greaterf)] = (2, static c => new Entity.Greaterf(c[0], c[1])),
+            [typeof(Entity.GreaterOrEqualf)] = (2, static c => new Entity.GreaterOrEqualf(c[0], c[1])),
+            [typeof(Entity.Lessf)] = (2, static c => new Entity.Lessf(c[0], c[1])),
+            [typeof(Entity.LessOrEqualf)] = (2, static c => new Entity.LessOrEqualf(c[0], c[1])),
+            [typeof(Entity.Andf)] = (2, static c => new Entity.Andf(c[0], c[1])),
+            [typeof(Entity.Orf)] = (2, static c => new Entity.Orf(c[0], c[1])),
+            [typeof(Entity.Xorf)] = (2, static c => new Entity.Xorf(c[0], c[1])),
+            [typeof(Entity.Impliesf)] = (2, static c => new Entity.Impliesf(c[0], c[1])),
+            // Sets, and a condition attached to a value.
+            [typeof(Entity.Set.Inf)] = (2, static c => new Entity.Set.Inf(c[0], c[1])),
+            [typeof(Entity.Set.Unionf)] = (2, static c => new Entity.Set.Unionf(c[0], c[1])),
+            [typeof(Entity.Set.Intersectionf)] = (2, static c => new Entity.Set.Intersectionf(c[0], c[1])),
+            [typeof(Entity.Set.SetMinusf)] = (2, static c => new Entity.Set.SetMinusf(c[0], c[1])),
+            [typeof(Entity.Providedf)] = (2, static c => new Entity.Providedf(c[0], c[1])),
+        };
+
+        /// <summary>
         /// A node of <paramref name="nodeType"/> over <paramref name="children"/>, or
-        /// <see langword="null"/> where that is not a node this builds.
+        /// <see langword="null"/> where that is not a node this builds at that arity.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -388,58 +462,59 @@ namespace AngouriMath.Core.Transformations.Matching
         /// and nothing else.
         /// </para>
         /// <para>
-        /// A node type absent from here is <b>matchable but not buildable</b>: a pattern over it is
-        /// still a rule's left-hand side, and <see cref="IsBuildable"/> is what says it cannot be a
-        /// right-hand side or be reached by reading a rule backwards. Adding a type is one line,
-        /// and <c>EveryDataRuleIsBuildableOnBothSides</c> is the test that says when one is owed.
+        /// A node type absent from <see cref="constructors"/> is <b>matchable but not buildable</b>:
+        /// a pattern over it is still a rule's left-hand side, and <see cref="IsBuildable"/> is what
+        /// says it cannot be a right-hand side or be reached by reading a rule backwards. Adding a
+        /// type is one line, and <c>EveryDataRuleIsBuildableOnBothSides</c> is the test that says
+        /// when one is owed.
+        /// </para>
+        /// <para>
+        /// <b>What is still absent, and why.</b> Two kinds. <b>Binders</b> — <c>Entity.Lambda</c>
+        /// and <c>Entity.Set.ConditionalSet</c> — take a bound variable whose scope their body is
+        /// under, and <see cref="EGraph"/> has no notion of binding: it would happily union a
+        /// bound occurrence with a free one, and <c>DirectChildren</c> hands out a
+        /// capture-avoidingly renamed body rather than the written one. Rebuilding either from an
+        /// e-class would produce a term that means something else. <b>Variable-arity nodes</b> —
+        /// <c>Piecewise</c>, <c>Application</c>, the finite <c>Set</c>s and the <c>Matrix</c> —
+        /// are out of this table's shape rather than out of principle: it keys on a type and an
+        /// arity of one or two, and widening it to n children is a different piece of work.
         /// </para>
         /// </remarks>
         private static Entity? Construct(Type nodeType, Entity[] children)
-        {
-            if (children.Length == 1)
-            {
-                var only = children[0];
-                return
-                    nodeType == typeof(Entity.Sinf) ? new Entity.Sinf(only) :
-                    nodeType == typeof(Entity.Cosf) ? new Entity.Cosf(only) :
-                    nodeType == typeof(Entity.Tanf) ? new Entity.Tanf(only) :
-                    nodeType == typeof(Entity.Cotanf) ? new Entity.Cotanf(only) :
-                    nodeType == typeof(Entity.Secantf) ? new Entity.Secantf(only) :
-                    nodeType == typeof(Entity.Cosecantf) ? new Entity.Cosecantf(only) :
-                    nodeType == typeof(Entity.Absf) ? new Entity.Absf(only) :
-                    nodeType == typeof(Entity.Signumf) ? new Entity.Signumf(only) :
-                    (Entity?)null;
-            }
-            if (children.Length == 2)
-            {
-                Entity first = children[0], second = children[1];
-                return
-                    nodeType == typeof(Entity.Sumf) ? new Entity.Sumf(first, second) :
-                    nodeType == typeof(Entity.Minusf) ? new Entity.Minusf(first, second) :
-                    nodeType == typeof(Entity.Mulf) ? new Entity.Mulf(first, second) :
-                    nodeType == typeof(Entity.Divf) ? new Entity.Divf(first, second) :
-                    nodeType == typeof(Entity.Powf) ? new Entity.Powf(first, second) :
-                    nodeType == typeof(Entity.Logf) ? new Entity.Logf(first, second) :
-                    (Entity?)null;
-            }
-            return null;
-        }
+            => constructors.TryGetValue(nodeType, out var entry) && entry.Arity == children.Length
+                ? entry.Build(children)
+                : null;
 
         /// <summary>
-        /// Whether <see cref="Construct"/> builds this type at this arity, asked by building one
-        /// over placeholders rather than by listing the types a second time — a list written twice
-        /// is a list that drifts.
+        /// The node types <see cref="Construct"/> builds. Derived from
+        /// <see cref="constructors"/> rather than listed again — <see cref="EGraph"/> resolves an
+        /// e-node's operator back to a type through <see cref="NodeTypeNamed"/>, and a list
+        /// written twice is a list that drifts, silently and with no compiler error.
         /// </summary>
-        private static bool CanConstruct(Type nodeType, int arity)
-        {
-            if (arity is not (1 or 2))
-                return false;
-            var placeholders = new Entity[arity];
-            for (var i = 0; i < arity; i++)
-                placeholders[i] = Entity.Number.Integer.Zero;
-            return Construct(nodeType, placeholders) is not null;
-        }
+        [ConstantField]
+        internal static readonly IReadOnlyList<Type> BuildableNodeTypes = constructors.Keys.ToList();
 
+        /// <summary>
+        /// <see cref="BuildableNodeTypes"/> by <see cref="System.Reflection.MemberInfo.Name"/>.
+        /// Declared after it, because a static field initialiser that reads another one in the
+        /// same class runs in declaration order and would otherwise see null.
+        /// </summary>
+        [ConstantField]
+        private static readonly Dictionary<string, Type> buildableByName
+            = BuildableNodeTypes.ToDictionary(type => type.Name, StringComparer.Ordinal);
+
+        /// <summary>
+        /// The buildable node type of this name, or <see langword="null"/> where none has it.
+        /// </summary>
+        internal static Type? NodeTypeNamed(string name)
+            => buildableByName.TryGetValue(name, out var type) ? type : null;
+
+        /// <summary>
+        /// Whether <see cref="Construct"/> builds this type at this arity — one lookup in the
+        /// table that does the building, so it cannot answer differently from what building would.
+        /// </summary>
+        internal static bool CanConstruct(Type nodeType, int arity)
+            => constructors.TryGetValue(nodeType, out var entry) && entry.Arity == arity;
         /// <summary>Whether it matches at all, which is <see cref="Match"/> asked for one answer.</summary>
         internal bool Matches(Entity expr) => Match(expr, Bindings.Empty).Any();
 

--- a/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
+++ b/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
@@ -526,7 +526,7 @@ namespace AngouriMath.Core.Transformations
                     var merged = false;
                     foreach (var id in graph.Classes.ToList())
                     {
-                        if (!ChargeGrowthSinceLastCall()) break;
+                        if (ledger.Exhausted) break;
                         Entity? term = null;
                         var extracted = false;
                         bool TryTerm(out Entity value)
@@ -542,6 +542,13 @@ namespace AngouriMath.Core.Transformations
 
                         foreach (var rule in SafeRules)
                         {
+                            // One step per match attempt, charged before the attempt -- the unit
+                            // Buchberger, FGLM and MatchPattern all charge, and the work this
+                            // loop actually does. Charging the node-count delta alone (below)
+                            // billed nothing on ordinary input, because SafeRules holds only
+                            // rules that do not expand: a budget of zero steps ran this sweep to
+                            // saturation and then reported that it had completed.
+                            if (!ledger.Spend()) break;
                             int other;
                             if (rule.Left.CanEMatch)
                             {
@@ -566,7 +573,14 @@ namespace AngouriMath.Core.Transformations
                             }
                             if (graph.Union(id, other)) merged = true;
                         }
+                        // What the sweep grew, charged after it rather than before the next
+                        // class's, so that the ceiling bounds the growth that has happened.
+                        if (!ChargeGrowthSinceLastCall()) break;
                     }
+                    // Rebuild rescans every node of every class, repeatedly until nothing more
+                    // becomes congruent -- a round of it is work, and it had no ledger
+                    // interaction anywhere in it.
+                    if (!ledger.Spend()) break;
                     graph.Rebuild();
                     if (!merged) saturated = true;
                 }

--- a/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
+++ b/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
@@ -505,7 +505,40 @@ namespace AngouriMath.Core.Transformations
             // the same convention every rule set in the registry already follows.
             public override Soundness Soundness => Soundness.SoundUnderAssumptions;
 
+            /// <remarks>
+            /// <para>
+            /// <b>What this reports to a <see cref="RewriteRecording"/>, and what it does not.</b>
+            /// The pass as a whole, and nothing finer. A rule set records each firing because a
+            /// firing there <i>is</i> the rewrite -- the node it matched leaves and the
+            /// replacement takes its place. A firing here is not: it adds another member to an
+            /// e-class, every member of which is already believed equal, and the answer is then
+            /// chosen by <c>EGraph.Extract</c> from all of them at once. Most firings
+            /// contribute nothing to what extraction picked, and none of them is a step on a route
+            /// from the input to the output, because there is no route -- that is the whole point
+            /// of saturating rather than rewriting. Reporting them as
+            /// <see cref="RewriteStep"/>s would name rewrites that are not in the answer.
+            /// </para>
+            /// <para>
+            /// So one edge, input to output, under this transformation's own
+            /// <see cref="Name"/>. That is a true statement at the grain a derivation is read at,
+            /// and it is what was missing: a caller who opened a recording round this used to get
+            /// a real rewrite with an empty derivation, and nothing to distinguish
+            /// "introspection cannot see this" from "there was nothing to see".
+            /// </para>
+            /// </remarks>
             protected override Entity? ApplyCore(Entity input)
+            {
+                // Read once, before the work: nothing here should pay for a recording nobody
+                // opened, which is the same reason RewriteRuleSet.ApplyOnce reads it once.
+                var recording = RewriteRecording.Current;
+                var mark = recording?.Mark() ?? 0;
+                var output = Saturate(input);
+                if (recording is not null && output is not null && !output.Equals(input))
+                    recording.Note(input, output, null, Name, mark);
+                return output;
+            }
+
+            private Entity? Saturate(Entity input)
             {
                 var graph = new EGraph();
                 var root = graph.AddEntity(input);
@@ -527,6 +560,19 @@ namespace AngouriMath.Core.Transformations
                     foreach (var id in graph.Classes.ToList())
                     {
                         if (ledger.Exhausted) break;
+
+                        // Which node types this class holds, gathered once for the whole sweep
+                        // rather than once per rule. A pattern that requires a root type cannot
+                        // match a class holding no node of it -- MatchPattern.RequiredRootType is
+                        // a necessary condition, not a sufficient one, which is the direction that
+                        // makes it a filter: it licenses skipping a rule, never firing one. This
+                        // is the dispatch a switch over node types gets from the compiler for
+                        // free, and a list of rules has to be told; without it every rule in
+                        // SafeRules ran a full pattern match against every class of every pass,
+                        // and the large majority of those could not have matched.
+                        var held = new HashSet<Type>();
+                        foreach (var node in graph.NodesOf(id)) held.Add(EGraph.RuntimeType(node));
+
                         Entity? term = null;
                         var extracted = false;
                         bool TryTerm(out Entity value)
@@ -542,6 +588,13 @@ namespace AngouriMath.Core.Transformations
 
                         foreach (var rule in SafeRules)
                         {
+                            // Before the charge, because a rule this skips was never attempted:
+                            // a step is a match attempt, and a type that cannot match is not one.
+                            if (rule.Left.RequiredRootType is { } required
+                                && !held.Contains(required)
+                                && !held.Any(type => required.IsAssignableFrom(type)))
+                                continue;
+
                             // One step per match attempt, charged before the attempt -- the unit
                             // Buchberger, FGLM and MatchPattern all charge, and the work this
                             // loop actually does. Charging the node-count delta alone (below)

--- a/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
+++ b/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
@@ -570,6 +570,11 @@ namespace AngouriMath.Core.Transformations
                         // free, and a list of rules has to be told; without it every rule in
                         // SafeRules ran a full pattern match against every class of every pass,
                         // and the large majority of those could not have matched.
+                        //
+                        // A union later in this same sweep can add a node type to the class that
+                        // this set does not have, so a rule can be skipped in a pass where it had
+                        // just become applicable. That costs nothing: a union is exactly what sets
+                        // `merged`, so there is another pass, and the set is gathered again there.
                         var held = new HashSet<Type>();
                         foreach (var node in graph.NodesOf(id)) held.Add(EGraph.RuntimeType(node));
 
@@ -590,10 +595,21 @@ namespace AngouriMath.Core.Transformations
                         {
                             // Before the charge, because a rule this skips was never attempted:
                             // a step is a match attempt, and a type that cannot match is not one.
-                            if (rule.Left.RequiredRootType is { } required
-                                && !held.Contains(required)
-                                && !held.Any(type => required.IsAssignableFrom(type)))
-                                continue;
+                            // Written as a loop rather than as `held.Any(t => ...)`: the lambda
+                            // would capture `required` and so allocate a closure every time the
+                            // exact-type test missed, which is most rules of most classes -- and
+                            // paying an allocation to avoid a pattern match is not a pre-filter.
+                            if (rule.Left.RequiredRootType is { } required && !held.Contains(required))
+                            {
+                                var reachable = false;
+                                foreach (var type in held)
+                                    if (required.IsAssignableFrom(type))
+                                    {
+                                        reachable = true;
+                                        break;
+                                    }
+                                if (!reachable) continue;
+                            }
 
                             // One step per match attempt, charged before the attempt -- the unit
                             // Buchberger, FGLM and MatchPattern all charge, and the work this

--- a/Sources/AngouriMath/Docs/Contributing/EqualitySaturationReviewFindings.md
+++ b/Sources/AngouriMath/Docs/Contributing/EqualitySaturationReviewFindings.md
@@ -3,15 +3,16 @@
 A review pass over [#1101](https://github.com/asc-community/AngouriMath/pull/1101) (`EGraph` and
 `Transformation.EqualitySaturation`) and [#1102](https://github.com/asc-community/AngouriMath/pull/1102)
 (`Transformation.SimplificationAtLevel`), run before either had a human reviewer, found fifteen
-issues. Ten are now fixed, each with a regression test named beside it below. The other five are
-recorded here rather than fixed, because fixing several of them is a real design question — the same
-shape as [`InversePairTable.md`](InversePairTable.md): naming what is true now, so the next attempt
-starts from a measured position instead of rediscovering one.
+issues. Fourteen are now fixed, each with a regression test named beside it below. What is left is not
+a defect but a design question — the same shape as [`InversePairTable.md`](InversePairTable.md):
+naming what is true now, so the next attempt starts from a measured position instead of rediscovering
+one.
 
-The two sections below are the live account; whoever closes one of the remaining five moves its entry
-up rather than adding a third place to look. One entry in **Fixed** also carries a correction to what
-this document originally claimed, because the recorded diagnosis turned out to be wrong once it was
-measured.
+The two sections below are the live account; whoever settles the last one moves its entry up rather
+than adding a third place to look. One entry in **Fixed** also carries a correction to what this
+document originally claimed, because the recorded diagnosis turned out to be wrong once it was
+measured — which is why every entry here now names the test that holds it, rather than only the
+reasoning that produced it.
 
 ## Fixed
 
@@ -110,6 +111,55 @@ keys on an arity of one or two; widening it to n children is a separate piece of
 principle. `EGraphTest.ExtractStillDeclinesWhatItCannotFaithfullyRebuild` pins both, including the
 case where the root is buildable and its operands are not.
 
+**`RewriteRecording` — the library's only "what rewrote this and why" mechanism — could not see
+`EqualitySaturation` at all.** It is populated inside `RewriteRuleSet.ApplyOnce`, and saturation asks
+rules directly, so a caller who opened a recording round it got a real rewrite with an empty
+derivation and nothing to distinguish "introspection cannot see this" from "there was nothing to
+see". Fixed by noting the pass — one edge, input to output, under the transformation's own name:
+`TransformationTest.EqualitySaturationIsVisibleToARecording`, with
+`EqualitySaturationRecordsNothingWhenItChangesNothing` for the other half of the convention.
+
+*Deliberately not finer than the pass, and this is a fact about e-graphs rather than a shortcut.* A
+rule set records each firing because a firing there **is** the rewrite: the node it matched leaves and
+the replacement takes its place. A firing in saturation is not — it adds another member to an e-class
+whose members are all already believed equal, and the answer is then chosen by `Extract` from all of
+them at once. Most firings contribute nothing to what extraction picked, and none of them is a step
+on a route from input to output, because there is no route. Reporting them as `RewriteStep`s would
+name rewrites that are not in the answer.
+
+**`RewriteRule.NodeTypes` — a documented fast pre-filter — was never consulted, so every rule ran a
+full pattern match against every class of every pass.** `MatchPattern.RequiredRootType` was already
+there to be asked; a pattern requiring a root type cannot match a class holding no node of it, and
+being a *necessary* condition is exactly what makes it a filter — it licenses skipping a rule, never
+firing one. Fixed by gathering each class's node types once per sweep and consulting it before the
+attempt. Measured over four expressions, match attempts fall by about thirteen times — 1076 steps to
+78 on the largest, 87 to 3 on `x + 0` — with the same answer in every case:
+`TransformationTest.EqualitySaturationDoesNotAttemptEveryRuleOnEveryClass`, asserted against the rule
+count rather than a recorded number so it stays true as rules are added.
+
+**`NeutralClass` hand-rolled an identity table that `InnerSimplify` already implements and tests.**
+Nothing kept the two in step, and the divergence would have been silent in the worst direction: the
+e-graph would go on asserting an equivalence the rest of the library had stopped believing, and merge
+two classes that are no longer equal. Fixed by deriving the table — asking `InnerSimplified` whether
+`op(x, leaf)` really is `x`, for each buildable binary operator and each of the two identities. That
+settles the asymmetries without anyone having to remember them (`0 - x` is a negation, `1 / x` a
+reciprocal, `1 ^ x` the constant 1), and it handles the case a written table cannot: an arm that
+answers with a condition attached does not answer with the bare operand, so no fold is claimed.
+`EGraphTest.TheFoldsAreExactlyWhatInnerSimplifyDoes` names what the derivation finds, so a change in
+`InnerSimplify` shows up as a changed list rather than as e-graph folding quietly gaining or losing a
+case.
+
+**`Entity.SimplifiedRate` answered one cost model's question with another's cached number (PR
+#1102).** The cache is one slot per `Entity` instance and the criteria is an ambient setting, so the
+two do not agree about what the cached number is a rate *of*. Not merely stale:
+`Simplificator.PickSimplest` compares candidates by this property, so it would weigh one model's
+cached rate against another's fresh one and choose on the strength of it, with nothing anywhere to say
+the comparison was meaningless. Fixed by caching only while nobody has scoped the setting — the
+`IsOverriden` test `BudgetLedger.For` already applies to `MathS.Settings.Budget` — so any other
+criteria is computed afresh and can neither be answered with somebody else's number nor leave one
+behind for them: `CostModelTest.ARateIsNotAnsweredFromAnotherCostModelsCache` and
+`EveryModelIsAnsweredWithItsOwnRate`.
+
 ## Recorded, not fixed
 
 **The deeper pattern: an e-node carries raw tree shape and nothing else.** `Codomain` and
@@ -124,43 +174,18 @@ whitelist rather than the node model: `Providedf` is an ordinary two-child node,
 `Construct` a line for it was the whole fix. What remains is genuinely about the node model —
 per-node data that is not a child, of which `Codomain` is the only instance the library has today.
 
-**`RewriteRecording` — the library's only "what rewrote this and why" mechanism — cannot see
-`EqualitySaturation` at all.** It is populated exclusively inside `RewriteRuleSet.ApplyOnce`;
-`EqualitySaturationTransformation.ApplyCore` calls `rule.TryApply` directly, bypassing it entirely.
-A caller who wraps a call in `RewriteRecording.Start()` — the library's own documented pattern for
-introspection — gets a real rewrite with an empty derivation and no signal that introspection failed
-rather than legitimately finding nothing.
-
-**`RewriteRule.NodeTypes` — an existing, documented fast pre-filter — is never consulted before
-`ApplyCore` calls the full `TryApply` pattern match on every `SafeRules` entry, per class, per pass.**
-Purely a performance gap: `Common` alone has roughly 100 arms, and the large majority of match
-attempts against any given class are wasted and uncharged against the budget.
-
-**`NeutralClass` hand-rolls an identity-element table for `Sumf`/`Minusf`/`Mulf`/`Divf`/`Powf` that
-already exists, tested, in each type's own `InnerSimplify`.** Nothing keeps the two in sync — a new
-special case added to `InnerSimplify` (`Powf`'s `1 ^ x` arm already attaches a `Providedf` domain
-condition `NeutralClass` has no way to learn about) would leave `EGraph` asserting an equivalence the
-rest of the library no longer believes, silently and with no test to catch the divergence.
-
-**`Entity.SimplifiedRate`'s cache can go stale across different `CostModel`s (PR #1102).** It is a
-`LazyPropertyA<double>` that computes once per `Entity` instance and caches forever, so a caller who
-reads `.SimplifiedRate` or calls `.Simplify()` under one `CostModel` and then runs
-`SimplificationAtLevel(level, differentCostModel)` on the same or an overlapping entity can have
-`Simplificator.PickSimplest` compare a stale rate against a fresh one with no error. The library
-already documents this exact trap elsewhere (`MathS.Settings.ComplexityCriteria`'s own example uses
-`FromString(expr, useCache: false)` to avoid it); `SimplificationTransformation.ApplyCore` does no
-analogous cache-busting.
-
 ## What is not decided here
 
-Whether the e-graph's node model should grow a general mechanism for metadata that travels with a
-node (the `Codomain`/`Providedf`/root-type-whitelist cluster above), or whether each case is worth
-its own targeted fix as found — same open question `InversePairTable.md` leaves for its own
-mechanism, and arguably the same question either way: how much should ride along on an e-node beyond
-its bare shape. That question is still open, and it is what the `Providedf` and root-type-whitelist
-entries above are both waiting on.
+The one question above, restated as the decision it is: **how much should ride along on an e-node
+beyond its bare shape.** A general "attach anything, forget nothing" representation, or a list of
+special cases extended as each is found. `InversePairTable.md` leaves the same question open for its
+own mechanism, and it is arguably the same question either way.
 
-The five closed since — the `Soundness` check, the `NaN` guard, the tie order, the depth cap and the
-budget — were each independent of it and of each other, which is why they went first. Of the eight
-that remain, only two (`Providedf`, the root-type whitelist) actually depend on that decision; the
-other six are ordinary work that nothing here blocks.
+What the fourteen closed findings say about it is worth recording, because it is not what the review
+expected. Only one of them turned out to depend on this decision at all — `Codomain`, which is still
+special-cased. The `Providedf` case, which this document originally offered as evidence that the
+e-graph had no way to represent a conditional equivalence, was the buildable-type table and nothing
+deeper. The rest were ordinary defects: a missing guard, an undefined order, an absent depth cap, a
+budget charging the wrong quantity, three lists written twice, a filter never consulted, a cache
+keyed on nothing. **A cluster of findings around one subsystem invites a single grand explanation,
+and thirteen of these fourteen did not have one.**

--- a/Sources/AngouriMath/Docs/Contributing/EqualitySaturationReviewFindings.md
+++ b/Sources/AngouriMath/Docs/Contributing/EqualitySaturationReviewFindings.md
@@ -3,15 +3,15 @@
 A review pass over [#1101](https://github.com/asc-community/AngouriMath/pull/1101) (`EGraph` and
 `Transformation.EqualitySaturation`) and [#1102](https://github.com/asc-community/AngouriMath/pull/1102)
 (`Transformation.SimplificationAtLevel`), run before either had a human reviewer, found fifteen
-issues. Seven are now fixed, each with a regression test named beside it below. The other eight are
+issues. Ten are now fixed, each with a regression test named beside it below. The other five are
 recorded here rather than fixed, because fixing several of them is a real design question — the same
 shape as [`InversePairTable.md`](InversePairTable.md): naming what is true now, so the next attempt
 starts from a measured position instead of rediscovering one.
 
-The two sections below are the live account; whoever closes one of the remaining eight moves its
-entry up rather than adding a third place to look. One entry in **Fixed** also carries a correction
-to what this document originally claimed, because the recorded diagnosis turned out to be wrong once
-it was measured.
+The two sections below are the live account; whoever closes one of the remaining five moves its entry
+up rather than adding a third place to look. One entry in **Fixed** also carries a correction to what
+this document originally claimed, because the recorded diagnosis turned out to be wrong once it was
+measured.
 
 ## Fixed
 
@@ -77,28 +77,52 @@ mechanism given for it was wrong, and the wrong mechanism was the more flatterin
 is slightly late reads as a rounding error, where a bound that never fires is the feature missing.
 The probe that separated them was four lines and had not been run.*
 
+**`EGraph` kept its own copy of the node-type list `MatchPattern.Construct` hardcodes.** Two lists of
+the same fourteen types, next to a doc comment on `Construct` itself warning that a list written twice
+is a list that drifts — and the drift would have been silent, since a type added to one and not the
+other simply stops being reachable from the e-graph with no compiler error. Fixed by making one table
+hold all three facts at once — the type, its arity, and the constructor call — with the list, the
+name lookup and `CanConstruct` all derived from its keys, so there is no second list left to drift.
+Being a table rather than a chain of `nodeType == typeof(T)` tests also makes the lookup O(1), which
+matters now that the list is three times longer: `BuildableNodeTypesTest` holds it to `Construct` by
+reflecting over every concrete node type, and builds each declared one for real, since a lookup that
+says "yes" does not prove a constructor runs.
+
+**`Extract` silently no-opped on any root type outside that list, and a `Providedf`-wrapped result was
+unioned onto a dead end.** Two findings with one cause. Fourteen types is what `Construct` had
+accumulated, not a principled boundary: comparisons, connectives, the inverse trigonometric functions,
+`floor`/`ceil`/`round`, `mod`, `gcd`, `min`/`max`, the set operations and `Providedf` were all absent,
+so `EqualitySaturation.Apply` on an expression rooted at any of them returned its input reporting
+`Changed = false` — indistinguishable from "already at its cheapest" — and a rule following the
+registry's own convention of wrapping a conditional result in `Providedf` had that result merged onto
+a class nothing could build. Fixed by widening the table to 44 types, which is every node type whose
+constructor takes one or two `Entity` children, less two binders. Six rules gain a reverse direction
+as a result (`a-sine-of-an-arcsine` and its three siblings, `a-union-with-itself-is-itself`,
+`an-intersection-with-itself-is-itself`); each reversed rule is `Expands`, so none of them joins
+`SafeRules`.
+
+*What stays out, and why, is now a statement rather than an accident.* **Binders** — `Lambda`,
+`ConditionalSet` — because the e-graph has no notion of a bound variable's scope and would union a
+bound occurrence with a free one, and because `DirectChildren` hands out a capture-avoidingly renamed
+body rather than the written one; rebuilding either would produce a term meaning something else.
+**Variable-arity nodes** — `Piecewise`, `Application`, the finite `Set`s, `Matrix` — because the table
+keys on an arity of one or two; widening it to n children is a separate piece of work rather than a
+principle. `EGraphTest.ExtractStillDeclinesWhatItCannotFaithfullyRebuild` pins both, including the
+case where the root is buildable and its operands are not.
+
 ## Recorded, not fixed
 
-**The deeper pattern under both fixes above.** The e-graph's node model has nowhere to carry
-anything beyond raw tree shape — no `Codomain`, no leaf reference identity beyond what the two
-targeted fixes now special-case, and, per the next two items, no way to represent a conditional
-equivalence at all. Both fixes here are narrow patches for the two cases a review happened to find;
-a rule that produces some other kind of metadata-bearing node would reopen the same class of bug.
-Whether that calls for a general "attach anything, forget nothing" e-node representation, or stays a
-list of special cases extended as each is found, is not decided here.
+**The deeper pattern: an e-node carries raw tree shape and nothing else.** `Codomain` and
+`EulerIntrinsic`'s reference identity are each special-cased, and a rule producing some other kind of
+metadata-bearing node would reopen the same class of bug. Whether that calls for a general "attach
+anything, forget nothing" e-node representation, or stays a list of special cases extended as each is
+found, is still not decided.
 
-**A `SoundUnderAssumptions` rule's `Providedf`-wrapped result is unioned onto a dead end.**
-`Providedf` is absent from `EGraph`'s 14-type reconstructible whitelist, so when a rule wraps its
-result in a condition — the registry's own documented convention for a rule that does not hold
-unconditionally — `Union` merges the original class onto an unbuildable wrapper class instead of the
-useful unwrapped payload, and the improvement never reaches extraction. Representing "equivalent
-under a condition" is not a data shape the e-graph has today.
-
-**`Extract` silently no-ops on any root type outside its 14-type whitelist.** `Providedf`,
-`Piecewise`, comparisons, and function application all fall outside it, so
-`EqualitySaturation.Apply` on any expression rooted at one of these returns the unchanged input —
-`Changed = false` — even when the e-graph proved an improvement somewhere inside it. Indistinguishable
-from "already optimal".
+*Narrower than it was, though, and worth saying how.* This entry used to name the `Providedf` case as
+evidence that the e-graph had "no way to represent a conditional equivalence at all". That was the
+whitelist rather than the node model: `Providedf` is an ordinary two-child node, and giving
+`Construct` a line for it was the whole fix. What remains is genuinely about the node model —
+per-node data that is not a child, of which `Codomain` is the only instance the library has today.
 
 **`RewriteRecording` — the library's only "what rewrote this and why" mechanism — cannot see
 `EqualitySaturation` at all.** It is populated exclusively inside `RewriteRuleSet.ApplyOnce`;
@@ -106,11 +130,6 @@ from "already optimal".
 A caller who wraps a call in `RewriteRecording.Start()` — the library's own documented pattern for
 introspection — gets a real rewrite with an empty derivation and no signal that introspection failed
 rather than legitimately finding nothing.
-
-**`EGraph.OperatorTypes` hand-duplicates the exact 14-type list `MatchPattern.Construct` already
-hardcodes**, next to a sibling doc comment on `Construct` itself warning that "a list written twice
-is a list that drifts". A future PR extending one without the other silently loses e-graph coverage
-for the new type, with no compiler error.
 
 **`RewriteRule.NodeTypes` — an existing, documented fast pre-filter — is never consulted before
 `ApplyCore` calls the full `TryApply` pattern match on every `SafeRules` entry, per class, per pass.**

--- a/Sources/AngouriMath/Docs/Contributing/EqualitySaturationReviewFindings.md
+++ b/Sources/AngouriMath/Docs/Contributing/EqualitySaturationReviewFindings.md
@@ -3,12 +3,15 @@
 A review pass over [#1101](https://github.com/asc-community/AngouriMath/pull/1101) (`EGraph` and
 `Transformation.EqualitySaturation`) and [#1102](https://github.com/asc-community/AngouriMath/pull/1102)
 (`Transformation.SimplificationAtLevel`), run before either had a human reviewer, found fifteen
-issues. Two were confirmed wrong-answer bugs and are fixed, with a regression test each
-(`EGraphTest.ExtractPreservesANarrowedCodomain`, `EGraphTest.ExtractPreservesEulerIntrinsicIdentity`,
-and their `TransformationTest` counterparts at the public-API level). The other thirteen are recorded
-here rather than fixed, because fixing several of them is a real design question — the same shape as
-[`InversePairTable.md`](InversePairTable.md): naming what is true now, so the next attempt starts
-from a measured position instead of rediscovering one.
+issues. Seven are now fixed, each with a regression test named beside it below. The other eight are
+recorded here rather than fixed, because fixing several of them is a real design question — the same
+shape as [`InversePairTable.md`](InversePairTable.md): naming what is true now, so the next attempt
+starts from a measured position instead of rediscovering one.
+
+The two sections below are the live account; whoever closes one of the remaining eight moves its
+entry up rather than adding a third place to look. One entry in **Fixed** also carries a correction
+to what this document originally claimed, because the recorded diagnosis turned out to be wrong once
+it was measured.
 
 ## Fixed
 
@@ -28,6 +31,51 @@ can capture. Keying a leaf by `Stringize()` alone means `Extract` re-parses `"e"
 named constant, which is invisible to every equality check and only wrong at a binder — silently
 changing what `sum(ln(x), e, 1, 2)` means after a round trip through the graph. Fixed by keying
 `EulerIntrinsic` on a distinguished sentinel instead of its printed form.
+
+**`SafeRules` filtered by `RewriteRuleGrowth` alone, never by the owning set's `Soundness`.** It held
+safely only because every set then registered happened to be `SoundUnderAssumptions` — a fact about
+that day's registry, not an invariant. Fixed when `SafeRules` moved onto `MatchedRules.All`, which
+carries a per-rule `Soundness` the public-surface-sourced version had no way to read.
+
+**A `CostModel` answering `NaN` corrupted every later comparison in `Extract`.** `here >= bestCost` is
+false whenever either side is `NaN` (IEEE-754), so `NaN` became the incumbent cheapest and every
+candidate after it then won unconditionally — the answer stopped being the cheapest and became
+whichever member the enumeration reached last. Fixed by declining an unranked candidate, which is
+already what a cost model that *throws* gets: `EGraphTest.ExtractDeclinesACandidateItsCostModelCannotRank`
+and `ExtractPicksTheCheapestPastACandidateItCannotRank`.
+
+**Cost ties in `Extract` were settled by `HashSet<ENode>` enumeration order.** An unspecified
+implementation detail, and string hashing is randomised per process, so one run's tie-break was not
+the next run's. Fixed with a total order on `ENode` — ordinal on the operator, then children — so a
+tie goes to the ordinally-first e-node: `EGraphTest.ExtractSettlesACostTieOnADefinedOrder`.
+
+**`Extract`'s recursion had cycle protection but no depth cap.** Its cycle guard bounds the chain only
+by the number of distinct classes, which unions grow past the input's own syntactic depth, so a deep
+enough graph exhausted the stack — and a `StackOverflowException` cannot be caught, so it takes the
+process down rather than failing one call. Fixed with a `MaxExtractionDepth` of 256 that declines to
+build, the answer the cycle case already gives and the shape `Gruntz.MaxDepth` already uses:
+`EGraphTest.ExtractDeclinesToBuildPastItsDepthCap`, with
+`ExtractStillBuildsAnExpressionOfOrdinaryDepth` holding the cap to being a crash guard rather than a
+quality knob.
+
+**`WorkBudget.Steps` bounded nothing at all — and the review said something weaker and wrong about
+why.** It was recorded here as a *timing* defect, that `ChargeGrowthSinceLastCall` ran before a
+class's sweep rather than after, so a sweep's growth landed uncounted. Measuring it found the timing
+is not the problem: `Steps` charged the e-graph's *node-count growth*, and `SafeRules` is by
+construction the rules whose `Growth` does not expand — so on ordinary input the ledger was charged
+nothing whatever. Under `Steps = 0`, three of five varied expressions ran the entire sweep to
+saturation and then reported that they had `Completed`, never having reached a ceiling. `Time` was the
+only bound that was really holding. Fixed by charging what every other bounded computation in the
+library charges — one step per unit of work attempted, as Buchberger, FGLM and `MatchPattern` all do —
+before the attempt, with the growth charge kept alongside it and moved after the sweep, and with
+`Rebuild`'s full-graph rescan charged for the first time:
+`TransformationTest.EqualitySaturationStopsWhenItHasNoStepsToSpend` and
+`EqualitySaturationSpendsNoMoreThanOneStepPastItsCeiling`.
+
+*Worth keeping as a note about reviews rather than about this code: the finding was real and the
+mechanism given for it was wrong, and the wrong mechanism was the more flattering one — a bound that
+is slightly late reads as a rounding error, where a bound that never fires is the feature missing.
+The probe that separated them was four lines and had not been run.*
 
 ## Recorded, not fixed
 
@@ -51,35 +99,6 @@ under a condition" is not a data shape the e-graph has today.
 `EqualitySaturation.Apply` on any expression rooted at one of these returns the unchanged input —
 `Changed = false` — even when the e-graph proved an improvement somewhere inside it. Indistinguishable
 from "already optimal".
-
-**A `CostModel` that returns `NaN` for one candidate corrupts every later comparison in `Extract`.**
-`if (here >= bestCost) continue` is false whenever either side is `NaN` (IEEE-754), so `NaN` becomes
-`bestCost` and every subsequent candidate then unconditionally overwrites `best` — silently returning
-an arbitrary, not-necessarily-cheapest answer instead of an error. A one-line `double.IsNaN(here)`
-guard fixes it; left unfixed here because it was outside the two findings prioritised for immediate
-correctness, not because it is hard.
-
-**`SafeRules` filters by `RewriteRuleGrowth` alone, never by the owning `RewriteRuleSet.Soundness`.**
-It holds safely today only because every set currently registered happens to be
-`SoundUnderAssumptions` — a fact about today's registry, not an invariant the code enforces. A future
-`Heuristic`-tier set contributing a `Collects`/`Rearranges` rule would be silently incorporated while
-`EqualitySaturation` keeps reporting `SoundUnderAssumptions`.
-
-**The saturation loop's budget gate charges late, and `Rebuild` is never charged at all.**
-`ChargeGrowthSinceLastCall` is called before a class's full `SafeRules` sweep runs, not after, so
-the entire sweep's growth lands uncounted before the next check — a `WorkBudget { Steps = 50 }` can
-already have overshot well past 50 by the time the overshoot is noticed. `Rebuild`'s own
-potentially-multi-round full-graph rescan has no `BudgetLedger` interaction anywhere in it.
-
-**Cost ties in `Extract` are broken by `HashSet<ENode>` enumeration order** — an undocumented .NET
-implementation detail — where `BudgetLedger`'s own stated principle is that a bounded computation is
-exactly reproducible given a defined algorithm order. `CostModelTest.OnlyTheDefaultCaresAboutARootInADenominator`
-already proves exact ties are not rare in practice.
-
-**`Extract`'s recursion has cycle protection but no explicit depth cap.** E-class dependency depth
-can exceed the original expression's syntactic depth after several saturation rounds link classes
-together, and under a generous or unlimited `WorkBudget` this risks an uncatchable
-`StackOverflowException` rather than a graceful budget exhaustion.
 
 **`RewriteRecording` — the library's only "what rewrote this and why" mechanism — cannot see
 `EqualitySaturation` at all.** It is populated exclusively inside `RewriteRuleSet.ApplyOnce`;
@@ -119,6 +138,10 @@ Whether the e-graph's node model should grow a general mechanism for metadata th
 node (the `Codomain`/`Providedf`/root-type-whitelist cluster above), or whether each case is worth
 its own targeted fix as found — same open question `InversePairTable.md` leaves for its own
 mechanism, and arguably the same question either way: how much should ride along on an e-node beyond
-its bare shape. The `NaN`-guard, the `Soundness` check, and the budget-timing fix are each small and
-independent of that question and of each other; nothing here blocks any one of them being picked up
-on its own.
+its bare shape. That question is still open, and it is what the `Providedf` and root-type-whitelist
+entries above are both waiting on.
+
+The five closed since — the `Soundness` check, the `NaN` guard, the tie order, the depth cap and the
+budget — were each independent of it and of each other, which is why they went first. Of the eight
+that remain, only two (`Providedf`, the root-type whitelist) actually depend on that decision; the
+other six are ordinary work that nothing here blocks.

--- a/Sources/Tests/UnitTests/Core/CostModelTest.cs
+++ b/Sources/Tests/UnitTests/Core/CostModelTest.cs
@@ -185,6 +185,49 @@ namespace AngouriMath.Tests.Core
                 "y ^ (1 * (-1)) * x really is a bigger tree, and SmallestTree counts trees");
         }
 
+        /// <summary>
+        /// <see cref="Entity.SimplifiedRate"/> caches one value per <see cref="Entity"/> instance
+        /// and the cost model is an ambient setting, so a rate computed under one model was handed
+        /// back unchanged under another. That is not merely a stale number:
+        /// <c>Simplificator.PickSimplest</c> compares candidates by this property, so it would
+        /// compare one model's cached rate against another's freshly computed one and pick on the
+        /// strength of it, with nothing to say anything had gone wrong.
+        /// </summary>
+        [Fact]
+        public void ARateIsNotAnsweredFromAnotherCostModelsCache()
+        {
+            var expr = "a / b + b / c".ToEntity();
+
+            var underDefault = expr.SimplifiedRate;          // fills the cache
+            double underFewestDivisions;
+            using (MathS.Settings.ComplexityCriteria.Set(CostModel.FewestDivisions.Cost))
+                underFewestDivisions = expr.SimplifiedRate;
+            var backUnderDefault = expr.SimplifiedRate;
+
+            Assert.Equal(CostModel.Default.Cost(expr), underDefault);
+            Assert.Equal(CostModel.FewestDivisions.Cost(expr), underFewestDivisions);
+            Assert.NotEqual(underDefault, underFewestDivisions);
+            // And the scoped model does not poison the slot on the way out either.
+            Assert.Equal(underDefault, backUnderDefault);
+        }
+
+        /// <summary>
+        /// Every model, so that this holds for one a caller wrote as well as for the named ones —
+        /// the cache is keyed on the criteria being the default, not on the model being known.
+        /// </summary>
+        [Fact]
+        public void EveryModelIsAnsweredWithItsOwnRate()
+        {
+            var expr = "1 / (sqrt(3) + 5) + x ^ 2".ToEntity();
+            _ = expr.SimplifiedRate;                          // fills the cache under the default
+
+            foreach (var model in CostModel.All)
+            {
+                using var _scoped = MathS.Settings.ComplexityCriteria.Set(model.Cost);
+                Assert.Equal(model.Cost(expr), expr.SimplifiedRate);
+            }
+        }
+
         /// <summary>They can be listed and named, which is what "as data" buys.</summary>
         [Fact]
         public void TheyCanBeListedAndNamed()

--- a/Sources/Tests/UnitTests/Core/Transformations/BuildableNodeTypesTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/BuildableNodeTypesTest.cs
@@ -1,0 +1,105 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Core.Transformations.Matching;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// <see cref="MatchPattern.BuildableNodeTypes"/> names the node types
+    /// <c>MatchPattern.Construct</c> builds, and <see cref="EGraph"/> resolves an e-node's
+    /// operator through it. Nothing in the language keeps a list and the <see langword="switch"/>
+    /// beside it in step, so these two tests do: whichever one is edited alone, one of them fails.
+    /// </summary>
+    /// <remarks>
+    /// The e-graph used to carry its own copy of the same fourteen types. A type added to
+    /// <c>Construct</c> and not to that copy was not a compiler error and not a test failure --
+    /// it silently stopped being reachable from the e-graph, which is exactly the kind of gap a
+    /// reflective enumeration closes and a hand-written list cannot.
+    /// </remarks>
+    [Trait("Area", "Transformations")]
+    public sealed class BuildableNodeTypesTest
+    {
+        /// <summary>
+        /// Every concrete node type there is. Abstract is the only exclusion, for the reason
+        /// <c>EveryNodeSurvivesEveryPipelineTest</c> gives: several concrete number types are
+        /// not sealed, and filtering on sealed drops them.
+        /// </summary>
+        private static IEnumerable<Type> ConcreteNodeTypes =>
+            typeof(Entity).Assembly.GetTypes()
+                .Where(type => !type.IsAbstract && typeof(Entity).IsAssignableFrom(type))
+                .OrderBy(type => type.FullName, StringComparer.Ordinal);
+
+        [Fact]
+        public void EveryNodeTypeConstructBuildsIsDeclaredBuildable()
+        {
+            var actuallyBuildable = ConcreteNodeTypes
+                .Where(type => MatchPattern.CanConstruct(type, 1) || MatchPattern.CanConstruct(type, 2))
+                .OrderBy(type => type.Name, StringComparer.Ordinal)
+                .ToList();
+            var declared = MatchPattern.BuildableNodeTypes
+                .OrderBy(type => type.Name, StringComparer.Ordinal)
+                .ToList();
+
+            Assert.Equal(declared, actuallyBuildable);
+        }
+
+        /// <summary>
+        /// <see cref="MatchPattern.CanConstruct"/> is a lookup in the same table that does the
+        /// building, so it says yes without proving a constructor runs. This builds every declared
+        /// type for real: a constructor that threw, or that returned something of another type,
+        /// would otherwise be a claim nothing checked.
+        /// </summary>
+        [Fact]
+        public void EveryDeclaredTypeReallyBuildsAtItsOwnArity()
+        {
+            foreach (var type in MatchPattern.BuildableNodeTypes)
+            {
+                var arity = MatchPattern.CanConstruct(type, 1) ? 1 : 2;
+                var children = Enumerable.Repeat((Entity)Entity.Number.Integer.Zero, arity).ToArray();
+
+                var built = MatchPattern.ConstructNode(type, children);
+
+                Assert.NotNull(built);
+                Assert.IsType(type, built);
+                // And it declines the arity it does not take, rather than reading past its children.
+                Assert.Null(MatchPattern.ConstructNode(
+                    type, Enumerable.Repeat((Entity)Entity.Number.Integer.Zero, 3 - arity).ToArray()));
+            }
+        }
+
+        /// <summary>
+        /// The lookup the e-graph goes through answers for every declared type and for nothing
+        /// else -- so an operator name that reaches it either resolves to a type <c>Construct</c>
+        /// really builds, or resolves to nothing at all.
+        /// </summary>
+        [Fact]
+        public void TheNameLookupAnswersForExactlyTheDeclaredTypes()
+        {
+            foreach (var type in MatchPattern.BuildableNodeTypes)
+                Assert.Same(type, MatchPattern.NodeTypeNamed(type.Name));
+
+            foreach (var type in ConcreteNodeTypes.Except(MatchPattern.BuildableNodeTypes))
+                Assert.Null(MatchPattern.NodeTypeNamed(type.Name));
+        }
+
+        /// <summary>
+        /// Two node types printing the same <c>Name</c> would make the lookup ambiguous, and the
+        /// e-graph keys e-nodes on that name -- so the two would share one e-class.
+        /// </summary>
+        [Fact]
+        public void NoTwoBuildableNodeTypesShareAName()
+            => Assert.Equal(
+                MatchPattern.BuildableNodeTypes.Count,
+                MatchPattern.BuildableNodeTypes.Select(type => type.Name).Distinct().Count());
+    }
+}

--- a/Sources/Tests/UnitTests/Core/Transformations/EGraphTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/EGraphTest.cs
@@ -319,6 +319,83 @@ namespace AngouriMath.Tests.Core.Transformations
             Assert.NotNull(extracted);
         }
 
+        /// <summary>
+        /// <see cref="EGraph.Extract"/> rebuilds through the node types
+        /// <c>MatchPattern.Construct</c> knows, and that used to be fourteen arithmetic and
+        /// trigonometric ones. Every other root -- a comparison, a condition attached to a value,
+        /// a set operation -- extracted as <see langword="null"/>, so
+        /// <c>Transformation.EqualitySaturation</c> handed back its input reporting
+        /// <c>Changed = false</c>, which is indistinguishable from "already at its cheapest" even
+        /// where the graph had proved an improvement inside it.
+        /// </summary>
+        [Theory]
+        [InlineData("x > 0")]
+        [InlineData("x = y")]
+        [InlineData("x >= y + 1")]
+        [InlineData("a and b")]
+        [InlineData("not a")]
+        [InlineData("x mod y")]
+        [InlineData("floor(x)")]
+        [InlineData("arcsin(x)")]
+        [InlineData("x!")]
+        // A special set is a leaf, so both operands rebuild and the union over them does too.
+        [InlineData("RR unite ZZ")]
+        public void ExtractRebuildsRootsThatUsedToFallOutsideTheBuildableTypes(string source)
+        {
+            var expr = source.ToEntity();
+            var graph = new EGraph();
+            var root = graph.AddEntity(expr);
+
+            var extracted = graph.Extract(root, CostModel.Default.Cost);
+
+            Assert.NotNull(extracted);
+            Assert.True(expr.Equals(extracted), $"{source} came back as {extracted!.Stringize()}");
+        }
+
+        /// <summary>
+        /// The case the review named specifically: a rule that does not hold unconditionally
+        /// wraps its result in a <see cref="Entity.Providedf"/>, which is the registry's own
+        /// documented convention -- and that wrapper used to be unbuildable, so the class it was
+        /// unioned onto was a dead end and the improvement never reached extraction.
+        /// </summary>
+        [Fact]
+        public void ExtractRebuildsAConditionAttachedToAValue()
+        {
+            Entity provided = new Entity.Providedf("x".ToEntity(), "x > 0".ToEntity());
+            var graph = new EGraph();
+            var root = graph.AddEntity(provided);
+
+            var extracted = graph.Extract(root, CostModel.Default.Cost);
+
+            Assert.NotNull(extracted);
+            Assert.IsType<Entity.Providedf>(extracted);
+            Assert.True(provided.Equals(extracted));
+        }
+
+        /// <summary>
+        /// A binder is still not rebuilt, and that is deliberate rather than pending: the e-graph
+        /// has no notion of a bound variable's scope, and <c>DirectChildren</c> hands out a
+        /// capture-avoidingly renamed body, so rebuilding one from an e-class would produce a term
+        /// meaning something else.
+        /// </summary>
+        /// <remarks>
+        /// The variable-arity nodes are declined for a different reason -- the table keys on a
+        /// type and an arity of one or two, so an n-child node has no entry -- and a union over
+        /// two finite sets shows that this reaches the root through its operands: the
+        /// <c>Unionf</c> itself is buildable and its operands are not.
+        /// </remarks>
+        [Theory]
+        [InlineData("{ x : x > 0 }")]                 // a binder: no notion of scope here
+        [InlineData("{ 1, 2 }")]                      // variable arity
+        [InlineData("{ 1, 2 } unite { 2, 3 }")]       // buildable root, unbuildable operands
+        public void ExtractStillDeclinesWhatItCannotFaithfullyRebuild(string source)
+        {
+            var graph = new EGraph();
+            var root = graph.AddEntity(source.ToEntity());
+
+            Assert.Null(graph.Extract(root, CostModel.Default.Cost));
+        }
+
         [Fact]
         public void ContainsLeafFindsAMatchingLiteral()
         {

--- a/Sources/Tests/UnitTests/Core/Transformations/EGraphTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/EGraphTest.cs
@@ -396,6 +396,49 @@ namespace AngouriMath.Tests.Core.Transformations
             Assert.Null(graph.Extract(root, CostModel.Default.Cost));
         }
 
+        /// <summary>
+        /// The folds the e-graph performs on insertion are read off <see cref="Entity.InnerSimplified"/>
+        /// rather than written out again, so the two cannot disagree. This names what that
+        /// derivation currently finds — not to restate the table, but so that a change in
+        /// <c>InnerSimplify</c> shows up here as a changed list rather than as e-graph folding
+        /// quietly gaining or losing a case.
+        /// </summary>
+        /// <remarks>
+        /// The asymmetries are the point. <c>x + 0</c> and <c>0 + x</c> both fold, because
+        /// addition is commutative; <c>x - 0</c> folds and <c>0 - x</c> does not, because that is
+        /// a negation and not this operand; <c>x ^ 1</c> folds and <c>1 ^ x</c> does not, because
+        /// that is the constant 1.
+        /// </remarks>
+        [Fact]
+        public void TheFoldsAreExactlyWhatInnerSimplifyDoes()
+            => Assert.Equal(
+                new[]
+                {
+                    "Divf(x, 1)", "Minusf(x, 0)", "Mulf(1, x)", "Mulf(x, 1)",
+                    "Powf(x, 1)", "Sumf(0, x)", "Sumf(x, 0)",
+                },
+                EGraph.NeutralFolds.OrderBy(fold => fold, System.StringComparer.Ordinal).ToArray());
+
+        [Theory]
+        // The e-graph folds exactly where InnerSimplify does, so these agree by construction.
+        [InlineData("x + 0")]
+        [InlineData("0 + x")]
+        [InlineData("x - 0")]
+        [InlineData("x * 1")]
+        [InlineData("1 * x")]
+        [InlineData("x / 1")]
+        [InlineData("x ^ 1")]
+        public void AFoldedInsertionAgreesWithInnerSimplify(string source)
+        {
+            var expr = source.ToEntity();
+            var graph = new EGraph();
+            var root = graph.AddEntity(expr);
+
+            var extracted = graph.Extract(root, CostModel.Default.Cost);
+
+            Assert.Equal(expr.InnerSimplified, extracted);
+        }
+
         [Fact]
         public void ContainsLeafFindsAMatchingLiteral()
         {

--- a/Sources/Tests/UnitTests/Core/Transformations/EGraphTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/EGraphTest.cs
@@ -216,6 +216,109 @@ namespace AngouriMath.Tests.Core.Transformations
             Assert.True(ReferenceEquals(Entity.Constant.EulerIntrinsic, extracted));
         }
 
+        /// <summary>
+        /// A cost model that answers <see cref="double.NaN"/> has not ranked the candidate, and
+        /// every IEEE-754 comparison against <see cref="double.NaN"/> is false -- so the
+        /// cheapest-so-far test never declines it. A model that <i>throws</i> is already declined
+        /// by the surrounding <see langword="catch"/>; one that answers
+        /// <see cref="double.NaN"/> is saying the same thing and is declined the same way.
+        /// </summary>
+        [Fact]
+        public void ExtractDeclinesACandidateItsCostModelCannotRank()
+        {
+            var graph = new EGraph();
+            var root = graph.AddEntity("x".ToEntity());
+
+            var extracted = graph.Extract(root, static _ => double.NaN);
+
+            Assert.Null(extracted);
+        }
+
+        /// <summary>
+        /// The consequence of the above when a class holds more than one candidate: an unranked
+        /// candidate that is not declined becomes the incumbent cheapest, and because every later
+        /// comparison against it is false, every candidate after it wins unconditionally --
+        /// <see cref="EGraph.Extract"/> stops answering with the cheapest and answers with
+        /// whichever member the enumeration reached last.
+        /// </summary>
+        [Fact]
+        public void ExtractPicksTheCheapestPastACandidateItCannotRank()
+        {
+            var graph = new EGraph();
+            var cheap = graph.AddEntity("x".ToEntity());
+            graph.Union(cheap, graph.AddEntity("y".ToEntity()));
+            graph.Union(cheap, graph.AddEntity("z".ToEntity()));
+
+            var extracted = graph.Extract(cheap, static candidate => candidate.Stringize() switch
+            {
+                "x" => 1,
+                "y" => double.NaN,
+                _ => 100
+            });
+
+            Assert.True("x".ToEntity().Equals(extracted));
+        }
+
+        /// <summary>
+        /// <see cref="System.Collections.Generic.HashSet{T}"/> enumeration order is an
+        /// unspecified implementation detail, and a string's hash code is randomised per process
+        /// -- so without a defined order over a class's members, an exact cost tie is settled
+        /// differently from one run to the next. <see cref="CostModel"/>'s own remarks say ties
+        /// are common enough to design the models against, and a bounded computation is meant to
+        /// be reproducible given a defined algorithm order. A tie goes to the ordinally-first
+        /// e-node.
+        /// </summary>
+        [Fact]
+        public void ExtractSettlesACostTieOnADefinedOrder()
+        {
+            var graph = new EGraph();
+            var id = graph.AddEntity("b".ToEntity());
+            graph.Union(id, graph.AddEntity("c".ToEntity()));
+            graph.Union(id, graph.AddEntity("a".ToEntity()));
+
+            var extracted = graph.Extract(id, static _ => 1);
+
+            Assert.True("a".ToEntity().Equals(extracted));
+        }
+
+        /// <summary>
+        /// <see cref="EGraph.Extract"/> recurses through an e-class's children, and its cycle
+        /// guard bounds the chain only by the number of distinct classes -- which unions grow
+        /// past the input expression's own syntactic depth. Past the cap it declines to build,
+        /// the same answer the cycle case already gives, rather than exhausting the stack: a
+        /// <see cref="System.StackOverflowException"/> cannot be caught, so it takes the process
+        /// down instead of failing one call.
+        /// </summary>
+        [Fact]
+        public void ExtractDeclinesToBuildPastItsDepthCap()
+        {
+            Entity deep = "x".ToEntity();
+            for (var i = 0; i < 300; i++) deep += 1;
+            var graph = new EGraph();
+            var root = graph.AddEntity(deep);
+
+            var extracted = graph.Extract(root, CostModel.Default.Cost);
+
+            Assert.Null(extracted);
+        }
+
+        /// <summary>
+        /// The cap is a crash guard, not a quality knob: an expression of ordinary depth must
+        /// still extract normally.
+        /// </summary>
+        [Fact]
+        public void ExtractStillBuildsAnExpressionOfOrdinaryDepth()
+        {
+            Entity ordinary = "x".ToEntity();
+            for (var i = 0; i < 30; i++) ordinary += 1;
+            var graph = new EGraph();
+            var root = graph.AddEntity(ordinary);
+
+            var extracted = graph.Extract(root, CostModel.Default.Cost);
+
+            Assert.NotNull(extracted);
+        }
+
         [Fact]
         public void ContainsLeafFindsAMatchingLiteral()
         {

--- a/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
@@ -132,8 +132,6 @@ namespace AngouriMath.Tests.Core.Transformations
                     "a-conjunction-with-a-falsehood-is-false: ReplacementIsCode",
                     "a-conjunction-with-itself-is-itself: ReplacementIsCode",
                     "a-cosecant-times-a-sine-of-one-angle-is-one: ReplacementIsCode",
-                    "a-cosine-of-an-arccosine: PatternCannotBeBuilt",
-                    "a-cotangent-of-an-arccotangent: PatternCannotBeBuilt",
                     "a-difference-chain-is-sorted-and-grouped: ReplacementIsCode",
                     "a-difference-of-even-powers-splits: ReplacementIsCode",
                     "a-difference-of-two-negatives-turns-round: ReplacementIsCode",
@@ -272,7 +270,6 @@ namespace AngouriMath.Tests.Core.Transformations
                     "a-shifted-factorial-times-the-next-term: ReplacementIsCode",
                     "a-sign-times-a-thing-over-its-own-absolute-value-cancels: ReplacementIsCode",
                     "a-sign-times-an-absolute-value-of-one-thing-is-that-thing: ReplacementIsCode",
-                    "a-sine-of-an-arcsine: PatternCannotBeBuilt",
                     "a-sine-times-a-cosine-of-one-angle-is-half-the-doubled-sine: ReplacementIsCode",
                     "a-square-less-a-number-splits: ReplacementIsCode",
                     "a-squared-cosecant-less-a-squared-cotangent-is-one: ReplacementIsCode",
@@ -288,7 +285,6 @@ namespace AngouriMath.Tests.Core.Transformations
                     "a-sum-of-two-negatives-is-a-negated-sum: ReplacementIsCode",
                     "a-sum-or-difference-that-is-a-perfect-square: ReplacementIsCode",
                     "a-sum-over-its-own-reverse-is-one: ReplacementIsCode",
-                    "a-tangent-of-an-arctangent: PatternCannotBeBuilt",
                     "a-tangent-times-a-cotangent-of-one-angle-is-one: ReplacementIsCode",
                     "a-term-added-to-a-difference-that-starts-from-it: ReplacementIsCode",
                     "a-term-added-to-a-difference-that-takes-it-away: ReplacementIsCode",
@@ -307,7 +303,6 @@ namespace AngouriMath.Tests.Core.Transformations
                     "a-thing-times-itself-is-its-square: ReplacementIsCode",
                     "a-two-term-denominator-is-multiplied-by-its-conjugate: ReplacementIsCode",
                     "a-union-chain-is-sorted-and-grouped: ReplacementIsCode",
-                    "a-union-with-itself-is-itself: PatternCannotBeBuilt",
                     "a-variable-times-a-number-puts-the-number-first: ReplacementIsCode",
                     "a-variable-times-a-power-puts-the-power-first: ReplacementIsCode",
                     "a-whole-power-comes-out-from-under-a-radical: ReplacementIsCode",
@@ -328,7 +323,6 @@ namespace AngouriMath.Tests.Core.Transformations
                     "an-intersection-chain-is-sorted-and-grouped: ReplacementIsCode",
                     "an-intersection-distributes-over-a-union-on-its-left: ReplacementIsCode",
                     "an-intersection-distributes-over-a-union-on-its-right: ReplacementIsCode",
-                    "an-intersection-with-itself-is-itself: PatternCannotBeBuilt",
                     "an-odd-function-of-a-negative-multiple-negates-cosecant: ReplacementIsCode",
                     "an-odd-function-of-a-negative-multiple-negates-cotan: ReplacementIsCode",
                     "an-odd-function-of-a-negative-multiple-negates-signum: ReplacementIsCode",
@@ -540,17 +534,22 @@ namespace AngouriMath.Tests.Core.Transformations
         [Fact]
         public void APatternOverAnUnbuildableNodeIsMatchableAndNotReversible()
         {
-            var overMod = new MatchedRule(
-                "modulus",
-                MatchPattern.Node<Modf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
+            // Integralf carries an optional integration range beside its two children, so no
+            // construction from children alone can rebuild it -- unbuildable for a reason that
+            // will not change, where Modf, which stood here before, was merely a type Construct
+            // had not been given a line for yet.
+            var overIntegral = new MatchedRule(
+                "integral",
+                MatchPattern.Node<Integralf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
                 MatchPattern.Node<Mulf>(MatchPattern.Any("b"), MatchPattern.Any("a")),
                 Soundness.Heuristic);
 
             // It still matches, which is what "matchable and not writable" means.
-            Assert.True(overMod.Left.Matches("x mod y".ToEntity()));
-            Assert.Equal("y * x", overMod.TryApply("x mod y".ToEntity())!.Stringize());
-            Assert.Equal(RuleReversal.PatternCannotBeBuilt, overMod.Reversal);
-            Assert.Null(overMod.Reversed);
+            var integral = MathS.Integral("x".ToEntity(), "y".ToEntity());
+            Assert.True(overIntegral.Left.Matches(integral));
+            Assert.Equal("y * x", overIntegral.TryApply(integral)!.Stringize());
+            Assert.Equal(RuleReversal.PatternCannotBeBuilt, overIntegral.Reversal);
+            Assert.Null(overIntegral.Reversed);
         }
 
         /// <summary>
@@ -570,7 +569,7 @@ namespace AngouriMath.Tests.Core.Transformations
             var thrown = Assert.Throws<ArgumentException>(() => new MatchedRule(
                 "unbuildable",
                 MatchPattern.Node<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
-                MatchPattern.Node<Modf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
+                MatchPattern.Node<Integralf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
                 Soundness.Heuristic));
             Assert.Contains("cannot build", thrown.Message);
         }

--- a/Sources/Tests/UnitTests/Core/Transformations/TransformationTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/TransformationTest.cs
@@ -661,6 +661,72 @@ namespace AngouriMath.Tests.Core.Transformations
                 $"a ceiling of {steps} was overshot to {outcome.Steps}");
         }
 
+        /// <summary>
+        /// <see cref="RewriteRecording"/> is the library's only "what rewrote this and why"
+        /// mechanism, and it is populated inside <see cref="RewriteRuleSet.ApplyOnce"/> --
+        /// which equality saturation does not go through, since it asks rules directly. A caller
+        /// who opened a recording therefore got a real rewrite with an empty derivation, and no
+        /// signal telling them introspection had missed it rather than found nothing.
+        /// </summary>
+        [Fact]
+        public void EqualitySaturationIsVisibleToARecording()
+        {
+            var transformation = Transformation.EqualitySaturation(SmallSaturationBudget, CostModel.Default);
+
+            using var recording = RewriteRecording.Start();
+            var result = transformation.Apply(Parse("x + 0"));
+
+            Assert.True(result.Changed);
+            var path = recording.PathFrom(result.Input, result.Output!);
+            Assert.NotNull(path);
+            Assert.Contains(path!.Steps, step => step.Name == transformation.Name);
+        }
+
+        /// <summary>
+        /// And it records nothing when it changed nothing, which is the convention every rule set
+        /// already follows -- a pass that did not fire is not a step.
+        /// </summary>
+        [Fact]
+        public void EqualitySaturationRecordsNothingWhenItChangesNothing()
+        {
+            var transformation = Transformation.EqualitySaturation(SmallSaturationBudget, CostModel.Default);
+
+            using var recording = RewriteRecording.Start();
+            var result = transformation.Apply(Parse("x"));
+
+            Assert.False(result.Changed);
+            Assert.Empty(recording.Steps);
+        }
+
+        /// <summary>
+        /// <see cref="MatchPattern.RequiredRootType"/> is a documented necessary condition on a
+        /// match, and the sweep did not consult it: every rule in <c>SafeRules</c> ran a full
+        /// pattern match against every class of every pass, and the large majority of those could
+        /// not have matched. Measured over four expressions, consulting it cuts match attempts by
+        /// about thirteen times — 1076 steps to 78 on the largest — with the same answer each time.
+        /// </summary>
+        /// <remarks>
+        /// Asserted against the rule count rather than against a recorded number, so that the
+        /// claim stays true as rules are added: saturating <c>x + 0</c> to its answer costs less
+        /// in total than one unfiltered pass over a single class would.
+        /// </remarks>
+        [Fact]
+        public void EqualitySaturationDoesNotAttemptEveryRuleOnEveryClass()
+        {
+            var generous = new WorkBudget { Steps = 10_000_000, Time = TimeSpan.FromSeconds(60) };
+            var transformation = Transformation.EqualitySaturation(generous, CostModel.Default);
+
+            using var recording = BudgetRecording.Start();
+            var result = transformation.Apply(Parse("x + 0"));
+
+            Assert.Equal(Parse("x"), result.Output);
+            var spent = recording.Outcomes.Single().Steps;
+            Assert.True(spent < Transformation.EqualitySaturationSafeRuleCount,
+                $"the whole saturation spent {spent} steps, which is not less than the "
+                + $"{Transformation.EqualitySaturationSafeRuleCount} one unfiltered pass over one "
+                + "class would cost -- the root-type filter is not being consulted");
+        }
+
         [Fact]
         public void EqualitySaturationNeverThrowsUnderAStarvedBudget()
         {

--- a/Sources/Tests/UnitTests/Core/Transformations/TransformationTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/TransformationTest.cs
@@ -613,6 +613,54 @@ namespace AngouriMath.Tests.Core.Transformations
             Assert.False(result.Changed);
         }
 
+        /// <summary>
+        /// <see cref="WorkBudget.Steps"/> charged the e-graph's node-count growth, and
+        /// <c>SafeRules</c> is by construction the rules whose
+        /// <see cref="RewriteRuleGrowth"/> does <i>not</i> expand -- so on ordinary input the
+        /// ledger was charged nothing at all, and a budget of zero steps ran the whole sweep to
+        /// saturation and then reported that it had <see cref="BudgetOutcome.Completed"/>.
+        /// Measured before the fix: three of five varied expressions reported exactly that.
+        /// A step here is what it is for Buchberger, FGLM and <c>MatchPattern</c> -- one unit of
+        /// work attempted -- not a node that happened to be created.
+        /// </summary>
+        [Theory]
+        [InlineData("(x + y) / (x - y) + (x - y) / (x + y)")]
+        [InlineData("(a + b + c + d) ^ 3")]
+        [InlineData("sqrt(2) / (sqrt(3) + sqrt(5)) + ln(a * b * c) + sin(x + y) * cos(x - y)")]
+        public void EqualitySaturationStopsWhenItHasNoStepsToSpend(string source)
+        {
+            var starved = new WorkBudget { Steps = 0, Time = TimeSpan.FromSeconds(30) };
+            var transformation = Transformation.EqualitySaturation(starved, CostModel.Default);
+
+            using var recording = BudgetRecording.Start();
+            transformation.Apply(Parse(source));
+
+            var outcome = recording.Outcomes.Single();
+            Assert.False(outcome.Completed);
+            Assert.Equal("steps", outcome.Reason);
+        }
+
+        /// <summary>
+        /// The other half of the same claim: a ceiling that is reached is a ceiling that was
+        /// counting, so what the ledger reports spent must not run away past what was allowed.
+        /// </summary>
+        [Theory]
+        [InlineData(10)]
+        [InlineData(50)]
+        [InlineData(200)]
+        public void EqualitySaturationSpendsNoMoreThanOneStepPastItsCeiling(int steps)
+        {
+            var budget = new WorkBudget { Steps = steps, Time = TimeSpan.FromSeconds(30) };
+            var transformation = Transformation.EqualitySaturation(budget, CostModel.Default);
+
+            using var recording = BudgetRecording.Start();
+            transformation.Apply(Parse("sqrt(2) / (sqrt(3) + sqrt(5)) + ln(a * b * c) + sin(x + y) * cos(x - y)"));
+
+            var outcome = recording.Outcomes.Single();
+            Assert.True(outcome.Steps <= steps + 1,
+                $"a ceiling of {steps} was overshot to {outcome.Steps}");
+        }
+
         [Fact]
         public void EqualitySaturationNeverThrowsUnderAStarvedBudget()
         {


### PR DESCRIPTION
The code review on #1101/#1102 found fifteen issues and fixed two, recording the other thirteen in [`EqualitySaturationReviewFindings.md`](https://github.com/asc-community/AngouriMath/blob/master/Sources/AngouriMath/Docs/Contributing/EqualitySaturationReviewFindings.md) rather than fixing them. This closes twelve of the thirteen. What is left is a design question rather than a defect, and the interesting result is how little of the cluster depended on it.

Three commits, each independently reviewable.

## Correctness in `Extract`

- **A `CostModel` answering `NaN` corrupted every later comparison.** `here >= bestCost` is false whenever either side is `NaN`, so a `NaN` became the incumbent cheapest and every candidate after it then won unconditionally — the answer stopped being the cheapest and became whichever member the enumeration reached last. A cost model that *throws* was already declined by the surrounding `catch`; one answering `NaN` is saying the same thing.
- **Cost ties were settled by `HashSet<ENode>` enumeration order** — unspecified, and string hashing is randomised per process, so one run's tie-break was not the next run's. `ENode` gains a total order.
- **No depth cap.** The cycle guard bounds the chain only by the number of distinct classes, which unions grow past the input's own syntactic depth, and a `StackOverflowException` cannot be caught. Capped at 256, declining to build — the answer the cycle case already gives, and the shape `Gruntz.MaxDepth` already uses.

**And one the review diagnosed wrongly.** `WorkBudget.Steps` was recorded as a *timing* defect: the growth charge landing after a sweep rather than before the next one. Measuring it found otherwise — `Steps` charged the e-graph's node-count growth, and `SafeRules` is by construction the rules whose `Growth` does not expand, so on ordinary input the ledger was charged nothing whatever. Under `Steps = 0`, three of five varied expressions ran the entire sweep to saturation and reported that they had **completed**, never having reached a ceiling. `Time` was the only bound really holding.

A step is now one unit of work attempted, charged before the attempt, as Buchberger, FGLM and `MatchPattern` all charge; the growth charge stays alongside it and moves after the sweep; and `Rebuild`'s full-graph rescan is charged for the first time.

## One table of buildable node types

`EGraph` kept a second copy of the fourteen-type list `MatchPattern.Construct` hardcodes, next to a doc comment on `Construct` warning that a list written twice is a list that drifts. One table now holds the type, its arity and the constructor call together, with the list, the name lookup and `CanConstruct` all derived from its keys. Being a table rather than a chain of `nodeType == typeof(T)` tests also makes it O(1).

Fourteen types was what `Construct` had accumulated, not a boundary anyone chose — so `Extract` silently no-opped on any root outside it, and a rule wrapping a conditional result in `Providedf` (the registry's own convention) had that result unioned onto a class nothing could build. The table now holds 44: every node type whose constructor takes one or two `Entity` children, less two binders.

What stays out is now a statement rather than an accident. **Binders**, because the e-graph has no notion of a bound variable's scope and `DirectChildren` hands out a capture-avoidingly renamed body. **Variable-arity nodes**, because the table keys on an arity of one or two.

Six rules gain a reverse direction as a consequence — the four inverse-trigonometric round trips and the two set idempotences, whose left-hand pattern named a type that could not be built. Each reversed rule is `Expands`, so none joins `SafeRules`.

## Introspection, a filter, a derived table, a cache

- **`RewriteRecording` could not see `EqualitySaturation` at all**, so a caller who opened a recording got a real rewrite with an empty derivation and no way to tell that introspection had missed it. The pass is noted now — and deliberately not finer, because a firing in saturation is not a rewrite: it adds a member to an e-class whose members are already believed equal, and most firings contribute nothing to what extraction chose. Reporting them as `RewriteStep`s would name rewrites that are not in the answer.
- **`MatchPattern.RequiredRootType` was never consulted**, so every rule ran a full pattern match against every class of every pass. Consulting it cuts match attempts about thirteenfold — 1076 steps to 78 on the largest of four expressions — with the same answer in every case.
- **`NeutralClass` hand-rolled an identity table `InnerSimplify` already implements**, with nothing keeping them in step; the divergence would have been silent in the worst direction. It is derived now, by asking `InnerSimplified` whether `op(x, leaf)` really is `x` — which settles `0 - x`, `1 / x` and `1 ^ x` without anyone having to remember them, and declines a fold whose answer carries a condition.
- **`Entity.SimplifiedRate` answered one cost model's question with another's cached number.** Not merely stale: `Simplificator.PickSimplest` compares candidates by this property, so it weighed a cached rate against a fresh one and chose on the strength of it.

## What is left

One entry, and it is a decision rather than a bug: how much should ride along on an e-node beyond its bare shape. Only `Codomain` turned out to depend on it. The `Providedf` case the findings document had offered as evidence that the e-graph could not represent a conditional equivalence was the buildable-type table and nothing deeper — a cluster of findings around one subsystem invites a single grand explanation, and thirteen of these fourteen did not have one.

## Verification

Full suite: **8919 passed, 14 skipped (pre-existing), 0 failed.**

Every fix has a regression test, named beside its entry in the findings document. Two tests that used `Modf` as their example of an unbuildable node now use `Integralf`, which is unbuildable for a reason that will not change: it carries an optional range beside its two children.

Part of #746 tier 2.
