### PR TITLE
A rule's own growth, tier and identity reach the registry

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
@@ -44,8 +44,9 @@ namespace AngouriMath.Core.Transformations.Matching
             MatchPattern right,
             Soundness soundness,
             Func<Bindings, bool>? when = null,
+            string? description = null,
             [CallerLineNumber] int line = 0)
-            : this(name, left, null, right ?? throw new ArgumentNullException(nameof(right)), soundness, null, when, line)
+            : this(name, left, null, right ?? throw new ArgumentNullException(nameof(right)), soundness, null, when, description, line)
         {
             // A name the replacement reads and the pattern never binds is a typo, and it is a
             // typo that would otherwise show up as a rule that silently never fires. Only a
@@ -76,10 +77,11 @@ namespace AngouriMath.Core.Transformations.Matching
             Soundness soundness,
             RewriteRuleGrowth? growth = null,
             Func<Bindings, bool>? when = null,
+            string? description = null,
             [CallerLineNumber] int line = 0)
             : this(name, left, right is null ? null : (_, bound) => right(bound),
                    right is null ? throw new ArgumentNullException(nameof(right)) : null,
-                   soundness, growth, when, line)
+                   soundness, growth, when, description, line)
         {
         }
 
@@ -110,9 +112,10 @@ namespace AngouriMath.Core.Transformations.Matching
             Soundness soundness,
             RewriteRuleGrowth? growth = null,
             Func<Bindings, bool>? when = null,
+            string? description = null,
             [CallerLineNumber] int line = 0)
             : this(name, left, right ?? throw new ArgumentNullException(nameof(right)), null,
-                   soundness, growth, when, line)
+                   soundness, growth, when, description, line)
         {
         }
 
@@ -124,9 +127,11 @@ namespace AngouriMath.Core.Transformations.Matching
             Soundness soundness,
             RewriteRuleGrowth? declaredGrowth,
             Func<Bindings, bool>? when,
