### PR TITLE
Six more rule sets describe the rules they run

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -68,24 +68,30 @@ read first.
 | **Silent** | `RewriteRules.RationalizeDenominator.Rules` | `[]` — the registry could not read the set | its two rules, addressable and named |
 | **Silent** | `RewriteRules.Power.ApplyOnce("ln(1 / x)")`, and every `log(_, 1/_)` and `log(1/_, _)` whose argument is not decidably a positive real | `-ln(x)`, which is wrong on the negative reals | `ln(1 / x)`, left alone |
 | **Silent** | `RewriteRules.Boolean.ApplyOnce("a and b or a")`, and two more orientations of absorption | left alone — the arm for that orientation was never written | `a` |
-| **Silent** | `RewriteRules.DivisionPreparing.Rules[0].Name`, and every rule of thirteen sets now described from their data form | `Mulf(var any1, Divf(Integer(1), var any2))` — the `switch` arm's rendered pattern | `reciprocal-factor-becomes-a-quotient` |
+| **Silent** | `RewriteRules.DivisionPreparing.Rules[0].Name`, and every rule of nineteen sets now described from their data form | `Mulf(var any1, Divf(Integer(1), var any2))` — the `switch` arm's rendered pattern | `reciprocal-factor-becomes-a-quotient` |
 | | `RewriteRules.ExpandFactorialDivisions.Rules.Count`, and `FactorizeFactorialMultiplications` | `8` | `3` — the same rewrites, five of the eight arms being one commutative pattern |
 | | `RewriteRules.All.Sum(set => set.Rules.Count)` | `407` | `397` |
 | **Silent** | `RewriteRules.ExpandFactorialDivisions.Rules[0].Growth` | `Collects` — guessed from string length | `Unknown`; whether it collects depends on the offsets |
 
-### Thirteen rule sets describe the rules they run
+### Nineteen rule sets describe the rules they run
 
 `RewriteRuleSet.Rules` is what the registry reports a set is made of, and for most of the library's
 life it came from `RuleRegistryGenerator` reading the `switch` that defined the set. Twenty-seven of
 the thirty sets stopped running that `switch` some releases ago — they run
 `MatchedRuleSet.ApplyHere` — and went on describing it. Thirteen of them now describe what they run.
 
-Which thirteen: `CollapseMultipleFractions`, the three `CommonDenominator` sets, `DivisionPreparing`,
+Which nineteen. Thirteen had **no described arm at all**, so repointing them could only add
+metadata: `CollapseMultipleFractions`, the three `CommonDenominator` sets, `DivisionPreparing`,
 `ExpandFactorialDivisions`, `ExpandMultipleAngle`, `ExpandTrigonometric`, `Expansion`,
 `FactorizeFactorialMultiplications`, `NormalTrigonometricForm`, `PhiFunction` and
-`PolynomialLongDivision`. They were chosen because **not one of them had a described arm**, so the
-change adds metadata rather than trading it; the sets left alone — `Common` and `Power` among them —
-would lose 33 and 22 descriptions today, and are for a later change.
+`PolynomialLongDivision`. Six more are **one arm to one rule**, so their existing descriptions carry
+across unchanged and the rules that had none gain one: `CollapseTrigonometricFunctions`,
+`InvertNegativeMultipliers`, `InvertNegativePowers`, `PerfectSquare`, `PolynomialGcdCancellation` and
+`SetOperator`. `RationalizeDenominator` was already reading its data form.
+
+The seven left on the `switch` are the ones where repointing would cost something today: `Common`
+would lose 33 descriptions and `Power` 22. Porting those identities is a later change. Three more —
+the `CanonicalOrder` family — still *run* their `switch`, so describing it is not a mismatch.
 
 Four things move, and only the second changes a count:
 
@@ -93,14 +99,14 @@ Four things move, and only the second changes a count:
 |---|---|---|
 | `Rules[i].Name` | the arm's rendered pattern, `Mulf(var any1, Divf(Integer(1), var any2))` | the rule's name, `reciprocal-factor-becomes-a-quotient` |
 | `Rules.Count`, for the two factorial sets | `8` | `3` |
