### PR TITLE
A canonicalisation framework on the rewrite graph

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/EGraph.cs
+++ b/Sources/AngouriMath/Core/Transformations/EGraph.cs
@@ -335,10 +335,89 @@ namespace AngouriMath.Core.Transformations
         /// type <see cref="MatchPattern.ConstructNode"/> does not build.
         /// </summary>
         internal Entity? Extract(int id, Func<Entity, double> cost)
-            => Extract(id, cost, new Dictionary<int, Entity>(), new HashSet<int>());
+            => Extract(id, new Cheapest(cost), new Dictionary<int, Entity>(), new HashSet<int>());
 
-        private Entity? Extract(int id, Func<Entity, double> cost,
+        /// <summary>
+        /// The least entity the e-class <paramref name="id"/> can be built as under
+        /// <paramref name="order"/>, or <see langword="null"/> where nothing in it can be built.
+        /// </summary>
+        /// <remarks>
+        /// The same walk as <see cref="Extract(int, Func{Entity, double})"/>, choosing by an order
+        /// rather than by a number. That is not a stylistic difference: a cost model ties, and a
+        /// tie is settled by whichever member was reached first, so "the cheapest member" is not a
+        /// well-defined expression where "the least member" is. See <see cref="EntityOrder"/>.
+        /// </remarks>
+        internal Entity? ExtractLeast(int id, IComparer<Entity> order)
+            => Extract(id, new Least(order), new Dictionary<int, Entity>(), new HashSet<int>());
+
+        /// <summary>
+        /// How <c>Extract</c> chooses between the members of one e-class. A
+        /// <see langword="struct"/> under a generic constraint rather than an interface reference,
+        /// so the choice is compiled in rather than dispatched, and no selection is allocated for
+        /// the classes an extraction walks.
+        /// </summary>
+        private interface ISelection
+        {
+            /// <summary>Forgets the previous class's incumbent.</summary>
+            void Begin();
+
+            /// <summary>Offers a candidate; the incumbent afterwards is the better of the two.</summary>
+            void Offer(Entity candidate);
+
+            /// <summary>The incumbent, or <see langword="null"/> where nothing was admissible.</summary>
+            Entity? Best { get; }
+        }
+
+        private struct Cheapest : ISelection
+        {
+            private readonly Func<Entity, double> cost;
+            private Entity? best;
+            private double bestCost;
+
+            internal Cheapest(Func<Entity, double> cost)
+                => (this.cost, best, bestCost) = (cost, null, double.MaxValue);
+
+            public void Begin() => (best, bestCost) = (null, double.MaxValue);
+
+            public void Offer(Entity candidate)
+            {
+                double here;
+                try { here = cost(candidate); } catch { return; }
+                // A model that answers NaN has not ranked this candidate, which is what a model
+                // that throws is already saying, so both decline it the same way. Without this,
+                // the comparison below is false for NaN on either side (IEEE-754), so NaN becomes
+                // the incumbent cheapest and every later candidate then beats it unconditionally
+                // -- the answer stops being the cheapest and becomes whichever member came last.
+                if (double.IsNaN(here)) return;
+                if (here >= bestCost) return;
+                (best, bestCost) = (candidate, here);
+            }
+
+            public readonly Entity? Best => best;
+        }
+
+        private struct Least : ISelection
+        {
+            private readonly IComparer<Entity> order;
+            private Entity? best;
+
+            internal Least(IComparer<Entity> order) => (this.order, best) = (order, null);
+
+            public void Begin() => best = null;
+
+            // No admissibility test to make: an order ranks every pair, where a cost model can
+            // decline one. Nothing here can throw that Compare does not.
+            public void Offer(Entity candidate)
+            {
+                if (best is null || order.Compare(candidate, best) < 0) best = candidate;
+            }
+
+            public readonly Entity? Best => best;
+        }
+
+        private Entity? Extract<TSelection>(int id, TSelection seed,
             Dictionary<int, Entity> memo, HashSet<int> visiting)
+            where TSelection : struct, ISelection
         {
             id = Find(id);
             if (memo.TryGetValue(id, out var done)) return done;
@@ -350,17 +429,18 @@ namespace AngouriMath.Core.Transformations
             // already gives, and the same shape as Gruntz's own MaxDepth.
             if (visiting.Count >= MaxExtractionDepth) return null;
             if (!visiting.Add(id)) return null;              // a cycle; the other node will do
-            Entity? best = null;
-            var bestCost = double.MaxValue;
-            // Ordered, not as the set enumerates: a tie on cost is settled by whichever candidate
-            // is reached first, and set order is neither specified nor stable across processes.
+            var selection = seed;
+            selection.Begin();
+            // Ordered, not as the set enumerates: where the selection ties, the answer is
+            // whichever candidate was reached first, and set order is neither specified nor
+            // stable across processes.
             foreach (var node in NodesOf(id).OrderBy(node => node))
             {
                 var parts = new Entity[node.Children.Length];
                 var ok = true;
                 for (var i = 0; i < parts.Length && ok; i++)
                 {
-                    var part = Extract(node.Children[i], cost, memo, visiting);
+                    var part = Extract(node.Children[i], seed, memo, visiting);
                     if (part is null) ok = false;
                     else parts[i] = part;
                 }
@@ -370,19 +450,10 @@ namespace AngouriMath.Core.Transformations
                     : MatchPattern.ConstructNode(OperatorType(node.Op), parts);
                 if (built is null) continue;
                 if (codomains.TryGetValue(node, out var domain)) built = built.WithCodomain(domain);
-                double here;
-                try { here = cost(built); } catch { continue; }
-                // A model that answers NaN has not ranked this candidate, which is what a model
-                // that throws is already saying, so both decline it the same way. Without this,
-                // the comparison below is false for NaN on either side (IEEE-754), so NaN becomes
-                // the incumbent cheapest and every later candidate then beats it unconditionally
-                // -- the answer stops being the cheapest and becomes whichever member came last.
-                if (double.IsNaN(here)) continue;
-                if (here >= bestCost) continue;
-                best = built;
-                bestCost = here;
+                selection.Offer(built);
             }
             visiting.Remove(id);
+            var best = selection.Best;
             if (best is not null) memo[id] = best;
             return best;
         }

--- a/Sources/AngouriMath/Core/Transformations/EntityOrder.cs
+++ b/Sources/AngouriMath/Core/Transformations/EntityOrder.cs
@@ -1,0 +1,92 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+
+namespace AngouriMath.Core.Transformations
+{
+    /// <summary>
+    /// A total order on expressions, for choosing <i>the</i> representative of a set of equal
+    /// ones rather than a nice one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why this is not a <see cref="CostModel"/>.</b> A cost model answers "which of these is
+    /// nicer" with a <see cref="double"/>, and two expressions it cannot separate therefore tie —
+    /// which <see cref="CostModel"/>'s own remarks say is common enough to design the models
+    /// against. A tie is settled by whichever candidate was reached first, and that is an accident
+    /// of traversal rather than a form anybody chose. A canonical form cannot be built on an
+    /// accident: it needs exactly one least member, and the same one every run. No
+    /// <see cref="double"/> can carry a total order on trees, so this is a comparison instead.
+    /// </para>
+    /// <para>
+    /// <b>Why this is not <c>Entity.SortHash</c>.</b> That key orders the operands <i>within</i> a
+    /// commutative chain, which is what <c>RewriteRules.CanonicalOrder</c> and its two siblings
+    /// sort by. Choosing between whole expressions that are equal is a different question — the
+    /// operands are not siblings, they are rival writings of one value — and a key built to answer
+    /// the first is not thereby an answer to the second. The two do not compete: a canonical
+    /// extraction under this order still wants its operands sorted by that one.
+    /// </para>
+    /// </remarks>
+    internal static class EntityOrder
+    {
+        /// <summary>
+        /// Smallest first, then structural. Total up to <see cref="object.Equals(object)"/> —
+        /// two expressions compare equal exactly when they are the same expression, which is what
+        /// makes "the least member" well defined.
+        /// </summary>
+        /// <remarks>
+        /// <b>Size first is the half that makes it useful</b> rather than merely well defined: the
+        /// representative of a class is its smallest member, so canonicalising never enlarges what
+        /// it was given. The structural half is what makes it total, and it is deliberately not
+        /// the printed form — <c>(x + y) + a</c> and <c>x + (y + a)</c> print identically while
+        /// being different trees, so ordering on text would call two distinct expressions one.
+        /// </remarks>
+        internal static IComparer<Entity> Canonical { get; } = new CanonicalOrdering();
+
+        private sealed class CanonicalOrdering : IComparer<Entity>
+        {
+            public int Compare(Entity? left, Entity? right)
+            {
+                if (ReferenceEquals(left, right)) return 0;
+                if (left is null) return -1;
+                if (right is null) return 1;
+
+                var bySize = left.Complexity.CompareTo(right.Complexity);
+                if (bySize != 0) return bySize;
+
+                var leftChildren = left.DirectChildren;
+                var rightChildren = right.DirectChildren;
+
+                // A leaf against a node of the same size cannot happen -- a node is bigger than
+                // any leaf -- but arity still separates two nodes the size test tied.
+                var byArity = leftChildren.Count.CompareTo(rightChildren.Count);
+                if (byArity != 0) return byArity;
+
+                // A leaf is what it prints as; anything else is its node type. Comparing a leaf
+                // by text is safe where comparing a node by text is not: a leaf has no structure
+                // for the text to lose.
+                var byName = leftChildren.Count == 0
+                    ? string.CompareOrdinal(left.Stringize(), right.Stringize())
+                    : string.CompareOrdinal(left.GetType().Name, right.GetType().Name);
+                if (byName != 0) return byName;
+
+                for (var i = 0; i < leftChildren.Count; i++)
+                {
+                    var byChild = Compare(leftChildren[i], rightChildren[i]);
+                    if (byChild != 0) return byChild;
+                }
+
+                // Per-node data that is not a child, and the only such data the library has: two
+                // expressions identical in every other way but restricted to different domains are
+                // different expressions, and one of them has to come first.
+                return string.CompareOrdinal(left.Codomain.ToString(), right.Codomain.ToString());
+            }
+        }
+    }
+}

--- a/Sources/AngouriMath/Core/Transformations/Saturation.cs
+++ b/Sources/AngouriMath/Core/Transformations/Saturation.cs
@@ -1,0 +1,240 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath.Core.Budgets;
+using AngouriMath.Core.Transformations.Matching;
+
+namespace AngouriMath.Core.Transformations
+{
+    /// <summary>
+    /// Runs rules over an e-graph until nothing more merges or the budget runs out — the shared
+    /// half of every transformation built on the rewrite graph.
+    /// </summary>
+    /// <remarks>
+    /// Shared rather than written once per caller because the loop is subtle in ways that are not
+    /// visible from a second copy of it: what is charged and when, which rules can be skipped
+    /// without an attempt, and which of two matching paths a rule takes. Two transformations
+    /// already want it — one extracting the cheapest member of the root class and one extracting
+    /// the least — and they differ only in that extraction, not in any of this.
+    /// </remarks>
+    internal static class Saturation
+    {
+        /// <summary>
+        /// The rules of <see cref="MatchedRules"/> whose justification is at least
+        /// <see cref="Soundness.SoundUnderAssumptions"/> and whose
+        /// <see cref="MatchedRule.Growth"/> is no wider than <paramref name="widest"/>.
+        /// </summary>
+        /// <param name="widest">
+        /// The widest growth admitted, as a ceiling in the order
+        /// <see cref="RewriteRuleGrowth.Collects"/>, <see cref="RewriteRuleGrowth.Rearranges"/>,
+        /// <see cref="RewriteRuleGrowth.Expands"/>, <see cref="RewriteRuleGrowth.Unknown"/> —
+        /// increasing risk, and the order the values are declared in.
+        /// </param>
+        /// <remarks>
+        /// <para>
+        /// <b><see cref="RewriteRuleGrowth.Unknown"/> is the last stop rather than an excluded
+        /// one, and that is a measurement rather than a preference.</b> It reads like the value a
+        /// ceiling should refuse — it means the rule's growth was not judged, because its
+        /// replacement is code rather than a written pattern, so admitting it accepts a rewrite
+        /// nobody measured. But it is where the rules are: of the sound rules in
+        /// <see cref="MatchedRules"/>, <b>26 collect, 17 rearrange, 9 expand and 270 are
+        /// unjudged</b>. A ceiling that refuses the fourth value refuses 84% of the library, and
+        /// what is left cannot do much — over six expression pairs equal only through a larger
+        /// intermediate form, the <see cref="RewriteRuleGrowth.Rearranges"/> ceiling proved two,
+        /// and <see cref="RewriteRuleGrowth.Expands"/> — all nine expanding rules added — proved
+        /// <i>the same two</i>. The third was proved only with the unjudged rules admitted.
+        /// </para>
+        /// <para>
+        /// So the dial that matters is not how far a rule may enlarge; it is whether rules nobody
+        /// classified may fire at all. Naming that as the widest setting makes it a request a
+        /// caller has to make on purpose, which is the most this can honestly do about it.
+        /// </para>
+        /// </remarks>
+        internal static IReadOnlyList<MatchedRule> RulesUpTo(RewriteRuleGrowth widest)
+            => MatchedRules.All
+                .SelectMany(set => set.Rules)
+                .Where(rule => rule.Soundness is Soundness.Sound or Soundness.SoundUnderAssumptions)
+                .Where(rule => rule.Growth <= widest)
+                .ToList();
+
+        /// <summary>
+        /// Merges into <paramref name="graph"/> every equality <paramref name="rules"/> reach from
+        /// what it already holds, until a pass changes nothing or <paramref name="ledger"/> stops
+        /// it. Answers whether it reached that fixed point rather than the ceiling.
+        /// </summary>
+        /// <param name="graph">The graph to saturate, in place.</param>
+        /// <param name="rules">Which rules to fire; see <see cref="RulesUpTo"/>.</param>
+        /// <param name="ledger">What bounds the work, and what records how much was done.</param>
+        /// <param name="witnessCost">
+        /// How a representative is chosen when one is needed — for a rule whose left-hand side
+        /// cannot e-match, which has to be shown a term, and for a rule's <c>when</c> predicate,
+        /// which is arbitrary code that has to be asked about something. It ranks a
+        /// <i>witness</i>, never the answer: what the caller finally extracts is the caller's own
+        /// business, and is where a cheapest-form and a canonical-form caller differ.
+        /// </param>
+        internal static bool Run(EGraph graph, IReadOnlyList<MatchedRule> rules,
+            BudgetLedger ledger, Func<Entity, double> witnessCost)
+        {
+            var chargedNodes = graph.NodeCount;
+            bool ChargeGrowthSinceLastCall()
+            {
+                var delta = graph.NodeCount - chargedNodes;
+                chargedNodes = graph.NodeCount;
+                return ledger.Spend(delta);
+            }
+
+            var saturated = false;
+            while (!saturated && !ledger.Exhausted)
+            {
+                var merged = false;
+                foreach (var id in graph.Classes.ToList())
+                {
+                    if (ledger.Exhausted) break;
+
+                    // Which node types this class holds, gathered once for the whole sweep rather
+                    // than once per rule. A pattern that requires a root type cannot match a class
+                    // holding no node of it -- RequiredRootType is a necessary condition, not a
+                    // sufficient one, which is the direction that makes it a filter: it licenses
+                    // skipping a rule, never firing one.
+                    //
+                    // A union later in this same sweep can add a node type this set does not have,
+                    // so a rule can be skipped in a pass where it had just become applicable. That
+                    // costs nothing: a union is exactly what sets `merged`, so there is another
+                    // pass, and the set is gathered again there.
+                    var held = new HashSet<Type>();
+                    foreach (var node in graph.NodesOf(id)) held.Add(EGraph.RuntimeType(node));
+
+                    Entity? term = null;
+                    var extracted = false;
+                    bool TryTerm(out Entity value)
+                    {
+                        if (!extracted)
+                        {
+                            term = graph.Extract(id, witnessCost);
+                            extracted = true;
+                        }
+                        value = term!;
+                        return term is not null;
+                    }
+
+                    foreach (var rule in rules)
+                    {
+                        // Before the charge, because a rule this skips was never attempted: a step
+                        // is a match attempt, and a type that cannot match is not one. Written as a
+                        // loop rather than as `held.Any(t => ...)`: the lambda would capture
+                        // `required` and so allocate a closure every time the exact-type test
+                        // missed, which is most rules of most classes -- and paying an allocation
+                        // to avoid a pattern match is not a pre-filter.
+                        if (rule.Left.RequiredRootType is { } required && !held.Contains(required))
+                        {
+                            var reachable = false;
+                            foreach (var type in held)
+                                if (required.IsAssignableFrom(type))
+                                {
+                                    reachable = true;
+                                    break;
+                                }
+                            if (!reachable) continue;
+                        }
+
+                        // One step per match attempt, charged before the attempt -- the unit
+                        // Buchberger, FGLM and MatchPattern all charge, and the work this loop
+                        // actually does. Charging the node-count delta alone (below) billed
+                        // nothing on ordinary input, because the rules that do not expand rarely
+                        // grow the graph at all: a budget of zero steps ran this sweep to
+                        // saturation and then reported that it had completed.
+                        if (!ledger.Spend()) break;
+                        int other;
+                        if (rule.Left.CanEMatch)
+                        {
+                            // Mirrors the fallback branch below: a rule's `when` is arbitrary code
+                            // asked about a witness this extracted rather than one the caller
+                            // wrote, and a predicate that throws on a shape it did not expect must
+                            // decline the candidate, not escape Apply.
+                            bool matched;
+                            try { matched = rule.TryEMatchApply(graph, id, witnessCost, out other); }
+                            catch { continue; }
+                            if (!matched) continue;
+                        }
+                        else
+                        {
+                            if (!TryTerm(out var t)) continue;
+                            Entity? rewritten;
+                            try { rewritten = rule.TryApply(t); }
+                            catch { continue; }
+                            if (rewritten is null || rewritten.Equals(t)) continue;
+                            try { other = graph.AddEntity(rewritten); }
+                            catch { continue; }
+                        }
+                        if (graph.Union(id, other)) merged = true;
+                    }
+
+                    // What the sweep grew, charged after it rather than before the next class's,
+                    // so that the ceiling bounds the growth that has happened.
+                    if (!ChargeGrowthSinceLastCall()) break;
+                }
+
+                // Rebuild rescans every node of every class, repeatedly until nothing more becomes
+                // congruent -- a round of it is work, and it had no ledger interaction anywhere.
+                if (!ledger.Spend()) break;
+                graph.Rebuild();
+                if (!merged) saturated = true;
+            }
+            return saturated;
+        }
+
+        /// <summary>
+        /// Whether <paramref name="rules"/> prove <paramref name="left"/> and
+        /// <paramref name="right"/> equal, within <paramref name="budget"/>. A
+        /// <see langword="false"/> means <i>not proved</i>, never <i>unequal</i>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>This is the reliable half, and canonicalising is not.</b> Bringing two expressions
+        /// separately to a canonical form and comparing the results only decides equality where
+        /// the rules are <i>confluent</i>: otherwise one side can reach a form the other cannot,
+        /// and two equal expressions end in different forms having each been canonicalised
+        /// correctly. Measured, on <c>(x + y) * (x - y)</c> against <c>x ^ 2 - y ^ 2</c>: the
+        /// product's graph reaches the difference of squares, the difference of squares' graph
+        /// does not reach the product, and the two forms are the same size — so each canonicalises
+        /// to itself.
+        /// </para>
+        /// <para>
+        /// Asking in one graph has no such gap. Both expressions are inserted, every equality the
+        /// rules reach from <i>either</i> is merged, and the question is whether they ended in one
+        /// class — which does not depend on the rules being confluent, only on their reaching far
+        /// enough within the budget.
+        /// </para>
+        /// </remarks>
+        internal static bool ProvesEqual(Entity left, Entity right,
+            IReadOnlyList<MatchedRule> rules, WorkBudget budget)
+        {
+            if (left is null) throw new ArgumentNullException(nameof(left));
+            if (right is null) throw new ArgumentNullException(nameof(right));
+            if (left.Equals(right)) return true;
+
+            var graph = new EGraph();
+            int a, b;
+            try
+            {
+                a = graph.AddEntity(left);
+                b = graph.AddEntity(right);
+            }
+            // A node the graph cannot hold is not a proof of anything, and not an error either.
+            catch (Exception) { return false; }
+            graph.Rebuild();
+
+            var ledger = BudgetLedger.For(nameof(ProvesEqual), budget);
+            Run(graph, rules, ledger, CostModel.Default.Cost);
+            ledger.Report();
+            return graph.Find(a) == graph.Find(b);
+        }
+    }
+}

--- a/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
+++ b/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
@@ -373,6 +373,84 @@ namespace AngouriMath.Core.Transformations
         internal static int EqualitySaturationSafeRuleCount => EqualitySaturationTransformation.SafeRuleCount;
 
         /// <summary>
+        /// Brings an expression to the least of the forms the rules can reach from it, over an
+        /// e-graph — <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a>
+        /// tier 2's "canonicalisation framework built on" the rewrite graph.
+        /// </summary>
+        /// <param name="budget">What bounds the search. See <see cref="EqualitySaturation"/>.</param>
+        /// <param name="widest">
+        /// The widest <see cref="RewriteRuleGrowth"/> admitted, as a ceiling over
+        /// <see cref="RewriteRuleGrowth.Collects"/>, <see cref="RewriteRuleGrowth.Rearranges"/>,
+        /// <see cref="RewriteRuleGrowth.Expands"/>. This is the knob that matters — see the
+        /// measurement below.
+        /// </param>
+        /// <remarks>
+        /// <para>
+        /// <b>How this differs from <see cref="Canonicalization"/>, which is a rule pass.</b> A
+        /// pass rewrites and commits: having applied a rule it is standing on the result, and if
+        /// recognising an equality needed a <i>larger</i> intermediate form, the pass cannot get
+        /// there and back. A graph does not commit — it holds every form at once and chooses at
+        /// the end — so it can pass through a bigger writing to reach a smaller one.
+        /// </para>
+        /// <para>
+        /// <b>That difference is measured, and the measurement says the ceiling matters less than
+        /// it looks.</b> Two rewrite chains run from each of 1458 generated expressions produced
+        /// <b>no divergent pair at all</b> under <see cref="RewriteRuleGrowth.Collects"/> ∪
+        /// <see cref="RewriteRuleGrowth.Rearranges"/>: those rules are confluent on that corpus,
+        /// so a pass already reaches the same form a graph would, and over that ceiling this
+        /// earns nothing at all. Widening it barely helps — over six expression pairs equal only
+        /// through a larger intermediate form, <see cref="RewriteRuleGrowth.Rearranges"/> proved
+        /// two and <see cref="RewriteRuleGrowth.Expands"/>, all nine expanding rules added, proved
+        /// <i>the same two</i>. Only <see cref="RewriteRuleGrowth.Unknown"/> — which admits the
+        /// 270 rules whose growth nobody judged, against 52 that were — proved a third.
+        /// </para>
+        /// <para>
+        /// <b>Why the default is nonetheless the narrow ceiling.</b> Because the widest one is
+        /// where the risk is, not merely where the rules are: the <c>work/egraph</c> harness
+        /// measured a 7,147× blow-up over the undirected rule set — a different mechanism (term
+        /// enumeration, no budget, no pre-filter) on the same question. Six pairs completing
+        /// inside their budget is not evidence against that. So each step up is offered and none
+        /// is assumed, and the caller who takes one is the caller who sets the budget.
+        /// </para>
+        /// <para>
+        /// <b>What this is not.</b> Not a canonical form <i>for the language</i> — no such thing
+        /// exists here, since zero-equivalence is undecidable, and
+        /// <c>Docs/Contributing/CanonicalForm.md</c> states that boundary. It is a canonical form
+        /// <i>modulo these rules and this budget</i>: equal trees mean the rules proved the two
+        /// expressions equal, different trees mean they did not, and a budget that ran out is
+        /// reported rather than hidden. Nothing in the library calls this — like
+        /// <see cref="Canonicalization"/> it is offered, not applied.
+        /// </para>
+        /// </remarks>
+        /// <remarks>
+        /// <para>
+        /// <b>Built on <see cref="Canonicalization"/> rather than beside it.</b> The graph does
+        /// not sort a commutative operand pair: the rules that do build their replacement in code,
+        /// so their <see cref="RewriteRuleGrowth"/> is <see cref="RewriteRuleGrowth.Unknown"/> and
+        /// no ceiling admits them — measured, by <c>x + y</c> and <c>y + x</c> canonicalising to
+        /// themselves. Nor does it flatten <c>(x + y) + a</c> against <c>x + (y + a)</c>, which
+        /// are different trees that print alike. The rule pass does both, is already measured
+        /// idempotent and order-independent, and is not improved by being written again — so it
+        /// runs on each side of the graph step: once so that equal inputs enter the graph as one
+        /// tree, and once so that what extraction rebuilt leaves as one.
+        /// </para>
+        /// </remarks>
+        public static Transformation CanonicalizationOverGraph(WorkBudget budget, RewriteRuleGrowth widest)
+            => Canonicalization
+                .Then(new GraphCanonicalizationTransformation(
+                    budget ?? throw new ArgumentNullException(nameof(budget)), widest))
+                .Then(Canonicalization);
+
+        /// <summary>
+        /// <see cref="CanonicalizationOverGraph(WorkBudget, RewriteRuleGrowth)"/> over the rules
+        /// that do not expand, which is the ceiling
+        /// <see cref="EqualitySaturation"/> also draws from.
+        /// </summary>
+        /// <param name="budget">What bounds the search.</param>
+        public static Transformation CanonicalizationOverGraph(WorkBudget budget)
+            => CanonicalizationOverGraph(budget, RewriteRuleGrowth.Rearranges);
+
+        /// <summary>
         /// Replaces every occurrence of <paramref name="what"/> with
         /// <paramref name="with"/>, as <see cref="Entity.Substitute(Entity, Entity)"/> does.
         /// </summary>
@@ -475,11 +553,7 @@ namespace AngouriMath.Core.Transformations
             /// </summary>
             [ConstantField]
             private static readonly IReadOnlyList<Matching.MatchedRule> SafeRules
-                = Matching.MatchedRules.All
-                    .SelectMany(set => set.Rules)
-                    .Where(rule => rule.Growth is RewriteRuleGrowth.Collects or RewriteRuleGrowth.Rearranges)
-                    .Where(rule => rule.Soundness is Soundness.Sound or Soundness.SoundUnderAssumptions)
-                    .ToList();
+                = Saturation.RulesUpTo(RewriteRuleGrowth.Rearranges);
 
             /// <summary>
             /// <see cref="SafeRules"/>.Count, for <see cref="Transformation.EqualitySaturationSafeRuleCount"/>
@@ -545,117 +619,55 @@ namespace AngouriMath.Core.Transformations
                 graph.Rebuild();
 
                 var ledger = BudgetLedger.For(Name, budget);
-                var chargedNodes = graph.NodeCount;
-                bool ChargeGrowthSinceLastCall()
-                {
-                    var delta = graph.NodeCount - chargedNodes;
-                    chargedNodes = graph.NodeCount;
-                    return ledger.Spend(delta);
-                }
-
-                var saturated = false;
-                while (!saturated && !ledger.Exhausted)
-                {
-                    var merged = false;
-                    foreach (var id in graph.Classes.ToList())
-                    {
-                        if (ledger.Exhausted) break;
-
-                        // Which node types this class holds, gathered once for the whole sweep
-                        // rather than once per rule. A pattern that requires a root type cannot
-                        // match a class holding no node of it -- MatchPattern.RequiredRootType is
-                        // a necessary condition, not a sufficient one, which is the direction that
-                        // makes it a filter: it licenses skipping a rule, never firing one. This
-                        // is the dispatch a switch over node types gets from the compiler for
-                        // free, and a list of rules has to be told; without it every rule in
-                        // SafeRules ran a full pattern match against every class of every pass,
-                        // and the large majority of those could not have matched.
-                        //
-                        // A union later in this same sweep can add a node type to the class that
-                        // this set does not have, so a rule can be skipped in a pass where it had
-                        // just become applicable. That costs nothing: a union is exactly what sets
-                        // `merged`, so there is another pass, and the set is gathered again there.
-                        var held = new HashSet<Type>();
-                        foreach (var node in graph.NodesOf(id)) held.Add(EGraph.RuntimeType(node));
-
-                        Entity? term = null;
-                        var extracted = false;
-                        bool TryTerm(out Entity value)
-                        {
-                            if (!extracted)
-                            {
-                                term = graph.Extract(id, costModel.Cost);
-                                extracted = true;
-                            }
-                            value = term!;
-                            return term is not null;
-                        }
-
-                        foreach (var rule in SafeRules)
-                        {
-                            // Before the charge, because a rule this skips was never attempted:
-                            // a step is a match attempt, and a type that cannot match is not one.
-                            // Written as a loop rather than as `held.Any(t => ...)`: the lambda
-                            // would capture `required` and so allocate a closure every time the
-                            // exact-type test missed, which is most rules of most classes -- and
-                            // paying an allocation to avoid a pattern match is not a pre-filter.
-                            if (rule.Left.RequiredRootType is { } required && !held.Contains(required))
-                            {
-                                var reachable = false;
-                                foreach (var type in held)
-                                    if (required.IsAssignableFrom(type))
-                                    {
-                                        reachable = true;
-                                        break;
-                                    }
-                                if (!reachable) continue;
-                            }
-
-                            // One step per match attempt, charged before the attempt -- the unit
-                            // Buchberger, FGLM and MatchPattern all charge, and the work this
-                            // loop actually does. Charging the node-count delta alone (below)
-                            // billed nothing on ordinary input, because SafeRules holds only
-                            // rules that do not expand: a budget of zero steps ran this sweep to
-                            // saturation and then reported that it had completed.
-                            if (!ledger.Spend()) break;
-                            int other;
-                            if (rule.Left.CanEMatch)
-                            {
-                                // Mirrors the fallback branch below: a rule's `when` is arbitrary
-                                // code asked about a witness this extracted rather than one the
-                                // caller wrote, and a predicate that throws on a shape it did not
-                                // expect must decline the candidate, not escape Apply.
-                                bool matched;
-                                try { matched = rule.TryEMatchApply(graph, id, costModel.Cost, out other); }
-                                catch { continue; }
-                                if (!matched) continue;
-                            }
-                            else
-                            {
-                                if (!TryTerm(out var t)) continue;
-                                Entity? rewritten;
-                                try { rewritten = rule.TryApply(t); }
-                                catch { continue; }
-                                if (rewritten is null || rewritten.Equals(t)) continue;
-                                try { other = graph.AddEntity(rewritten); }
-                                catch { continue; }
-                            }
-                            if (graph.Union(id, other)) merged = true;
-                        }
-                        // What the sweep grew, charged after it rather than before the next
-                        // class's, so that the ceiling bounds the growth that has happened.
-                        if (!ChargeGrowthSinceLastCall()) break;
-                    }
-                    // Rebuild rescans every node of every class, repeatedly until nothing more
-                    // becomes congruent -- a round of it is work, and it had no ledger
-                    // interaction anywhere in it.
-                    if (!ledger.Spend()) break;
-                    graph.Rebuild();
-                    if (!merged) saturated = true;
-                }
-
+                Saturation.Run(graph, SafeRules, ledger, costModel.Cost);
                 ledger.Report();
                 return graph.Extract(root, costModel.Cost) ?? input;
+            }
+        }
+
+        /// <summary>
+        /// <see cref="Transformation.CanonicalizationOverGraph(WorkBudget, RewriteRuleGrowth)"/>.
+        /// </summary>
+        private sealed class GraphCanonicalizationTransformation : Transformation
+        {
+            private readonly WorkBudget budget;
+            private readonly RewriteRuleGrowth widest;
+            private readonly IReadOnlyList<Matching.MatchedRule> rules;
+
+            internal GraphCanonicalizationTransformation(WorkBudget budget, RewriteRuleGrowth widest)
+                => (this.budget, this.widest, rules)
+                    = (budget, widest, Saturation.RulesUpTo(widest));
+
+            public override string Name => $"canonical-over-graph[{widest}]";
+
+            public override TransformationRelation Relation => TransformationRelation.Equivalence;
+
+            // The weakest tier represented in what it may use, which is the convention every rule
+            // set in the registry already follows.
+            public override Soundness Soundness => Soundness.SoundUnderAssumptions;
+
+            /// <inheritdoc cref="EqualitySaturationTransformation.ApplyCore"/>
+            protected override Entity? ApplyCore(Entity input)
+            {
+                var recording = RewriteRecording.Current;
+                var mark = recording?.Mark() ?? 0;
+
+                var graph = new EGraph();
+                var root = graph.AddEntity(input);
+                graph.Rebuild();
+
+                var ledger = BudgetLedger.For(Name, budget);
+                Saturation.Run(graph, rules, ledger, CostModel.Default.Cost);
+                ledger.Report();
+
+                // The least member, not the cheapest: a cost model ties, and a tie would make the
+                // answer depend on which member was reached first, which is exactly the thing a
+                // canonical form may not depend on. See EntityOrder.
+                var output = graph.ExtractLeast(root, EntityOrder.Canonical) ?? input;
+
+                if (recording is not null && !output.Equals(input))
+                    recording.Note(input, output, null, Name, mark);
+                return output;
             }
         }
 

