### PR TITLE
Power describes the rules it runs, and the confluence record names its arms

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -68,25 +68,26 @@ read first.
 | **Silent** | `RewriteRules.RationalizeDenominator.Rules` | `[]` — the registry could not read the set | its two rules, addressable and named |
 | **Silent** | `RewriteRules.Power.ApplyOnce("ln(1 / x)")`, and every `log(_, 1/_)` and `log(1/_, _)` whose argument is not decidably a positive real | `-ln(x)`, which is wrong on the negative reals | `ln(1 / x)`, left alone |
 | **Silent** | `RewriteRules.Boolean.ApplyOnce("a and b or a")`, and two more orientations of absorption | left alone — the arm for that orientation was never written | `a` |
-| **Silent** | `RewriteRules.DivisionPreparing.Rules[0].Name`, and every rule of twenty-four sets now described from their data form | `Mulf(var any1, Divf(Integer(1), var any2))` — the `switch` arm's rendered pattern | `reciprocal-factor-becomes-a-quotient` |
+| **Silent** | `RewriteRules.DivisionPreparing.Rules[0].Name`, and every rule of twenty-five sets now described from their data form | `Mulf(var any1, Divf(Integer(1), var any2))` — the `switch` arm's rendered pattern | `reciprocal-factor-becomes-a-quotient` |
 | | `RewriteRules.ExpandFactorialDivisions.Rules.Count`, and `FactorizeFactorialMultiplications` | `8` | `3` — the same rewrites, five of the eight arms being one commutative pattern |
 | | `RewriteRules.Boolean.Rules.Count` | `36` | `20` — a commutative pattern finds a shared operand wherever it sits |
 | | `RewriteRules.NumericNeat.Rules.Count`, and `Factorization` 22 -> 11 | `16` | `11` |
 | | `RewriteRules.Trigonometric.Rules.Count` | `43` | `33` |
-| | `RewriteRules.All.Sum(set => set.Rules.Count)` | `407` | `355` |
+| | `RewriteRules.Power.Rules.Count` | `35` | `31` |
+| | `RewriteRules.All.Sum(set => set.Rules.Count)` | `407` | `351` |
 | **Silent** | `RewriteRules.ExpandFactorialDivisions.Rules[0].Growth` | `Collects` — guessed from string length | `Unknown`; whether it collects depends on the offsets |
 | **Silent** | `RewriteStep.Soundness` on a rewrite whose rule declares a tier — `RewriteRules.SetOperator` on `A /\ A`, and every rewrite of the nineteen sets described from their data form | `SoundUnderAssumptions` — its rule set's tier, which is the minimum over every rule in the set | `Sound` — the rule's own |
 | **Silent** | `DerivationStep.Soundness` | its rule set's tier | the weakest tier any rewrite that actually fired inside the step holds at |
 | **Silent** | `"arccotan(-1)".ToEntity().Simplify()`, and every negative argument the inverse-trigonometric table knows | `3/4 * pi` — the textbook range, and **not equal to `arccotan(-1)`**, whose value is `-pi/4` | `-1/4 * pi` |
 
-### Twenty-four rule sets describe the rules they run
+### Twenty-five rule sets describe the rules they run
 
 `RewriteRuleSet.Rules` is what the registry reports a set is made of, and for most of the library's
 life it came from `RuleRegistryGenerator` reading the `switch` that defined the set. Twenty-seven of
 the thirty sets stopped running that `switch` some releases ago — they run
 `MatchedRuleSet.ApplyHere` — and went on describing it. Thirteen of them now describe what they run.
 
-Which twenty-four. Thirteen had **no described arm at all**, so repointing them could only add
+Which twenty-five. Thirteen had **no described arm at all**, so repointing them could only add
 metadata: `CollapseMultipleFractions`, the three `CommonDenominator` sets, `DivisionPreparing`,
 `ExpandFactorialDivisions`, `ExpandMultipleAngle`, `ExpandTrigonometric`, `Expansion`,
 `FactorizeFactorialMultiplications`, `NormalTrigonometricForm`, `PhiFunction` and