-| `Rules[i].Description` | `null` for all 38 of these arms | the identity, `a * (1 / b) = a / b`, for all 38 |
+| `Rules[i].Description` | `null` for 38 of these arms and set for 8 | the identity, `a * (1 / b) = a / b`, for all 59 |
 | `Rules[i].Soundness` | `null` — an arm declares no tier | the rule's own tier |
 
 **The two counts that change are not rewrites lost.** `ExpandFactorialDivisions` and
 `FactorizeFactorialMultiplications` are eight arms each that the data form writes as three: the other
 five are the same rewrite spelled once for each side a factorial can sit on, which is one commutative
 pattern. Every other repointed set is one arm to one rule. Across the registry, 407 becomes 397 while
-the number of described rules goes from **95 to 135**.
+the number of described rules goes from **95 to 147**.
 
 `Rules[i].Growth` also stops being a guess. `AsAddressable` used to infer it by comparing the lengths
 of the two rendered pattern strings — the only thing available to a generator reading source text —

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -372,7 +372,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 // else in the complex plane: this is the definition of a negative power rather
                 // than an identity that needs one. Measured at 0 as well as away from it before
                 // the tier was written down.
-                Soundness.Sound));
+                Soundness.Sound,
+                description: "a ^ n = 1 / a ^ (-n), for a negative integer n"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.InvertNegativeMultipliers"/>, as data.
@@ -396,7 +397,8 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Any<Real>("c", c => c.IsNegative),
                         MatchPattern.Any("b"))),
                 bound => bound["a"] - (-1 * (Real)bound["c"]) * bound["b"],
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "a + (c * b) = a - (-c) * b, for a negative real c"),
 
             // (-1) * (a - b) -> b - a
             new MatchedRule(
@@ -405,7 +407,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Exact(Integer.Create(-1)),
                     MatchPattern.Node<Minusf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
                 MatchPattern.Node<Minusf>(MatchPattern.Any("b"), MatchPattern.Any("a")),
-                Soundness.Sound));
+                Soundness.Sound,
+                description: "(-1) * (a - b) = b - a"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.NormalTrigonometricForm"/>, as data.
@@ -517,7 +520,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Sinf>(MatchPattern.Any("a")),
                     MatchPattern.Node<Cosf>(MatchPattern.Any("a"))),
                 MatchPattern.Node<Tanf>(MatchPattern.Any("a")),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "sin(a) / cos(a) = tan(a)"),
 
             // cos(a) / sin(a) -> cotan(a)
             new MatchedRule(
@@ -526,7 +530,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Cosf>(MatchPattern.Any("a")),
                     MatchPattern.Node<Sinf>(MatchPattern.Any("a"))),
                 MatchPattern.Node<Cotanf>(MatchPattern.Any("a")),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "cos(a) / sin(a) = cotan(a)"),
 
             // a / sin(b) -> a * cosec(b)
             new MatchedRule(
@@ -537,7 +542,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Mulf>(
                     MatchPattern.Any("a"),
                     MatchPattern.Node<Cosecantf>(MatchPattern.Any("b"))),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "a / sin(b) = a * cosec(b)"),
 
             // a / cos(b) -> a * sec(b)
             new MatchedRule(
@@ -548,7 +554,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Mulf>(
                     MatchPattern.Any("a"),
                     MatchPattern.Node<Secantf>(MatchPattern.Any("b"))),
-                Soundness.SoundUnderAssumptions));
+                Soundness.SoundUnderAssumptions,
+                description: "a / cos(b) = a * sec(b)"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.ExpandRules"/>, as data.
@@ -718,7 +725,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 (node, bound) => PolynomialGcd.TryCancel(bound["n"], bound["d"], out var cancelled)
                     ? cancelled
                     : node,
-                Soundness.SoundUnderAssumptions));
+                Soundness.SoundUnderAssumptions,
+                description: "n / d = (n / g) / (d / g), for g the gcd of n and d"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.ExpandFactorialDivisions"/>, as data.
@@ -847,7 +855,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 // sqrt(u)^2 is u for every complex u, so the identity itself is unconditional.
                 // What is not is the test for whether the cross term matches, which needs
                 // Simplify -- see the remark on Patterns.CollapseToPerfectSquare.
-                Soundness.SoundUnderAssumptions));
+                Soundness.SoundUnderAssumptions,
+                description: "a +- 2*sqrt(a)*sqrt(b) + b = (sqrt(a) +- sqrt(b))^2"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.RationalizeDenominator"/>, as data.
@@ -1674,7 +1683,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 "an-intersection-with-itself-is-itself",
                 MatchPattern.Node<Set.Intersectionf>(MatchPattern.Any("a"), MatchPattern.Any("a")),
                 MatchPattern.Any("a"),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "A /\\ A = A"),
 
             // A /\ (B \/ C) = (A /\ B) \/ (A /\ C), and the same with the union on the left.
             // Two rules rather than one commutative pattern, because each builds its answer with
