### PR TITLE
Thirteen rule sets describe the rules they run

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -68,6 +68,49 @@ read first.
 | **Silent** | `RewriteRules.RationalizeDenominator.Rules` | `[]` — the registry could not read the set | its two rules, addressable and named |
 | **Silent** | `RewriteRules.Power.ApplyOnce("ln(1 / x)")`, and every `log(_, 1/_)` and `log(1/_, _)` whose argument is not decidably a positive real | `-ln(x)`, which is wrong on the negative reals | `ln(1 / x)`, left alone |
 | **Silent** | `RewriteRules.Boolean.ApplyOnce("a and b or a")`, and two more orientations of absorption | left alone — the arm for that orientation was never written | `a` |
+| **Silent** | `RewriteRules.DivisionPreparing.Rules[0].Name`, and every rule of thirteen sets now described from their data form | `Mulf(var any1, Divf(Integer(1), var any2))` — the `switch` arm's rendered pattern | `reciprocal-factor-becomes-a-quotient` |
+| | `RewriteRules.ExpandFactorialDivisions.Rules.Count`, and `FactorizeFactorialMultiplications` | `8` | `3` — the same rewrites, five of the eight arms being one commutative pattern |
+| | `RewriteRules.All.Sum(set => set.Rules.Count)` | `407` | `397` |
+| **Silent** | `RewriteRules.ExpandFactorialDivisions.Rules[0].Growth` | `Collects` — guessed from string length | `Unknown`; whether it collects depends on the offsets |
+
+### Thirteen rule sets describe the rules they run
+
+`RewriteRuleSet.Rules` is what the registry reports a set is made of, and for most of the library's
+life it came from `RuleRegistryGenerator` reading the `switch` that defined the set. Twenty-seven of
+the thirty sets stopped running that `switch` some releases ago — they run
+`MatchedRuleSet.ApplyHere` — and went on describing it. Thirteen of them now describe what they run.
+
+Which thirteen: `CollapseMultipleFractions`, the three `CommonDenominator` sets, `DivisionPreparing`,
+`ExpandFactorialDivisions`, `ExpandMultipleAngle`, `ExpandTrigonometric`, `Expansion`,
+`FactorizeFactorialMultiplications`, `NormalTrigonometricForm`, `PhiFunction` and
+`PolynomialLongDivision`. They were chosen because **not one of them had a described arm**, so the
+change adds metadata rather than trading it; the sets left alone — `Common` and `Power` among them —
+would lose 33 and 22 descriptions today, and are for a later change.
+
+Four things move, and only the second changes a count:
+
+| | Was | Is |
+|---|---|---|
+| `Rules[i].Name` | the arm's rendered pattern, `Mulf(var any1, Divf(Integer(1), var any2))` | the rule's name, `reciprocal-factor-becomes-a-quotient` |
+| `Rules.Count`, for the two factorial sets | `8` | `3` |
+| `Rules[i].Description` | `null` for all 38 of these arms | the identity, `a * (1 / b) = a / b`, for all 38 |
+| `Rules[i].Soundness` | `null` — an arm declares no tier | the rule's own tier |
+
+**The two counts that change are not rewrites lost.** `ExpandFactorialDivisions` and
+`FactorizeFactorialMultiplications` are eight arms each that the data form writes as three: the other
+five are the same rewrite spelled once for each side a factorial can sit on, which is one commutative
+pattern. Every other repointed set is one arm to one rule. Across the registry, 407 becomes 397 while
+the number of described rules goes from **95 to 135**.
+
+`Rules[i].Growth` also stops being a guess. `AsAddressable` used to infer it by comparing the lengths
+of the two rendered pattern strings — the only thing available to a generator reading source text —
+and the exact node count disagrees 23 times in 322. Mostly it corrects a wrong answer; for
+`ExpandFactorialDivisions` it replaces one with `Unknown`, which is right, since a quotient of
+factorials collects when the offsets are one apart and expands when they are five.
+
+`PatternSource` changes too, from the C# the arm was written in to the pattern the matcher holds —
+`Mulf(var a, Divf(1, var b))` for the same rule. Both are source text for reading; neither is
+something to match against.
 
 ### An equation nothing settled is no longer answered with the empty set
 

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -77,7 +77,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 // a * (1/b) and a/b are undefined at exactly the same points, but the quotient
                 // is a quotient either way, so this inherits division's own condition rather
                 // than adding one. Left at the conservative tier until the audit reaches it.
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "a * (1 / b) = a / b"),
 
             // (c * a) / b -> c * (a / b), for a numeric c
             new MatchedRule(
@@ -88,7 +89,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Mulf>(
                     MatchPattern.Any("c"),
                     MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "(c * a) / b = c * (a / b), for a numeric c"),
 
             // (c / a) * b -> c * (b / a), for a numeric c
             new MatchedRule(
@@ -99,7 +101,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Mulf>(
                     MatchPattern.Any("c"),
                     MatchPattern.Node<Divf>(MatchPattern.Any("b"), MatchPattern.Any("a"))),
-                Soundness.SoundUnderAssumptions));
+                Soundness.SoundUnderAssumptions,
+                description: "(c / a) * b = c * (b / a), for a numeric c"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.CollapseMultipleFractions"/>, as data.
@@ -139,7 +142,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Divf>(
                     MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("c")),
                     MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("c"))),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "(a / b) ^ c = a^c / b^c, for a positive whole c"),
 
             // (a * b) ^ c -> a^c * b^c, for a positive whole c
             new MatchedRule(
@@ -150,7 +154,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Mulf>(
                     MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("c")),
                     MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("c"))),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "(a * b) ^ c = a^c * b^c, for a positive whole c"),
 
             // (a/b) * (c/d) -> (a*c) / (b*d). Before the two below it, which are more general.
             new MatchedRule(
@@ -161,7 +166,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Divf>(
                     MatchPattern.Node<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("c")),
                     MatchPattern.Node<Mulf>(MatchPattern.Any("b"), MatchPattern.Any("d"))),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "(a / b) * (c / d) = (a * c) / (b * d)"),
 
             new MatchedRule(
                 "product-with-a-quotient-on-the-right",
@@ -171,7 +177,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Divf>(
                     MatchPattern.Node<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
                     MatchPattern.Any("c")),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "a * (b / c) = (a * b) / c"),
 
             new MatchedRule(
                 "product-with-a-quotient-on-the-left",
@@ -181,7 +188,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Divf>(
                     MatchPattern.Node<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("c")),
                     MatchPattern.Any("b")),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "(a / b) * c = (a * c) / b"),
 
             // (a/b) / (c/d) -> (a*d) / (b*c). Likewise before the two below it.
             new MatchedRule(
@@ -192,7 +200,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Divf>(
                     MatchPattern.Node<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("d")),
                     MatchPattern.Node<Mulf>(MatchPattern.Any("b"), MatchPattern.Any("c"))),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "(a / b) / (c / d) = (a * d) / (b * c)"),
 
             new MatchedRule(
                 "quotient-whose-numerator-is-a-quotient",
@@ -202,7 +211,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Divf>(
                     MatchPattern.Any("a"),
                     MatchPattern.Node<Mulf>(MatchPattern.Any("b"), MatchPattern.Any("c"))),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "(a / b) / c = a / (b * c)"),
 
             new MatchedRule(
                 "quotient-whose-denominator-is-a-quotient",
@@ -212,7 +222,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Divf>(
                     MatchPattern.Node<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("c")),
                     MatchPattern.Any("b")),
