### PR TITLE
Rule priorities, computed from the patterns rather than typed

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchPattern.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchPattern.cs
@@ -314,6 +314,63 @@ namespace AngouriMath.Core.Transformations.Matching
         internal abstract int NodeCount { get; }
 
         /// <summary>
+        /// Whether every expression <paramref name="other"/> matches, this one matches too — so
+        /// that <i>this pattern is the more general of the two</i>, and a rule written on it
+        /// would swallow a rule written on <paramref name="other"/> if it were tried first.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>The fact behind an ordering that is currently a comment.</b>
+        /// <c>MatchedRules.CollapseMultipleFractions</c> says of itself that it "is
+        /// order-dependent, since <c>Mulf(Divf, Divf)</c> has to be tried before
+        /// <c>Mulf(a, Divf)</c> or the more general rule would swallow the special one". That is
+        /// this relation, observed by hand and then maintained by hand. Computed instead, the
+        /// order it implies is derived from the patterns rather than from where somebody typed
+        /// them.
+        /// </para>
+        /// <para>
+        /// <b>Sound in one direction only.</b> <see langword="true"/> is a claim — every
+        /// expression the other matches, this matches — and every clause below is structural, so
+        /// the claim holds for all expressions rather than for the ones a test happened to
+        /// generate. <see langword="false"/> means <i>not proved</i> and never <i>disproved</i>:
+        /// a hole carrying a predicate is arbitrary code, an <c>Exact</c> literal can be equal to
+        /// a value of another runtime type (a rational that reduced to an integer), and an n-ary
+        /// <c>Gathered</c> pattern matches a family this does not attempt to reason about. Each of
+        /// those answers <see langword="false"/> and leaves the pair ordered by where it was
+        /// written, which is what the code did before.
+        /// </para>
+        /// <para>
+        /// <b>It is a matching problem, not a size comparison.</b> A hole repeated across a
+        /// pattern is an equality constraint — <c>Mulf(a, a)</c> matches strictly less than
+        /// <c>Mulf(a, b)</c> while having the same node count — so this matches this pattern
+        /// <i>against</i> the other as a term, carrying an assignment from this pattern's holes to
+        /// the other's subpatterns and requiring a repeated hole to be assigned consistently.
+        /// Comparing <see cref="NodeCount"/> would call those two equally general and get the
+        /// ordering wrong in the one case the ordering exists for.
+        /// </para>
+        /// </remarks>
+        internal bool Subsumes(MatchPattern other)
+            => other is not null
+               && SubsumesCore(other, new Dictionary<string, MatchPattern>(StringComparer.Ordinal));
+
+        /// <summary>
+        /// <see cref="Subsumes"/>, carrying the assignment from this pattern's holes to the
+        /// subpatterns of the one being subsumed. Refusing is always sound, so the base answers
+        /// <see langword="false"/> and a pattern kind that can reason about itself says so.
+        /// </summary>
+        private protected virtual bool SubsumesCore(
+            MatchPattern other, Dictionary<string, MatchPattern> assigned) => false;
+
+        /// <summary>
+        /// Whether two patterns are written the same way, used to check that a repeated hole was
+        /// assigned consistently. Structural, and stricter than semantic equality: two patterns
+        /// that mean the same thing while being written differently answer <see langword="false"/>
+        /// here, which loses a subsumption rather than inventing one.
+        /// </summary>
+        private protected virtual bool SameShapeAs(MatchPattern other)
+            => ReferenceEquals(this, other);
+
+        /// <summary>
         /// The expression this pattern stands for under <paramref name="bindings"/>, or
         /// <see langword="false"/> where those bindings do not satisfy it.
         /// </summary>
@@ -649,6 +706,50 @@ namespace AngouriMath.Core.Transformations.Matching
 
             internal override int NodeCount => 1;
 