@@ -1687,7 +1697,8 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Any<Set>("b"), MatchPattern.Any<Set>("c"))),
                 bound => ((Set)bound["a"]).Intersect((Set)bound["b"])
                     .Unite(((Set)bound["a"]).Intersect((Set)bound["c"])),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "A /\\ (B \\/ C) = (A /\\ B) \\/ (A /\\ C)"),
 
             new MatchedRule(
                 "an-intersection-distributes-over-a-union-on-its-left",
@@ -1697,21 +1708,24 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any<Set>("a")),
                 bound => ((Set)bound["b"]).Intersect((Set)bound["a"])
                     .Unite(((Set)bound["c"]).Intersect((Set)bound["a"])),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "(B \\/ C) /\\ A = (B /\\ A) \\/ (C /\\ A)"),
 
             // A \/ A = A
             new MatchedRule(
                 "a-union-with-itself-is-itself",
                 MatchPattern.Node<Set.Unionf>(MatchPattern.Any("a"), MatchPattern.Any("a")),
                 MatchPattern.Any("a"),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "A \\/ A = A"),
 
             // A \ A = {}
             new MatchedRule(
                 "a-set-less-itself-is-empty",
                 MatchPattern.Node<Set.SetMinusf>(MatchPattern.Any("a"), MatchPattern.Any("a")),
                 bound => Set.Empty,
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "A \\ A = {}"),
 
             // { x : x in S } = S. Bound whole and taken apart in the replacement, because a
             // node pattern cannot reach inside a binder -- see the remark on this set.
@@ -1720,7 +1734,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Any<Set.ConditionalSet>(
                     "cs", set => set.Predicate is Set.Inf(var member, _) && member == set.Var),
                 bound => ((Set.Inf)((Set.ConditionalSet)bound["cs"]).Predicate).SupSet,
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "{ x : x in S } = S"),
 
             // x in {a} = (x = a)
             new MatchedRule(
@@ -1729,7 +1744,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any("x"),
                     MatchPattern.Any<Set.FiniteSet>("s", finite => finite.Count == 1)),
                 bound => bound["x"].EqualTo(((Set.FiniteSet)bound["s"]).First()),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "x in {a} = (x = a)"),
 
             // x in (a; b) is written out as the inequalities it stands for
             new MatchedRule(
@@ -1744,7 +1760,8 @@ namespace AngouriMath.Core.Transformations.Matching
                         bound["x"], interval.Left, interval.LeftClosed,
                         interval.Right, interval.RightClosed);
                 },
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "x in (a; b) = the inequalities it stands for"),
 
             // { True, False } is the boolean domain
             new MatchedRule(
@@ -1752,7 +1769,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Any<Set.FiniteSet>(
                     "s", finite => finite == Functions.Patterns.FullBooleanSet),
                 bound => Set.SpecialSet.Create(Domain.Boolean),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "{ True, False } = the boolean domain"),
 
             // (-oo; +oo) is the domain it is an interval of
             new MatchedRule(
@@ -1761,7 +1779,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     "i", interval => interval.Left == Real.NegativeInfinity
                                      && interval.Right == Real.PositiveInfinity),
                 bound => Set.SpecialSet.Create(((Set.Interval)bound["i"]).Codomain),
-                Soundness.Sound));
+                Soundness.Sound,
+                description: "(-oo; +oo) = the domain it is an interval of"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.SortRules"/>, as data — one set per sort level.

--- a/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
@@ -94,8 +94,7 @@ namespace AngouriMath.Core.Transformations
             "Rewrites negative powers as quotients.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.InvertNegativePowers.ApplyHere,
-            Patterns.InvertNegativePowersArms);
+            Matching.MatchedRules.InvertNegativePowers);
 
         /// <summary>
         /// Brings a negative numeric factor out in front of the term it multiplies.
@@ -111,8 +110,7 @@ namespace AngouriMath.Core.Transformations
             "Moves a negative numeric factor out of a product into the sign of the term.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.InvertNegativeMultipliers.ApplyHere,
-            Patterns.InvertNegativeMultipliersArms);
+            Matching.MatchedRules.InvertNegativeMultipliers);
 
         /// <summary>
         /// The arithmetic housekeeping rules — collecting like terms, flattening nested