-                Soundness.SoundUnderAssumptions));
+                Soundness.SoundUnderAssumptions,
+                description: "a / (b / c) = (a * c) / b"));
 
         /// <summary>
         /// The one rule from <see cref="Functions.Patterns.PowerRules"/> that carries a real
@@ -420,7 +431,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 // The quotient is undefined exactly where the tangent is -- at a zero of the
                 // cosine -- so the domain neither widens nor narrows. Left at the conservative
                 // tier with its three neighbours until the audit reaches them together.
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "tan(a) = sin(a) / cos(a)"),
 
             // cotan(a) -> cos(a) / sin(a)
             new MatchedRule(
@@ -429,7 +441,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Divf>(
                     MatchPattern.Node<Cosf>(MatchPattern.Any("a")),
                     MatchPattern.Node<Sinf>(MatchPattern.Any("a"))),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "cotan(a) = cos(a) / sin(a)"),
 
             // sec(a) -> 1 / cos(a)
             new MatchedRule(
@@ -438,7 +451,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Divf>(
                     MatchPattern.Exact(Integer.Create(1)),
                     MatchPattern.Node<Cosf>(MatchPattern.Any("a"))),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "sec(a) = 1 / cos(a)"),
 
             // cosec(a) -> 1 / sin(a)
             new MatchedRule(
@@ -447,7 +461,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Divf>(
                     MatchPattern.Exact(Integer.Create(1)),
                     MatchPattern.Node<Sinf>(MatchPattern.Any("a"))),
-                Soundness.SoundUnderAssumptions));
+                Soundness.SoundUnderAssumptions,
+                description: "cosec(a) = 1 / sin(a)"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.PhiFunctionRules"/>, as data.
@@ -478,7 +493,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 // Euler's product formula, which is a theorem and not an assumption: for a prime
                 // p the integers below p^k sharing a factor with it are exactly the multiples of
                 // p, of which there are p^(k-1).