+            string? description,
             int line)
         {
             SourceLine = line;
+            Description = description;
             Name = name ?? throw new ArgumentNullException(nameof(name));
             Left = left ?? throw new ArgumentNullException(nameof(left));
             this.right = rightCode;
@@ -145,6 +150,30 @@ namespace AngouriMath.Core.Transformations.Matching
 
         /// <summary>What to call this rule in a report, a test or a bug.</summary>
         internal string Name { get; }
+
+        /// <summary>
+        /// The identity this rule is, in the notation a mathematician would write it in — or
+        /// <see langword="null"/> where nobody has written one.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Not the same thing as <see cref="Name"/> or as the rendered pattern.</b>
+        /// <c>a / (b / c) = a * c / b</c> is what this says; <c>dividing-by-a-quotient-multiplies-by-its-reciprocal</c>
+        /// is what to call it, and <c>Divf(var a, Divf(var b, var c))</c> is how the matcher spells
+        /// it. #746 tier 2 wants metadata "rich enough that v5.0 can render a step as a sentence",
+        /// and of those three only this one is the sentence.
+        /// </para>
+        /// <para>
+        /// <b>It exists because the generator has one and this did not.</b>
+        /// <c>RuleRegistryGenerator</c> reads the comment written above a <c>switch</c> arm into
+        /// <see cref="RewriteRule.Description"/> — <b>95 of the registry's 407 arms</b> carry one
+        /// that way. A rule written as data has its identity in a comment too, and a comment is
+        /// not readable at run time, so until this parameter existed converting a set to data
+        /// <i>lost</i> the description rather than keeping it. That is what stands between the
+        /// registry and describing the rules it actually runs.
+        /// </para>
+        /// </remarks>
+        internal string? Description { get; }
 
         /// <summary>
         /// The line this rule is declared on, taken from the compiler rather than written down.
@@ -363,7 +392,8 @@ namespace AngouriMath.Core.Transformations.Matching
         /// </remarks>
         internal MatchedRule? Reversed
             => Reversal is RuleReversal.Reversible
-                ? reversed ??= new MatchedRule($"reversed {Name}", Right!, Left, Soundness, when)
+                ? reversed ??= new MatchedRule($"reversed {Name}", Right!, Left, Soundness, when,
+                    Description is null ? null : $"read backwards: {Description}")
                 : null;
 
         private MatchedRule? reversed;
@@ -617,19 +647,30 @@ namespace AngouriMath.Core.Transformations.Matching
                     source: Name,
                     index: i,
                     name: rule.Name,
-                    description: null,
+                    description: rule.Description,
                     nodeTypes: rule.Left.RequiredRootType is { } root
                         ? new[] { root }
                         : Array.Empty<Type>(),
                     patternSource: pattern,
                     guardSource: rule.HasCondition ? "a side condition on the bindings" : null,
                     replacementSource: replacement ?? "(built by code)",
-                    growth: replacement is null ? RewriteRuleGrowth.Unknown
-                        : replacement.Length > pattern.Length ? RewriteRuleGrowth.Expands
-                        : replacement.Length < pattern.Length ? RewriteRuleGrowth.Collects
-                        : RewriteRuleGrowth.Rearranges,
+                    // The rule's own answer, not a proxy for it. This used to compare the lengths
+                    // of the two rendered strings, which is what the generator has to do -- it
+                    // reads C# source text and has no tree to count. Here there is a tree, and
+                    // guessing from the rendering was wrong 23 times in 322 and in both
+                    // directions: `Divf(var a, Sinf(var b))` to `Mulf(var a, Cosecantf(var b))`
+                    // read as Expands because `Cosecantf` is a longer word than `Sinf`, while
+                    // DivisionPreparing's two read as Collects for the same reason reversed. Worse
+                    // for the thirteen Boolean rules that *declare* their growth on a code-built
+                    // replacement: with no string to measure, the proxy answered Unknown and threw
+                    // the author's declaration away.
+                    growth: rule.Growth,
                     sourceLine: rule.SourceLine,
-                    apply: rule.TryApply);
+                    apply: rule.TryApply,
+                    // Per rule, which is the whole point of a rule being a value. A set's tier is
+                    // the minimum over its rules, so one conditional rule makes a set of a hundred
+                    // report as conditional; 181 of these 322 are Sound.
+                    soundness: rule.Soundness);
             }
             return built;
         }

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -838,14 +838,16 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any<Rational>("k"),
                     MatchPattern.Node<Divf>(MatchPattern.Any("value"), MatchPattern.Any<Rational>("d"))),
                 (node, _) => Functions.Patterns.GatherNumericCoefficientOverASurd(node),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "k * (value / d) = (k * value) / d"),
 
             // num / (a + b) -> num * (a - b) / (a^2 - b^2)
             new MatchedRule(
                 "a-two-term-denominator-is-multiplied-by-its-conjugate",
                 MatchPattern.Node<Divf>(MatchPattern.Any("num"), MatchPattern.Any("den")),
                 (node, _) => Functions.Patterns.MultiplyByTheConjugate(node),
-                Soundness.SoundUnderAssumptions));
+                Soundness.SoundUnderAssumptions,
+                description: "num / (a + b) = num * (a - b) / (a^2 - b^2)"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.NumericNeatRules"/>, as data.

--- a/Sources/AngouriMath/Core/Transformations/RewriteRule.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRule.cs
@@ -75,11 +75,16 @@ namespace AngouriMath.Core.Transformations
     /// <see cref="Entity.Simplify(int)"/> per rule set exchanged.
     /// </para>
     /// <para>
-    /// <b>What is not here.</b> A per-rule <see cref="Soundness"/>. A rule's tier is a claim
-    /// somebody has to argue for, and there is no honest way to derive one from syntax — so
-    /// <see cref="RewriteRuleSet.Soundness"/> remains the declared tier and this type does not
-    /// invent a finer one it cannot justify. What being addressable buys is that the finer tier
-    /// now has somewhere to live once the argument is made, which it did not before.
+    /// <b>A per-rule <see cref="Soundness"/> is here now, and it is empty for most rules on
+    /// purpose.</b> This paragraph used to say the tier was absent, on the argument that a rule's
+    /// tier is a claim somebody has to argue for and cannot be derived from syntax. That argument
+    /// is right and it is not a reason for the property to be missing: where the argument <i>has</i>
+    /// been made, the claim needs somewhere to live. A rule written as data declares one, and 181
+    /// of the 322 such rules are <see cref="Transformations.Soundness.Sound"/> against every set in
+    /// the registry declaring <see cref="Transformations.Soundness.SoundUnderAssumptions"/>. A rule
+    /// read off a <c>switch</c> arm declares nothing, so its <see cref="Soundness"/> is
+    /// <see langword="null"/> — which says the set's tier is a fallback rather than a measurement,
+    /// where silently copying the set's down would have said the opposite.
     /// </para>
     /// </remarks>
     public sealed class RewriteRule
