### PR TITLE
Three more rule sets describe the rules they run, and their identities are written out

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -68,31 +68,37 @@ read first.
 | **Silent** | `RewriteRules.RationalizeDenominator.Rules` | `[]` — the registry could not read the set | its two rules, addressable and named |
 | **Silent** | `RewriteRules.Power.ApplyOnce("ln(1 / x)")`, and every `log(_, 1/_)` and `log(1/_, _)` whose argument is not decidably a positive real | `-ln(x)`, which is wrong on the negative reals | `ln(1 / x)`, left alone |
 | **Silent** | `RewriteRules.Boolean.ApplyOnce("a and b or a")`, and two more orientations of absorption | left alone — the arm for that orientation was never written | `a` |
-| **Silent** | `RewriteRules.DivisionPreparing.Rules[0].Name`, and every rule of nineteen sets now described from their data form | `Mulf(var any1, Divf(Integer(1), var any2))` — the `switch` arm's rendered pattern | `reciprocal-factor-becomes-a-quotient` |
+| **Silent** | `RewriteRules.DivisionPreparing.Rules[0].Name`, and every rule of twenty-three sets now described from their data form | `Mulf(var any1, Divf(Integer(1), var any2))` — the `switch` arm's rendered pattern | `reciprocal-factor-becomes-a-quotient` |
 | | `RewriteRules.ExpandFactorialDivisions.Rules.Count`, and `FactorizeFactorialMultiplications` | `8` | `3` — the same rewrites, five of the eight arms being one commutative pattern |
-| | `RewriteRules.All.Sum(set => set.Rules.Count)` | `407` | `397` |
+| | `RewriteRules.Boolean.Rules.Count` | `36` | `20` — a commutative pattern finds a shared operand wherever it sits |
+| | `RewriteRules.NumericNeat.Rules.Count`, and `Factorization` 22 -> 11 | `16` | `11` |
+| | `RewriteRules.All.Sum(set => set.Rules.Count)` | `407` | `365` |
 | **Silent** | `RewriteRules.ExpandFactorialDivisions.Rules[0].Growth` | `Collects` — guessed from string length | `Unknown`; whether it collects depends on the offsets |
 | **Silent** | `RewriteStep.Soundness` on a rewrite whose rule declares a tier — `RewriteRules.SetOperator` on `A /\ A`, and every rewrite of the nineteen sets described from their data form | `SoundUnderAssumptions` — its rule set's tier, which is the minimum over every rule in the set | `Sound` — the rule's own |
 | **Silent** | `DerivationStep.Soundness` | its rule set's tier | the weakest tier any rewrite that actually fired inside the step holds at |
 
-### Nineteen rule sets describe the rules they run
+### Twenty-three rule sets describe the rules they run
 
 `RewriteRuleSet.Rules` is what the registry reports a set is made of, and for most of the library's
 life it came from `RuleRegistryGenerator` reading the `switch` that defined the set. Twenty-seven of
 the thirty sets stopped running that `switch` some releases ago — they run
 `MatchedRuleSet.ApplyHere` — and went on describing it. Thirteen of them now describe what they run.
 
-Which nineteen. Thirteen had **no described arm at all**, so repointing them could only add
+Which twenty-three. Thirteen had **no described arm at all**, so repointing them could only add
 metadata: `CollapseMultipleFractions`, the three `CommonDenominator` sets, `DivisionPreparing`,
 `ExpandFactorialDivisions`, `ExpandMultipleAngle`, `ExpandTrigonometric`, `Expansion`,
 `FactorizeFactorialMultiplications`, `NormalTrigonometricForm`, `PhiFunction` and
 `PolynomialLongDivision`. Six more are **one arm to one rule**, so their existing descriptions carry
 across unchanged and the rules that had none gain one: `CollapseTrigonometricFunctions`,
 `InvertNegativeMultipliers`, `InvertNegativePowers`, `PerfectSquare`, `PolynomialGcdCancellation` and
-`SetOperator`. `RationalizeDenominator` was already reading its data form.
+`SetOperator`. `RationalizeDenominator` was already reading its data form. And `Boolean` is the first
+where the identities were **written** rather than carried across: its comments named the laws
+(De Morgan, absorption, contraposition) where an identity was wanted, so all twenty were read off the
+rules' own patterns and replacements. `NumericNeat` and `Factorization` follow it, their comments
+already being identities and needing only the arrow turned into an equals sign.
 
-The seven left on the `switch` are the ones where repointing would cost something today: `Common`
-would lose 33 descriptions and `Power` 22. Porting those identities is a later change. Three more —
+The four left on the `switch` are the ones where repointing would cost something today: `Common`
+would lose 33 descriptions, `Power` 22, `Trigonometric` 13 and `InequalityEquality` 11. Porting those identities is a later change. Three more —
 the `CanonicalOrder` family — still *run* their `switch`, so describing it is not a mismatch.
 
 Four things move, and only the second changes a count:
@@ -104,11 +110,15 @@ Four things move, and only the second changes a count:
 | `Rules[i].Description` | `null` for 38 of these arms and set for 8 | the identity, `a * (1 / b) = a / b`, for all 59 |
 | `Rules[i].Soundness` | `null` — an arm declares no tier | the rule's own tier |
 
-**The two counts that change are not rewrites lost.** `ExpandFactorialDivisions` and
-`FactorizeFactorialMultiplications` are eight arms each that the data form writes as three: the other
-five are the same rewrite spelled once for each side a factorial can sit on, which is one commutative
-pattern. Every other repointed set is one arm to one rule. Across the registry, 407 becomes 397 while
-the number of described rules goes from **95 to 147**.
+**The three counts that change are not rewrites lost.** They are arms the data form writes once.
+`Boolean`'s thirty-six become twenty: eight arms of distributivity are two rules, because a
+commutative pattern finds the shared operand wherever it sits, and absorption's four-arms-each is one
+rule twice. `ExpandFactorialDivisions` and `FactorizeFactorialMultiplications` are eight arms each
+written as three, the other five being one rewrite spelled once for each side a factorial can sit on.
+`NumericNeat`'s sixteen are eleven, six of them being three rules written once per side a negative
+factor can sit on; `Factorization`'s twenty-two are eleven for the same reason. Every other repointed
+set is one arm to one rule. Across the registry, 407 becomes **365** while the number of described
+rules goes from **95 to 180**.
 
 `Rules[i].Growth` also stops being a guess. `AsAddressable` used to infer it by comparing the lengths
 of the two rendered pattern strings — the only thing available to a generator reading source text —

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -923,7 +923,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any<Real>("l", value => value.IsNegative),
                     MatchPattern.Any<Real>("r", value => value.IsNegative)),
                 bound => -((-(Real)bound["l"]) + (Entity)(-(Real)bound["r"])),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "(-a) + (-b) = -(a + b)"),
 
             // x + (-a) -> x - a, either way round
             new MatchedRule(
@@ -932,7 +933,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any("x"),
                     MatchPattern.Any<Real>("n", value => value.IsNegative)),
                 bound => bound["x"] - -(Real)bound["n"],
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "x + (-a) = x - a"),
 
             // (-a) - (-b) -> b - a
             new MatchedRule(
@@ -941,7 +943,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any<Real>("l", value => value.IsNegative),
                     MatchPattern.Any<Real>("r", value => value.IsNegative)),
                 bound => (-(Real)bound["r"]) - (Entity)(-(Real)bound["l"]),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "(-a) - (-b) = b - a"),
 
             // x - (-a) -> x + a
             new MatchedRule(
@@ -950,7 +953,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any("x"),
                     MatchPattern.Any<Real>("n", value => value.IsNegative)),
                 bound => bound["x"] + -(Real)bound["n"],
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "x - (-a) = x + a"),
 
             // (-a) - x -> -(x + a)
             new MatchedRule(
@@ -959,7 +963,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any<Real>("n", value => value.IsNegative),
                     MatchPattern.Any("x")),
                 bound => -(bound["x"] + -(Real)bound["n"]),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "(-a) - x = -(x + a)"),
 
             // (-a) * (-b) -> a * b
             new MatchedRule(
@@ -968,7 +973,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any<Real>("l", value => value.IsNegative),
                     MatchPattern.Any<Real>("r", value => value.IsNegative)),
                 bound => (-(Real)bound["l"]) * (Entity)(-(Real)bound["r"]),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "(-a) * (-b) = a * b"),
 
             // (-a) / (-b) -> a / b
             new MatchedRule(
@@ -977,7 +983,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any<Real>("l", value => value.IsNegative),
                     MatchPattern.Any<Real>("r", value => value.IsNegative)),
                 bound => (-(Real)bound["l"]) / (Entity)(-(Real)bound["r"]),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "(-a) / (-b) = a / b"),
 
             // (-a * x) * y -> -(a * (x * y)), the negative factor either way round
             new MatchedRule(
@@ -988,7 +995,8 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Any("x")),
                     MatchPattern.Any("y")),
                 bound => -((-(Real)bound["n"]) * (bound["x"] * bound["y"])),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "(-a * x) * y = -(a * (x * y))"),
 
             // (-a * x) / y -> -(a * (x / y))
             new MatchedRule(
@@ -999,7 +1007,8 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Any("x")),
                     MatchPattern.Any("y")),
                 bound => -((-(Real)bound["n"]) * (bound["x"] / bound["y"])),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "(-a * x) / y = -(a * (x / y))"),
 
             // y * (-a * x) -> -(a * (x * y))
             new MatchedRule(
@@ -1010,7 +1019,8 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Any<Real>("n", value => value.IsNegative),
                         MatchPattern.Any("x"))),
                 bound => -((-(Real)bound["n"]) * (bound["x"] * bound["y"])),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "y * (-a * x) = -(a * (x * y))"),
 
             // y / (-a * x) -> -(y / (a * x)). What is left stays under the line: written the
             // other way, as the numerator rules above are, the quotient came back inverted --