@@ -99,8 +100,8 @@ where the identities were **written** rather than carried across: its comments n
 rules' own patterns and replacements. `NumericNeat` and `Factorization` follow it, their comments
 already being identities and needing only the arrow turned into an equals sign.
 
-The three left on the `switch` are the ones where repointing would cost something today: `Common`
-would lose 33 descriptions, `Power` 22 and `InequalityEquality` 11. Porting those identities is a later change. Three more —
+The two left on the `switch` are the ones where repointing would cost something today: `Common`
+would lose 33 descriptions and `InequalityEquality` 11. Porting those identities is a later change. Three more —
 the `CanonicalOrder` family — still *run* their `switch`, so describing it is not a mismatch.
 
 Four things move, and only the second changes a count:
@@ -119,8 +120,9 @@ rule twice. `ExpandFactorialDivisions` and `FactorizeFactorialMultiplications` a
 written as three, the other five being one rewrite spelled once for each side a factorial can sit on.
 `NumericNeat`'s sixteen are eleven, six of them being three rules written once per side a negative
 factor can sit on; `Factorization`'s twenty-two are eleven for the same reason, and
-`Trigonometric`'s forty-three are thirty-three. Every other repointed set is one arm to one rule.
-Across the registry, 407 becomes **355** while the number of described rules goes from **95 to 200**.
+`Trigonometric`'s forty-three are thirty-three and `Power`'s thirty-five are thirty-one. Every
+other repointed set is one arm to one rule. Across the registry, 407 becomes **351** while the number
+of described rules goes from **95 to 209**.
 
 `Rules[i].Growth` also stops being a guess. `AsAddressable` used to infer it by comparing the lengths
 of the two rendered pattern strings — the only thing available to a generator reading source text —

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -2456,7 +2456,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 "a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero",
                 MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("a")),
                 bound => new Providedf(1, !bound["a"].EqualTo(0)),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "a / a = 1, provided a is not zero"),
 
             new MatchedRule(
                 "a-power-whose-exponent-divides-by-a-logarithm-of-its-own-base-changes-base",
@@ -2466,7 +2467,8 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Any("n"),
                         MatchPattern.Node<Logf>(MatchPattern.Any("c"), MatchPattern.Any("a")))),
                 bound => new Powf(bound["c"], bound["n"]),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "a ^ (n / log(c, a)) = c ^ n"),
 
             // Both orientations are written out in the `switch`, so one commutative rule fires
             // exactly where the pair did.
@@ -2476,7 +2478,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("n")),
                     MatchPattern.Any("a")),
                 bound => new Powf(bound["a"], bound["n"] + 1),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "a ^ n * a = a ^ (n + 1)"),
 
             new MatchedRule(
                 "two-powers-of-one-base-multiply-by-adding-exponents",
@@ -2484,7 +2487,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("n")),
                     MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("m"))),
                 bound => new Powf(bound["a"], bound["n"] + bound["m"]),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "a ^ n * a ^ m = a ^ (n + m)"),
 
             new MatchedRule(
                 "two-powers-of-one-base-divide-by-subtracting-exponents",
@@ -2492,7 +2496,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("n")),
                     MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("m"))),
                 bound => new Powf(bound["a"], bound["n"] - bound["m"]),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "a ^ n / a ^ m = a ^ (n - m)"),
 
             // True for a positive base whatever the exponents, and for any base when the outer
             // exponent is whole. Outside those two it moves the branch, which is what #752
@@ -2506,7 +2511,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 bound => new Powf(bound["a"], bound["n"] * bound["m"]),
                 Soundness.SoundUnderAssumptions,
                 when: bound => bound["m"] is Integer