-                Soundness.Sound));
+                Soundness.Sound,
+                description: "phi(p ^ k) = p ^ (k - 1) * (p - 1), for a prime p"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.CollapseTrigonometricFunctions"/>, as data.
@@ -559,7 +575,8 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Node<Cosf>(MatchPattern.Any("a")))),
                 // Holds for every complex a and b: the identity is the addition theorem, which
                 // has no branch to fall off.
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "sin(a + b) = sin(a)cos(b) + sin(b)cos(a)"),
 
             // sin(a - b) -> sin(a)cos(b) - sin(b)cos(a)
             new MatchedRule(
@@ -573,7 +590,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Mulf>(
                         MatchPattern.Node<Sinf>(MatchPattern.Any("b")),
                         MatchPattern.Node<Cosf>(MatchPattern.Any("a")))),
-                Soundness.Sound));
+                Soundness.Sound,
+                description: "sin(a - b) = sin(a)cos(b) - sin(b)cos(a)"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.ExpandTrigonometricRules"/>, as data.
@@ -593,7 +611,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Mulf>(
                     MatchPattern.Node<Sinf>(MatchPattern.Any("a")),
                     MatchPattern.Node<Cosf>(MatchPattern.Any("a"))),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "(1/2) * sin(2a) = sin(a) * cos(a)"),
 
             // cos(2a) -> cos(a)^2 - sin(a)^2
             new MatchedRule(
@@ -609,7 +628,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Powf>(
                         MatchPattern.Node<Sinf>(MatchPattern.Any("a")),
                         MatchPattern.Exact(Integer.Create(2)))),
-                Soundness.Sound));
+                Soundness.Sound,
+                description: "cos(2a) = cos(a)^2 - sin(a)^2"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.ExpandMultipleAngleRules"/>, as data.
@@ -633,7 +653,13 @@ namespace AngouriMath.Core.Transformations.Matching
                 bound => TrigonometricAngleExpansion.ExpandSineArgumentMultiplied(
                     new Sinf(bound["a"]), new Cosf(bound["a"]),
                     ((Integer)bound["n"]).EInteger.ToInt32Checked()),