@@ -1023,7 +1033,8 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Any<Real>("n", value => value.IsNegative),
                         MatchPattern.Any("x"))),
                 bound => -(bound["y"] / ((-(Real)bound["n"]) * bound["x"])),
-                Soundness.Sound));
+                Soundness.Sound,
+                description: "y / (-a * x) = -(y / (a * x))"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.BooleanRules"/>, as data.
@@ -1060,7 +1071,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Exact(Entity.Boolean.False), MatchPattern.Any("b")),
                 bound => Entity.Boolean.True.Provided(bound["b"].DomainCondition),
                 Soundness.Sound,
-                when: bound => Functions.Patterns.IsLogic(bound["b"])),
+                when: bound => Functions.Patterns.IsLogic(bound["b"]),
+                description: "(False implies b) = True"),
 
             // De Morgan, both ways round
             new MatchedRule(
@@ -1073,7 +1085,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 // Two negations become one, and nothing else moves: three nodes around `a` and
                 // `b` become two.
                 growth: RewriteRuleGrowth.Collects,
-                when: bound => Functions.Patterns.IsLogic(bound["a"], bound["b"])),
+                when: bound => Functions.Patterns.IsLogic(bound["a"], bound["b"]),
+                description: "(not a) and (not b) = not (a or b)"),
 
             new MatchedRule(
                 "a-disjunction-of-negations-is-a-negated-conjunction",
@@ -1085,7 +1098,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 // Two negations become one, and nothing else moves: three nodes around `a` and
                 // `b` become two.
                 growth: RewriteRuleGrowth.Collects,
-                when: bound => Functions.Patterns.IsLogic(bound["a"], bound["b"])),
+                when: bound => Functions.Patterns.IsLogic(bound["a"], bound["b"]),
+                description: "(not a) or (not b) = not (a and b)"),
 
             // Excluded middle, either way round. Before the implication rule below, which would
             // otherwise take it -- and conditional, because a proposition without a truth value
@@ -1097,7 +1111,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Notf>(MatchPattern.Any("a")), MatchPattern.Any("a")),
                 bound => Entity.Boolean.True.Provided(Functions.Patterns.TruthCondition(bound["a"])),
                 Soundness.SoundUnderAssumptions,