@@ -231,8 +229,7 @@ namespace AngouriMath.Core.Transformations
             "Collapses a written-out perfect square into a squared binomial.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.PerfectSquare.ApplyHere,
-            Patterns.PerfectSquareRulesArms);
+            Matching.MatchedRules.PerfectSquare);
 
         #endregion
 
@@ -356,8 +353,7 @@ namespace AngouriMath.Core.Transformations
             "Cancels the greatest common divisor of a polynomial quotient's numerator and denominator.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.PolynomialGcdCancellation.ApplyHere,
-            Patterns.PolynomialGcdCancellationArms);
+            Matching.MatchedRules.PolynomialGcdCancellation);
 
         #endregion
 
@@ -413,8 +409,7 @@ namespace AngouriMath.Core.Transformations
             "Recognises a quotient or reciprocal of sines and cosines as a tangent, cotangent, secant or cosecant.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.CollapseTrigonometricFunctions.ApplyHere,
-            Patterns.CollapseTrigonometricFunctionsArms);
+            Matching.MatchedRules.CollapseTrigonometricFunctions);
 
         /// <summary>
         /// Opens a trigonometric function of a sum into functions of its terms.
@@ -508,8 +503,7 @@ namespace AngouriMath.Core.Transformations
             "Applies the identities of set algebra to unions, intersections and set differences.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.SetOperator.ApplyHere,
-            Patterns.SetOperatorRulesArms);
+            Matching.MatchedRules.SetOperator);
 
         /// <summary>
         /// Cancels a quotient of factorials down to the terms that survive.

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleMetadataTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleMetadataTest.cs
@@ -100,9 +100,10 @@ namespace AngouriMath.Tests.Core.Transformations
         /// reported as absent rather than as its set's.
         /// </summary>
         /// <remarks>
-        /// Fourteen sets are described from their data form and carry a tier per rule; the other
-        /// sixteen are still described by <c>RuleRegistryGenerator</c>, which reads a <c>switch</c>
-        /// and has no tier to give. Named rather than counted, so that repointing a set is a change
+        /// Twenty sets are described from their data form and carry a tier per rule. Of the ten
+        /// left, seven are still described by <c>RuleRegistryGenerator</c> reading a <c>switch</c>
+        /// they no longer run, and three — the <c>CanonicalOrder</c> family — still run theirs, so
+        /// describing it is honest. Named rather than counted, so that repointing a set is a change
         /// to this list rather than a silent one.
         /// </remarks>
         [Fact]
@@ -111,6 +112,7 @@ namespace AngouriMath.Tests.Core.Transformations
             var fromData = new[]
             {
                 nameof(RewriteRules.CollapseMultipleFractions),
+                nameof(RewriteRules.CollapseTrigonometricFunctions),
                 nameof(RewriteRules.CommonDenominator),
                 nameof(RewriteRules.CommonDenominatorCountingConstants),
                 nameof(RewriteRules.CommonDenominatorExact),
@@ -120,10 +122,15 @@ namespace AngouriMath.Tests.Core.Transformations
                 nameof(RewriteRules.ExpandTrigonometric),
                 nameof(RewriteRules.Expansion),
                 nameof(RewriteRules.FactorizeFactorialMultiplications),
+                nameof(RewriteRules.InvertNegativeMultipliers),
+                nameof(RewriteRules.InvertNegativePowers),
                 nameof(RewriteRules.NormalTrigonometricForm),
+                nameof(RewriteRules.PerfectSquare),
                 nameof(RewriteRules.PhiFunction),
+                nameof(RewriteRules.PolynomialGcdCancellation),
                 nameof(RewriteRules.PolynomialLongDivision),
                 nameof(RewriteRules.RationalizeDenominator),
+                nameof(RewriteRules.SetOperator),
             };
 
             var described = RewriteRules.All
@@ -141,13 +148,12 @@ namespace AngouriMath.Tests.Core.Transformations
         /// <b>Repointing a set at its data form gains descriptions rather than trading them.</b>
         /// </summary>
         /// <remarks>