-                Soundness.Sound),
+                Soundness.Sound,
+                // Declared, because the replacement is code and so nothing counts it. The
+                // Chebyshev expansion of sin(n * a) is a sum of n terms where the pattern is one
+                // node, for every n this fires on -- IsWorthExpanding is what bounds n, not what
+                // makes the direction uncertain.
+                RewriteRuleGrowth.Expands,
+                description: "sin(n * a) = its expansion, for a whole n worth expanding"),
 
             // cos(n * a) -> the expansion, for a whole n worth expanding
             new MatchedRule(
@@ -645,7 +671,13 @@ namespace AngouriMath.Core.Transformations.Matching
                 bound => TrigonometricAngleExpansion.ExpandCosineArgumentMultiplied(
                     new Sinf(bound["a"]), new Cosf(bound["a"]),
                     ((Integer)bound["n"]).EInteger.ToInt32Checked()),
-                Soundness.Sound));
+                Soundness.Sound,
+                // Declared, because the replacement is code and so nothing counts it. The
+                // Chebyshev expansion of sin(n * a) is a sum of n terms where the pattern is one
+                // node, for every n this fires on -- IsWorthExpanding is what bounds n, not what
+                // makes the direction uncertain.
+                RewriteRuleGrowth.Expands,
+                description: "cos(n * a) = its expansion, for a whole n worth expanding"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.PolynomialLongDivision"/>, as data.
@@ -667,7 +699,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     is var (divided, remainder)
                     ? divided + remainder
                     : node,
-                Soundness.SoundUnderAssumptions));
+                Soundness.SoundUnderAssumptions,
+                description: "n / d = quotient + remainder, by polynomial long division"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.PolynomialGcdCancellation"/>, as data.
@@ -710,7 +743,8 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Any("y"), MatchPattern.Any<Number>("b")))),
                 (node, bound) => Functions.Patterns.CancelFactorials(
                     node, bound["x"], bound["y"], (Number)bound["a"], (Number)bound["b"]),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "(x + a)! / (y + b)! = the product between them, where the offsets are close"),
 
             // x! / (y + b)!
             new MatchedRule(
@@ -721,7 +755,8 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Any("y"), MatchPattern.Any<Number>("b")))),
                 (node, bound) => Functions.Patterns.CancelFactorials(
                     node, bound["x"], bound["y"], Integer.Create(0), (Number)bound["b"]),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "x! / (y + b)! = the product between them, where the offsets are close"),
 
             // (x + a)! / y!
             new MatchedRule(
@@ -732,7 +767,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Factorialf>(MatchPattern.Any("y"))),
                 (node, bound) => Functions.Patterns.CancelFactorials(
                     node, bound["x"], bound["y"], (Number)bound["a"], Integer.Create(0)),
-                Soundness.SoundUnderAssumptions));
+                Soundness.SoundUnderAssumptions,
+                description: "(x + a)! / y! = the product between them, where the offsets are close"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.FactorizeFactorialMultiplications"/>, as data.
@@ -754,7 +790,8 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Any("y"), MatchPattern.Any<Number>("b"))),
                 (node, bound) => Functions.Patterns.GatherFactorial(
                     node, bound["x"], bound["y"], (Number)bound["a"], (Number)bound["b"]),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "(x + a)! * (y + b) = (x + a + 1)!, where (y + b) is the next term"),
 
             // x! * (y + b)
             new MatchedRule(
@@ -765,7 +802,8 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Any("y"), MatchPattern.Any<Number>("b"))),
                 (node, bound) => Functions.Patterns.GatherFactorial(
                     node, bound["x"], bound["y"], Integer.Create(0), (Number)bound["b"]),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "x! * (y + b) = (x + 1)!, where (y + b) is the next term"),
 
             // (x + a)! * y
             new MatchedRule(
@@ -776,7 +814,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any("y")),
                 (node, bound) => Functions.Patterns.GatherFactorial(
                     node, bound["x"], bound["y"], (Number)bound["a"], Integer.Create(0)),