-                when: bound => Functions.Patterns.IsLogic(bound["a"])),
+                when: bound => Functions.Patterns.IsLogic(bound["a"]),
+                description: "((not a) or a) = True, where a has a truth value"),
 
             // Not commutative: `a or not b` is not an implication of anything.
             new MatchedRule(
@@ -1109,7 +1124,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 // The `not` disappears and the `or` becomes an `->`: the same `a` and `b` under
                 // one node instead of two.
                 growth: RewriteRuleGrowth.Collects,
-                when: bound => Functions.Patterns.IsLogic(bound["a"], bound["b"])),
+                when: bound => Functions.Patterns.IsLogic(bound["a"], bound["b"]),
+                description: "((not a) or b) = (a implies b)"),
 
             // Idempotence
             new MatchedRule(
@@ -1119,7 +1135,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 Soundness.Sound,
                 // The replacement is the matched node's own child, unconditionally.
                 growth: RewriteRuleGrowth.Collects,
-                when: bound => Functions.Patterns.IsLogic(bound["a"])),
+                when: bound => Functions.Patterns.IsLogic(bound["a"]),
+                description: "(a and a) = a"),
 
             new MatchedRule(
                 "a-disjunction-with-itself-is-itself",
@@ -1128,7 +1145,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 Soundness.Sound,
                 // The replacement is the matched node's own child, unconditionally.
                 growth: RewriteRuleGrowth.Collects,
-                when: bound => Functions.Patterns.IsLogic(bound["a"])),
+                when: bound => Functions.Patterns.IsLogic(bound["a"]),
+                description: "(a or a) = a"),
 
             new MatchedRule(
                 "a-statement-implies-itself",
@@ -1137,14 +1155,16 @@ namespace AngouriMath.Core.Transformations.Matching
                 Soundness.Sound,
                 // One leaf, from a node that had two copies of `a` under it.
                 growth: RewriteRuleGrowth.Collects,
-                when: bound => Functions.Patterns.IsLogic(bound["a"])),
+                when: bound => Functions.Patterns.IsLogic(bound["a"]),
+                description: "(a implies a) = True"),
 
             new MatchedRule(
                 "a-statement-differs-from-itself-nowhere",
                 MatchPattern.Node<Xorf>(MatchPattern.Any("a"), MatchPattern.Any("a")),
                 bound => Entity.Boolean.False.Provided(bound["a"].DomainCondition),
                 Soundness.Sound,
-                when: bound => Functions.Patterns.IsLogic(bound["a"])),
+                when: bound => Functions.Patterns.IsLogic(bound["a"]),
+                description: "(a xor a) = False"),
 
             new MatchedRule(
                 "a-double-negation-cancels",
@@ -1153,7 +1173,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 Soundness.Sound,
                 // The replacement is the matched node's own grandchild, unconditionally.
                 growth: RewriteRuleGrowth.Collects,
-                when: bound => Functions.Patterns.IsLogic(bound["a"])),
+                when: bound => Functions.Patterns.IsLogic(bound["a"]),
+                description: "not (not a) = a"),
 
             // Constants, after the implication rule above: `not x or True` is `x -> True`.
             new MatchedRule(
@@ -1163,7 +1184,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     .Provided(bound["a"].DomainCondition).Provided(bound["b"].DomainCondition),
                 Soundness.Sound,
                 when: bound => (bound["a"] == Entity.Boolean.True || bound["b"] == Entity.Boolean.True)
-                               && Functions.Patterns.IsLogic(bound["a"], bound["b"])),
+                               && Functions.Patterns.IsLogic(bound["a"], bound["b"]),
+                description: "(a or True) = True"),
 
             new MatchedRule(
                 "a-conjunction-with-a-falsehood-is-false",
@@ -1172,7 +1194,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     .Provided(bound["a"].DomainCondition).Provided(bound["b"].DomainCondition),
                 Soundness.Sound,
                 when: bound => (bound["a"] == Entity.Boolean.False || bound["b"] == Entity.Boolean.False)
-                               && Functions.Patterns.IsLogic(bound["a"], bound["b"])),
+                               && Functions.Patterns.IsLogic(bound["a"], bound["b"]),
+                description: "(a and False) = False"),
 
             // Distributivity. Eight arms of the switch, two rules here: commutative at both
             // levels finds the shared operand wherever it sits.
@@ -1183,7 +1206,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Commutative<Andf>(MatchPattern.Any("k"), MatchPattern.Any("q"))),
                 bound => bound["k"] & (bound["p"] | bound["q"]),
                 Soundness.Sound,
-                when: bound => Functions.Patterns.IsLogic(bound["k"], bound["p"], bound["q"])),
+                when: bound => Functions.Patterns.IsLogic(bound["k"], bound["p"], bound["q"]),
+                description: "((k and p) or (k and q)) = (k and (p or q))"),
 
             new MatchedRule(
                 "a-conjunction-of-disjunctions-sharing-an-operand-distributes",
@@ -1192,7 +1216,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Commutative<Orf>(MatchPattern.Any("k"), MatchPattern.Any("q"))),
                 bound => bound["k"] | (bound["p"] & bound["q"]),
                 Soundness.Sound,
-                when: bound => Functions.Patterns.IsLogic(bound["k"], bound["p"], bound["q"])),
+                when: bound => Functions.Patterns.IsLogic(bound["k"], bound["p"], bound["q"]),
+                description: "((k or p) and (k or q)) = (k or (p and q))"),
 
             // Absorption, and the absorption that leaves something behind. Four arms each in the
             // switch, and the negated form four more.
@@ -1205,7 +1230,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 Soundness.Sound,
                 // The replacement is one of the matched node's own operands, unconditionally.
                 growth: RewriteRuleGrowth.Collects,