-        /// The thirteen sets repointed here were chosen for exactly this: not one of them had a
-        /// single described arm, because <c>RuleRegistryGenerator</c> only has a description where
-        /// somebody wrote a comment above the arm and nobody had. Their data rules carry the
-        /// identity instead, so the registry goes from <b>0 of those 38 arms described to 38 of
-        /// 38</b> — where repointing <c>Common</c> or <c>Power</c> today would lose 33 and 22.
-        /// The 40 here is those 38 plus <c>RationalizeDenominator</c>'s two, which were repointed
-        /// before this and described alongside them.
+        /// A set is repointed only once every rule of it carries an identity, so that the registry
+        /// gains descriptions rather than trading them. The first thirteen were the ones with no
+        /// described arm at all; the six after them are one arm to one rule, so their existing
+        /// descriptions carry across and the rules that had none gain one. Of the seven still on
+        /// the <c>switch</c>, repointing <c>Common</c> today would lose 33 descriptions and
+        /// <c>Power</c> 22, which is what porting those identities is for.
         /// </remarks>
         [Fact]
         public void EveryRuleOfARepointedSetCarriesItsIdentity()
@@ -155,7 +161,7 @@ namespace AngouriMath.Tests.Core.Transformations
             var repointed = RewriteRules.All
                 .Where(set => set.Rules.Count > 0 && set.Rules.All(rule => rule.Soundness is not null))
                 .ToList();
-            Assert.Equal(40, repointed.Sum(set => set.Rules.Count));
+            Assert.Equal(59, repointed.Sum(set => set.Rules.Count));
             Assert.All(repointed, set => Assert.All(set.Rules, rule => Assert.NotNull(rule.Description)));
         }
 


### PR DESCRIPTION
The second tranche of the repoint. #1108 took the thirteen sets with **no described arm at all**,
where the change could only add metadata. These six are the other free case: **one arm to one rule**,
so their existing descriptions carry across unchanged and the rules that had none gain one.

`CollapseTrigonometricFunctions`, `InvertNegativeMultipliers`, `InvertNegativePowers`,
`PerfectSquare`, `PolynomialGcdCancellation`, `SetOperator`. Nineteen rules.

## The identities

Sixteen already carried theirs as a comment. Three did not, and those were read off the rules rather
than guessed from their names:

| rule | identity |
|---|---|
| `a-quotient-of-polynomials-is-put-in-lowest-terms` | `n / d = (n / g) / (d / g)`, for `g` the gcd of `n` and `d` |
| `a-sum-or-difference-that-is-a-perfect-square` | `a +- 2*sqrt(a)*sqrt(b) + b = (sqrt(a) +- sqrt(b))^2` |
| `an-intersection-distributes-over-a-union-on-its-left` | `(B \/ C) /\ A = (B /\ A) \/ (C /\ A)` |

The third is the mirror of the rule above it, whose comment covers both — the two exist separately
because each builds its answer with the operands in the order it found them, which a single
commutative pattern would lose.

Where a comment carried commentary as well as the identity, only the identity is taken:
`sin(a) / cos(a) = tan(a)` without the sentence about how the pattern says *"of the same argument"*,
which is a remark about the encoding rather than about the mathematics.

## No count moves, and that is the check

The registry stays at **397** arms. That is what confirms these six really are one for one:
`AddressableRulesTest.TheRegistryIsAddressableAsFarAsItSaysItIs` asserts the total, and it did not
fire. So unlike #1108 there is no arm-count change here — only names, descriptions, tiers and
`PatternSource` move, and `BREAKING-CHANGES.md`'s existing entry is widened rather than joined by a
new one.

| | Was | Is |
|---|---|---|
| described rules in the registry | 135 | **147** |
| rules carrying a tier of their own | 40 | **59** |
| sets describing what they run | 14 | **20** |

The 147 is measured, not computed: seven of these nineteen rules were already described from their
arms, so the arithmetic is not `135 + 19`. I wrote 146 first and the measurement corrected it.

## What is left

Of the eleven sets not repointed, **three are the `CanonicalOrder` family, which still runs its
`switch`** — describing it is honest there, and they are not a target.

The other seven are where repointing still costs something today: `Common` would lose 33 descriptions
and `Power` 22. Porting those identities is the next change, and it is the last of the work — after
which every set that stopped running its `switch` also stops describing it, and #825's remaining
question is only whether the dead `switch` methods may be deleted at all. They are the oracle
`MatchedRulesAgreeWithTheSwitchTest` proves the data form against, so that stays a maintainer
decision rather than mine.

## State

Full suite: **8974 passed, 14 skipped, 0 failed.** No public API change.

Part of #746 tier 2 and #825.