-                Soundness.SoundUnderAssumptions));
+                Soundness.SoundUnderAssumptions,
+                description: "(x + a)! * y = (x + a + 1)!, where y is the next term"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.PerfectSquareRules"/>, as data.
@@ -1866,7 +1905,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Divf>(MatchPattern.Any("rn"), MatchPattern.Any("rd"))),
                 (node, bound) => Functions.Patterns.SumOfFractions(
                     node, bound["ln"], bound["ld"], bound["rn"], bound["rd"]),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "ln / ld + rn / rd = one quotient over a common denominator"),
 
             new MatchedRule(
                 "two-subtracted-fractions-take-a-common-denominator",
@@ -1875,7 +1915,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Divf>(MatchPattern.Any("rn"), MatchPattern.Any("rd"))),
                 (node, bound) => Functions.Patterns.SumOfFractions(
                     node, bound["ln"], bound["ld"], -bound["rn"], bound["rd"]),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "ln / ld - rn / rd = one quotient over a common denominator"),
 
             new MatchedRule(
                 "a-quotient-of-symbolic-parts-is-grouped-pairwise",
@@ -1883,7 +1924,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 (node, bound) => Functions.Patterns.PairwiseGroupedQuotient(
                     node, bound["num"], bound["den"], level),
                 Soundness.SoundUnderAssumptions,
-                when: bound => bound["num"].Vars.Any() && bound["den"].Vars.Any()));
+                when: bound => bound["num"].Vars.Any() && bound["den"].Vars.Any(),
+                description: "num / den = the quotient with shared factors paired off"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.InequalityEqualityRules"/>, as data.

--- a/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
@@ -139,8 +139,7 @@ namespace AngouriMath.Core.Transformations
             "Lifts numeric factors out of a quotient so that the division rules can see it.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.DivisionPreparing.ApplyHere,
-            Patterns.DivisionPreparingRulesArms);
+            Matching.MatchedRules.DivisionPreparing);
 
         /// <summary>
         /// Cosmetic arrangement of signs, so that adding a negative reads as a difference.
@@ -198,8 +197,7 @@ namespace AngouriMath.Core.Transformations
             "Distributes products and powers over sums.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.Expansion.ApplyHere,
-            Patterns.ExpandRulesArms);
+            Matching.MatchedRules.Expansion);
 
         /// <summary>
         /// Takes common factors back out of a sum.
@@ -295,8 +293,7 @@ namespace AngouriMath.Core.Transformations
             "Collapses nested quotients into a single numerator over a single denominator.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.CollapseMultipleFractions.ApplyHere,
-            Patterns.CollapseMultipleFractionsArms);
+            Matching.MatchedRules.CollapseMultipleFractions);
 
         /// <summary>
         /// Puts a sum of quotients over one denominator, grouping the terms by variables and
@@ -307,8 +304,7 @@ namespace AngouriMath.Core.Transformations
             "Adds quotients by putting them over a common denominator.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.CommonDenominator(TreeAnalyzer.SortLevel.HIGH_LEVEL).ApplyHere,
-            Patterns.FractionCommonDenominatorRulesArms(TreeAnalyzer.SortLevel.HIGH_LEVEL));
+            Matching.MatchedRules.CommonDenominator(TreeAnalyzer.SortLevel.HIGH_LEVEL));
 
         /// <summary>
         /// <see cref="CommonDenominator"/>, counting constants when it groups terms.
@@ -318,8 +314,7 @@ namespace AngouriMath.Core.Transformations
             "Adds quotients over a common denominator, distinguishing terms by their constants too.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.CommonDenominator(TreeAnalyzer.SortLevel.MIDDLE_LEVEL).ApplyHere,
-            Patterns.FractionCommonDenominatorRulesArms(TreeAnalyzer.SortLevel.MIDDLE_LEVEL));
+            Matching.MatchedRules.CommonDenominator(TreeAnalyzer.SortLevel.MIDDLE_LEVEL));
 
         /// <summary>
         /// <see cref="CommonDenominator"/>, grouping terms by the whole subtree.
@@ -329,8 +324,7 @@ namespace AngouriMath.Core.Transformations
             "Adds quotients over a common denominator, grouping terms by the whole subtree.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.CommonDenominator(TreeAnalyzer.SortLevel.LOW_LEVEL).ApplyHere,
-            Patterns.FractionCommonDenominatorRulesArms(TreeAnalyzer.SortLevel.LOW_LEVEL));
+            Matching.MatchedRules.CommonDenominator(TreeAnalyzer.SortLevel.LOW_LEVEL));
 
         /// <summary>
         /// Divides one polynomial by another, leaving a quotient plus a remainder.