-                when: bound => Functions.Patterns.IsLogic(bound["a"])),
+                when: bound => Functions.Patterns.IsLogic(bound["a"]),
+                description: "(a or (a and b)) = a"),
 
             new MatchedRule(
                 "a-conjunction-absorbs-a-disjunction-it-shares-an-operand-with",
@@ -1216,7 +1242,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 Soundness.Sound,
                 // The replacement is one of the matched node's own operands, unconditionally.
                 growth: RewriteRuleGrowth.Collects,
-                when: bound => Functions.Patterns.IsLogic(bound["a"])),
+                when: bound => Functions.Patterns.IsLogic(bound["a"]),
+                description: "(a and (a or b)) = a"),
 
             new MatchedRule(
                 "a-disjunction-drops-a-negated-copy-of-its-other-operand",
@@ -1229,7 +1256,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 // The second copy of `a` and its `not` and the inner `and` all go; `a` and `b`
                 // are left under the one `or`.
                 growth: RewriteRuleGrowth.Collects,
-                when: bound => Functions.Patterns.IsLogic(bound["a"])),
+                when: bound => Functions.Patterns.IsLogic(bound["a"]),
+                description: "(a or ((not a) and b)) = (a or b)"),
 
             new MatchedRule(
                 "a-conjunction-drops-a-negated-copy-of-its-other-operand",
@@ -1242,7 +1270,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 // The second copy of `a` and its `not` and the inner `or` all go; `a` and `b`
                 // are left under the one `and`.
                 growth: RewriteRuleGrowth.Collects,
-                when: bound => Functions.Patterns.IsLogic(bound["a"])),
+                when: bound => Functions.Patterns.IsLogic(bound["a"]),
+                description: "(a and ((not a) or b)) = (a and b)"),
 
             // Exclusive disjunction, written four ways in the switch.
             new MatchedRule(
@@ -1257,7 +1286,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 // Two `and`s, two `not`s and the duplicate `a` and `b` collapse into one `xor`
                 // over one copy of each.
                 growth: RewriteRuleGrowth.Collects,
-                when: bound => Functions.Patterns.IsLogic(bound["a"], bound["b"])),
+                when: bound => Functions.Patterns.IsLogic(bound["a"], bound["b"]),
+                description: "((a and not b) or (b and not a)) = (a xor b)"),
 
             // Contraposition
             new MatchedRule(
@@ -1269,7 +1299,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 Soundness.Sound,
                 // The same `a` and `b` under the same `->`, swapped, with both `not`s dropped.
                 growth: RewriteRuleGrowth.Collects,
-                when: bound => Functions.Patterns.IsLogic(bound["a"], bound["b"])));
+                when: bound => Functions.Patterns.IsLogic(bound["a"], bound["b"]),
+                description: "((not a) implies (not b)) = (b implies a)"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.FactorizeRules"/>, as data.
@@ -1308,7 +1339,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 // Both exponents even, or halving them introduces radicals and the rule fires
                 // again on what it just produced.
                 when: bound => ((Integer)bound["n"]).EInteger.IsEven
-                               && ((Integer)bound["m"]).EInteger.IsEven),
+                               && ((Integer)bound["m"]).EInteger.IsEven,
+                description: "a^2n - b^2m = (a^n - b^m)(a^n + b^m)",
+                // Declared, because the replacement is code and nothing counts it: one difference becomes a product of two.
+                growth: RewriteRuleGrowth.Expands),
 
             // a^2 - c -> (a - sqrt(c))(a + sqrt(c)), for a numeric c
             new MatchedRule(
@@ -1318,7 +1352,10 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any<Number>("c")),
                 bound => (bound["a"] - new Powf(bound["c"], Rational.Create(1, 2)))
                        * (bound["a"] + new Powf(bound["c"], Rational.Create(1, 2))),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "a^2 - c = (a - sqrt(c))(a + sqrt(c)), for a numeric c",
+                // Declared, because the replacement is code and nothing counts it: one difference becomes a product of two, with a root introduced.
+                growth: RewriteRuleGrowth.Expands),
 
             // k*p + k*q -> k*(p + q), the shared factor anywhere in either product
             new MatchedRule(
@@ -1327,7 +1364,10 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Commutative<Mulf>(MatchPattern.Any("k"), MatchPattern.Any("p")),
                     MatchPattern.Commutative<Mulf>(MatchPattern.Any("k"), MatchPattern.Any("q"))),
                 bound => bound["k"] * (bound["p"] + bound["q"]),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "k*p + k*q = k*(p + q)",
+                // Declared, because the replacement is code and nothing counts it: k*p + k*q is seven nodes and k*(p + q) is five.
+                growth: RewriteRuleGrowth.Collects),
 
             // k + k*q -> k*(1 + q), either way round at both levels
             new MatchedRule(
@@ -1336,14 +1376,16 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any("k"),
                     MatchPattern.Commutative<Mulf>(MatchPattern.Any("k"), MatchPattern.Any("q"))),
                 bound => bound["k"] * (1 + bound["q"]),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "k + k*q = k*(1 + q)"),
 
             // k + k -> 2k
             new MatchedRule(
                 "a-term-added-to-itself-doubles",
                 MatchPattern.Node<Sumf>(MatchPattern.Any("k"), MatchPattern.Any("k")),
                 bound => 2 * bound["k"],
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "k + k = 2k"),
 
             // k*p - k*q -> k*(p - q). The outer node is a difference and stays one.
             new MatchedRule(
@@ -1352,7 +1394,10 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Commutative<Mulf>(MatchPattern.Any("k"), MatchPattern.Any("p")),
                     MatchPattern.Commutative<Mulf>(MatchPattern.Any("k"), MatchPattern.Any("q"))),
                 bound => bound["k"] * (bound["p"] - bound["q"]),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "k*p - k*q = k*(p - q)",