-                               || bound["a"].Evaled is Real { IsPositive: true }),
+                               || bound["a"].Evaled is Real { IsPositive: true },
+                description: "(a ^ n) ^ m = a ^ (n * m)"),
 
             // https://github.com/asc-community/AngouriMath/issues/801
             new MatchedRule(
@@ -2518,7 +2524,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 Soundness.SoundUnderAssumptions,
                 when: bound => bound["n"] is Integer
                                || (bound["a"].Evaled is Real { IsPositive: true }
-                                   && bound["b"].Evaled is Real { IsPositive: true })),
+                                   && bound["b"].Evaled is Real { IsPositive: true }),
+                description: "a ^ n * b ^ n = (a * b) ^ n"),
 
             // https://github.com/asc-community/AngouriMath/issues/802
             new MatchedRule(
@@ -2530,7 +2537,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 Soundness.SoundUnderAssumptions,
                 when: bound => bound["n"] is Integer
                                || (bound["a"].Evaled is Real { IsPositive: true }
-                                   && bound["b"].Evaled is Real { IsPositive: true })),
+                                   && bound["b"].Evaled is Real { IsPositive: true }),
+                description: "a ^ n / b ^ n = (a / b) ^ n"),
 
             // The pair the rule above loses whenever only one of the two bases is itself a power,
             // read back. https://github.com/asc-community/AngouriMath/issues/740
@@ -2544,7 +2552,8 @@ namespace AngouriMath.Core.Transformations.Matching
                             MatchPattern.Any<Integer>("c", whole => whole.IsPositive),
                             MatchPattern.Any("n")))),
                 bound => new Powf(bound["a"] / new Powf(bound["b"], bound["c"]), bound["n"]),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "a ^ n / b ^ (c * n) = (a / b ^ c) ^ n, for a positive whole c"),
 
             new MatchedRule(
                 "a-quotient-of-powers-whose-exponents-differ-by-a-whole-factor-takes-it-into-the-dividend",
@@ -2556,7 +2565,8 @@ namespace AngouriMath.Core.Transformations.Matching
                             MatchPattern.Any("n"))),
                     MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("n"))),
                 bound => new Powf(new Powf(bound["a"], bound["c"]) / bound["b"], bound["n"]),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "a ^ (c * n) / b ^ n = (a ^ c / b) ^ n, for a positive whole c"),
 
             new MatchedRule(
                 "a-thing-over-a-power-of-itself-is-one-power",
@@ -2564,7 +2574,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any("a"),
                     MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("n"))),
                 bound => new Powf(bound["a"], 1 - bound["n"]),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "a / a ^ n = a ^ (1 - n)"),
 
             new MatchedRule(
                 "a-power-over-its-own-base-lowers-the-exponent",
@@ -2572,7 +2583,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("n")),
                     MatchPattern.Any("a")),
                 bound => new Powf(bound["a"], bound["n"] - 1),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "a ^ n / a = a ^ (n - 1)"),
 
             new MatchedRule(
                 "a-number-raised-to-a-logarithm-of-itself-is-the-antilogarithm",
@@ -2580,7 +2592,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any<Number>("c"),
                     MatchPattern.Node<Logf>(MatchPattern.Any<Number>("c"), MatchPattern.Any("a"))),
                 bound => bound["a"],
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "a ^ log(a, b) = b"),
 
             // Four `switch` arms: the power on either side of a product, and the shared base in
             // either position inside it. A commutative pattern says both halves at once.
@@ -2590,7 +2603,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("n")),
                     MatchPattern.Commutative<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("rest"))),
                 bound => new Powf(bound["a"], bound["n"] + 1) * bound["rest"],
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "a ^ n * (a * rest) = a ^ (n + 1) * rest"),
 
             // Taking a factor out from under a root needs that factor positive, or the root to be
             // a whole power. https://github.com/asc-community/AngouriMath/issues/752
@@ -2601,13 +2615,15 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any<Number>("d")),
                 bound => new Powf(bound["c"], bound["d"]) * new Powf(bound["a"], bound["d"]),
                 Soundness.SoundUnderAssumptions,