@@ -346,8 +340,7 @@ namespace AngouriMath.Core.Transformations
             "Divides a polynomial by a polynomial, giving the quotient plus the remainder.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.PolynomialLongDivision.ApplyHere,
-            Patterns.PolynomialLongDivisionArms);
+            Matching.MatchedRules.PolynomialLongDivision);
 
         /// <summary>
         /// Puts a quotient of polynomials into lowest terms.
@@ -404,8 +397,7 @@ namespace AngouriMath.Core.Transformations
             "Writes tangents, cotangents, secants and cosecants as sines and cosines.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.NormalTrigonometricForm.ApplyHere,
-            Patterns.NormalTrigonometricFormArms);
+            Matching.MatchedRules.NormalTrigonometricForm);
 
         /// <summary>
         /// Gathers sines and cosines back into the derived functions where that is shorter.
@@ -438,8 +430,7 @@ namespace AngouriMath.Core.Transformations
             "Expands a sine or cosine of a sum into products of sines and cosines of its terms.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.ExpandTrigonometric.ApplyHere,
-            Patterns.ExpandTrigonometricRulesArms);
+            Matching.MatchedRules.ExpandTrigonometric);
 
         /// <summary>
         /// Opens a trigonometric function of a multiplied angle.
@@ -459,8 +450,7 @@ namespace AngouriMath.Core.Transformations
             "Expands a sine or cosine of an integer multiple of an angle.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.ExpandMultipleAngle.ApplyHere,
-            Patterns.ExpandMultipleAngleRulesArms);
+            Matching.MatchedRules.ExpandMultipleAngle);
 
         #endregion
 
@@ -535,8 +525,7 @@ namespace AngouriMath.Core.Transformations
             "Cancels a quotient of factorials into the product of the terms that do not cancel.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.ExpandFactorialDivisions.ApplyHere,
-            Patterns.ExpandFactorialDivisionsArms);
+            Matching.MatchedRules.ExpandFactorialDivisions);
 
         /// <summary>
         /// Recognises a product of consecutive terms as a factorial.
@@ -552,8 +541,7 @@ namespace AngouriMath.Core.Transformations
             "Gathers a product of a factorial and its neighbouring terms back into one factorial.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.FactorizeFactorialMultiplications.ApplyHere,
-            Patterns.FactorizeFactorialMultiplicationsArms);
+            Matching.MatchedRules.FactorizeFactorialMultiplications);
 
         /// <summary>
         /// Rules about Euler's totient function.
@@ -570,8 +558,7 @@ namespace AngouriMath.Core.Transformations
             "Applies the multiplicative identities of Euler's totient function.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.PhiFunction.ApplyHere,
-            Patterns.PhiFunctionRulesArms);
+            Matching.MatchedRules.PhiFunction);
 
         #endregion
 

--- a/Sources/Tests/UnitTests/Core/Transformations/AddressableRulesTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/AddressableRulesTest.cs
@@ -289,7 +289,14 @@ namespace AngouriMath.Tests.Core.Transformations
             Assert.Empty(without);
 
             Assert.Equal(30, withRules.Count);
-            Assert.Equal(407, withRules.Sum(set => set.Rules.Count));
+
+            // 397, and it was 407 before thirteen sets started reporting the rules they run
+            // rather than the `switch` they no longer run. The ten that went are not rules lost:
+            // ExpandFactorialDivisions and FactorizeFactorialMultiplications are eight arms each
+            // that the data form writes as three, the other five being the same rewrite spelled
+            // for each side a factorial can sit on -- which is one commutative pattern. Every
+            // other repointed set is one for one.
+            Assert.Equal(397, withRules.Sum(set => set.Rules.Count));
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleMetadataTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleMetadataTest.cs
@@ -5,6 +5,7 @@
 // Website: https://am.angouri.org.
 //
 
+using System;
 using System.Linq;
 using AngouriMath.Core.Transformations;
 using AngouriMath.Core.Transformations.Matching;
@@ -98,15 +99,64 @@ namespace AngouriMath.Tests.Core.Transformations
         /// A rule's own tier reaches the registry, and a <c>switch</c> arm's absence of one is
         /// reported as absent rather than as its set's.
         /// </summary>