@@ -95,7 +100,8 @@ namespace AngouriMath.Core.Transformations
             string replacementSource,
             RewriteRuleGrowth growth,
             int sourceLine,
-            Func<Entity, Entity?> apply)
+            Func<Entity, Entity?> apply,
+            Soundness? soundness = null)
         {
             Source = source;
             Index = index;
@@ -108,6 +114,7 @@ namespace AngouriMath.Core.Transformations
             Growth = growth;
             SourceLine = sourceLine;
             this.apply = apply;
+            Soundness = soundness;
         }
 
         private readonly Func<Entity, Entity?> apply;
@@ -181,6 +188,32 @@ namespace AngouriMath.Core.Transformations
 
         /// <summary>Which way the rewrite moves. See <see cref="RewriteRuleGrowth"/>.</summary>
         public RewriteRuleGrowth Growth { get; }
+
+        /// <summary>
+        /// How well justified <b>this one rule's</b> claim is, or <see langword="null"/> where the
+        /// rule has no tier of its own and its set's applies. See
+        /// <see cref="Transformations.Soundness"/> for what a tier is and is not.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>A set's tier is the minimum over its rules, so reading it as every rule's tier
+        /// understates most of them.</b> All thirty sets in the registry declare
+        /// <see cref="Transformations.Soundness.SoundUnderAssumptions"/>, and one conditional rule
+        /// is enough to make that true of a set of a hundred. Asked per rule instead, <b>181 of the
+        /// 322 rules written as data are <see cref="Transformations.Soundness.Sound"/></b> — they
+        /// hold for every complex argument, with nothing assumed — and 141 are conditional. That
+        /// difference is invisible at set grain and is what a derivation needs in order to say why
+        /// a particular step was allowed.
+        /// </para>
+        /// <para>
+        /// <see langword="null"/> is the honest answer for a rule read off a <c>switch</c>: an arm
+        /// declares no tier, so it has none of its own, and inventing its set's would be a claim
+        /// the source does not make. A caller wanting the effective tier writes
+        /// <c>rule.Soundness ?? set.Soundness</c>, and the <see langword="null"/> is what tells it
+        /// that the second value is a fallback rather than a measurement.
+        /// </para>
+        /// </remarks>
+        public Soundness? Soundness { get; }
 
         /// <summary>The line of the source file the arm is written on.</summary>
         public int SourceLine { get; }

--- a/Sources/AngouriMath/Core/Transformations/RewriteRuleSet.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRuleSet.cs
@@ -33,6 +33,32 @@ namespace AngouriMath.Core.Transformations
             => (Name, Description, Relation, Soundness, this.rules, Rules, IsNormalization)
                 = (name, description, relation, soundness, rules, addressable ?? Array.Empty<RewriteRule>(), isNormalization);
 
+        /// <summary>
+        /// A set whose rewrites are written as data: it both <i>runs</i>
+        /// <paramref name="source"/> and <i>describes</i> it.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>One argument rather than two, because two could disagree.</b> The other constructor
+        /// takes what to run and what to report separately, and for most of the registry's life
+        /// those were a matcher on one side and a <c>switch</c> read by
+        /// <c>RuleRegistryGenerator</c> on the other — so a set could describe arms it no longer
+        /// executed, and 26 of them did. Passing the set itself makes that unrepresentable.
+        /// </para>
+        /// <para>
+        /// It also takes the factory call off the caller. A set built by a parameterised factory —
+        /// the common-denominator family, one definition read at three sort levels — would
+        /// otherwise be constructed twice, once for the delegate and once for the rules, and the
+        /// description would be of a different instance from the one that runs.
+        /// </para>
+        /// </remarks>
+        internal RewriteRuleSet(string name, string description, TransformationRelation relation, Soundness soundness, Matching.MatchedRuleSet source, bool isNormalization = false)
+            : this(name, description, relation, soundness,
+                   (source ?? throw new ArgumentNullException(nameof(source))).ApplyHere,
+                   source.AsAddressable(), isNormalization)
+        {
+        }
+
         /// <summary>A stable identity for this set.</summary>
         public string Name { get; }
 

--- a/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
@@ -256,8 +256,7 @@ namespace AngouriMath.Core.Transformations
             "Multiplies a quotient by the conjugate of its denominator to clear a surd from it.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.RationalizeDenominator.ApplyHere,
-            Matching.MatchedRules.RationalizeDenominator.AsAddressable());
+            Matching.MatchedRules.RationalizeDenominator);
 
         /// <summary>
         /// Brings a quotient of quotients down to a single one.