-                when: bound => bound["d"] is Integer || bound["c"] is Real { IsPositive: true }),
+                when: bound => bound["d"] is Integer || bound["c"] is Real { IsPositive: true },
+                description: "(c * a) ^ d = c ^ d * a ^ d, for numeric c and d"),
 
             new MatchedRule(
                 "a-reciprocal-power-is-a-quotient",
                 MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Exact(Integer.Create(-1))),
                 bound => 1 / bound["a"],
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "a ^ (-n) = 1 / a ^ n"),
 
             new MatchedRule(
                 "a-power-of-a-numeric-reciprocal-times-its-own-denominator-lowers-the-exponent",
@@ -2620,7 +2636,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 // as numbers, so `1 - c` folds to a literal there and would build a `Minusf` here.
                 bound => new Powf(bound["c"], bound["d"])
                     * new Powf(bound["a"], 1 - (Number)bound["d"]),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "(c / a) ^ d * a = c ^ d * a ^ (1 - d), for numeric c and d"),
 
             new MatchedRule(
                 "a-power-of-a-numeric-reciprocal-times-a-power-of-its-own-denominator-subtracts-the-exponents",
@@ -2631,7 +2648,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any<Number>("e"))),
                 bound => new Powf(bound["c"], bound["d"])
                     * new Powf(bound["a"], (Number)bound["e"] - (Number)bound["d"]),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "(c / a) ^ d * a ^ e = c ^ d * a ^ (e - d), for numeric c, d and e"),
 
             new MatchedRule(
                 "dividing-twice-by-one-thing-squares-it",
@@ -2639,7 +2657,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
                     MatchPattern.Any("b")),
                 bound => bound["a"] / new Powf(bound["b"], 2),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "a / b / b = a / b ^ 2"),
 
             new MatchedRule(
                 "dividing-by-a-power-and-then-by-its-base-raises-the-exponent",
@@ -2649,7 +2668,8 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("n"))),
                     MatchPattern.Any("b")),
                 bound => bound["a"] / new Powf(bound["b"], bound["n"] + 1),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "a / b ^ n / b = a / b ^ (n + 1)"),
 
             new MatchedRule(
                 "dividing-by-a-thing-and-then-by-a-power-of-it-raises-the-exponent",
@@ -2657,7 +2677,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
                     MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("n"))),
                 bound => bound["a"] / new Powf(bound["b"], bound["n"] + 1),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "a / b / b ^ n = a / b ^ (n + 1)"),
 
             new MatchedRule(
                 "dividing-by-two-powers-of-one-base-adds-the-exponents",
@@ -2667,7 +2688,8 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("m"))),
                     MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("n"))),
                 bound => bound["a"] / new Powf(bound["b"], bound["n"] + bound["m"]),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "a / b ^ n / b ^ m = a / b ^ (n + m)"),
 
             new MatchedRule(
                 "a-variable-times-a-power-puts-the-power-first",
@@ -2675,7 +2697,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any<Variable>("v"),
                     MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("n"))),
                 bound => new Powf(bound["a"], bound["n"]) * bound["v"],
-                Soundness.Sound),
+                Soundness.Sound,
+                description: "v * a ^ n = a ^ n * v, for a variable v"),
 
             // https://github.com/asc-community/AngouriMath/issues/902
             new MatchedRule(
@@ -2685,7 +2708,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("n"))),
                 bound => bound["n"] * MathS.Log(bound["a"], bound["b"]),
                 Soundness.SoundUnderAssumptions,
-                when: bound => Functions.Patterns.MayTakeLogOfPower(bound["b"], bound["n"])),
+                when: bound => Functions.Patterns.MayTakeLogOfPower(bound["b"], bound["n"]),
+                description: "log(a, b ^ n) = n * log(a, b)"),
 
             // The condition to carry is the node's own: log(-3, -3) is 1 where a written-out
             // `a > 0` calls it undefined, and log(1, 1) is NaN where that guard calls it 1.
@@ -2694,7 +2718,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 "a-logarithm-of-its-own-base-is-one-where-it-is-defined",
                 MatchPattern.Node<Logf>(MatchPattern.Any("a"), MatchPattern.Any("a")),
                 (node, bound) => new Providedf(1, ((Logf)node).DomainCondition),
-                Soundness.SoundUnderAssumptions),
+                Soundness.SoundUnderAssumptions,
+                description: "log(a, a) = 1, where log(a, a) is defined"),
 
             // ln(1/b) = -ln(b) is false on the negative reals: at b = -0.63 the two differ by the
             // full turn of the argument the principal branch discards.