+            /// <summary>
+            /// A hole is the most general thing a pattern can be, and it subsumes whatever it is
+            /// allowed to stand for — subject to the two constraints it may carry.
+            /// </summary>
+            /// <remarks>
+            /// <para>
+            /// A <c>where</c> predicate is arbitrary code over an expression, so what it admits
+            /// cannot be read off the pattern and this refuses rather than guesses.
+            /// </para>
+            /// <para>
+            /// A required type is checked against what the other pattern <i>guarantees</i> at its
+            /// root, which is <see cref="RequiredRootType"/> — a necessary condition, and here the
+            /// direction that makes it usable: a pattern whose root is always a <c>Divf</c> is
+            /// certainly matched by a hole asking for an <c>Entity</c>. A pattern that guarantees
+            /// nothing, an <c>Exact</c> literal among them, is refused: two entities can be equal
+            /// without being the same runtime type, so a literal's own type is not what it
+            /// guarantees.
+            /// </para>
+            /// <para>
+            /// Then the assignment. A hole seen for the second time must stand for the same thing
+            /// it stood for the first time, which is what makes <c>Mulf(a, a)</c> strictly less
+            /// general than <c>Mulf(a, b)</c> rather than equally general.
+            /// </para>
+            /// </remarks>
+            private protected override bool SubsumesCore(
+                MatchPattern other, Dictionary<string, MatchPattern> assigned)
+            {
+                if (where is not null) return false;
+                if (required is not null
+                    && (other.RequiredRootType is not { } guaranteed
+                        || !required.IsAssignableFrom(guaranteed)))
+                    return false;
+                if (assigned.TryGetValue(name, out var already))
+                    return already.SameShapeAs(other);
+                assigned[name] = other;
+                return true;
+            }
+
+            private protected override bool SameShapeAs(MatchPattern other)
+                => other is AnyPattern that
+                   && string.Equals(name, that.name, StringComparison.Ordinal)
+                   && required == that.required
+                   && where == that.where;
+
             internal override bool TryBuild(Bindings bindings, out Entity built)
             {
                 built = null!;
@@ -745,6 +846,17 @@ namespace AngouriMath.Core.Transformations.Matching
 
             internal override int NodeCount => 1;
 
+            /// <summary>
+            /// A literal admits exactly one value, so it subsumes only a pattern admitting no
+            /// more than that — which among the kinds here is the same literal.
+            /// </summary>
+            private protected override bool SubsumesCore(
+                MatchPattern other, Dictionary<string, MatchPattern> assigned)
+                => other is ExactPattern that && value.Equals(that.value);
+
+            private protected override bool SameShapeAs(MatchPattern other)
+                => other is ExactPattern that && value.Equals(that.value);
+
             internal override bool TryBuild(Bindings bindings, out Entity built)
             {
                 built = value;
@@ -808,6 +920,88 @@ namespace AngouriMath.Core.Transformations.Matching
             private readonly int nodeCount;
 
             internal override int NodeCount => nodeCount;
+
+            /// <summary>
+            /// A node pattern pins the node type and the arity, so it subsumes only another node
+            /// pattern of that type and arity whose children it subsumes in turn — under one
+            /// assignment, so that a hole repeated across children has to be assigned the same
+            /// subpattern in each.
+            /// </summary>
+            /// <remarks>
+            /// <b>Commutativity is a claim about this side.</b> A commutative pattern matches a
+            /// node in either order, so subsuming needs only <i>one</i> of the two pairings to
+            /// work; a non-commutative one gets the written pairing and nothing else. When the
+            /// pattern being subsumed is the commutative one, it matches both orders, so this must
+            /// cover both — and a non-commutative pattern covers both only when its two children
+            /// are interchangeable, which the written pairing already decides. The assignment is
+            /// copied before each attempt, because a pairing that fails half way must not leave
+            /// its bindings behind for the other one.
+            /// </remarks>
+            private protected override bool SubsumesCore(
+                MatchPattern other, Dictionary<string, MatchPattern> assigned)
+            {
+                if (other is not NodePattern that
+                    || nodeType != that.nodeType
+                    || children.Length != that.children.Length)
+                    return false;
+
+                if (that.commutative && !commutative)
+                {
+                    var both = new Dictionary<string, MatchPattern>(assigned, StringComparer.Ordinal);
+                    if (!InOrder(that.children, both, swapped: false)) return false;
+                    if (!InOrder(that.children, both, swapped: true)) return false;
+                    Adopt(assigned, both);
+                    return true;
+                }
+
+                if (commutative)
+                {
+                    var straight = new Dictionary<string, MatchPattern>(assigned, StringComparer.Ordinal);
+                    if (InOrder(that.children, straight, swapped: false))
+                    {
+                        Adopt(assigned, straight);
+                        return true;
+                    }
+                    var crossed = new Dictionary<string, MatchPattern>(assigned, StringComparer.Ordinal);
+                    if (InOrder(that.children, crossed, swapped: true))
+                    {
+                        Adopt(assigned, crossed);
+                        return true;
+                    }
+                    return false;
+                }
+
+                return InOrder(that.children, assigned, swapped: false);
+            }
+
+            private bool InOrder(
+                MatchPattern[] theirs, Dictionary<string, MatchPattern> assigned, bool swapped)
+            {
+                for (var i = 0; i < children.Length; i++)
+                {
+                    var theirIndex = swapped ? children.Length - 1 - i : i;
+                    if (!children[i].SubsumesCore(theirs[theirIndex], assigned)) return false;
+                }
+                return true;
+            }
+
+            private static void Adopt(
+                Dictionary<string, MatchPattern> into, Dictionary<string, MatchPattern> from)
+            {
+                foreach (var pair in from) into[pair.Key] = pair.Value;
+            }
+
+            private protected override bool SameShapeAs(MatchPattern other)
+            {
+                if (other is not NodePattern that
+                    || nodeType != that.nodeType
+                    || commutative != that.commutative
+                    || children.Length != that.children.Length)
+                    return false;
+                for (var i = 0; i < children.Length; i++)
+                    if (!children[i].SameShapeAs(that.children[i])) return false;
+                return true;
+            }
 
             internal override IEnumerable<string> BoundNames => children.SelectMany(c => c.BoundNames);
 

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
@@ -416,6 +416,7 @@ namespace AngouriMath.Core.Transformations.Matching
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
             this.rules = rules ?? throw new ArgumentNullException(nameof(rules));
+            byPriority = ByPriority(this.rules);
         }
 
         /// <summary>
@@ -426,6 +427,85 @@ namespace AngouriMath.Core.Transformations.Matching
         /// tree, and it was the whole of what remained after the match itself stopped allocating.
         /// </summary>
         private readonly MatchedRule[] rules;
+
+        /// <summary>
+        /// The same rules in the order they are actually tried: <b>the more specific rule
+        /// first</b>, and declaration order wherever specificity has no opinion. See
+        /// <see cref="ByPriority"/>.
+        /// </summary>
+        private readonly MatchedRule[] byPriority;
+
+        /// <summary>
+        /// <paramref name="declared"/> ordered so that no rule is tried before a rule its pattern
+        /// subsumes — the more specific one first — keeping declaration order everywhere else.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>What this replaces is the position somebody typed a rule at.</b> A set is
+        /// first-match-wins, so where two rules both fire at a node and disagree, whichever comes
+        /// first decides the answer. Where one pattern subsumes the other that decision is not a
+        /// preference: the general rule would swallow the special one and the special one would
+        /// never fire at all, so the specific rule has to be tried first. That was maintained by
+        /// hand and written in a comment on one set;
+        /// <see cref="MatchPattern.Subsumes"/> computes it, and this applies it.
+        /// </para>
+        /// <para>
+        /// <b>It changes no answer today, and that is a measurement rather than an intention.</b>
+        /// Over the 5,480 within-set rule pairs in <see cref="MatchedRules"/>, subsumption has an
+        /// opinion about <b>28</b> of them — spread across eight sets, <c>Boolean</c> and
+        /// <c>InequalityEquality</c> carrying half — and in <b>every one</b> the specific rule is
+        /// already declared first. None is mutual. So this orders what was already ordered; what
+        /// it adds is that inserting a general rule above a specific one no longer silently
+        /// reverses an answer. <c>RulePriorityTest</c> holds the two orders equal, so the file
+        /// stays readable as well as correct.
+        /// </para>
+        /// <para>
+        /// A stable topological sort, taking the earliest-declared rule that has nothing left
+        /// which must precede it. Subsumption is conservative, so most pairs constrain nothing and
+        /// fall through to declaration order. It cannot cycle — a cycle would need each of two
+        /// rules to be strictly more general than the other — but a cycle is emitted in
+        /// declaration order rather than trusted not to happen, because a sort that silently drops
+        /// a rule would be a set quietly missing a rewrite.
+        /// </para>
+        /// </remarks>
+        private static MatchedRule[] ByPriority(MatchedRule[] declared)
+        {
+            var count = declared.Length;
+            if (count < 2) return declared;
+
+            // mustPrecede[g] is the set of rules that have to be tried before rule g, which is
+            // every rule g's pattern strictly subsumes.
+            var waitingOn = new int[count];
+            var blocks = new List<int>[count];
+            for (var g = 0; g < count; g++)
+                for (var sp = 0; sp < count; sp++)
+                {
+                    if (g == sp) continue;
+                    if (!declared[g].Left.Subsumes(declared[sp].Left)) continue;
+                    if (declared[sp].Left.Subsumes(declared[g].Left)) continue;
+                    (blocks[sp] ??= new List<int>()).Add(g);
+                    waitingOn[g]++;
+                }
+
+            var ordered = new MatchedRule[count];
+            var taken = new bool[count];
+            for (var slot = 0; slot < count; slot++)
+            {
+                var next = -1;
+                for (var i = 0; i < count; i++)
+                    if (!taken[i] && waitingOn[i] == 0) { next = i; break; }
+                // Only reachable if subsumption were not antisymmetric. Falling back to
+                // declaration order keeps every rule in the set.
+                if (next < 0)
+                    for (var i = 0; i < count; i++)
+                        if (!taken[i]) { next = i; break; }
+                taken[next] = true;
+                ordered[slot] = declared[next];
+                if (blocks[next] is { } blocked)
+                    foreach (var g in blocked) waitingOn[g]--;
+            }
+            return ordered;
+        }
 
         // Indexing the rules by the node type each one requires -- the thing a `switch` cannot
         // do and a set of values can -- was tried here and is deliberately absent. Measured, a
@@ -438,7 +518,17 @@ namespace AngouriMath.Core.Transformations.Matching
 
         internal string Name { get; }
 
-        /// <summary>The rules, in the order they are tried. <b>Enumerable</b>, which is the whole point.</summary>
+        /// <summary>
+        /// The rules, <b>in the order they are written</b>. <b>Enumerable</b>, which is the whole
+        /// point.
+        /// </summary>
+        /// <remarks>
+        /// Not necessarily the order they are tried in — see <see cref="RulesByPriority"/>, which
+        /// puts a rule ahead of any rule whose pattern subsumes it. The two are equal today and
+        /// <c>RulePriorityTest</c> holds them equal, so this is the order to read the set in and to
+        /// index it by; <see cref="AsAddressable"/> and <see cref="Reversed"/> use it for that
+        /// reason.
+        /// </remarks>
         internal IReadOnlyList<MatchedRule> Rules => rules;
 
         /// <summary>
@@ -473,14 +563,24 @@ namespace AngouriMath.Core.Transformations.Matching
         internal Soundness Soundness
             => rules.Length == 0 ? Soundness.Sound : rules.Max(rule => rule.Soundness);
 
-        /// <summary>The first rule that applies at this node, or null.</summary>
+        /// <summary>
+        /// The first rule that applies at this node, or null — first in
+        /// <see cref="ByPriority"/>'s order, which is the order it would be tried in.
+        /// </summary>
         internal MatchedRule? FirstMatching(Entity expr)
         {
-            foreach (var rule in rules)
+            foreach (var rule in byPriority)
                 if (rule.TryApply(expr) is not null)
                     return rule;
             return null;
         }
+
+        /// <summary>
+        /// The rules in the order they are tried, which is <see cref="ByPriority"/>'s and not
+        /// necessarily <see cref="Rules"/>'s. Exposed so that the two can be compared rather than
+        /// assumed equal.
+        /// </summary>
+        internal IReadOnlyList<MatchedRule> RulesByPriority => byPriority;
 
         /// <summary>One rewrite at this node only, leaving children alone.</summary>
         /// <summary>
@@ -575,11 +675,11 @@ namespace AngouriMath.Core.Transformations.Matching
             if (known.TryGetValue(type, out var found))
                 return found;
 
-            var matching = new List<MatchedRule>(rules.Length);
-            foreach (var rule in rules)
+            var matching = new List<MatchedRule>(byPriority.Length);
+            foreach (var rule in byPriority)
                 if (rule.Left.RequiredRootType is not { } required || required.IsAssignableFrom(type))
                     matching.Add(rule);
-            found = matching.Count == rules.Length ? rules : matching.ToArray();
+            found = matching.Count == byPriority.Length ? byPriority : matching.ToArray();
 
             applicable = new Dictionary<Type, MatchedRule[]>(known) { [type] = found };
             return found;

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -117,6 +117,15 @@ namespace AngouriMath.Core.Transformations.Matching
         /// One feature was added for it and nothing else changed, which is the answer to the
         /// question this set was picked to ask.
         /// </para>
+        /// <para>
+        /// <b>The order-dependence above is no longer maintained by hand.</b>
+        /// <see cref="MatchPattern.Subsumes"/> computes it — <c>Mulf(a, Divf(b, c))</c> matches
+        /// everything <c>Mulf(Divf(a, b), Divf(c, d))</c> matches and more — and
+        /// <c>MatchedRuleSet.RulesByPriority</c> puts the specific rule first because of that
+        /// rather than because of where it sits in this file. Four of this set's rule pairs are
+        /// ordered that way, and they are four of only six such conflicts in the whole registry;
+        /// <c>RulePriorityTest</c> lists them.
+        /// </para>
         /// </remarks>
         internal static MatchedRuleSet CollapseMultipleFractions { get; } = new(
             nameof(CollapseMultipleFractions),

--- a/Sources/Tests/UnitTests/Core/Transformations/MatchedRulesAgreeWithTheSwitchTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/MatchedRulesAgreeWithTheSwitchTest.cs
@@ -596,12 +596,20 @@ namespace AngouriMath.Tests.Core.Transformations
         }
 
         /// <summary>
-        /// Order is part of the data. Reversing the two rules that overlap makes the general
-        /// one swallow the special one, which is what an ordered list is for and what a
-        /// <c>switch</c> gets by accident of being written top to bottom.
+        /// Order is part of the data — and <b>where one pattern subsumes another it is no longer
+        /// part of the writing</b>. Reversing this set used to make the general rule swallow the
+        /// special one; it does not any more, because the specific rule is put first by what the
+        /// two patterns are rather than by which was typed above the other.
         /// </summary>
+        /// <remarks>
+        /// This test asserted the opposite until <c>MatchedRuleSet.RulesByPriority</c> existed, and
+        /// its own comment gave the reason to change it: a <c>switch</c> gets its ordering "by
+        /// accident of being written top to bottom", and an accident is what an ordered list of
+        /// values does not have to inherit. <c>RulePriorityTest</c> is where the mechanism and its
+        /// limits are.
+        /// </remarks>
         [Fact]
-        public void TheOrderOfTheRulesIsLoadBearing()
+        public void ASubsumedRuleIsTriedFirstHoweverTheSetIsWritten()
         {
             var expr = "(a / b) * (c / d)".ToEntity();
             var asWritten = MatchedRules.CollapseMultipleFractions.FirstMatching(expr);
@@ -609,8 +617,37 @@ namespace AngouriMath.Tests.Core.Transformations
 
             var reversed = new MatchedRuleSet("reversed",
                 MatchedRules.CollapseMultipleFractions.Rules.Reverse().ToArray());
-            Assert.NotEqual("product-of-two-quotients", reversed.FirstMatching(expr)!.Name);
+            Assert.Equal("product-of-two-quotients", reversed.FirstMatching(expr)!.Name);
         }
+
+        /// <summary>
+        /// And where neither pattern subsumes the other, order is still the whole of the answer.
+        /// </summary>
+        /// <remarks>
+        /// The two rules here both match a product of two quotients, and neither is more general
+        /// than the other — one takes the quotient on the left, the other the quotient on the
+        /// right — so nothing but their order decides which fires. Asked as a set of two so that
+        /// the rule which subsumes them both is out of the way; in the real set it wins, which is
+        /// the previous test.
+        /// </remarks>
+        [Fact]
+        public void WhereNeitherRuleSubsumesTheOtherTheOrderStillDecides()
+        {
+            var expr = "(a / b) * (c / d)".ToEntity();
+            var left = Named("product-with-a-quotient-on-the-left");
+            var right = Named("product-with-a-quotient-on-the-right");
+
+            Assert.False(left.Left.Subsumes(right.Left));
+            Assert.False(right.Left.Subsumes(left.Left));
+
+            Assert.Equal(left.Name, new MatchedRuleSet("left first", left, right)
+                .FirstMatching(expr)!.Name);
+            Assert.Equal(right.Name, new MatchedRuleSet("right first", right, left)
+                .FirstMatching(expr)!.Name);
+        }
+
+        private static MatchedRule Named(string name)
+            => MatchedRules.CollapseMultipleFractions.Rules.Single(rule => rule.Name == name);
 
         /// <summary>
         /// A rule-level guard over <b>two</b> bindings at once, which no predicate on a single

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleConfluenceTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleConfluenceTest.cs
@@ -38,6 +38,17 @@ namespace AngouriMath.Tests.Core.Transformations
     /// <b>A sample, not a proof.</b> Two arms that never overlap on the generated input say
     /// nothing either way, and are not recorded as agreeing.
     /// </para>
+    /// <para>
+    /// <b>And a shallower sample than it reads as.</b> The third level below is grown with unary
+    /// shapes only, so this corpus never builds a quotient of quotients or a product of quotients —
+    /// which is where a special rule and the general rule that would swallow it meet.
+    /// <c>RulePriorityTest</c> asks the same question of the same rules written as data, over a
+    /// corpus grown with binary shapes at every level, and finds <b>45</b> conflicts where this
+    /// finds three. It also names them as the rules they are between rather than as the indices
+    /// below, which is what the note on
+    /// <see cref="AConflictIsReportableAsThePatternsItIsBetween"/> asks for; a data rule has a name
+    /// and a <c>switch</c> arm does not.
+    /// </para>
     /// </remarks>
     [Trait("Area", "Core")]
     public sealed class RuleConfluenceTest

--- a/Sources/Tests/UnitTests/Core/Transformations/RulePriorityTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RulePriorityTest.cs
@@ -1,0 +1,410 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath.Core.Transformations.Matching;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// Which of two rules that both fire decides the answer, and why.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> tier 2 asks for
+    /// "rule priorities and conflict resolution, with confluence and termination checked by tooling
+    /// rather than asserted by authors". This is the priorities half;
+    /// <see cref="RuleConfluenceTest"/> is the confluence half.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A rule set is first-match-wins, so where two rules fire at one node and disagree,
+    /// <b>whichever is tried first decides the answer</b>. Until now that was the position somebody
+    /// typed the rule at, and the one place it is written down is a comment on
+    /// <see cref="MatchedRules.CollapseMultipleFractions"/>: the set "is order-dependent, since
+    /// <c>Mulf(Divf, Divf)</c> has to be tried before <c>Mulf(a, Divf)</c> or the more general rule
+    /// would swallow the special one".
+    /// </para>
+    /// <para>
+    /// <see cref="MatchPattern.Subsumes"/> makes that a computed fact, and
+    /// <c>MatchedRuleSet.RulesByPriority</c> applies it. What is left over — a conflict where
+    /// neither pattern subsumes the other — is a bare choice, and those are recorded below by name
+    /// rather than left implicit in a file's layout.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class RulePriorityTest
+    {
+        private static readonly string[] Leaves = { "x", "y", "2", "-1", "1/2", "0", "1", "3" };
+
+        private static readonly string[] Unary =
+        {
+            "-({0})", "sqrt({0})", "abs({0})", "ln({0})", "e ^ ({0})",
+            "sin({0})", "cos({0})", "tan({0})", "sgn({0})", "1 / ({0})",
+            "({0}) ^ 2", "({0}) ^ (-1)", "({0}) ^ (1/2)", "({0})!",
+        };
+
+        private static readonly string[] Binary =
+        {
+            "({0}) + ({1})", "({0}) - ({1})", "({0}) * ({1})", "({0}) / ({1})", "({0}) ^ ({1})",
+        };
+
+        private static List<string> Grow(IReadOnlyList<string> below, bool binary)
+        {
+            var grown = new List<string>();
+            foreach (var shape in Unary)
+                foreach (var inner in below)
+                    grown.Add(string.Format(shape, inner));
+            if (binary)
+                foreach (var shape in Binary)
+                    foreach (var left in below)
+                        foreach (var right in below)
+                            grown.Add(string.Format(shape, left, right));
+            return grown;
+        }
+
+        /// <summary>
+        /// Generated, deterministic, and <b>three levels deep with binary shapes at every one</b>,
+        /// which is the difference that matters here.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="RuleConfluenceTest"/> grows its third level with unary shapes only, so it
+        /// never builds a quotient of quotients or a product of quotients — and those are exactly
+        /// the shapes where a specific rule and the general rule that would swallow it both fire.
+        /// On that corpus <b>none</b> of the subsumption-ordered pairs below overlaps at all.
+        /// Growing the third level with binary shapes too finds six of them, and takes the
+        /// conflicts this sees from 3 to 45.
+        /// </remarks>
+        private static List<Entity> Expressions()
+        {
+            var level1 = new List<string>(Leaves);
+            var level2 = Grow(level1, binary: true);
+            var level3 = Grow(level2.Where((_, i) => i % 11 == 0).ToList(), binary: true);
+            var parsed = new List<Entity>();
+            foreach (var source in level1.Concat(level2).Concat(level3))
+            {
+                // Not every generated string parses, and that is the generator's business.
+                try { parsed.Add(source.ToEntity()); }
+                catch (Exception) { }
+            }
+            return parsed;
+        }
+
+        private static List<Entity> Nodes()
+        {
+            var nodes = new List<Entity>();
+            foreach (var expression in Expressions())
+                foreach (var node in expression.Nodes)
+                    nodes.Add(node);
+            return nodes;
+        }
+
+        /// <summary>
+        /// Every pair of rules of one set where one pattern is strictly more general than the
+        /// other, as <c>Set: specific before general</c> — which is the order they have to be
+        /// tried in.
+        /// </summary>
+        private static SortedSet<string> Subsumptions()
+        {
+            var found = new SortedSet<string>(StringComparer.Ordinal);
+            foreach (var set in MatchedRules.All)
+            {
+                var rules = set.Rules;
+                for (var i = 0; i < rules.Count; i++)
+                    for (var j = 0; j < rules.Count; j++)
+                    {
+                        if (i == j) continue;
+                        if (!rules[i].Left.Subsumes(rules[j].Left)) continue;
+                        if (rules[j].Left.Subsumes(rules[i].Left)) continue;
+                        found.Add($"{set.Name}: {rules[j].Name} before {rules[i].Name}");
+                    }
+            }
+            return found;
+        }
+
+        /// <summary>
+        /// <b>The claim checked against the behaviour.</b> <see cref="MatchPattern.Subsumes"/>
+        /// answers from the shape of two patterns, for every expression there is; this asks whether
+        /// it was telling the truth about the expressions there are. Wherever it claims one pattern
+        /// is at least as general as another, every node the narrower one matches has to be matched
+        /// by the wider one too.
+        /// </summary>
+        /// <remarks>
+        /// Over all 322 rules rather than within a set, because the relation is about patterns and
+        /// nothing about it stops at a set boundary: <b>961</b> ordered pairs claim subsumption,
+        /// <b>513</b> of them are put to the test by the corpus containing something the narrower
+        /// pattern matches, and none is contradicted across 56,892 nodes. The count of witnessed
+        /// claims is asserted as well — a corpus that stopped reaching these shapes would otherwise
+        /// turn this into a test that passes by asking nothing.
+        /// </remarks>
+        [Fact]
+        public void SubsumptionIsNeverContradictedByMatching()
+        {
+            var rules = MatchedRules.All
+                .SelectMany(set => set.Rules.Select(rule => (Set: set.Name, Rule: rule)))
+                .ToList();
+            var claims =
+                new List<(string General, string Specific, MatchPattern Wide, MatchPattern Narrow)>();
+            foreach (var wider in rules)
+                foreach (var narrower in rules)
+                {
+                    if (ReferenceEquals(wider.Rule, narrower.Rule)) continue;
+                    if (wider.Rule.Left.Subsumes(narrower.Rule.Left))
+                        claims.Add((
+                            $"{wider.Set}/{wider.Rule.Name}",
+                            $"{narrower.Set}/{narrower.Rule.Name}",
+                            wider.Rule.Left,
+                            narrower.Rule.Left));
+                }
+
+            var nodes = Nodes();
+            var witnessed = 0;
+            foreach (var (general, specific, wide, narrow) in claims)
+            {
+                var put = false;
+                foreach (var node in nodes)
+                {
+                    bool narrowMatches;
+                    try { narrowMatches = narrow.Matches(node); }
+                    catch (Exception) { continue; }
+                    if (!narrowMatches) continue;
+                    put = true;
+                    bool wideMatches;
+                    try { wideMatches = wide.Matches(node); }
+                    catch (Exception) { wideMatches = false; }
+                    Assert.True(wideMatches,
+                        $"'{general}' claims to subsume '{specific}', but {node.Stringize()} "
+                        + $"matches {narrow} and not {wide}");
+                }
+                if (put) witnessed++;
+            }
+
+            Assert.Equal(961, claims.Count);
+            Assert.Equal(513, witnessed);
+        }
+
+        /// <summary>
+        /// <b>The invariant that used to be a comment.</b> Where one rule of a set is strictly more
+        /// specific than another it has to be tried first, or it never fires at all and the set
+        /// quietly loses a rewrite. This holds the order rules are tried in equal to the order they
+        /// are written in, so the file stays readable as well as correct — and it is what fires
+        /// when somebody inserts a general rule above a specific one.
+        /// </summary>
+        [Fact]
+        public void TheOrderRulesAreTriedInIsTheOrderTheyAreWrittenIn()
+        {
+            foreach (var set in MatchedRules.All)
+                Assert.Equal(
+                    set.Rules.Select(rule => rule.Name),
+                    set.RulesByPriority.Select(rule => rule.Name));
+        }
+
+        /// <summary>
+        /// The orderings specificity has an opinion about, by name.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Twenty-eight of the 5,480 within-set pairs, across eight sets, and none of them mutual.
+        /// They are recorded because the list is the thing that changes: a rule added to
+        /// <c>Boolean</c> or <c>InequalityEquality</c> whose pattern sits under an existing one
+        /// joins this list, and that is worth noticing when it happens rather than the first time
+        /// the two overlap.
+        /// </para>
+        /// <para>
+        /// One of the eight sets says anything about this in its own documentation, which is the
+        /// argument for computing it rather than writing it down.
+        /// </para>
+        /// </remarks>
+        [Fact]
+        public void TheRecordedSubsumptionsAreTheOnesThereAre()
+        {
+            var recorded = new[]
+            {
+                "Boolean: a-conjunction-of-negations-is-a-negated-disjunction before a-conjunction-with-a-falsehood-is-false",
+                "Boolean: a-conjunction-with-itself-is-itself before a-conjunction-with-a-falsehood-is-false",
+                "Boolean: a-disjunction-of-negations-is-a-negated-conjunction before a-disjunction-with-a-truth-is-true",
+                "Boolean: a-disjunction-of-negations-is-a-negated-conjunction before a-negation-or-something-is-an-implication",
+                "Boolean: a-disjunction-with-itself-is-itself before a-disjunction-with-a-truth-is-true",
+                "Boolean: a-negation-or-something-is-an-implication before a-disjunction-with-a-truth-is-true",
+                "CollapseMultipleFractions: product-of-two-quotients before product-with-a-quotient-on-the-left",
+                "CollapseMultipleFractions: product-of-two-quotients before product-with-a-quotient-on-the-right",
+                "CollapseMultipleFractions: quotient-of-two-quotients before quotient-whose-denominator-is-a-quotient",
+                "CollapseMultipleFractions: quotient-of-two-quotients before quotient-whose-numerator-is-a-quotient",
+                "CollapseTrigonometricFunctions: cosine-over-sine-is-the-cotangent before a-quotient-by-a-sine-is-a-cosecant",
+                "CollapseTrigonometricFunctions: sine-over-cosine-is-the-tangent before a-quotient-by-a-cosine-is-a-secant",
+                "Common: a-product-of-two-quotients-is-one-quotient before a-quotient-times-a-thing-keeps-the-divisor-outermost",
+                "Common: a-product-of-two-quotients-is-one-quotient before a-thing-times-a-quotient-keeps-the-divisor-outermost",
+                "ExpandFactorialDivisions: a-quotient-of-shifted-factorials before a-quotient-of-a-plain-factorial-by-a-shifted-one",
+                "ExpandFactorialDivisions: a-quotient-of-shifted-factorials before a-quotient-of-a-shifted-factorial-by-a-plain-one",
+                "FactorizeFactorialMultiplications: a-shifted-factorial-times-the-next-term before a-plain-factorial-times-the-next-term",
+                "FactorizeFactorialMultiplications: a-shifted-factorial-times-the-next-term before a-shifted-factorial-times-a-bare-term",
+                "InequalityEquality: a-greater-than-or-equal-as-written-is-at-least before two-comparisons-of-one-pair-that-leave-no-case-are-true",
+                "InequalityEquality: a-greater-than-or-equal-the-other-way-round-is-at-most before two-comparisons-of-one-pair-that-leave-no-case-are-true",
+                "InequalityEquality: a-less-than-or-equal-as-written-is-at-most before two-comparisons-of-one-pair-that-leave-no-case-are-true",
+                "InequalityEquality: a-less-than-or-equal-the-other-way-round-is-at-least before two-comparisons-of-one-pair-that-leave-no-case-are-true",
+                "InequalityEquality: an-equality-or-a-greater-than-as-written-is-at-least before two-comparisons-of-one-pair-that-leave-no-case-are-true",
+                "InequalityEquality: an-equality-or-a-greater-than-the-other-way-round-is-at-most before two-comparisons-of-one-pair-that-leave-no-case-are-true",
+                "InequalityEquality: an-equality-or-a-less-than-as-written-is-at-most before two-comparisons-of-one-pair-that-leave-no-case-are-true",
+                "InequalityEquality: an-equality-or-a-less-than-the-other-way-round-is-at-least before two-comparisons-of-one-pair-that-leave-no-case-are-true",
+                "Power: a-logarithm-of-a-reciprocal-in-a-reciprocal-base-turns-round-twice before a-logarithm-in-a-reciprocal-base-negates",
+                "Power: a-logarithm-of-a-reciprocal-in-a-reciprocal-base-turns-round-twice before a-logarithm-of-a-reciprocal-negates",
+            };
+            Assert.Equal(recorded.OrderBy(name => name, StringComparer.Ordinal), Subsumptions());
+        }
+
+        /// <summary>
+        /// Every conflict observed on the corpus, split by whether priority decides it.
+        /// </summary>
+        private static (SortedSet<string> ByPriority, SortedSet<string> ByDeclaration) Conflicts()
+        {
+            var byPriority = new SortedSet<string>(StringComparer.Ordinal);
+            var byDeclaration = new SortedSet<string>(StringComparer.Ordinal);
+            var expressions = Expressions();
+            foreach (var set in MatchedRules.All)
+            {
+                var rules = set.RulesByPriority;
+                foreach (var expression in expressions)
+                    foreach (var node in expression.Nodes)
+                    {
+                        var firing = new List<int>();
+                        for (var i = 0; i < rules.Count; i++)
+                        {
+                            Entity? applied;
+                            try { applied = rules[i].TryApply(node); }
+                            catch (Exception) { continue; }
+                            // A rule that matches and hands the node back has not fired.
+                            if (applied is not null && !applied.Equals(node)) firing.Add(i);
+                        }
+                        if (firing.Count < 2) continue;
+
+                        // Compared after normalisation, so that two rules writing one answer two
+                        // ways are not called a conflict.
+                        var settled = new Dictionary<int, Entity>();
+                        foreach (var i in firing)
+                        {
+                            try { settled[i] = rules[i].TryApply(node)!.InnerSimplified; }
+                            catch (Exception) { }
+                        }
+                        foreach (var i in firing)
+                            foreach (var j in firing)
+                            {
+                                if (i >= j) continue;
+                                if (!settled.TryGetValue(i, out var left)) continue;
+                                if (!settled.TryGetValue(j, out var right)) continue;
+                                if (left.Equals(right)) continue;
+                                var key = $"{set.Name}: {rules[i].Name} | {rules[j].Name}";
+                                var wider = rules[i].Left.Subsumes(rules[j].Left);
+                                var narrower = rules[j].Left.Subsumes(rules[i].Left);
+                                if (wider ^ narrower) byPriority.Add(key);
+                                else byDeclaration.Add(key);
+                            }
+                    }
+            }
+            return (byPriority, byDeclaration);
+        }
+
+        /// <summary>
+        /// The conflicts priority settles: two rules fire, they disagree, and one pattern is
+        /// strictly more general than the other — so which of them wins is a consequence of what
+        /// the rules are rather than of where they were typed.
+        /// </summary>
+        /// <remarks>
+        /// All six are a general and a special case of one rewrite meeting on a nested quotient,
+        /// and four are the pair <see cref="MatchedRules.CollapseMultipleFractions"/> describes in
+        /// prose. That the prose was right is the point: what it could not do is stay right on its
+        /// own.
+        /// </remarks>
+        [Fact]
+        public void PrioritySettlesTheConflictsItHasAnOpinionAbout()
+        {
+            var recorded = new[]
+            {
+                "CollapseMultipleFractions: product-of-two-quotients | product-with-a-quotient-on-the-left",
+                "CollapseMultipleFractions: product-of-two-quotients | product-with-a-quotient-on-the-right",
+                "CollapseMultipleFractions: quotient-of-two-quotients | quotient-whose-denominator-is-a-quotient",
+                "CollapseMultipleFractions: quotient-of-two-quotients | quotient-whose-numerator-is-a-quotient",
+                "Common: a-product-of-two-quotients-is-one-quotient | a-quotient-times-a-thing-keeps-the-divisor-outermost",
+                "Common: a-product-of-two-quotients-is-one-quotient | a-thing-times-a-quotient-keeps-the-divisor-outermost",
+            };
+            Assert.Equal(
+                recorded.OrderBy(name => name, StringComparer.Ordinal), Conflicts().ByPriority);
+        }
+
+        /// <summary>
+        /// The conflicts priority does <b>not</b> settle: two rules fire and disagree, and neither
+        /// pattern is more general than the other, so the answer is decided by which was written
+        /// first and by nothing else.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>These are the ones a reader cannot see.</b> Where one pattern subsumes another the
+        /// ordering is at least legible in the patterns; here it is legible nowhere, and this list
+        /// is the only place it is written down.
+        /// </para>
+        /// <para>
+        /// Three of them are what <see cref="RuleConfluenceTest"/> records at <c>switch</c> grain,
+        /// by index. The other thirty-six come from asking the data rules instead — which have
+        /// names, so an ordering can be recorded as the rules it is between rather than as two
+        /// numbers that move whenever somebody edits the file.
+        /// </para>
+        /// <para>
+        /// None of the thirty-nine changes what <see cref="Entity.Simplify(int)"/> returns: the
+        /// normalisation and the passes after it converge. They are recorded because that is a fact
+        /// about the current rules and not a guarantee.
+        /// </para>
+        /// </remarks>
+        [Fact]
+        public void OnlyTheRecordedConflictsAreLeftToDeclarationOrder()
+        {
+            var recorded = new[]
+            {
+                "CollapseMultipleFractions: product-with-a-quotient-on-the-right | product-with-a-quotient-on-the-left",
+                "CollapseMultipleFractions: quotient-whose-numerator-is-a-quotient | quotient-whose-denominator-is-a-quotient",
+                "Common: a-common-factor-of-two-added-products-comes-out | a-negated-term-in-a-sum-is-a-subtraction",
+                "Common: a-common-factor-of-two-added-products-comes-out | a-term-added-to-itself-doubles",
+                "Common: a-common-factor-of-two-subtracted-products-comes-out | a-term-subtracted-from-itself-vanishes",
+                "Common: a-factor-shared-by-a-product-and-a-quotient-added-comes-out | a-negated-term-in-a-sum-is-a-subtraction",
+                "Common: a-factor-shared-by-a-quotient-and-a-product-added-comes-out | a-negated-term-in-a-sum-is-a-subtraction",
+                "Common: a-function-times-a-number-puts-the-number-first | a-negated-reciprocal-rational-factor-is-a-negated-division",
+                "Common: a-product-of-two-quotients-is-one-quotient | a-thing-times-itself-is-its-square",
+                "Common: a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero | a-difference-over-its-own-reverse-is-minus-one",
+                "Common: a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero | a-shared-factor-cancels-between-two-products",
+                "Common: a-quotient-times-a-thing-keeps-the-divisor-outermost | a-negated-reciprocal-rational-factor-is-a-negated-division",
+                "Common: a-quotient-times-a-thing-keeps-the-divisor-outermost | a-thing-times-a-quotient-keeps-the-divisor-outermost",
+                "Common: a-quotient-times-a-thing-keeps-the-divisor-outermost | a-thing-times-itself-is-its-square",
+                "Common: a-term-added-to-itself-doubles | a-negated-term-in-a-sum-is-a-subtraction",
+                "Common: a-thing-times-a-quotient-keeps-the-divisor-outermost | a-negated-reciprocal-rational-factor-is-a-negated-division",
+                "Common: a-thing-times-a-quotient-keeps-the-divisor-outermost | a-thing-times-itself-is-its-square",
+                "Common: a-variable-times-a-number-puts-the-number-first | a-reciprocal-rational-factor-is-a-division",
+                "Common: dividing-by-a-quotient-multiplies-by-its-reciprocal | a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero",
+                "Common: dividing-by-a-quotient-multiplies-by-its-reciprocal | dividing-twice-divides-by-the-product",
+                "Common: dividing-twice-divides-by-the-product | a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero",
+                "Common: two-numbers-around-a-factor-collect | a-negated-reciprocal-rational-factor-is-a-negated-division",
+                "Common: two-numeric-factors-around-a-variable-collect | a-negated-reciprocal-rational-factor-is-a-negated-division",
+                "Common: two-numeric-multiples-of-one-variable-add | a-common-factor-of-two-added-products-comes-out",
+                "Common: two-numeric-multiples-of-one-variable-add | a-negated-term-in-a-sum-is-a-subtraction",
+                "Common: two-numeric-multiples-of-one-variable-add | a-term-added-to-itself-doubles",
+                "Common: two-numeric-multiples-of-one-variable-subtract | a-common-factor-of-two-subtracted-products-comes-out",
+                "DivisionPreparing: reciprocal-factor-becomes-a-quotient | numeric-numerator-out-of-a-product",
+                "Factorization: a-factor-shared-by-two-added-products-comes-out | a-term-added-to-itself-doubles",
+                "Factorization: a-factor-shared-by-two-subtracted-products-comes-out | a-term-subtracted-from-itself-vanishes",
+                "Factorization: a-term-added-to-itself-doubles | a-common-factor-is-collected-out-of-a-whole-sum",
+                "NumericNeat: a-negative-factor-in-a-left-product-comes-out | a-negative-factor-in-a-right-product-comes-out",
+                "NumericNeat: a-negative-factor-in-a-numerator-comes-out | a-negative-factor-in-a-denominator-comes-out",
+                "Power: a-numeric-factor-comes-out-of-a-power-of-a-product | a-reciprocal-power-is-a-quotient",
+                "Power: a-power-of-a-power-multiplies-the-exponents | a-reciprocal-power-is-a-quotient",
+                "Power: a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero | two-powers-of-one-base-divide-by-subtracting-exponents",
+                "Power: a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero | two-powers-of-one-exponent-share-a-quotient-of-bases",
+                "Power: two-powers-of-one-base-divide-by-subtracting-exponents | two-powers-of-one-exponent-share-a-quotient-of-bases",
+                "Power: two-powers-of-one-base-multiply-by-adding-exponents | two-powers-of-one-exponent-share-a-base",
+            };
+            Assert.Equal(
+                recorded.OrderBy(name => name, StringComparer.Ordinal), Conflicts().ByDeclaration);
+        }
+    }
+}