--- a/Sources/Tests/UnitTests/Common/PublicApi.txt
+++ b/Sources/Tests/UnitTests/Common/PublicApi.txt
@@ -180,6 +180,7 @@ AngouriMath.Core.Transformations.RewriteRule.Name { } : System.String
 AngouriMath.Core.Transformations.RewriteRule.NodeTypes { } : System.Collections.Generic.IReadOnlyList<System.Type>
 AngouriMath.Core.Transformations.RewriteRule.PatternSource { } : System.String
 AngouriMath.Core.Transformations.RewriteRule.ReplacementSource { } : System.String
+AngouriMath.Core.Transformations.RewriteRule.Soundness { } : System.Nullable<AngouriMath.Core.Transformations.Soundness>
 AngouriMath.Core.Transformations.RewriteRule.Source { } : System.String
 AngouriMath.Core.Transformations.RewriteRule.SourceLine { } : System.Int32
 AngouriMath.Core.Transformations.RewriteRule.ToString() : System.String

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleMetadataTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleMetadataTest.cs
@@ -1,0 +1,160 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Linq;
+using AngouriMath.Core.Transformations;
+using AngouriMath.Core.Transformations.Matching;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// What a rule says about itself, and whether the registry is able to repeat it.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> tier 2 asks for
+    /// rules that are data carrying "identity, name, direction, applicability conditions,
+    /// justification tier, provenance, cost effect", and for metadata "rich enough that v5.0 can
+    /// render a step as a sentence".
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The registry runs one thing and describes another.</b> 27 of the 30 sets execute
+    /// <see cref="MatchedRuleSet.ApplyHere"/>, and 29 of them take their
+    /// <see cref="RewriteRuleSet.Rules"/> from <c>RuleRegistryGenerator</c> reading the
+    /// <c>switch</c> those sets no longer run. That is
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/825">#825</a>'s open half.
+    /// </para>
+    /// <para>
+    /// This file is about the three things that had to be true of
+    /// <see cref="MatchedRuleSet.AsAddressable"/> before it could be what the registry reads:
+    /// growth that is the rule's own answer rather than a proxy for it, a justification tier per
+    /// rule, and somewhere for the identity to live.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class RuleMetadataTest
+    {
+        /// <summary>
+        /// <b>Growth is the rule's exact answer, not a guess from how long the rendering is.</b>
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>AsAddressable</c> used to compare the lengths of the two rendered pattern strings,
+        /// which is what <c>RuleRegistryGenerator</c> has to do — it reads C# source text and has
+        /// no tree to count nodes on. Here there is a tree, and the proxy disagreed with it
+        /// <b>23 times in 322, in both directions</b>:
+        /// </para>
+        /// <list type="bullet">
+        /// <item>thirteen <c>Boolean</c> rules that <i>declare</i> <c>Collects</c> on a code-built
+        /// replacement read as <c>Unknown</c>, because with no string to measure the proxy threw
+        /// the author's declaration away;</item>
+        /// <item>two <c>CollapseTrigonometricFunctions</c> rules read as <c>Expands</c> because
+        /// <c>Cosecantf</c> is a longer word than <c>Sinf</c> — the same number of nodes;</item>
+        /// <item>two <c>DivisionPreparing</c> rules read as <c>Collects</c> for that reason
+        /// reversed.</item>
+        /// </list>
+        /// </remarks>
+        [Fact]
+        public void AddressableGrowthIsTheRulesOwnAnswer()
+        {
+            foreach (var set in MatchedRules.All)
+            {
+                var addressable = set.AsAddressable();
+                Assert.Equal(set.Rules.Count, addressable.Count);
+                for (var i = 0; i < set.Rules.Count; i++)
+                    Assert.Equal(set.Rules[i].Growth, addressable[i].Growth);
+            }
+        }
+
+        /// <summary>
+        /// <b>A set's tier is the minimum over its rules, so reading it as every rule's tier
+        /// understates most of them.</b>
+        /// </summary>
+        /// <remarks>
+        /// All thirty registry sets declare <see cref="Soundness.SoundUnderAssumptions"/>, and one
+        /// conditional rule is enough to make that true of a set of a hundred. Asked per rule
+        /// instead, <b>181 of the 322 rules written as data are <see cref="Soundness.Sound"/></b> —
+        /// they hold for every complex argument, with nothing assumed. The counts are asserted
+        /// rather than the ratio, because the interesting failure is a rule quietly changing tier.
+        /// </remarks>
+        [Fact]
+        public void SoundnessIsFinerPerRuleThanPerSet()
+        {
+            var rules = MatchedRules.All.SelectMany(set => set.Rules).ToList();
+            Assert.Equal(322, rules.Count);
+            Assert.Equal(181, rules.Count(rule => rule.Soundness is Soundness.Sound));
+            Assert.Equal(141, rules.Count(rule => rule.Soundness is Soundness.SoundUnderAssumptions));
+
+            // And every set still reports the weakest of them, which is what makes the set grain
+            // uninformative rather than wrong.
+            Assert.All(RewriteRules.All,
+                set => Assert.Equal(Soundness.SoundUnderAssumptions, set.Soundness));
+        }
+
+        /// <summary>
+        /// A rule's own tier reaches the registry, and a <c>switch</c> arm's absence of one is
+        /// reported as absent rather than as its set's.
+        /// </summary>
+        [Fact]
+        public void ARuleWrittenAsDataCarriesItsTierIntoTheRegistry()
+        {
+            var rationalize = RewriteRules.RationalizeDenominator;
+            Assert.All(rationalize.Rules, rule => Assert.NotNull(rule.Soundness));
+
+            // Every other set is still described by the generator, which has no tier to give.
+            var generated = RewriteRules.All.Where(set => set.Name != rationalize.Name);
+            Assert.All(generated, set => Assert.All(set.Rules, rule => Assert.Null(rule.Soundness)));
+        }
+
+        /// <summary>
+        /// <b>The identity has somewhere to live now, which is what blocked the registry from
+        /// describing the rules it runs.</b>
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>RuleRegistryGenerator</c> reads the comment above a <c>switch</c> arm into
+        /// <see cref="RewriteRule.Description"/>, and <b>95 of the registry's 407 arms</b> carry one
+        /// — <c>a / (b / c) = a * c / b</c> and its like, which is the sentence a step would be
+        /// rendered as. A rule written as data has its identity in a comment too, and a comment is
+        /// not readable at run time, so converting a set to data used to <i>lose</i> the
+        /// description. Now it does not have to.
+        /// </para>
+        /// <para>
+        /// Demonstrated end to end on the one set the registry already describes from its data
+        /// form: two rules that reported no identity at all now report one, through the public
+        /// surface.
+        /// </para>
+        /// </remarks>
+        [Fact]
+        public void ADescriptionSurvivesTheJourneyIntoTheRegistry()
+        {
+            var described = RewriteRules.RationalizeDenominator.Rules;
+            Assert.Equal(2, described.Count);
+            Assert.Equal("k * (value / d) = (k * value) / d", described[0].Description);
+            Assert.Equal("num / (a + b) = num * (a - b) / (a^2 - b^2)", described[1].Description);
+        }
+
+        /// <summary>
+        /// A rule read backwards says so, rather than repeating the forward identity as though it
+        /// were the same claim.
+        /// </summary>
+        [Fact]
+        public void AReversedRuleDoesNotClaimTheForwardIdentity()
+        {
+            var described = MatchedRules.All
+                .SelectMany(set => set.Rules)
+                .Where(rule => rule.Description is not null && rule.Reversed is not null)
+                .ToList();
+            Assert.All(described, rule =>
+                Assert.StartsWith("read backwards: ", rule.Reversed!.Description!));
+
+            var undescribed = MatchedRules.All
+                .SelectMany(set => set.Rules)
+                .Where(rule => rule.Description is null && rule.Reversed is not null);
+            Assert.All(undescribed, rule => Assert.Null(rule.Reversed!.Description));
+        }
+    }
+}