@@ -2707,7 +2732,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 bound => MathS.Log(bound["a"], bound["b"]),
                 Soundness.SoundUnderAssumptions,
                 when: bound => Functions.Patterns.MayGatherLogarithms(Integer.One, bound["a"], isDifference: true)
-                               && Functions.Patterns.MayGatherLogarithms(Integer.One, bound["b"], isDifference: true)),
+                               && Functions.Patterns.MayGatherLogarithms(Integer.One, bound["b"], isDifference: true),
+                description: "log(1 / a, 1 / b) = log(a, b)"),
 
             new MatchedRule(
                 "a-logarithm-of-a-reciprocal-negates",
@@ -2716,7 +2742,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Divf>(MatchPattern.Exact(Integer.Create(1)), MatchPattern.Any("b"))),
                 bound => -MathS.Log(bound["a"], bound["b"]),
                 Soundness.SoundUnderAssumptions,
-                when: bound => Functions.Patterns.MayGatherLogarithms(Integer.One, bound["b"], isDifference: true)),
+                when: bound => Functions.Patterns.MayGatherLogarithms(Integer.One, bound["b"], isDifference: true),
+                description: "log(a, 1 / b) = -log(a, b)"),
 
             new MatchedRule(
                 "a-logarithm-in-a-reciprocal-base-negates",
@@ -2725,7 +2752,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any("b")),
                 bound => -MathS.Log(bound["a"], bound["b"]),
                 Soundness.SoundUnderAssumptions,
-                when: bound => Functions.Patterns.MayGatherLogarithms(Integer.One, bound["a"], isDifference: true)),
+                when: bound => Functions.Patterns.MayGatherLogarithms(Integer.One, bound["a"], isDifference: true),
+                description: "log(1 / a, b) = -log(a, b)"),
 
             // https://github.com/asc-community/AngouriMath/issues/721
             new MatchedRule(
@@ -2735,7 +2763,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Logf>(MatchPattern.Any("c"), MatchPattern.Any("b"))),
                 bound => bound["c"].Log(bound["a"] * bound["b"]),
                 Soundness.SoundUnderAssumptions,
-                when: bound => Functions.Patterns.MayGatherLogarithms(bound["a"], bound["b"], isDifference: false)),
+                when: bound => Functions.Patterns.MayGatherLogarithms(bound["a"], bound["b"], isDifference: false),
+                description: "log(a, b) + log(a, c) = log(a, b * c)"),
 
             new MatchedRule(
                 "two-logarithms-of-one-base-subtract-by-dividing-their-antilogarithms",
@@ -2744,7 +2773,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Logf>(MatchPattern.Any("c"), MatchPattern.Any("b"))),
                 bound => bound["c"].Log(bound["a"] / bound["b"]),
                 Soundness.SoundUnderAssumptions,
-                when: bound => Functions.Patterns.MayGatherLogarithms(bound["a"], bound["b"], isDifference: true)),
+                when: bound => Functions.Patterns.MayGatherLogarithms(bound["a"], bound["b"], isDifference: true),
+                description: "log(a, b) - log(a, c) = log(a, b / c)"),
 
             // sqrt(8) = 2 * sqrt(2). Whether it applies and what it produces are one computation,
             // so the `when` asks the same helper the replacement does.
@@ -2757,7 +2787,8 @@ namespace AngouriMath.Core.Transformations.Matching
                     (Integer)bound["radicand"], (Rational)bound["power"])!,
                 Soundness.Sound,
                 when: bound => Functions.Patterns.ReduceRadical(
-                    (Integer)bound["radicand"], (Rational)bound["power"]) is not null));
+                    (Integer)bound["radicand"], (Rational)bound["power"]) is not null,
+                description: "sqrt(8) = 2 * sqrt(2), and its like for a positive whole radicand"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.CommonRules"/>, as data.

--- a/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRules.cs
@@ -177,8 +177,7 @@ namespace AngouriMath.Core.Transformations
             // (a ^ b) ^ c is a ^ (b c) only on a branch; the rules guard for it, and the
             // guard is what the tier is stating.
             Soundness.SoundUnderAssumptions,
