### PR TITLE
A step renders as a sentence

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -72,6 +72,8 @@ read first.
 | | `RewriteRules.ExpandFactorialDivisions.Rules.Count`, and `FactorizeFactorialMultiplications` | `8` | `3` — the same rewrites, five of the eight arms being one commutative pattern |
 | | `RewriteRules.All.Sum(set => set.Rules.Count)` | `407` | `397` |
 | **Silent** | `RewriteRules.ExpandFactorialDivisions.Rules[0].Growth` | `Collects` — guessed from string length | `Unknown`; whether it collects depends on the offsets |
+| **Silent** | `RewriteStep.Soundness` on a rewrite whose rule declares a tier — `RewriteRules.SetOperator` on `A /\ A`, and every rewrite of the nineteen sets described from their data form | `SoundUnderAssumptions` — its rule set's tier, which is the minimum over every rule in the set | `Sound` — the rule's own |
+| **Silent** | `DerivationStep.Soundness` | its rule set's tier | the weakest tier any rewrite that actually fired inside the step holds at |
 
 ### Nineteen rule sets describe the rules they run
 
@@ -117,6 +119,33 @@ factorials collects when the offsets are one apart and expands when they are fiv
 `PatternSource` changes too, from the C# the arm was written in to the pattern the matcher holds —
 `Mulf(var a, Divf(1, var b))` for the same rule. Both are source text for reading; neither is
 something to match against.
+
+### A step is justified by the rule that fired, not by the set it came from
+
+`RewriteStep.Soundness` read `RuleSet.Soundness` and nothing else, so every rewrite of a set reported
+the same tier. A set's tier is the **minimum** over its rules, and one conditional rule is enough to
+make a set of a hundred report as conditional: all thirty sets in the registry declare
+`SoundUnderAssumptions`, while **181 of the 322 rules written as data are `Sound`** — they hold for
+every complex argument, with nothing assumed.
+
+A rewrite now reports its rule's own tier where the rule has one, and its set's where it has not:
+
+```csharp
+using var recording = RewriteRecording.Start();
+RewriteRules.SetOperator.ApplyOnce(@"A /\ A".ToEntity());
+recording.Dispose();
+recording.Steps[0].Soundness           // was SoundUnderAssumptions, is Sound
+recording.Steps[0].RuleSet.Soundness   // still SoundUnderAssumptions, and correctly so
+```
+
+The fallback is not a claim. A rule read off a `switch` declares no tier, so `RewriteRule.Soundness`
+is `null` there and the set's tier is what is known — see *Nineteen rule sets describe the rules they
+run* above for which sets carry per-rule tiers today.
+
+`DerivationStep.Soundness` changes for the same reason and one more: it is now the weakest tier any
+rewrite that **actually fired** inside the step holds at, rather than its set's minimum over rules
+the step may never have reached. A pass of nine unconditional rewrites and one conditional one is
+still a conditional pass; a pass of ten unconditional ones now says so.
 
 ### An equation nothing settled is no longer answered with the empty set
 

--- a/Sources/AngouriMath/Core/Transformations/DerivationPath.cs
+++ b/Sources/AngouriMath/Core/Transformations/DerivationPath.cs
@@ -66,8 +66,60 @@ namespace AngouriMath.Core.Transformations
         /// <summary>What this step claims about its output, where it is a rule set. See <see cref="RewriteRuleSet.Relation"/>.</summary>
         public TransformationRelation? Relation => RuleSet?.Relation;
 