+        /// <remarks>
+        /// Fourteen sets are described from their data form and carry a tier per rule; the other
+        /// sixteen are still described by <c>RuleRegistryGenerator</c>, which reads a <c>switch</c>
+        /// and has no tier to give. Named rather than counted, so that repointing a set is a change
+        /// to this list rather than a silent one.
+        /// </remarks>
         [Fact]
         public void ARuleWrittenAsDataCarriesItsTierIntoTheRegistry()
         {
-            var rationalize = RewriteRules.RationalizeDenominator;
-            Assert.All(rationalize.Rules, rule => Assert.NotNull(rule.Soundness));
+            var fromData = new[]
+            {
+                nameof(RewriteRules.CollapseMultipleFractions),
+                nameof(RewriteRules.CommonDenominator),
+                nameof(RewriteRules.CommonDenominatorCountingConstants),
+                nameof(RewriteRules.CommonDenominatorExact),
+                nameof(RewriteRules.DivisionPreparing),
+                nameof(RewriteRules.ExpandFactorialDivisions),
+                nameof(RewriteRules.ExpandMultipleAngle),
+                nameof(RewriteRules.ExpandTrigonometric),
+                nameof(RewriteRules.Expansion),
+                nameof(RewriteRules.FactorizeFactorialMultiplications),
+                nameof(RewriteRules.NormalTrigonometricForm),
+                nameof(RewriteRules.PhiFunction),
+                nameof(RewriteRules.PolynomialLongDivision),
+                nameof(RewriteRules.RationalizeDenominator),
+            };
 
-            // Every other set is still described by the generator, which has no tier to give.
-            var generated = RewriteRules.All.Where(set => set.Name != rationalize.Name);
+            var described = RewriteRules.All
+                .Where(set => set.Rules.Count > 0 && set.Rules.All(rule => rule.Soundness is not null))
+                .Select(set => set.Name)
+                .OrderBy(name => name, StringComparer.Ordinal);
+            Assert.Equal(fromData.OrderBy(name => name, StringComparer.Ordinal), described);
+
+            // And the rest report no tier of their own rather than their set's.
+            var generated = RewriteRules.All.Where(set => !fromData.Contains(set.Name));
             Assert.All(generated, set => Assert.All(set.Rules, rule => Assert.Null(rule.Soundness)));
+        }
+
+        /// <summary>
+        /// <b>Repointing a set at its data form gains descriptions rather than trading them.</b>
+        /// </summary>
+        /// <remarks>
+        /// The thirteen sets repointed here were chosen for exactly this: not one of them had a
+        /// single described arm, because <c>RuleRegistryGenerator</c> only has a description where
+        /// somebody wrote a comment above the arm and nobody had. Their data rules carry the
+        /// identity instead, so the registry goes from <b>0 of those 38 arms described to 38 of
+        /// 38</b> — where repointing <c>Common</c> or <c>Power</c> today would lose 33 and 22.
+        /// The 40 here is those 38 plus <c>RationalizeDenominator</c>'s two, which were repointed
+        /// before this and described alongside them.
+        /// </remarks>
+        [Fact]
+        public void EveryRuleOfARepointedSetCarriesItsIdentity()
+        {
+            var repointed = RewriteRules.All
+                .Where(set => set.Rules.Count > 0 && set.Rules.All(rule => rule.Soundness is not null))
+                .ToList();
+            Assert.Equal(40, repointed.Sum(set => set.Rules.Count));
+            Assert.All(repointed, set => Assert.All(set.Rules, rule => Assert.NotNull(rule.Description)));
         }
 
         /// <summary>


### PR DESCRIPTION
`RewriteRuleSet.Rules` is what the registry reports a set is made of, and it came from
`RuleRegistryGenerator` reading the `switch` that defined the set. **Twenty-seven of the thirty sets
stopped running that `switch` some releases ago** — they run `MatchedRuleSet.ApplyHere` — and went on
describing it. That is #825's open half, and what #746 tier 2 names as gating the rest.