-            Matching.MatchedRules.Power.ApplyHere,
-            Patterns.PowerRulesArms);
+            Matching.MatchedRules.Power);
 
         /// <summary>
         /// Multiplies products over sums out.

--- a/Sources/AngouriMath/Docs/Contributing/WritingARule.md
+++ b/Sources/AngouriMath/Docs/Contributing/WritingARule.md
@@ -21,7 +21,7 @@ effect". This is how to supply those seven things.
 **322** rules live there today.
 
 The `switch` statements in `Functions/Simplification/Patterns` are the older form. Twenty-seven of
-the thirty registered sets no longer run theirs, and twenty-four no longer describe it either; the
+the thirty registered sets no longer run theirs, and twenty-five no longer describe it either; the
 remainder are being moved set by set ([#825](https://github.com/asc-community/AngouriMath/issues/825)).
 **Do not add a rule to a `switch`.** A `switch` arm cannot carry a name, a tier, an identity or a
 direction, and everything below is about those.
@@ -88,7 +88,7 @@ debugged for an afternoon.
 | `Left.ToString()` | `Divf(var a, Divf(var b, var c))` — how the matcher spells it |
 
 Write the identity with `=`, not `->`: it is an equality, and the arrow belongs to the direction the
-rule happens to be applied in. **134** rules carry one today; a new rule should.
+rule happens to be applied in. **165** rules carry one today; a new rule should.
 
 ## The pattern language
 

--- a/Sources/Tests/UnitTests/Core/Transformations/AddressableRulesTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/AddressableRulesTest.cs
@@ -290,8 +290,8 @@ namespace AngouriMath.Tests.Core.Transformations
 
             Assert.Equal(30, withRules.Count);
 
-            // 355, and it was 407 before the registry started reporting the rules it runs rather
-            // than the `switch` it no longer runs. The fifty-two that went are not rules lost, they
+            // 351, and it was 407 before the registry started reporting the rules it runs rather
+            // than the `switch` it no longer runs. The fifty-six that went are not rules lost, they
             // are arms the data form writes once. Boolean's thirty-six are twenty, because a
             // commutative pattern finds a shared operand wherever it sits, so eight arms of
             // distributivity are two rules and absorption's four-arms-each is one rule twice;
@@ -299,7 +299,7 @@ namespace AngouriMath.Tests.Core.Transformations
             // are thirty-three; NumericNeat's sixteen are eleven, six of them being three rules
             // written once per side a negative factor can sit on; and the two factorial sets are
             // eight arms each written as three. Every other repointed set is one arm for one rule.
-            Assert.Equal(355, withRules.Sum(set => set.Rules.Count));
+            Assert.Equal(351, withRules.Sum(set => set.Rules.Count));
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
@@ -49,7 +49,7 @@ namespace AngouriMath.Tests.Core.Transformations
                     MatchedRules.All.Any(data => data.Name == set.Name)
                     || set.Name.StartsWith("CommonDenominator", StringComparison.Ordinal)),
                 "how many registered sets run the matcher");