--- a/Sources/Tests/UnitTests/Common/PublicApi.txt
+++ b/Sources/Tests/UnitTests/Common/PublicApi.txt
@@ -245,6 +245,8 @@ AngouriMath.Core.Transformations.Transformation.Apply(AngouriMath.Entity) : Ango
 AngouriMath.Core.Transformations.Transformation.ApplyCore(AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Core.Transformations.Transformation.ApplyOrKeep(AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.Core.Transformations.Transformation.Canonicalization { } : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.CanonicalizationOverGraph(AngouriMath.Core.Budgets.WorkBudget) : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.CanonicalizationOverGraph(AngouriMath.Core.Budgets.WorkBudget, AngouriMath.Core.Transformations.RewriteRuleGrowth) : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Differentiation(AngouriMath.Entity+Variable) : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.EqualitySaturation(AngouriMath.Core.Budgets.WorkBudget, AngouriMath.Core.CostModel) : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Expansion { } : AngouriMath.Core.Transformations.Transformation

--- a/Sources/Tests/UnitTests/Core/Transformations/CanonicalExtractionTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/CanonicalExtractionTest.cs
@@ -1,0 +1,437 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Core;
+using AngouriMath.Core.Budgets;
+using AngouriMath.Core.Transformations;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// A canonical form asks a different question from a cost model. A cost model asks which of
+    /// two expressions is <i>nicer</i>, and answers with a number, so two it cannot separate tie —
+    /// and a tie is settled by whoever was reached first, which is not a form anybody chose.
+    /// <see cref="EntityOrder.Canonical"/> asks which one <i>is the representative</i>, and answers
+    /// with an order, so there is exactly one least member and it is the same one every time.
+    /// </summary>
+    [Trait("Area", "Transformations")]
+    public sealed class CanonicalExtractionTest
+    {
+        private static readonly string[] Corpus =
+        {
+            "x", "1", "0", "-1", "1/2", "x + y", "y + x", "x * y", "x - 1", "-1 + x",
+            "sin(x)", "cos(x)", "sin(x) + cos(x)", "(x + 1) ^ 2", "a * b + a * c",
+            "1 / x", "x / y", "x ^ 2", "sqrt(x)", "ln(x)", "x > 0", "a and b",
+        };
+
+        private static IEnumerable<Entity> Parsed => Corpus.Select(source => source.ToEntity());
+
+        #region The order itself
+
+        /// <summary>
+        /// Total up to <see cref="object.Equals(object)"/>: two expressions compare equal exactly
+        /// when they are the same expression. Without that a canonical form is not well defined —
+        /// two distinct members of a class could both be "least".
+        /// </summary>
+        [Fact]
+        public void ComparingEqualIsBeingEqual()
+        {
+            foreach (var left in Parsed)
+                foreach (var right in Parsed)
+                    Assert.Equal(left.Equals(right), EntityOrder.Canonical.Compare(left, right) == 0);
+        }
+
+        [Fact]
+        public void TheOrderIsAntisymmetric()
+        {
+            foreach (var left in Parsed)
+                foreach (var right in Parsed)
+                    Assert.Equal(
+                        Math.Sign(EntityOrder.Canonical.Compare(left, right)),
+                        -Math.Sign(EntityOrder.Canonical.Compare(right, left)));
+        }
+
+        [Fact]
+        public void TheOrderIsTransitive()
+        {
+            var all = Parsed.ToList();
+            foreach (var a in all)
+                foreach (var b in all)
+                    foreach (var c in all)
+                        if (EntityOrder.Canonical.Compare(a, b) < 0 && EntityOrder.Canonical.Compare(b, c) < 0)
+                            Assert.True(EntityOrder.Canonical.Compare(a, c) < 0,
+                                $"{a.Stringize()} < {b.Stringize()} < {c.Stringize()} but not a < c");
+        }
+
+        /// <summary>
+        /// Size first, so the representative of a class is its smallest member rather than
+        /// whichever one happens to sort first. A canonical form that preferred the larger writing
+        /// would be well defined and useless.
+        /// </summary>
+        [Fact]
+        public void SmallerComesFirst()
+        {
+            Assert.True(EntityOrder.Canonical.Compare("x".ToEntity(), "x + y".ToEntity()) < 0);
+            Assert.True(EntityOrder.Canonical.Compare("x + y".ToEntity(), "(x + 1) ^ 2 + y".ToEntity()) < 0);
+        }
+
+        /// <summary>
+        /// It does not depend on the culture, on a hash, or on anything else that changes between
+        /// two runs of the same program — the property <c>ENode</c>'s own order exists for.
+        /// </summary>
+        [Fact]
+        public void TheOrderIsTheSameOnASecondPass()
+        {
+            var once = Parsed.OrderBy(e => e, EntityOrder.Canonical).Select(e => e.Stringize()).ToList();
+            var twice = Parsed.Reverse().OrderBy(e => e, EntityOrder.Canonical).Select(e => e.Stringize()).ToList();
+            Assert.Equal(once, twice);
+        }
+
+        #endregion
+
+        #region Extraction by that order
+
+        [Fact]
+        public void TheLeastMemberOfAClassIsWhatComesBack()
+        {
+            var graph = new EGraph();
+            var big = graph.AddEntity("(x + 1) ^ 2".ToEntity());
+            graph.Union(big, graph.AddEntity("y".ToEntity()));
+
+            Assert.Equal("y".ToEntity(), graph.ExtractLeast(big, EntityOrder.Canonical));
+        }
+
+        /// <summary>
+        /// The whole point: two writings of one thing, put in one class, extract to the same tree.
+        /// Under a cost model they can tie and then the answer is whichever was reached first.
+        /// </summary>
+        [Fact]
+        public void TwoWritingsOfOneClassExtractToOneTree()
+        {
+            var graph = new EGraph();
+            var first = graph.AddEntity("x + y".ToEntity());
+            var second = graph.AddEntity("y + x".ToEntity());
+            graph.Union(first, second);
+            graph.Rebuild();
+
+            Assert.Equal(
+                graph.ExtractLeast(first, EntityOrder.Canonical),
+                graph.ExtractLeast(second, EntityOrder.Canonical));
+        }
+
+        /// <summary>
+        /// And it does not depend on which one was inserted first, which a set-order-dependent
+        /// extraction would.
+        /// </summary>
+        [Fact]
+        public void ExtractionDoesNotDependOnInsertionOrder()
+        {
+            static Entity? Extract(string a, string b)
+            {
+                var graph = new EGraph();
+                var first = graph.AddEntity(a.ToEntity());
+                graph.Union(first, graph.AddEntity(b.ToEntity()));
+                graph.Rebuild();
+                return graph.ExtractLeast(first, EntityOrder.Canonical);
+            }
+
+            Assert.Equal(Extract("x + y", "y + x"), Extract("y + x", "x + y"));
+            Assert.Equal(Extract("sin(x)", "cos(x)"), Extract("cos(x)", "sin(x)"));
+        }
+
+        [Fact]
+        public void ExtractLeastDeclinesAClassItCannotBuild()
+        {
+            var graph = new EGraph();
+            var root = graph.AddEntity("{ 1, 2 }".ToEntity());
+
+            Assert.Null(graph.ExtractLeast(root, EntityOrder.Canonical));
+        }
+
+        /// <summary>
+        /// A narrowed codomain survives extraction here for the same reason it does under a cost
+        /// model — it is per-node data the rebuild has to put back.
+        /// </summary>
+        [Fact]
+        public void ExtractLeastPreservesANarrowedCodomain()
+        {
+            Entity narrowed = MathS.Sqrt(-1).WithCodomain(Domain.Real);
+            var graph = new EGraph();
+            var root = graph.AddEntity(narrowed);
+
+            var extracted = graph.ExtractLeast(root, EntityOrder.Canonical);
+
+            Assert.NotNull(extracted);
+            Assert.Equal(Domain.Real, extracted!.Codomain);
+        }
+
+        #endregion
+
+        #region The transformation
+
+        private static WorkBudget Budget { get; }
+            = new() { Steps = 300_000, Time = TimeSpan.FromSeconds(20) };
+
+        private static Transformation Narrow => Transformation.CanonicalizationOverGraph(Budget);
+
+        private static Transformation Wide
+            => Transformation.CanonicalizationOverGraph(Budget, RewriteRuleGrowth.Unknown);
+
+        /// <summary>
+        /// The property that makes it a canonical form at all: running it twice says nothing more
+        /// than running it once. Without this the answer is a step in a process rather than a form.
+        /// </summary>
+        [Theory]
+        [InlineData("x + y")]
+        [InlineData("y + x")]
+        [InlineData("x - 1")]
+        [InlineData("a * b + a * c")]
+        [InlineData("1 / x + 1 / y")]
+        [InlineData("sin(x) ^ 2 + cos(x) ^ 2")]
+        [InlineData("(x + 1) ^ 2")]
+        [InlineData("x > 0")]
+        public void CanonicalisingTwiceIsCanonicalisingOnce(string source)
+        {
+            var once = Narrow.ApplyOrKeep(source.ToEntity());
+            Assert.Equal(once, Narrow.ApplyOrKeep(once));
+        }
+
+        /// <summary>
+        /// And the property that makes it worth having: two writings of one expression reach the
+        /// same tree, not merely trees that print alike.
+        /// </summary>
+        [Theory]
+        [InlineData("x + y", "y + x")]
+        [InlineData("x - 1", "-1 + x")]
+        [InlineData("x * y", "y * x")]
+        [InlineData("(x + y) + a", "x + (y + a)")]
+        public void TwoWritingsReachOneTree(string left, string right)
+            => Assert.Equal(Narrow.ApplyOrKeep(left.ToEntity()), Narrow.ApplyOrKeep(right.ToEntity()));
+
+        /// <summary>
+        /// The extraction never picks a member larger than one it could have picked — the half of
+        /// the order that makes it useful rather than merely well defined. Asserted of the graph
+        /// step itself: the composed transformation runs a rule pass on each side of it, and
+        /// <c>InnerSimplified</c> is free to enlarge on its way to a tidier form.
+        /// </summary>
+        [Theory]
+        [InlineData("x + y", "(x + 1) ^ 2")]
+        [InlineData("a", "a * b + a * c")]
+        [InlineData("1 / x", "sqrt(2) / (sqrt(3) + sqrt(5))")]
+        public void TheLeastMemberIsNeverTheLargerOne(string small, string large)
+        {
+            var graph = new EGraph();
+            var id = graph.AddEntity(small.ToEntity());
+            graph.Union(id, graph.AddEntity(large.ToEntity()));
+            graph.Rebuild();
+
+            var extracted = graph.ExtractLeast(id, EntityOrder.Canonical);
+
+            Assert.NotNull(extracted);
+            Assert.True(extracted!.Complexity <= large.ToEntity().Complexity);
+        }
+
+        /// <summary>
+        /// What the wide ceiling buys: an equality that only shows through a <i>larger</i>
+        /// intermediate form, which a rule pass cannot reach because having expanded it is
+        /// standing on the expansion.
+        /// </summary>
+        [Fact]
+        public void TheWideCeilingReachesWhatARulePassCannot()
+        {
+            var l = "sin(x) ^ 2 + cos(x) ^ 2".ToEntity();
+            var r = "1".ToEntity();
+
+            // The claim is about the ceiling, so it is only worth making where the pass fails.
+            Assert.NotEqual(
+                Transformation.Canonicalization.ApplyOrKeep(l),
+                Transformation.Canonicalization.ApplyOrKeep(r));
+
+            Assert.Equal(Wide.ApplyOrKeep(l), Wide.ApplyOrKeep(r));
+        }
+
+        /// <summary>
+        /// Widening the ceiling brings the difference of squares together — the narrow ceiling
+        /// leaves the product and the expansion as two forms, and the widest one canonicalises
+        /// both to the same tree.
+        /// </summary>
+        [Fact]
+        public void TheWidestCeilingBringsTheDifferenceOfSquaresTogether()
+        {
+            var product = "(x + y) * (x - y)".ToEntity();
+            var squares = "x ^ 2 - y ^ 2".ToEntity();
+
+            Assert.NotEqual(Narrow.ApplyOrKeep(product), Narrow.ApplyOrKeep(squares));
+            Assert.Equal(Wide.ApplyOrKeep(product), Wide.ApplyOrKeep(squares));
+        }
+
+        /// <summary>
+        /// The relationship that holds whether or not the rules are confluent, and the reason
+        /// <see cref="Saturation.ProvesEqual"/> is the half to rely on: asking in one graph is
+        /// never weaker than canonicalising separately and comparing. Two separate graphs each
+        /// reach only what their own side reaches, so where the rules are not confluent one side
+        /// can arrive somewhere the other cannot, and both are canonicalised correctly to
+        /// different forms. One graph merges everything reachable from either.
+        /// </summary>
+        [Theory]
+        [InlineData("x + y", "y + x")]
+        [InlineData("x - 1", "-1 + x")]
+        [InlineData("(x + y) * (x - y)", "x ^ 2 - y ^ 2")]
+        [InlineData("sin(x) ^ 2 + cos(x) ^ 2", "1")]
+        [InlineData("a * b + a * c", "a * (b + c)")]
+        [InlineData("(x + 1) ^ 2", "x ^ 2 + 2 * x + 1")]
+        [InlineData("1 / x + 1 / y", "(x + y) / (x * y)")]
+        [InlineData("x", "y")]
+        public void ProvingInOneGraphIsNeverWeakerThanComparingTwoCanonicalForms(string left, string right)
+        {
+            var l = left.ToEntity();
+            var r = right.ToEntity();
+            var rules = Saturation.RulesUpTo(RewriteRuleGrowth.Unknown);
+
+            if (Wide.ApplyOrKeep(l).Equals(Wide.ApplyOrKeep(r)))
+                Assert.True(Saturation.ProvesEqual(l, r, rules, Budget),
+                    $"{left} and {right} canonicalise alike but one graph did not prove them equal");
+        }
+
+        /// <summary>
+        /// A false is "not proved", never "unequal" — the distinction the library's own
+        /// unevaluated-versus-NaN convention rests on.
+        /// </summary>
+        [Fact]
+        public void NotProvedIsNotTheSameAsUnequal()
+        {
+            var rules = Saturation.RulesUpTo(RewriteRuleGrowth.Unknown);
+
+            Assert.True(Saturation.ProvesEqual("x + 0".ToEntity(), "x".ToEntity(), rules, Budget));
+            Assert.True(Saturation.ProvesEqual("x".ToEntity(), "x".ToEntity(), rules, Budget));
+
+            // Genuinely unequal, and also not proved -- the two answers are the same word.
+            Assert.False(Saturation.ProvesEqual("x".ToEntity(), "y".ToEntity(), rules, Budget));
+            // Equal, and beyond what these rules reach: still not proved.
+            Assert.False(Saturation.ProvesEqual(
+                "1 / x + 1 / y".ToEntity(), "(x + y) / (x * y)".ToEntity(), rules, Budget));
+        }
+
+        /// <summary>
+        /// Under no budget it proves only what insertion alone already showed. That is more than
+        /// nothing — the graph folds a neutral element as it inserts, so <c>x + 0</c> and
+        /// <c>x + 0 + 0</c> are one class before a rule has fired — and it is much less than what
+        /// a rule would find.
+        /// </summary>
+        [Fact]
+        public void UnderNoBudgetItProvesOnlyWhatInsertionAlreadyShowed()
+        {
+            var starved = new WorkBudget { Steps = 0, Time = TimeSpan.Zero };
+            var rules = Saturation.RulesUpTo(RewriteRuleGrowth.Unknown);
+
+            Assert.True(Saturation.ProvesEqual("x".ToEntity(), "x".ToEntity(), rules, starved));
+            Assert.True(Saturation.ProvesEqual("x + 0".ToEntity(), "x + 0 + 0".ToEntity(), rules, starved));
+
+            // Needs a rule to fire, so no budget means not proved.
+            Assert.False(Saturation.ProvesEqual(
+                "sin(x) ^ 2 + cos(x) ^ 2".ToEntity(), "1".ToEntity(), rules, starved));
+        }
+
+        /// <summary>
+        /// A budget of nothing still answers, with the input — the convention every bounded
+        /// computation here follows, and the reason a caller can hand this a small budget without
+        /// having to catch anything.
+        /// </summary>
+        [Fact]
+        public void AStarvedBudgetAnswersWithTheInput()
+        {
+            var starved = Transformation.CanonicalizationOverGraph(
+                new WorkBudget { Steps = 0, Time = TimeSpan.Zero });
+            var result = starved.Apply("x + y".ToEntity());
+
+            Assert.True(result.Succeeded);
+            Assert.Equal("x + y".ToEntity(), result.OutputOrInput);
+        }
+
+        /// <summary>
+        /// The name says the ceiling, because that is the parameter that changes what it can do,
+        /// and it says the rule pass on either side, because a reader of a derivation needs to see
+        /// that those ran too.
+        /// </summary>
+        [Fact]
+        public void ItSaysWhatItIsAndWhatItClaims()
+        {
+            Assert.Contains("canonical-over-graph[Rearranges]", Narrow.Name);
+            Assert.Contains("canonical-over-graph[Unknown]", Wide.Name);
+            Assert.Contains("rewrite[CanonicalOrderExact]", Narrow.Name);
+            Assert.Equal(TransformationRelation.Equivalence, Narrow.Relation);
+            Assert.Equal(Soundness.SoundUnderAssumptions, Narrow.Soundness);
+        }
+
+        [Fact]
+        public void ItRefusesANullBudget()
+            => Assert.Throws<ArgumentNullException>(
+                () => Transformation.CanonicalizationOverGraph(null!));
+
+        /// <summary>
+        /// Only the widest ceiling admits a rule whose growth nobody judged, so firing one is a
+        /// request a caller has to make on purpose rather than something a ceiling does quietly.
+        /// </summary>
+        [Fact]
+        public void OnlyTheWidestCeilingAdmitsAnUnjudgedRule()
+        {
+            foreach (var widest in new[]
+                     {
+                         RewriteRuleGrowth.Collects, RewriteRuleGrowth.Rearranges,
+                         RewriteRuleGrowth.Expands,
+                     })
+                Assert.DoesNotContain(Saturation.RulesUpTo(widest),
+                    rule => rule.Growth is RewriteRuleGrowth.Unknown);
+
+            Assert.Contains(Saturation.RulesUpTo(RewriteRuleGrowth.Unknown),
+                rule => rule.Growth is RewriteRuleGrowth.Unknown);
+        }
+
+        /// <summary>Each ceiling admits everything the one below it does.</summary>
+        [Fact]
+        public void AWiderCeilingIsASuperset()
+        {
+            var ceilings = new[]
+            {
+                RewriteRuleGrowth.Collects, RewriteRuleGrowth.Rearranges,
+                RewriteRuleGrowth.Expands, RewriteRuleGrowth.Unknown,
+            }.Select(Saturation.RulesUpTo).ToList();
+
+            for (var i = 1; i < ceilings.Count; i++)
+            {
+                Assert.All(ceilings[i - 1], rule => Assert.Contains(rule, ceilings[i]));
+                Assert.True(ceilings[i].Count > ceilings[i - 1].Count,
+                    $"ceiling {i} admitted nothing over ceiling {i - 1}, so it is not a knob");
+            }
+        }
+
+        /// <summary>
+        /// Where the rules actually are, asserted rather than described — the fact that decides
+        /// what the growth ceiling is worth. The great majority are unjudged, because their
+        /// replacement is code rather than a written pattern, so a ceiling below the widest
+        /// leaves most of the library out.
+        /// </summary>
+        [Fact]
+        public void MostSoundRulesHaveNoJudgedGrowth()
+        {
+            var judged = Saturation.RulesUpTo(RewriteRuleGrowth.Expands).Count;
+            var all = Saturation.RulesUpTo(RewriteRuleGrowth.Unknown).Count;
+
+            Assert.True(all > 4 * judged,
+                $"{judged} of {all} sound rules have a judged growth, which is a larger share "
+                + "than when this was measured -- the ceiling may now be worth more than it was");
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
#746 tier 2 asks for **"a canonicalisation framework built on"** the rewrite graph. This is that:
`Transformation.CanonicalizationOverGraph(budget, widest)` saturates under a rule set, then extracts
the *least* member of the root class under a total order.

Offered, not applied. `CanonicalForm.md` §8 says wiring a canonical form into `Simplify` is a release
decision of its own, and this does not take it.

## The order is the piece that had to be new

A cost model answers "which is nicer" with a `double`, so two forms it cannot separate **tie** — and a
tie is settled by whichever was reached first, an accident of traversal. A canonical form cannot be
built on that. No double carries a total order on trees, so `EntityOrder.Canonical` is a comparison:

- **size first**, so the representative is the smallest member and canonicalising never enlarges;
- **then structural**, so it is total up to `Equals`.

Deliberately *not* the printed form — `(x + y) + a` and `x + (y + a)` print alike and are different
trees. Deliberately *not* `Entity.SortHash`, which orders operands **within** a commutative chain: a
different question, and the two do not compete.

`EGraph.ExtractLeast` is the same walk as `Extract` choosing by an order instead of a number. They
share one recursion rather than two copies of a subtle one, over a struct selector under a generic
constraint — compiled in rather than dispatched, and no selection allocated per class.

The saturation loop moves to `Saturation.Run`, shared with `EqualitySaturation`. Two transformations
wanting it is the reason: they differ only in what they extract, not in what is charged, which rules
can be skipped unattempted, or which matching path a rule takes.

## Three things measured, two of which corrected what I had assumed

**The safe rules are already confluent, so over that ceiling a graph earns nothing.** Two rewrite
chains run from each of 1458 generated expressions produced **no divergent pair at all** under
`Collects` and `Rearranges`. A rule pass already reaches the form a graph would.

**The growth ceiling is a much smaller knob than it looks.** Of the sound rules in `MatchedRules`:

| growth | rules |
|---|---|
| `Collects` | 26 |
| `Rearranges` | 17 |
| `Expands` | 9 |
| `Unknown` | **270** |

Those 270 are unjudged because their replacement is code rather than a written pattern, so nothing
counted it. Over six expression pairs equal only through a larger intermediate form:

| ceiling | proves |
|---|---|
| `Rearranges` | 2 / 6 |
| `Expands` — all nine expanding rules added | **2 / 6**, the same two |
| `Unknown` | 3 / 6 |

So the dial that matters is not how far a rule may enlarge; it is whether rules nobody classified may
fire at all. `Unknown` is therefore the widest *stop* rather than an excluded value — refusing it
refuses 84% of the library — and naming it as the widest setting makes it a request a caller has to
make on purpose. The default stays narrow, because the widest setting is where the harness's 7,147×
blow-up lives.

**And the graph does not sort commutative operands.** The rules that do are among the 270, so no
ceiling below the widest admits them, and `x + y` and `y + x` canonicalised to themselves.
`Transformation.Canonicalization` already sorts and flattens and is already measured idempotent, so it
runs on each side of the graph step rather than being written again.

## `ProvesEqual` is the half to rely on, and it is not a transformation

Bringing two expressions separately to a canonical form and comparing decides equality **only where
the rules are confluent**. Otherwise one side reaches a form the other cannot, and two equal
expressions end in different forms having each been canonicalised correctly. Measured, on
`(x + y) * (x - y)` against `x ^ 2 - y ^ 2`: the product's graph reaches the difference of squares,
the difference of squares' graph does not reach the product, and the two forms are the same size — so
each canonicalises to itself.

Asking in **one** graph has no such gap: both are inserted, every equality the rules reach from either
is merged, and the question is whether they ended in one class. That does not depend on confluence,
only on reaching far enough within the budget.

`Saturation.ProvesEqual` is internal here. It wants a public home and a name chosen by someone who
owns the surface.

## Tests

43 new, in `CanonicalExtractionTest`: the order's totality and antisymmetry, that extraction never
enlarges, idempotence of the composed transformation, the budget being respected and reported, and the
confluence gap above as an explicit expectation rather than a surprise.

Full suite on this branch, rebased onto master after #1104: **8962 passed, 14 skipped, 0 failed.**

Part of #746 tier 2.