### PR DESCRIPTION
**The registry runs one thing and describes another.** 27 of the 30 sets execute
`MatchedRuleSet.ApplyHere`; 29 take their `Rules` from `RuleRegistryGenerator` reading the `switch`
those sets no longer run. That is #825's open half, and #746 tier 2 names it as what gates the rest:
*"`RuleRegistryGenerator` reads `PatternSource` and `SourceLine` off a `switch`'s arms, so the
`switch` cannot be deleted even where it no longer runs."*

Pointing those sets at `AsAddressable()` is the change that fixes it. This is the three things that
had to be true of `AsAddressable()` first — each of them a defect on its own.

## Growth was a proxy, and wrong 23 times in 322 — in both directions

It compared the **lengths of the two rendered pattern strings**. That is what the generator has to
do: it reads C# source text and has no tree to count nodes on. Here there is a tree.

| set | exact | proxy said | why |
|---|---|---|---|
| `Boolean`, 13 rules | `Collects` | `Unknown` | code-built replacement, no string to measure — so the proxy **threw the author's declaration away** |
| `CollapseTrigonometricFunctions`, 2 | `Rearranges` | `Expands` | `Cosecantf` is a longer word than `Sinf`. Same number of nodes |
| `Common`, 4 | `Rearranges` | `Unknown` | as above |
| `DivisionPreparing`, 2 | `Rearranges` | `Collects` | the same thing reversed |
| `InequalityEquality`, 2 | `Rearranges` | `Unknown` | as above |