-            Stated(24, RewriteRules.All.Count(set =>
+            Stated(25, RewriteRules.All.Count(set =>
                     set.Rules.Count > 0 && set.Rules.All(rule => rule.Soundness is not null)),
                 "how many registered sets describe what they run");
         }
@@ -68,7 +68,7 @@ namespace AngouriMath.Tests.Core.Transformations
 
         [Fact]
         public void TheIdentityIsNotTheName()
-            => Stated(134,
+            => Stated(165,
                 MatchedRules.All.SelectMany(set => set.Rules).Count(rule => rule.Description is not null),
                 "how many rules carry an identity");
 

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleConfluenceTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleConfluenceTest.cs
@@ -120,6 +120,22 @@ namespace AngouriMath.Tests.Core.Transformations
         }
 
         /// <summary>
+        /// How an arm is referred to: <b>by name where it has one</b>, and by its index where the
+        /// only name it has is its own rendered pattern.
+        /// </summary>
+        /// <remarks>
+        /// This is what the note on <see cref="AConflictIsReportableAsThePatternsItIsBetween"/>
+        /// asks for — "an index moves whenever somebody edits the <c>switch</c>, which is exactly
+        /// when this test fires" — and it became possible one set at a time, as the registry was
+        /// repointed at the rules it runs. It is not hypothetical: repointing <c>Power</c> moved
+        /// its arms from 35 to 31 and invalidated two recorded orderings that named nothing but
+        /// numbers. A set still described by <c>RuleRegistryGenerator</c> has no name to give, so
+        /// it keeps the index and will stop needing to when it is repointed.
+        /// </remarks>
+        private static string Ident(RewriteRuleSet set, int index)
+            => Explanation.IsProse(set.Rules[index].Name) ? set.Rules[index].Name : index.ToString();
+
+        /// <summary>
         /// Every pair of arms of one set observed to fire at the same node and disagree about the
         /// result, as <c>Set[earlier,later]</c>.
         /// </summary>
@@ -143,7 +159,7 @@ namespace AngouriMath.Tests.Core.Transformations
                             {
                                 if (i >= j || settled[i].Equals(settled[j]))
                                     continue;
-                                var key = $"{set.Name}[{i},{j}]";
+                                var key = $"{set.Name}[{Ident(set, i)},{Ident(set, j)}]";
                                 conflicts.Add(key);
                                 if (!examples.ContainsKey(key))
                                     examples[key] = $"{node.Stringize()} -> {settled[i].Stringize()} "
@@ -163,6 +179,13 @@ namespace AngouriMath.Tests.Core.Transformations
         /// way. They are recorded because that is a fact about the current arms and not a
         /// guarantee: an arm inserted above one of these changes an answer, and without this list
         /// nothing would notice.
+        /// <para/>
+        /// <b>Two of the three now name their arms and one still cannot</b>, which is the state of
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/825">#825</a> written into a
+        /// test: <c>Power</c> is described from the rules it runs and <c>Common</c> is not. The two
+        /// that name them used to read <c>Power[18,19]</c> and <c>Power[6,19]</c>, and repointing
+        /// that set moved its arms from 35 to 31 and invalidated both — which is the failure the
+        /// note on <see cref="AConflictIsReportableAsThePatternsItIsBetween"/> predicted.
         /// </remarks>
         [Fact]
         public void OnlyTheRecordedArmOrderingsAreLoadBearing()
@@ -172,12 +195,14 @@ namespace AngouriMath.Tests.Core.Transformations
             var recorded = new[]
             {
                 // x * 1/2 -> 1/2 * x (the sort) rather than x / 2 (the quotient). Both settle to
-                // x / 2 once InnerSimplified has run.
+                // x / 2 once InnerSimplified has run. Still by index, because `Common` is one of
+                // the two sets the registry still describes from its `switch`, and a generated arm
+                // has no name but its own rendered pattern.
                 "Common[12,89]",
                 // (-x) ^ (-1) -> -1 / x rather than 1 / (-x).
-                "Power[18,19]",
+                "Power[a-numeric-factor-comes-out-of-a-power-of-a-product,a-reciprocal-power-is-a-quotient]",
                 // (e ^ y) ^ (-1) -> e ^ (y * (-1)) rather than 1 / e ^ y.
-                "Power[6,19]",
+                "Power[a-power-of-a-power-multiplies-the-exponents,a-reciprocal-power-is-a-quotient]",
             };
 
             Assert.Equal(
@@ -201,11 +226,15 @@ namespace AngouriMath.Tests.Core.Transformations
             foreach (var conflict in conflicts)
             {
                 var name = conflict.Substring(0, conflict.IndexOf('['));
-                var indices = conflict.Substring(conflict.IndexOf('[') + 1).TrimEnd(']')
-                    .Split(',').Select(int.Parse).ToList();
+                var arms = conflict.Substring(conflict.IndexOf('[') + 1).TrimEnd(']').Split(',');
                 var set = Assert.Single(RewriteRules.All.Where(s => s.Name == name));
-                Assert.NotEmpty(set.Rules[indices[0]].PatternSource);
-                Assert.NotEmpty(set.Rules[indices[1]].PatternSource);
+                foreach (var arm in arms)
+                {
+                    var rule = int.TryParse(arm, out var index)
+                        ? set.Rules[index]
+                        : Assert.Single(set.Rules.Where(r => r.Name == arm));
+                    Assert.NotEmpty(rule.PatternSource);
+                }
                 Assert.NotEmpty(examples[conflict]);
             }
         }

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleMetadataTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleMetadataTest.cs
@@ -132,6 +132,7 @@ namespace AngouriMath.Tests.Core.Transformations
                 nameof(RewriteRules.PhiFunction),
                 nameof(RewriteRules.PolynomialGcdCancellation),
                 nameof(RewriteRules.PolynomialLongDivision),
+                nameof(RewriteRules.Power),
                 nameof(RewriteRules.RationalizeDenominator),
                 nameof(RewriteRules.SetOperator),
                 nameof(RewriteRules.Trigonometric),
@@ -165,7 +166,7 @@ namespace AngouriMath.Tests.Core.Transformations
             var repointed = RewriteRules.All
                 .Where(set => set.Rules.Count > 0 && set.Rules.All(rule => rule.Soundness is not null))
                 .ToList();
-            Assert.Equal(134, repointed.Sum(set => set.Rules.Count));
+            Assert.Equal(165, repointed.Sum(set => set.Rules.Count));
             Assert.All(repointed, set => Assert.All(set.Rules, rule => Assert.NotNull(rule.Description)));
         }
 


### PR DESCRIPTION
The fifth tranche of the repoint, and the one that finally converts `RuleConfluenceTest` to naming arms instead of numbering them.

## Thirty-one identities

`Power`'s comments are notes on **soundness and branch cuts** — the right thing for a comment above a rule, and not identities — so none carried across:

```
a ^ n * a ^ m = a ^ (n + m)
a ^ n / b ^ (c * n) = (a / b ^ c) ^ n, for a positive whole c
(c / a) ^ d * a ^ e = c ^ d * a ^ (e - d), for numeric c, d and e
log(1 / a, 1 / b) = log(a, b)
```

**Five needed reading rather than deriving from the name** — the change-of-base rule, the two that take a whole factor into the divisor or the dividend, and the two numeric-reciprocal ones. Reading them was the point: `a ^ (n / log(c, a)) = c ^ n` is not what its name alone would have got.

## The index-named conflicts finally broke, exactly as their own comment predicted

`RuleConfluenceTest` recorded three load-bearing arm orderings, two of them as `Power[18,19]` and `Power[6,19]`. Repointing `Power` moved its arms from 35 to 31 and **invalidated both**.

The note on `AConflictIsReportableAsThePatternsItIsBetween` had said this would happen — *"an index moves whenever somebody edits the `switch`, which is exactly when this test fires"* — and until a set was described by the rules it runs, there was no name to use instead. Now there is:

```
Power[a-power-of-a-power-multiplies-the-exponents,a-reciprocal-power-is-a-quotient]
Common[12,89]
```

The identifier is the rule's name where it has one and the index where it does not. **Two of the three name their arms and one still cannot**, which is the state of #825 written into a test rather than into prose.

## One thing the tooling caught

`two-powers-of-one-exponent-share-a-base` exists in **both** `Factorization` and `Power`, and the first already carried an identity from #1112. Describing it twice is a compile error — a better failure than silently overwriting one.

## Counts

| | Was | Is |
|---|---|---|
| `RewriteRules.Power.Rules.Count` | 35 | **31** |
| registry total | 407 | **351** |
| described rules | 95 | **209** |
| sets describing what they run | 24 | **25** |

Recorded in `BREAKING-CHANGES.md`, measured on a build.

## What is left

Three of the five sets not repointed are the `CanonicalOrder` family, which still **runs** its `switch`. The two others are `Common` (33 descriptions to port) and `InequalityEquality` (11).

Full suite: **9010 passed, 14 skipped, 0 failed.** No public API change.

Part of #746 tier 2 and #825.