+                // Declared, because the replacement is code and nothing counts it: as its added twin: seven nodes become five.
+                growth: RewriteRuleGrowth.Collects),
 
             // k - k*q -> k*(1 - q)
             new MatchedRule(
@@ -1361,7 +1406,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any("k"),
                     MatchPattern.Commutative<Mulf>(MatchPattern.Any("k"), MatchPattern.Any("q"))),
                 bound => bound["k"] * (1 - bound["q"]),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "k - k*q = k*(1 - q)"),
 
             // k*q - k -> k*(q - 1)
             new MatchedRule(
@@ -1370,14 +1416,18 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Commutative<Mulf>(MatchPattern.Any("k"), MatchPattern.Any("q")),
                     MatchPattern.Any("k")),
                 bound => bound["k"] * (bound["q"] - 1),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "k*q - k = k*(q - 1)"),
 
             // k - k -> 0
             new MatchedRule(
                 "a-term-subtracted-from-itself-vanishes",
                 MatchPattern.Node<Minusf>(MatchPattern.Any("k"), MatchPattern.Any("k")),
                 bound => Integer.Create(0),
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "k - k = 0",
+                // Declared, because the replacement is code and nothing counts it: three nodes become one.
+                growth: RewriteRuleGrowth.Collects),
 
             // a^b * c^b -> (a*c)^b, guarded as its twin in PowerRules is
             new MatchedRule(
@@ -1393,7 +1443,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 Soundness.SoundUnderAssumptions,
                 when: bound => bound["b"] is Integer
                                || (bound["a"].Evaled is Real { IsPositive: true }
-                                   && bound["c"].Evaled is Real { IsPositive: true })),
+                                   && bound["c"].Evaled is Real { IsPositive: true }),
+                description: "a^b * c^b = (a*c)^b",
+                // Declared, because the replacement is code and nothing counts it: a^b * c^b is seven nodes and (a*c)^b is five.
+                growth: RewriteRuleGrowth.Collects),
 
             // Anything left, over a whole sum or difference rather than two of its terms. Last,
             // because it is the general case of the rules above it.
@@ -1401,7 +1454,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 "a-common-factor-is-collected-out-of-a-whole-sum",
                 MatchPattern.Any<Entity>("x", node => node is Sumf or Minusf),
                 (node, _) => Functions.Patterns.CollectCommonFactors(node) ?? node,
-                Soundness.Sound));
+                Soundness.Sound,
+                description: "k*p + k*q + ... = k*(p + q + ...), over a whole sum rather than two of its terms",
+                // Declared, because the replacement is code and nothing counts it: the whole point of it is to be smaller.
+                growth: RewriteRuleGrowth.Collects));
 
         /// <summary>
         /// <see cref="Functions.Patterns.TrigonometricRules"/>, as data.

--- a/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
@@ -153,8 +153,7 @@ namespace AngouriMath.Core.Transformations
             "Arranges signs so that adding a negative is written as subtracting a positive.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.NumericNeat.ApplyHere,
-            Patterns.NumericNeatRulesArms);
+            Matching.MatchedRules.NumericNeat);
 
         #endregion
 
@@ -211,8 +210,7 @@ namespace AngouriMath.Core.Transformations
             "Gathers common factors out of sums.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.Factorization.ApplyHere,
-            Patterns.FactorizeRulesArms);
+            Matching.MatchedRules.Factorization);
 
         /// <summary>
         /// Recognises a perfect square written out, so that factorisation has something to
@@ -466,8 +464,7 @@ namespace AngouriMath.Core.Transformations
             "Applies the identities of boolean algebra to conjunctions, disjunctions and negations.",
             TransformationRelation.Equivalence,
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.Boolean.ApplyHere,
-            Patterns.BooleanRulesArms);
+            Matching.MatchedRules.Boolean);
 
         /// <summary>
         /// Rules about equalities and inequalities.

--- a/Sources/AngouriMath/Docs/Contributing/WritingARule.md
+++ b/Sources/AngouriMath/Docs/Contributing/WritingARule.md
@@ -21,7 +21,7 @@ effect". This is how to supply those seven things.
 **322** rules live there today.
 
 The `switch` statements in `Functions/Simplification/Patterns` are the older form. Twenty-seven of