`MatchedRule.Growth` is exact from `MatchPattern.NodeCount`, and is now what gets reported. The
thirteen `Boolean` rules are the sharp case: those rules *declare* their growth, and a proxy over
rendered text cannot see a declaration.

## A tier per rule, and `null` where there is none

A set's tier is the minimum over its rules, so **one** conditional rule makes a set of a hundred
report as conditional. That is why all thirty sets declare `SoundUnderAssumptions` and the field
distinguishes nothing. Asked per rule instead:

| | rules |
|---|---|
| `Sound` — holds for every complex argument, nothing assumed | **181** |
| `SoundUnderAssumptions` | 141 |

`RewriteRule.Soundness` is `Soundness?`, not `Soundness`. A `switch` arm declares no tier, so it has
none of its own, and copying its set's down would assert a claim the source does not make. A caller
wanting the effective tier writes `rule.Soundness ?? set.Soundness` — and the `null` is what tells it
the second is a fallback rather than a measurement.

## And somewhere for the identity to live, which is what blocked the repoint

The generator reads the comment above a `switch` arm into `RewriteRule.Description` — `a / (b / c) =
a * c / b` and its like, **95 of the registry's 407 arms**. A rule written as data has its identity
in a comment too, and a comment is not readable at run time, so `AsAddressable` passed
`description: null`: converting a set to data **lost** the description rather than keeping it.

#746 tier 2 wants metadata *"rich enough that v5.0 can render a step as a sentence"*. Of a rule's
name (`dividing-by-a-quotient-multiplies-by-its-reciprocal`), its rendered pattern
(`Divf(var a, Divf(var b, var c))`) and its identity (`a / (b / c) = a * c / b`), only the third is
the sentence.

`MatchedRule` takes one now; a reversed rule prefixes rather than repeats it; and
`RationalizeDenominator` — the one set the registry already describes from its data form —
demonstrates it end to end: **0 of its 2 rules reported an identity, now both do**, through the
public surface.

`RewriteRuleSet` also gains a constructor taking a `MatchedRuleSet` and reading *both* the runner and
the rules off it, so a set cannot describe arms it does not execute. It takes the factory call off
the caller too: the common-denominator family — one definition read at three sort levels — would
otherwise be constructed twice, once for the delegate and once for the rules, and describe a
different instance from the one that runs.

## What is deliberately not in this: the repoint itself

It was written, built and measured, and then taken back out. Pointing all 27 converted sets at
`AsAddressable()` compiles and leaves nine test failures, seven distinct — and they are informative
rather than churn:

- **The registry's arm count goes 407 → 313.** Not rot: that is the collapse the commutative
  patterns achieved — `Common` 100 → 62, `Trigonometric` 43 → 33, `Boolean` 36 → 20, `Factorization`
  22 → 11. But it changes public enumeration and so needs a `BREAKING-CHANGES.md` entry.
- **Rules start being named by their data names** rather than by their rendered patterns, which is
  better and is still a change to a public string.
- **All 95 descriptions become `null`**, until they are ported. Until then the repoint is a net loss
  of metadata, which is the reason this PR stops here.
- **`RuleConfluenceTest`'s recorded conflicts are index-named** (`Common[12,89]`), and index 89 stops
  existing. #1106's name-based recording is what replaces them.

So the repoint is the next change, and it is one set at a time with
`MatchedRulesAgreeWithTheSwitchTest` as the net. Deleting the ~27 dead `switch` methods is a separate
decision again, and not mine: those switches are the oracle that agreement test proves the data form
against, so deleting them deletes the evidence the exchange was safe.

## State

Public surface: **one additive property**. Full suite: **8973 passed, 14 skipped, 0 failed.**

Part of #746 tier 2 and #825.