-        /// <summary>How well justified that claim is, where it is a rule set. See <see cref="Soundness"/>.</summary>
-        public Soundness? Soundness => RuleSet?.Soundness;
+        /// <summary>
+        /// How well justified that claim is — the weakest tier any rewrite inside it holds at,
+        /// falling back to the set's where no rewrite was recorded. <see langword="null"/> where
+        /// the step is not a rule set at all.
+        /// </summary>
+        /// <remarks>
+        /// The weakest, because a step is only as justified as the least justified thing in it: a
+        /// pass of nine unconditional rewrites and one conditional one is a conditional pass. Read
+        /// off the rewrites rather than off the set, so that a pass of rules which all hold
+        /// universally says so instead of inheriting its set's minimum over rules it did not fire.
+        /// </remarks>
+        public Soundness? Soundness
+        {
+            get
+            {
+                if (RuleSet is null) return null;
+                var weakest = (Soundness?)null;
+                foreach (var rewrite in Rewrites)
+                    if (weakest is not { } known || rewrite.Soundness > known)
+                        weakest = rewrite.Soundness;
+                return weakest ?? RuleSet.Soundness;
+            }
+        }
+
+        /// <summary>
+        /// This pass as a sentence: what it did to the whole expression, and why.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// A pass is not a rewrite, so this is not <see cref="RewriteStep.Explain"/> at another
+        /// grain. Three shapes, and which one is used is a fact about the step rather than a
+        /// choice:
+        /// </para>
+        /// <list type="bullet">
+        /// <item>a pass in which <b>one</b> rewrite fired is that rewrite, so it is explained as
+        /// one — anything else wraps a layer of narration around a single identity;</item>
+        /// <item>a pass that only tidies says so and names no identity, because
+        /// <see cref="RewriteRuleSet.IsNormalization"/> is the author saying this step is not where
+        /// the mathematics happened;</item>
+        /// <item>a pass of several rewrites names how many and what did them. The identities are in
+        /// <see cref="Rewrites"/> for a reader who wants them, and repeating all of them here would
+        /// make the chain unreadable at the grain it is read at.</item>
+        /// </list>
+        /// </remarks>
+        public string Explain()
+        {
+            if (RuleSet is { IsNormalization: true })
+                return $"Tidying: {Explanation.Transition(Before, After)}.";
+            if (Rewrites.Count == 1)
+                return Rewrites[0].Explain();
+            if (Rewrites.Count == 0)
+                return $"{Explanation.Transition(Before, After)}, by {Name}.";
+            return $"{Explanation.Transition(Before, After)}, by {Rewrites.Count} rewrites of {Name}.";
+        }
 
         /// <inheritdoc/>
         public override string ToString() => $"{Name}: {Before.Stringize()} -> {After.Stringize()}";
@@ -161,12 +213,83 @@ namespace AngouriMath.Core.Transformations
         }
 
         /// <summary>
+        /// The derivation in prose: what it did, then a numbered sentence per step, then what the
+        /// whole of it is justified by.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> tier 2 asks
+        /// for "transformation metadata rich enough that v5.0 can render a step as a sentence".
+        /// This is the check on that: the metadata is rich enough exactly when a sentence can be
+        /// built from it, and every word of one here is read off a rule — the clause is the rule's
+        /// name with its hyphens replaced, and the identity in brackets is its description.
+        /// </para>
+        /// <para>
+        /// <b>The closing note is counted, not asserted.</b> How many steps hold universally, how
+        /// many hold under assumptions, and how much of the search was discarded are all read off
+        /// this path, so the paragraph cannot come to disagree with the steps above it — which is
+        /// the failure a written-out summary has and a computed one does not.
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// Console.WriteLine(DerivationPath.OfSimplifying("x ^ (-1) / (y / z)")!.Explain());
+        /// </code>
+        /// </example>
+        public string Explain()
+        {
+            var text = new StringBuilder();
+            if (Steps.Count == 0)
+            {
+                // Nothing was kept, which is not the same as nothing having been tried -- and the
+                // difference is the whole of what this sentence has to say. The search below
+                // reports it: on `(a + b) ^ 2` five expressions were reached and none was better,
+                // where "nothing was done to it" would have described an engine that did not look.
+                text.Append(Input.Stringize()).Append(" was already ").Append(Result.Stringize())
+                    .Append('.');
+            }
+            else
+            {
+                text.Append(Input.Stringize()).Append(" becomes ").Append(Result.Stringize())
+                    .Append(Steps.Count == 1 ? ", in one step." : $", in {Steps.Count} steps.")
+                    .Append('\n');
+                for (var i = 0; i < Steps.Count; i++)
+                    text.Append('\n').Append(i + 1).Append(". ").Append(Steps[i].Explain());
+            }
+
+            var tiers = new List<Soundness>();
+            foreach (var step in Steps)
+                if (step.Soundness is { } tier)
+                    tiers.Add(tier);
+            var closing = new StringBuilder();
+            if (Explanation.TierNote(tiers, Steps.Count) is { } note)
+                closing.Append(note);
+            // The search, so that the chain does not read as the whole of what happened. Only
+            // where something was discarded: on a path that explored nothing else there is no
+            // discrepancy to explain, and saying so anyway is a sentence that never varies.
+            if (ExpressionsExplored > Steps.Count)
+            {
+                if (closing.Length > 0) closing.Append(' ');
+                closing.Append("The search reached ").Append(ExpressionsExplored)
+                    .Append(Steps.Count == 0
+                        ? " expressions and kept none of them."
+                        : $" expressions and kept these {Steps.Count}.");
+            }
+            if (closing.Length > 0)
+                text.Append(Steps.Count == 0 ? " " : "\n\n").Append(closing);
+            return text.ToString();
+        }
+
+        /// <summary>
         /// The path written out: the input, then one line per step giving what the expression
         /// became and what made it so.
         /// </summary>
         /// <remarks>
         /// The names are lined up in a column, which is what makes a derivation scannable — the
         /// reader is looking down the list of identities used, not reading the expressions.