-the thirty registered sets no longer run theirs, and twenty no longer describe it either; the
+the thirty registered sets no longer run theirs, and twenty-three no longer describe it either; the
 remainder are being moved set by set ([#825](https://github.com/asc-community/AngouriMath/issues/825)).
 **Do not add a rule to a `switch`.** A `switch` arm cannot carry a name, a tier, an identity or a
 direction, and everything below is about those.
@@ -88,7 +88,7 @@ debugged for an afternoon.
 | `Left.ToString()` | `Divf(var a, Divf(var b, var c))` — how the matcher spells it |
 
 Write the identity with `=`, not `->`: it is an equality, and the arrow belongs to the direction the
-rule happens to be applied in. **59** rules carry one today; a new rule should.
+rule happens to be applied in. **101** rules carry one today; a new rule should.
 
 ## The pattern language
 
@@ -131,7 +131,7 @@ A pattern replacement gets:
 - **an exact growth**, counted from the two patterns rather than declared.
 
 A code replacement gets neither, and its growth is `Unknown` unless you declare one. That is the
-honest default — **268** rules sit at `Unknown` — but declare it where you can justify it:
+honest default — **261** rules sit at `Unknown` — but declare it where you can justify it:
 
 ```csharp
 // The Chebyshev expansion of sin(n * a) is a sum of n terms where the pattern is one node,

--- a/Sources/Tests/UnitTests/Core/Transformations/AddressableRulesTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/AddressableRulesTest.cs
@@ -290,13 +290,16 @@ namespace AngouriMath.Tests.Core.Transformations
 
             Assert.Equal(30, withRules.Count);
 
-            // 397, and it was 407 before thirteen sets started reporting the rules they run
-            // rather than the `switch` they no longer run. The ten that went are not rules lost:
-            // ExpandFactorialDivisions and FactorizeFactorialMultiplications are eight arms each
-            // that the data form writes as three, the other five being the same rewrite spelled
-            // for each side a factorial can sit on -- which is one commutative pattern. Every
-            // other repointed set is one for one.
-            Assert.Equal(397, withRules.Sum(set => set.Rules.Count));
+            // 365, and it was 407 before the registry started reporting the rules it runs rather
+            // than the `switch` it no longer runs. The forty-two that went are not rules lost, they
+            // are arms the data form writes once. Boolean's thirty-six are twenty, because a
+            // commutative pattern finds a shared operand wherever it sits, so eight arms of
+            // distributivity are two rules and absorption's four-arms-each is one rule twice;
+            // Factorization's twenty-two are eleven for the same reason; NumericNeat's sixteen are
+            // eleven, six of them being three rules written once per side a negative factor can sit
+            // on; and the two factorial sets are eight arms each written as three. Every other
+            // repointed set is one arm for one rule.
+            Assert.Equal(365, withRules.Sum(set => set.Rules.Count));
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
@@ -49,7 +49,7 @@ namespace AngouriMath.Tests.Core.Transformations
                     MatchedRules.All.Any(data => data.Name == set.Name)
                     || set.Name.StartsWith("CommonDenominator", StringComparison.Ordinal)),
                 "how many registered sets run the matcher");
-            Stated(20, RewriteRules.All.Count(set =>
+            Stated(23, RewriteRules.All.Count(set =>
                     set.Rules.Count > 0 && set.Rules.All(rule => rule.Soundness is not null)),
                 "how many registered sets describe what they run");
         }
@@ -68,7 +68,7 @@ namespace AngouriMath.Tests.Core.Transformations
 
         [Fact]
         public void TheIdentityIsNotTheName()
-            => Stated(59,
+            => Stated(101,
                 MatchedRules.All.SelectMany(set => set.Rules).Count(rule => rule.Description is not null),
                 "how many rules carry an identity");
 
@@ -84,7 +84,7 @@ namespace AngouriMath.Tests.Core.Transformations
                 "how many rules have a pattern on both sides");
             Stated(32, rules.Count(rule => rule.Reversed is not null),
                 "how many two-sided rules have a direction");
-            Stated(268, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
+            Stated(261, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
                 "how many rules sit at Unknown growth");
 
             // And the thirty-third is the one the document names. Asserted by its own name rather

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleMetadataTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleMetadataTest.cs
@@ -100,8 +100,8 @@ namespace AngouriMath.Tests.Core.Transformations
         /// reported as absent rather than as its set's.
         /// </summary>
         /// <remarks>
-        /// Twenty sets are described from their data form and carry a tier per rule. Of the ten
-        /// left, seven are still described by <c>RuleRegistryGenerator</c> reading a <c>switch</c>
+        /// Twenty-one sets are described from their data form and carry a tier per rule. Of the
+        /// nine left, six are still described by <c>RuleRegistryGenerator</c> reading a <c>switch</c>
         /// they no longer run, and three — the <c>CanonicalOrder</c> family — still run theirs, so
         /// describing it is honest. Named rather than counted, so that repointing a set is a change
         /// to this list rather than a silent one.
@@ -111,6 +111,7 @@ namespace AngouriMath.Tests.Core.Transformations
         {
             var fromData = new[]
             {
+                nameof(RewriteRules.Boolean),
                 nameof(RewriteRules.CollapseMultipleFractions),
                 nameof(RewriteRules.CollapseTrigonometricFunctions),
                 nameof(RewriteRules.CommonDenominator),
@@ -121,10 +122,12 @@ namespace AngouriMath.Tests.Core.Transformations
                 nameof(RewriteRules.ExpandMultipleAngle),
                 nameof(RewriteRules.ExpandTrigonometric),
                 nameof(RewriteRules.Expansion),
+                nameof(RewriteRules.Factorization),
                 nameof(RewriteRules.FactorizeFactorialMultiplications),
                 nameof(RewriteRules.InvertNegativeMultipliers),
                 nameof(RewriteRules.InvertNegativePowers),
                 nameof(RewriteRules.NormalTrigonometricForm),
+                nameof(RewriteRules.NumericNeat),
                 nameof(RewriteRules.PerfectSquare),
                 nameof(RewriteRules.PhiFunction),
                 nameof(RewriteRules.PolynomialGcdCancellation),
@@ -161,7 +164,7 @@ namespace AngouriMath.Tests.Core.Transformations
             var repointed = RewriteRules.All
                 .Where(set => set.Rules.Count > 0 && set.Rules.All(rule => rule.Soundness is not null))
                 .ToList();
-            Assert.Equal(59, repointed.Sum(set => set.Rules.Count));
+            Assert.Equal(101, repointed.Sum(set => set.Rules.Count));
             Assert.All(repointed, set => Assert.All(set.Rules, rule => Assert.NotNull(rule.Description)));
         }
 


### PR DESCRIPTION
`Boolean`, `NumericNeat` and `Factorization`. The third tranche of the repoint, and the first where identities had to be **written** rather than carried across.

## The identities

`Boolean`'s comments name the *laws* — De Morgan, idempotence, distributivity, absorption, contraposition — which is the right thing for a comment above a rule and is not an identity. All twenty were read off the rules' own patterns and replacements:

| rule | identity |
|---|---|
| `a-conjunction-of-negations-is-a-negated-disjunction` | `(not a) and (not b) = not (a or b)` |
| `a-disjunction-of-conjunctions-sharing-an-operand-distributes` | `((k and p) or (k and q)) = (k and (p or q))` |
| `a-disjunction-drops-a-negated-copy-of-its-other-operand` | `(a or ((not a) and b)) = (a or b)` |
| `an-implication-between-negations-turns-round` | `((not a) implies (not b)) = (b implies a)` |

`NumericNeat` and `Factorization` already had identities in their comments and needed only the arrow turned into an equals sign and the commentary after it dropped.

## Forty-two arms go, and no rewrite with them

They are arms the data form writes once:

| set | arms | rules | why |
|---|---|---|---|
| `Boolean` | 36 | **20** | a commutative pattern finds a shared operand wherever it sits, so eight arms of distributivity are two rules and absorption's four-arms-each is one rule twice |
| `Factorization` | 22 | **11** | the same |
| `NumericNeat` | 16 | **11** | six of them are three rules written once per side a negative factor can sit on |

| | Was | Is |
|---|---|---|
| registry total | 407 | **365** |
| described rules | 95 | **180** |
| sets describing what they run | 20 | **23** |

Recorded in `BREAKING-CHANGES.md`, measured on a build.

## Seven growths are now declared rather than guessed

`GrowthSaysWhichWayTheSetMoves` failed the moment `Factorization` stopped being described by the `switch`: the string-length proxy had guessed `Collects`, and the exact answer for a code-built rule nobody declared is `Unknown`.

The fix is the one the authoring guide asks for — declare it where you can justify it. The two splitters are `Expands`; the four shared-factor collectors and `a^b * c^b = (a*c)^b` are `Collects`, each with the node count in the comment.

**Four are left at `Unknown` on purpose.** `k + k*q = k*(1 + q)` and its three siblings are the same size on both sides, and a code replacement has no tree to count — declaring `Rearranges` would be a claim about arithmetic nobody did.

That took `Unknown` from 268 to 261, which failed `RuleAuthoringGuideTest`: the guide merged in #1111 states that figure and the test holds it. Both updated. **That is the mechanism working on its first day** — a document that would otherwise have gone stale invisibly instead failed a build.

## What is left

Of the seven sets not repointed, three are the `CanonicalOrder` family, which still **runs** its `switch`. The four others are where repointing still costs something: `Common` would lose 33 descriptions, `Power` 22, `Trigonometric` 13 and `InequalityEquality` 11.

Full suite: **8988 passed, 14 skipped, 0 failed.** No public API change.

Part of #746 tier 2 and #825.