### PR DESCRIPTION
#746 tier 2 asks for **"rule priorities and conflict resolution, with confluence and termination
checked by tooling rather than asserted by authors"**. This is the priorities half;
`RuleConfluenceTest` was already the confluence half.

A rule set is first-match-wins, so where two rules fire at one node and disagree, **whichever is
tried first decides the answer** — and until now that was where somebody typed it.

The one place it is written down is a comment on `MatchedRules.CollapseMultipleFractions`: the set
*"is order-dependent, since `Mulf(Divf, Divf)` has to be tried before `Mulf(a, Divf)` or the more
general rule would swallow the special one"*. That is **subsumption**, observed by hand and then
maintained by hand.

## `MatchPattern.Subsumes`

A matching problem, not a size comparison. A hole repeated across a pattern is an equality
constraint, so `Mulf(a, a)` matches strictly less than `Mulf(a, b)` **while having the same node
count** — comparing `NodeCount` would call those two equally general and get the ordering wrong in
the one case the ordering exists for. So this matches one pattern against the other as a term,
carrying an assignment from the wider pattern's holes to the narrower one's subpatterns and requiring
a repeated hole to be assigned consistently.

Sound in one direction only. `true` is a structural claim about every expression; `false` means *not
proved*, never *disproved* — a hole carrying a predicate is arbitrary code, an `Exact` literal can be
equal to a value of another runtime type (a rational that reduced to an integer), and an n-ary
`Gathered` pattern matches a family this does not attempt to reason about. Each refuses, and leaves
the pair ordered as written, which is what the code did before.