+        /// <para/>
+        /// <see cref="Explain"/> is the same path for the other reader: prose, naming the identity
+        /// rather than the rule set.
         /// </remarks>
         public override string ToString()
         {

--- a/Sources/AngouriMath/Core/Transformations/Explanation.cs
+++ b/Sources/AngouriMath/Core/Transformations/Explanation.cs
@@ -1,0 +1,191 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Collections.Generic;
+using System.Text;
+
+namespace AngouriMath.Core.Transformations
+{
+    /// <summary>
+    /// Turns a rewrite into a sentence, in one place so that a step, a pass and a whole derivation
+    /// all say things the same way.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> tier 2's last
+    /// requirement is "transformation metadata rich enough that v5.0 can render a step as a
+    /// sentence". This is the check on that claim: metadata is rich enough to render a sentence
+    /// exactly when a sentence can be rendered from it, and nothing else settles it.
+    /// </para>
+    /// <para>
+    /// <b>Every word here comes off a rule.</b> There is no table of phrasings, no per-rule English
+    /// written a second time, and no verb chosen by looking at what a rewrite did — which is the
+    /// shape this would have taken if the metadata had not been there, and the shape that goes
+    /// stale the first time a rule changes. A rule's name is already a clause a person wrote, its
+    /// description is already the identity, and the only work is joining them.
+    /// </para>
+    /// </remarks>
+    internal static class Explanation
+    {
+        /// <summary>
+        /// Whether a rule's name is a phrase in English, rather than a rendered pattern.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>The distinction is real and this is not a heuristic about it.</b> A rule written as
+        /// data is named by whoever wrote it, in words:
+        /// <c>dividing-by-a-quotient-multiplies-by-its-reciprocal</c>. A rule read off a
+        /// <c>switch</c> is named by <c>RuleRegistryGenerator</c>, which has no words to use and
+        /// names the arm by its own pattern:
+        /// <c>Divf(Sinf(var any1), Cosf(var any1a)) when any1 == any1a</c>. The two are told apart
+        /// exactly, by whether the name is lower-case letters and hyphens — a rendered pattern has
+        /// capitals, brackets and spaces, and cannot be mistaken for one.
+        /// </para>
+        /// <para>
+        /// It matters because the first version of this rendered every name as a clause, and
+        /// produced <i>"Divf(Sinf(var any1), Cosf(var any1a)) when any1 == any1a, so sin(x) /
+        /// cos(x) becomes tan(x)"</i> — a sentence that quotes a matcher at the reader, which the
+        /// remark on <see cref="Sentence"/> says not to do while doing it. A name that is not prose
+        /// is not made into prose here; the sentence falls back to the identity, and then to naming
+        /// the set.
+        /// </para>
+        /// </remarks>
+        internal static bool IsProse(string? ruleName)
+        {
+            if (string.IsNullOrEmpty(ruleName)) return false;
+            var hyphens = 0;
+            foreach (var ch in ruleName!)
+            {
+                if (ch == '-') { hyphens++; continue; }
+                if (ch < 'a' || ch > 'z') return false;
+            }
+            return hyphens > 0;
+        }
+
+        /// <summary>
+        /// A rule's name as the clause it was written as:
+        /// <c>dividing-by-a-quotient-multiplies-by-its-reciprocal</c> is <i>dividing by a quotient
+        /// multiplies by its reciprocal</i>, with the first letter raised to open a sentence.
+        /// </summary>
+        /// <remarks>
+        /// <b>A rename rather than a translation, and deliberately nothing more.</b> Replacing the
+        /// hyphens is the whole of it: every one of the rule names written as data is already a
+        /// phrase in English, because that is what they were written as. A rule whose name does not
+        /// read as prose is a name to fix — <c>RuleProseTest</c> is where that is held — and not a
+        /// case for a table of exceptions here, which would put the readable version somewhere the
+        /// author of the rule does not look.
+        /// </remarks>
+        internal static string AsSentenceOpening(string ruleName)
+        {
+            var clause = ruleName.Replace('-', ' ');
+            return clause.Length == 0 ? clause : char.ToUpperInvariant(clause[0]) + clause.Substring(1);
+        }
+
+        /// <summary>
+        /// <paramref name="before"/> turning into <paramref name="after"/>, said in a way that is
+        /// true even when the two print the same.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Two different trees can print identically, and a derivation full of "X becomes X" is
+        /// what that produces if nobody looks.</b> <c>1 + (x + y)</c> and <c>(1 + x) + y</c> are
+        /// not the same tree and print the same way, so a normalisation that regroups a chain has a
+        /// real before and after and nothing to show for it. It happened on two of the first six
+        /// derivations this was tried on.
+        /// </para>
+        /// <para>
+        /// Saying so is better than hiding it. A reader who sees a step reshaping a chain without
+        /// the printed form moving has learned something true about the engine; a reader who sees
+        /// <c>a becomes a</c> has learned to distrust the feature.
+        /// </para>
+        /// </remarks>
+        internal static string Transition(Entity before, Entity after)
+        {
+            var written = before.Stringize();
+            var becomes = after.Stringize();
+            return written == becomes
+                ? $"{written} is reshaped into an equal tree that prints the same way"
+                : $"{written} becomes {becomes}";
+        }
+
+        /// <summary>
+        /// One rewrite as a sentence: why it was allowed, then what it did.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>The reason comes first.</b> A reader following a derivation already knows the
+        /// expression — it is the answer to the step above — and what they are looking for is the
+        /// identity that moved it. Leading with the rewrite and appending the reason makes the
+        /// reader hold a transformation in mind until they are told why it happened.
+        /// </para>
+        /// <para>
+        /// Three shapes, and which one is used is a fact about what the rule carries rather than a
+        /// choice: a rule with a name in prose is said in its own words, with its identity in
+        /// brackets where it has one; a rule named by its rendered pattern is said by its identity
+        /// instead; and a rewrite with neither is <i>attributed</i> to its set rather than dressed
+        /// up as a reason it does not have.
+        /// </para>
+        /// </remarks>
+        internal static string Sentence(RewriteRuleSet set, RewriteRule? rule, Entity before, Entity after)
+        {
+            var transition = Transition(before, after);
+            if (rule is not null && IsProse(rule.Name))
+            {
+                var text = new StringBuilder(AsSentenceOpening(rule.Name));
+                if (rule.Description is { } identity)
+                    text.Append(" (").Append(identity).Append(')');
+                return text.Append(", so ").Append(transition).Append('.').ToString();
+            }
+            if (rule?.Description is { } stated)
+                return $"By {stated}, {transition}.";
+            return $"{transition}, by {set.Name}.";
+        }
+
+        /// <summary>
+        /// What a run of steps is justified by, as a sentence — or <see langword="null"/> where
+        /// nothing is known about any of them.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Not repeated on every line, and that is the point of it being here.</b> A tier
+        /// printed against each step is noise on the steps that share it, and a reader stops seeing
+        /// it — which is the failure mode of a caveat, not the discharge of one. Said once over the
+        /// whole path, with a count, it is information.
+        /// </para>
+        /// <para>
+        /// <b>The count is over the steps that have a tier, and it says so.</b> A derivation's
+        /// steps are not all rule sets — inner simplification, factoring and polynomial
+        /// rearrangement are steps and declare nothing — so a path of four steps may have one tier
+        /// between them. Reporting that as "the step holds under assumptions" reads as though there
+        /// had been one step, which was the first version of this and was wrong twice over: it hid
+        /// three steps and it implied the other three were justified.
+        /// </para>
+        /// </remarks>
+        internal static string? TierNote(IReadOnlyList<Soundness> tiers, int steps)
+        {
+            if (tiers.Count == 0) return null;
+            var conditional = 0;
+            foreach (var tier in tiers)
+                if (tier is not Soundness.Sound)
+                    conditional++;
+
+            // How the tiered steps are referred to, which depends on whether they are all of them.
+            var subject = tiers.Count == steps
+                ? (steps == 1 ? "The one step" : $"All {steps} steps")
+                : (tiers.Count == 1
+                    ? $"One of the {steps} steps is a registered rule set, and it"
+                    : $"{tiers.Count} of the {steps} steps are registered rule sets, and they");
+
+            if (conditional == 0)
+                return $"{subject} hold{(tiers.Count == 1 ? "s" : "")} for every value, with nothing assumed.";
+            if (conditional == tiers.Count)
+                return $"{subject} hold{(tiers.Count == 1 ? "s" : "")} under assumptions rather than universally.";
+            return $"{subject} carry a tier: {conditional} hold under assumptions rather than "
+                + "universally, and the rest hold for every value.";
+        }
+    }
+}

--- a/Sources/AngouriMath/Core/Transformations/RewriteStep.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteStep.cs
@@ -46,8 +46,49 @@ namespace AngouriMath.Core.Transformations
         /// <summary>What the rule set claims about the rewrite. See <see cref="RewriteRuleSet.Relation"/>.</summary>
         public TransformationRelation Relation => RuleSet.Relation;
 
-        /// <summary>How well justified that claim is. See <see cref="Soundness"/> on what a tier is and is not.</summary>
-        public Soundness Soundness => RuleSet.Soundness;
+        /// <summary>
+        /// How well justified that claim is — <b>this rewrite's own tier where it has one</b>, and
+        /// its set's where it has not. See <see cref="Soundness"/> on what a tier is and is not.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This read the set's tier and nothing else until a rule could carry one, which made it
+        /// the same answer for every step of a set — and a set's tier is the <i>minimum</i> over
+        /// its rules, so one conditional rule spoke for a hundred. All thirty sets declare
+        /// <see cref="Transformations.Soundness.SoundUnderAssumptions"/> and 181 of the 322 rules
+        /// written as data are <see cref="Transformations.Soundness.Sound"/>; a step that fires one
+        /// of those 181 now says so.
+        /// </para>
+        /// <para>
+        /// The fallback is not a claim about the rule. Where <see cref="Rule"/> is null, or is an
+        /// arm read off a <c>switch</c> and so declares no tier, what is known is the set's tier
+        /// and that is what this gives.
+        /// </para>
+        /// </remarks>
+        public Soundness Soundness => Rule?.Soundness ?? RuleSet.Soundness;
+
+        /// <summary>
+        /// This rewrite as a sentence: why it was allowed, then what it did.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>Dividing by a quotient multiplies by its reciprocal (a / (b / c) = a * c / b), so
+        /// x / (y / z) becomes x * z / y.</c>
+        /// </para>
+        /// <para>
+        /// Every word of it is read off the rule — the clause is
+        /// <see cref="RewriteRule.Name"/> with its hyphens replaced, and the identity in brackets
+        /// is <see cref="RewriteRule.Description"/>. Nothing is phrased a second time here, so a
+        /// rule that is renamed or re-described says the new thing without this being touched.
+        /// </para>
+        /// <para>
+        /// Where the rewrite is only addressable at set grain — <see cref="Rule"/> is null — the
+        /// sentence attributes rather than explains: <c>x / (y / z) becomes x * z / y, by
+        /// Common.</c> That is the whole of what is known, and dressing it as a reason would be
+        /// inventing one.
+        /// </para>
+        /// </remarks>
+        public string Explain() => Explanation.Sentence(RuleSet, Rule, Before, After);
 
         /// <inheritdoc/>
         public override string ToString()

--- a/Sources/Tests/UnitTests/Common/PublicApi.txt
+++ b/Sources/Tests/UnitTests/Common/PublicApi.txt
@@ -153,6 +153,7 @@ AngouriMath.Core.Serialization.EntityJsonConverter.ReadAsPropertyName(System.Tex
 AngouriMath.Core.Serialization.EntityJsonConverter.Write(System.Text.Json.Utf8JsonWriter, AngouriMath.Entity, System.Text.Json.JsonSerializerOptions) : System.Void
 AngouriMath.Core.Serialization.EntityJsonConverter.WriteAsPropertyName(System.Text.Json.Utf8JsonWriter, AngouriMath.Entity, System.Text.Json.JsonSerializerOptions) : System.Void
 AngouriMath.Core.Serialization.EntityJsonConverter.ctor()
+AngouriMath.Core.Transformations.DerivationPath.Explain() : System.String
 AngouriMath.Core.Transformations.DerivationPath.ExpressionsExplored { } : System.Int32
 AngouriMath.Core.Transformations.DerivationPath.Input { } : AngouriMath.Entity
 AngouriMath.Core.Transformations.DerivationPath.OfSimplifying(AngouriMath.Entity, System.Int32) : AngouriMath.Core.Transformations.DerivationPath
@@ -161,6 +162,7 @@ AngouriMath.Core.Transformations.DerivationPath.Steps { } : System.Collections.G
 AngouriMath.Core.Transformations.DerivationPath.ToString() : System.String
 AngouriMath.Core.Transformations.DerivationStep.After { } : AngouriMath.Entity
 AngouriMath.Core.Transformations.DerivationStep.Before { } : AngouriMath.Entity
+AngouriMath.Core.Transformations.DerivationStep.Explain() : System.String
 AngouriMath.Core.Transformations.DerivationStep.Name { } : System.String
 AngouriMath.Core.Transformations.DerivationStep.Relation { } : System.Nullable<AngouriMath.Core.Transformations.TransformationRelation>
 AngouriMath.Core.Transformations.DerivationStep.Rewrites { } : System.Collections.Generic.IReadOnlyList<AngouriMath.Core.Transformations.RewriteStep>
@@ -233,6 +235,7 @@ AngouriMath.Core.Transformations.RewriteRules.SetOperator { } : AngouriMath.Core
 AngouriMath.Core.Transformations.RewriteRules.Trigonometric { } : AngouriMath.Core.Transformations.RewriteRuleSet
 AngouriMath.Core.Transformations.RewriteStep.After { } : AngouriMath.Entity
 AngouriMath.Core.Transformations.RewriteStep.Before { } : AngouriMath.Entity
+AngouriMath.Core.Transformations.RewriteStep.Explain() : System.String
 AngouriMath.Core.Transformations.RewriteStep.Relation { } : AngouriMath.Core.Transformations.TransformationRelation
 AngouriMath.Core.Transformations.RewriteStep.Rule { } : AngouriMath.Core.Transformations.RewriteRule
 AngouriMath.Core.Transformations.RewriteStep.RuleSet { } : AngouriMath.Core.Transformations.RewriteRuleSet

--- a/Sources/Tests/UnitTests/Core/Transformations/StepAsASentenceTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/StepAsASentenceTest.cs
@@ -1,0 +1,186 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath.Core.Transformations;
+using AngouriMath.Core.Transformations.Matching;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// Whether a step renders as a sentence.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> tier 2's last
+    /// piece of required infrastructure is "transformation metadata rich enough that v5.0 can
+    /// render a step as a sentence" — and the only way to check that a description is rich enough
+    /// to render from is to render from it.
+    /// </summary>
+    /// <remarks>
+    /// Every word of a sentence comes off a rule: the clause is <see cref="RewriteRule.Name"/> with
+    /// its hyphens replaced, and the identity in brackets is <see cref="RewriteRule.Description"/>.
+    /// So these tests are about the rules as much as about the rendering — a rule that cannot be
+    /// said is a rule that is missing something, and this is where that shows.
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class StepAsASentenceTest
+    {
+        private static readonly string[] Corpus =
+        {
+            "tan(x) * cos(x)", "x ^ (-1) / (y / z)", "a / (b / c)", "sin(x) / cos(x)",
+            "(x + 1) ^ 2 - 1", "1/2 * x + 1/2 * x", "sin(x) ^ 2 + cos(x) ^ 2", "x / x",
+            "(a + b) ^ 2", "ln(e ^ x)", "x! / (x - 1)!", "A /\\ (B \\/ C)",
+        };
+
+        private static IEnumerable<DerivationPath> Paths()
+        {
+            foreach (var source in Corpus)
+                if (DerivationPath.OfSimplifying(source.ToEntity()) is { } path)
+                    yield return path;
+        }
+
+        /// <summary>
+        /// <b>A rule written as data is named in words; a rule read off a <c>switch</c> is named by
+        /// its own pattern.</b> The two are told apart exactly rather than guessed at.
+        /// </summary>
+        /// <remarks>
+        /// This is what stops the rendering quoting a matcher at the reader. The first version of
+        /// it rendered every name as a clause and produced <i>"Divf(Sinf(var any1), Cosf(var
+        /// any1a)) when any1 == any1a, so sin(x) / cos(x) becomes tan(x)"</i>.
+        /// </remarks>
+        [Fact]
+        public void EveryRuleWrittenAsDataIsNamedInProse()
+        {
+            var names = MatchedRules.All.SelectMany(set => set.Rules).Select(rule => rule.Name)
+                .Distinct(StringComparer.Ordinal).ToList();
+            Assert.Equal(293, names.Count);
+            Assert.All(names, name => Assert.True(Explanation.IsProse(name),
+                $"'{name}' is a rule name that does not read as a phrase in English"));
+
+            // And a generated one is not mistaken for prose. Trigonometric still reads its arms
+            // from the `switch`, so its names are rendered patterns.
+            var generated = RewriteRules.Trigonometric.Rules.Select(rule => rule.Name);
+            Assert.All(generated, name => Assert.False(Explanation.IsProse(name),
+                $"'{name}' is a rendered pattern and was taken for prose"));
+        }
+
+        /// <summary>
+        /// Every step of every derivation says something, and none of them says nothing.
+        /// </summary>
+        /// <remarks>
+        /// The <c>X becomes X</c> check is the one that earns its place. Two different trees can
+        /// print identically — <c>1 + (x + y)</c> and <c>(1 + x) + y</c> — so a normalisation that
+        /// regroups a chain has a real before and after and nothing to show for it, and it happened
+        /// on two of the first six derivations this was tried on.
+        /// <see cref="Explanation.Transition"/> says so instead.
+        /// </remarks>
+        [Fact]
+        public void EveryStepRendersAsASentenceThatSaysSomething()
+        {
+            var rendered = 0;
+            foreach (var path in Paths())
+                foreach (var step in path.Steps)
+                {
+                    var sentence = step.Explain();
+                    rendered++;
+                    Assert.NotEmpty(sentence);
+                    Assert.EndsWith(".", sentence, StringComparison.Ordinal);
+                    Assert.True(char.IsUpper(sentence[0]) || char.IsLetterOrDigit(sentence[0])
+                                || sentence[0] is '(' or '-' or '{',
+                        $"a sentence should not open with '{sentence[0]}': {sentence}");
+
+                    var written = step.Before.Stringize();
+                    if (written == step.After.Stringize())
+                        Assert.Contains("prints the same way", sentence, StringComparison.Ordinal);
+                    else
+                        Assert.DoesNotContain($"{written} becomes {written}.", sentence,
+                            StringComparison.Ordinal);
+                }
+            // A corpus that stopped reaching the simplifier would otherwise make this a test that
+            // passes by asking nothing.
+            Assert.True(rendered > 20, $"only {rendered} steps were rendered");
+        }
+
+        /// <summary>
+        /// The whole derivation reads as prose, and the paragraph that closes it is counted from
+        /// the steps rather than written out.
+        /// </summary>
+        [Fact]
+        public void ADerivationExplainsItselfAndItsClosingNoteIsCounted()
+        {
+            foreach (var path in Paths())
+            {
+                var prose = path.Explain();
+                Assert.StartsWith(path.Input.Stringize(), prose, StringComparison.Ordinal);
+                Assert.Contains(path.Result.Stringize(), prose, StringComparison.Ordinal);
+                for (var i = 0; i < path.Steps.Count; i++)
+                    Assert.Contains($"{i + 1}. ", prose, StringComparison.Ordinal);
+
+                var tiered = path.Steps.Count(step => step.Soundness is not null);
+                if (tiered > 0 && tiered < path.Steps.Count)
+                    Assert.Contains($"of the {path.Steps.Count} steps", prose, StringComparison.Ordinal);
+                if (path.ExpressionsExplored > path.Steps.Count)
+                    Assert.Contains($"reached {path.ExpressionsExplored} expressions", prose,
+                        StringComparison.Ordinal);
+            }
+        }
+
+        /// <summary>
+        /// <b>The one worked example, because a feature like this is judged by reading it.</b>
+        /// </summary>
+        /// <remarks>
+        /// <c>tan(x) * cos(x)</c> is the case worth pinning: four steps, three of them naming an
+        /// identity, and an answer that carries the condition the last rule attached rather than
+        /// asserting an equality that is false at a pole. If this stops reading as an explanation,
+        /// the feature has stopped working whatever else still passes.
+        /// </remarks>
+        [Fact]
+        public void TheWorkedExample()
+        {
+            var path = DerivationPath.OfSimplifying("tan(x) * cos(x)".ToEntity());
+            Assert.NotNull(path);
+            var prose = path!.Explain();
+
+            Assert.Contains("tan(x) * cos(x) becomes sin(x) provided not cos(x) = 0", prose,
+                StringComparison.Ordinal);
+            Assert.Contains("Tangent is sine over cosine (tan(a) = sin(a) / cos(a)), so", prose,
+                StringComparison.Ordinal);
+            Assert.Contains("A quotient of symbolic parts is grouped pairwise", prose,
+                StringComparison.Ordinal);
+            Assert.Contains("hold under assumptions rather than universally", prose,
+                StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// A rewrite reports <b>its own</b> tier where it has one, not its set's.
+        /// </summary>
+        /// <remarks>
+        /// A set's tier is the minimum over its rules, so reading it as every rewrite's tier
+        /// understates most of them: all thirty sets declare
+        /// <see cref="Soundness.SoundUnderAssumptions"/> while 181 of the 322 rules written as data
+        /// are <see cref="Soundness.Sound"/>. This is the step grain
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> tier 5 records
+        /// as missing.
+        /// </remarks>
+        [Fact]
+        public void ARewriteReportsItsOwnTierWhereItHasOne()
+        {
+            using var recording = RewriteRecording.Start();
+            RewriteRules.SetOperator.ApplyOnce(@"A /\ A".ToEntity());
+            recording.Dispose();
+
+            var step = Assert.Single(recording.Steps);
+            Assert.NotNull(step.Rule);
+            Assert.Equal(Soundness.Sound, step.Rule!.Soundness);
+            Assert.Equal(Soundness.Sound, step.Soundness);
+            // While the set it came from still reports the weakest of all its rules.
+            Assert.Equal(Soundness.SoundUnderAssumptions, step.RuleSet.Soundness);
+        }
+    }
+}


### PR DESCRIPTION
#746 tier 2's last piece of required infrastructure is **"transformation metadata rich enough that
v5.0 can render a step as a sentence"**. The only check on that is to render one: metadata is rich
enough exactly when a sentence can be built from it, and nothing else settles it.

```csharp
Console.WriteLine(DerivationPath.OfSimplifying("tan(x) * cos(x)")!.Explain());
```

```
tan(x) * cos(x) becomes sin(x) provided not cos(x) = 0, in 4 steps.

1. Tidying: tan(x) * cos(x) becomes cos(x) * tan(x).
2. Tangent is sine over cosine (tan(a) = sin(a) / cos(a)), so tan(x) becomes sin(x) / cos(x).
3. Product with a quotient on the right (a * (b / c) = (a * b) / c), so cos(x) * sin(x) / cos(x)
   is reshaped into an equal tree that prints the same way.
4. A quotient of symbolic parts is grouped pairwise (num / den = the quotient with shared factors
   paired off), so cos(x) * sin(x) / cos(x) becomes sin(x) provided not cos(x) = 0.

All 4 steps hold under assumptions rather than universally. The search reached 6 expressions
and kept these 4.
```

## Every word comes off a rule

The clause is `RewriteRule.Name` with its hyphens replaced; the identity in brackets is
`RewriteRule.Description`. **There is no table of phrasings and no per-rule English written a second
time**, so a rule that is renamed or re-described says the new thing without this being touched.

That is only possible because the names were written as phrases — `dividing-by-a-quotient-multiplies-by-its-reciprocal`
is a clause, not an identifier. There are **293** of them and `EveryRuleWrittenAsDataIsNamedInProse`
holds all 293 to it, so a rule whose name stops reading as English is a name to fix rather than a
case for an exceptions table here.

`Explain()` is on `RewriteStep`, `DerivationStep` and `DerivationPath` — three additive methods, the
whole public surface change.

## Three things the first version got wrong, each found by reading the output

**It rendered every name as a clause**, including the ones `RuleRegistryGenerator` invents for a
`switch` arm — producing *"Divf(Sinf(var any1), Cosf(var any1a)) when any1 == any1a, so sin(x) /
cos(x) becomes tan(x)"*: a sentence that quotes a matcher at the reader while its own doc comment
said not to. The two kinds of name are now told apart **exactly** rather than heuristically — a
rendered pattern has capitals, brackets and spaces and cannot be mistaken for lower-case letters and
hyphens. A name that is not prose falls back to the identity (*"By sin / cos = tan, …"*) and then to
naming the set.

**It said "X becomes X"** whenever two different trees printed alike — `1 + (x + y)` against
`(1 + x) + y` — which happened on **two of the first six** derivations tried. Saying so is better
than hiding it: a reader who sees a step reshaping a chain without the printed form moving has learnt
something true about the engine, where a reader who sees `a becomes a` has learnt to distrust the
feature.

**And the closing note said "The step holds under assumptions"** over a path of four steps, one of
which was a rule set. Wrong twice over: it hid three steps, and it implied the other three were
justified. It now counts, and says what it is counting — *"One of the 4 steps is a registered rule
set, and it holds under assumptions rather than universally."*

A fourth came from the tests rather than from reading: a path of **zero** steps said *"nothing was
done to it"* where the search had reached five expressions and kept none. Those are not the same
fact, and the difference is the whole of what that sentence has to say.

## A step is justified by the rule that fired

`RewriteStep.Soundness` read `RuleSet.Soundness` and nothing else, so **every rewrite of a set
reported the same tier**. A set's tier is the minimum over its rules, and one conditional rule is
enough to make a set of a hundred report as conditional: all thirty sets declare
`SoundUnderAssumptions` while **181 of the 322 rules written as data are `Sound`**.

`DerivationStep.Soundness` changes for the same reason and one more — it is now the weakest tier any
rewrite that **actually fired** inside the step holds at, rather than its set's minimum over rules
the step may never have reached. A pass of nine unconditional rewrites and one conditional one is
still a conditional pass; a pass of ten unconditional ones now says so.

Both are silent changes and both are in `BREAKING-CHANGES.md`, measured on a build. This closes what
#746 tier 5 records as *"justification is per rule set, not per step"* and *"no step renders as a
sentence"*.

## A property that improves on its own

`sin(x) / cos(x)` currently renders as *"By sin / cos = tan, …"* because `Trigonometric` still reads
its arms from the `switch`. When it is repointed — the work #1108 and #1109 have been doing set by
set — the same derivation will read *"Sine over cosine is the tangent (sin(a) / cos(a) = tan(a)),
so …"* with nothing here changing. The rendering gets better as the rules become data, which is the
right dependency direction.

## State

Full suite: **8979 passed, 14 skipped, 0 failed.**

Part of #746 tier 2.