Thirteen of them now describe what they run. #1107 made that possible by giving `AsAddressable()` the
rule's exact growth, its tier, and somewhere for its identity to live.

## Which thirteen, and why those

`CollapseMultipleFractions`, the three `CommonDenominator` sets, `DivisionPreparing`,
`ExpandFactorialDivisions`, `ExpandMultipleAngle`, `ExpandTrigonometric`, `Expansion`,
`FactorizeFactorialMultiplications`, `NormalTrigonometricForm`, `PhiFunction`,
`PolynomialLongDivision`.

**Not one of them had a single described arm.** The generator only has a description where somebody
wrote a comment above the arm, and for these nobody had — so repointing them *adds* metadata rather
than trading it. The sets left alone would trade: `Common` would lose 33 descriptions today and
`Power` 22. Porting those is the next change, not this one.

The identities come from the comments the data rules already carry, **checked against each rule's own
pattern and replacement rather than copied** — `a * (1 / b) = a / b`,
`(a / b) / (c / d) = (a * d) / (b * c)`, `tan(a) = sin(a) / cos(a)`. Four of the eight
`CollapseMultipleFractions` rules had no comment at all and their identities were read off the
patterns. Thirty-two rules gain one, and across the registry the number of described rules goes from
**95 to 135**.

## What changes for a caller

Measured on a build of each version rather than read off the diff, and recorded in
`BREAKING-CHANGES.md`.

| | Was | Is |
|---|---|---|
| `Rules[i].Name` | the arm's rendered pattern, `Mulf(var any1, Divf(Integer(1), var any2))` | the rule's name, `reciprocal-factor-becomes-a-quotient` |
| `Rules.Count`, two factorial sets | `8` | `3` |
| `RewriteRules.All.Sum(set => set.Rules.Count)` | `407` | `397` |
| `Rules[i].Description` | `null`, for all 38 of these arms | the identity, for all 38 |
| `Rules[i].Soundness` | `null` — an arm declares no tier | the rule's own tier |
| `Rules[i].PatternSource` | the C# the arm was written in | the pattern the matcher holds |

**The two counts that fall are not rewrites lost.** `ExpandFactorialDivisions` and
`FactorizeFactorialMultiplications` are eight arms each that the data form writes as three: the other
five are the same rewrite spelled once for each side a factorial can sit on, which is one commutative
pattern. Every other repointed set is one arm to one rule.

## One growth becomes *less* certain, and that is the right answer

`ExpandFactorialDivisions[0]` reported `Collects`. That was the string-length proxy guessing. The
exact answer for a code-built rule nobody declared is `Unknown` — and `Unknown` is right here: a
quotient of factorials **collects when the offsets are one apart and expands when they are five**, so
no single value is true of the rule.

The two `ExpandMultipleAngle` rules went the other way. The proxy had guessed `Expands` and happened
to be right, so the exact `Unknown` would have lost real information; they are now *declared*
`Expands`, since the Chebyshev expansion of `sin(n * a)` is a sum of n terms where the pattern is one
node, for every n the rule fires on. That is what `RewriteRuleGrowth.Unknown` exists to prompt.

**The test suite is what found this.** `GrowthSaysWhichWayTheSetMoves` failed on `ExpandMultipleAngle`
the moment the proxy's guess was gone, which is how the declaration got written rather than the
assertion got relaxed.

## What is untouched

`RuleConfluenceTest`, `DerivationPathTest` and `RewriteRecordingTest` all pass unchanged — they are
about `Common` and `Power`, which this does not repoint. Three tests changed: the two registry counts,
and my own `RuleMetadataTest` list of which sets carry a per-rule tier, which is now named rather than
counted so that repointing a set is a visible change.

Still explicitly not here: **deleting the ~27 dead `switch` methods.** They are the oracle
`MatchedRulesAgreeWithTheSwitchTest` proves the data form against, so deleting them deletes the
evidence the exchange was safe. That is a maintainer decision for #825.

## State

Full suite: **8974 passed, 14 skipped, 0 failed.** No public API change.

Part of #746 tier 2 and #825.