`MatchedRuleSet.RulesByPriority` applies it as a stable topological sort: no rule is tried before a
rule its pattern subsumes, declaration order everywhere else.

## Four things measured

**Subsumption does not lie.** Over all 322 rules — the relation is about patterns, and nothing about
it stops at a set boundary — **961** ordered pairs claim it, **513** are put to the test by the
corpus containing something the narrower pattern matches, and **none** is contradicted across 56,892
nodes. The count of witnessed claims is asserted as well, so a corpus that stopped reaching these
shapes cannot quietly turn that into a test which passes by asking nothing.

**It changes no answer today.** Of the 5,480 within-set rule pairs, subsumption has an opinion about
**28**, and in every one the specific rule is already declared first. None is mutual.

| set | pairs |
|---|---|
| `InequalityEquality` | 8 |
| `Boolean` | 6 |
| `CollapseMultipleFractions` | 4 |
| `CollapseTrigonometricFunctions`, `Common`, `ExpandFactorialDivisions`, `FactorizeFactorialMultiplications`, `Power` | 2 each |

So this orders what was already ordered. What it adds is that inserting a general rule above a
specific one no longer silently reverses an answer — and one of those eight sets says anything about
it in its own documentation, which is the argument for computing it rather than writing it down.
`RulePriorityTest` holds the two orders equal, so the file stays readable as well as correct.

**The existing confluence corpus cannot see any of it.** `RuleConfluenceTest` grows its third level
with unary shapes only, so it never builds a quotient of quotients or a product of quotients — which
is exactly where a special rule and the general rule that would swallow it meet. On that corpus
**none** of the 28 pairs overlaps at all. Growing the third level with binary shapes too takes the
conflicts from **3 to 45**:

- **6** settled by priority — a general and a special case of one rewrite meeting on a nested
  quotient, four of them the pair `CollapseMultipleFractions` describes in prose;
- **39** where neither pattern subsumes the other, so the answer is decided by which was written
  first and by nothing else.

Those 39 are recorded **by name**. The data rules have names, which is what the note on
`AConflictIsReportableAsThePatternsItIsBetween` asks for — *"the failure message has to name the
arms, not their indices — an index moves whenever somebody edits the `switch`, which is exactly when
this test fires"* — and what a `switch` arm cannot supply. None of the 39 changes what `Simplify`
returns; the normalisation and the passes after it converge.

**And one test asserted the opposite of this.** `TheOrderOfTheRulesIsLoadBearing` built the set with
its rules reversed and required the general rule to swallow the special one. It does not any more,
which is the whole point, and the test's own comment gave the reason: a `switch` gets its ordering
*"by accident of being written top to bottom"*, and an accident is what an ordered list of values
does not have to inherit. Replaced by two — the specific rule wins **however the set is written**,
and where neither rule subsumes the other the order still decides everything.

## One thing the classification surfaced and this leaves alone

`quotient-of-two-quotients` answers `0` where the general rule answers `NaN`, on
`x / (1/2) / (1 / 0)`. Left alone deliberately: `Simplify` returns `NaN` for that input, priority
picks the same arm the declared order already picked so nothing here changes it, and the missing
hypothesis is what `Soundness.SoundUnderAssumptions` on that rule is declaring. Recorded because the
tooling found it, not because this PR fixes it.

## State

No public API change. Full suite on this branch: **8925 passed, 14 skipped, 0 failed.**

Independent of #1105 — the two touch no file in common and can merge in either order.

Part of #746 tier 2.
