### PR TITLE
Factorize takes out a common whole factor

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -86,6 +86,8 @@ read first.
 | | `"[2; 3] / 2".ToEntity().Simplify()` | `[2; 3] / 2` | `[1; 3/2]` |
 | **Silent** | `"[2; 3) * (-1)".ToEntity().Simplify()` | `[2; 3) * (-1)` | `(-3; -2]` — reflected, ends and openness both |
 | | `"0 - [0; 1)".ToEntity().Simplify()` | `-[0; 1)` | `(-1; 0]` |
+| | `"2 * x + 4 * a".ToEntity().Factorize()`, and every sum whose whole coefficients share a divisor | `2 * x + 4 * a` — left alone | `2 * (x + 2 * a)` |
+| | `Transformation.Factorization.Name` | `… then polynomial-factorization` | `… then polynomial-factorization then numeric-content` |
 | **Silent** | `"arccotan(-1)".ToEntity().Simplify()`, and every negative argument the inverse-trigonometric table knows | `3/4 * pi` — the textbook range, and **not equal to `arccotan(-1)`**, whose value is `-pi/4` | `-1/4 * pi` |
 
 ### Every rule set describes the rules it runs
@@ -265,6 +267,38 @@ says it "will be possible once we implement quantifiers"; scaling needs none —
 factor's sign and in nothing else. Applying a non-monotonic function to an interval, which is the
 other half, is still open: `ln((0; 1))` is `(-oo; 0)` because `ln` increases, but `sin((0; 7))` needs
 to know where the turning points are.
+
+### `Factorize` takes out a common whole factor
+
+`2x + 2a` has been collected under plain `Simplify` for some time — the factorisation rules take out a
+factor that appears *identically* in every term. A factor that is only a common **divisor** was not,
+and still is not, because `2 * (x + 2 * a)` is a node larger than `4 * a + 2 * x` and
+`Entity.SimplifiedRate` will not choose it.
+
+`Factorize` now does, which is
+[#195](https://github.com/asc-community/AngouriMath/issues/195)'s "forcefully… but not peacefully":
+
+```csharp
+"2 * x + 4 * a".ToEntity().Factorize()          // was 2 * x + 4 * a, is 2 * (x + 2 * a)
+"4 * x + 6 * y + 10 * z".ToEntity().Factorize() // is 2 * (2 * x + 3 * y + 5 * z)
+"2 * x - 4 * a".ToEntity().Factorize()          // is 2 * (x - 2 * a)
+"2 * x + 4 * a".ToEntity().Simplify()           // unchanged: 4 * a + 2 * x
+```
+
+**`Simplify` is untouched**, and that is asserted rather than assumed — the peaceful behaviour is
+what a caller who did not ask to factorise still gets.
+
+Whole numbers only, and a positive content. `x/2 + a/3` has a common divisor too, but taking `1/6` out
+puts a quotient outside the sum rather than a factor, which is a different rewrite. And the sign stays
+inside: `-2x - 4a` is `2 * (-x - 2a)` rather than `-2 * (x + 2a)`, because which of those is wanted is
+a second question.
+
+A term whose coefficient is not a whole number stops the whole sum rather than contributing a 1: the
+content of `2x + a/3` is not 1, it is a thing this does not compute, and answering 1 would say there
+was nothing to take.
+
+`Transformation.NumericContentExtraction` is the step on its own, and `Transformation.Factorization`'s
+`Name` gains it — a chain names its parts.
 
 ### An equation nothing settled is no longer answered with the empty set
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -24,6 +24,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [AngouriMath/Core/Transformations/*.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[AngouriMath/Functions/Simplification/NumericContent.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [Tests/UnitTests/Core/DomainConditionInAReadingTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 

--- a/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
+++ b/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
@@ -108,7 +108,61 @@ namespace AngouriMath.Core.Transformations
                     // And then the polynomial layer, which factors what no rule set has a rule
                     // for. Last, so that the rules keep every answer they already gave and this
                     // only ever adds one. See PolynomialFactorization.
-                    .Then(PolynomialFactorization));
+                    .Then(PolynomialFactorization)
+                    // And last of all the numeric content, which is the only step here that
+                    // `Simplify` deliberately does not get: `2 * (x + 2 * a)` is a node larger
+                    // than `4 * a + 2 * x`, so the cost model will not take it and only a caller
+                    // who asked to factorise wants it. https://github.com/asc-community/AngouriMath/issues/195
+                    .Then(NumericContentExtraction));
+
+        /// <summary>
+        /// Takes the whole number every term of a sum divides by out in front of it:
+        /// <c>2x + 4a</c> becomes <c>2 * (x + 2a)</c>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>The "forcefully" of
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/195">#195</a>.</b> A factor
+        /// appearing <i>identically</i> in every term already comes out peacefully — <c>2x + 2a</c>
+        /// is <c>2 * (a + x)</c> under plain <see cref="Entity.Simplify(int)"/> — and a common
+        /// <b>divisor</b> does not, because the result is larger and
+        /// <c>Entity.SimplifiedRate</c> will not choose it.
+        /// </para>
+        /// <para>
+        /// Offered on its own as well as inside <see cref="FactorizationAtLevel"/>, because it is
+        /// the one step of factorisation whose answer a caller might want without the rest.
+        /// </para>
+        /// </remarks>
+        /// <remarks>
+        /// Held in a nested class rather than in a static field of this one, and that is not a
+        /// style choice. <see cref="Factorization"/> is declared <i>above</i> this and calls
+        /// <see cref="FactorizationAtLevel"/> in its own initialiser, which reads this — and a
+        /// static field initialiser runs in declaration order, so it would read <see langword="null"/>
+        /// and fail as a <c>TypeInitializationException</c> from somewhere else entirely. A nested
+        /// type initialises on first use instead, whatever order the fields are written in.
+        /// </remarks>
+        public static Transformation NumericContentExtraction => Held.Instance;
+
+        private static class Held
+        {
+            [ConstantField]
+            internal static readonly Transformation Instance = new NumericContentTransformation();
+        }
+
+        private sealed class NumericContentTransformation : Transformation
+        {
+            public override string Name => "numeric-content";
+            public override TransformationRelation Relation => TransformationRelation.Equivalence;
+            public override Soundness Soundness => Soundness.Sound;
+
+            // Never null. `Then` propagates a null from its second half as the whole chain having
+            // no answer, so a step that says "I did not apply" by returning null does not step
+            // aside -- it discards everything the steps before it produced. Returning the input
+            // unchanged is how the polynomial layer above does it and for the same reason: this
+            // only ever adds an answer to the ones already given.
+            protected override Entity? ApplyCore(Entity input)
+                => Functions.NumericContent.Extracted(input);
+        }
 
         /// <summary>
         /// The rule-based half of <see cref="FactorizationAtLevel"/>, without the polynomial

--- a/Sources/AngouriMath/Functions/Simplification/NumericContent.cs
+++ b/Sources/AngouriMath/Functions/Simplification/NumericContent.cs
@@ -1,0 +1,166 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Collections.Generic;
+using AngouriMath.Core;
+using PeterO.Numbers;
+
+namespace AngouriMath.Functions
+{
+    using static Entity;
+    using static Entity.Number;
+
+    /// <summary>
+    /// The whole number every term of a sum divides by, taken out in front of it:
+    /// <c>2x + 4a</c> is <c>2 * (x + 2a)</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/195">#195</a>, and the reason
+    /// it says "forcefully… but not peacefully". The rules already take out a factor that appears
+    /// <i>identically</i> in every term — <c>2x + 2a</c> is <c>2 * (a + x)</c> under plain
+    /// <see cref="Entity.Simplify(int)"/> — and that is what "peacefully" means here. A factor that
+    /// is only a common <b>divisor</b> is different: <c>2 * (x + 2 * a)</c> is one node larger than
+    /// <c>4 * a + 2 * x</c>, so <c>SimplifiedRate</c> will not choose it and <c>Simplify</c> should
+    /// not offer it.
+    /// </para>
+    /// <para>
+    /// So this runs in <see cref="Entity.Factorize(int)"/> and nowhere else. That is already the
+    /// forceful half of the pair — the call a user makes when they have decided they want the
+    /// factored form, whatever it rates — and putting it there needs no new mode and leaves
+    /// <c>Simplify</c> untouched.
+    /// </para>
+    /// <para>
+    /// <b>Whole numbers only, and a positive one.</b> Rational coefficients have a common divisor
+    /// too — <c>x/2 + a/3</c> over <c>1/6</c> — but taking it out puts a quotient outside the sum
+    /// rather than a factor, which is a different rewrite and arguably the wrong direction. And the
+    /// sign is left inside: <c>-2x - 4a</c> becomes <c>2 * (-x - 2a)</c> rather than
+    /// <c>-2 * (x + 2a)</c>, because deciding which of those is wanted is a second question and
+    /// this answers the first one.
+    /// </para>
+    /// </remarks>
+    internal static class NumericContent
+    {
+        /// <summary>
+        /// <paramref name="expr"/> with its numeric content in front, or the expression itself
+        /// where there is none to take out.
+        /// </summary>
+        internal static Entity Extracted(Entity expr)
+        {
+            if (expr is not (Sumf or Minusf))
+                return expr;
+
+            var terms = new List<(Entity Term, bool Negated)>();
+            Terms(expr, negated: false, terms);
+            if (terms.Count < 2)
+                return expr;
+
+            var content = EInteger.Zero;
+            var coefficients = new List<EInteger>(terms.Count);
+            foreach (var (term, negated) in terms)
+            {
+                if (CoefficientOf(term) is not { } coefficient)
+                    return expr;
+                // The sign is carried here rather than by negating the term, because negating it
+                // changes its shape: `-(4 * a)` comes back as a product by -1 wrapping a product
+                // by 4, whose coefficient then reads as -1 and takes the content of every
+                // difference down to 1. The sign belongs to the number, so it is applied to the
+                // number.
+                if (negated) coefficient = -coefficient;
+                coefficients.Add(coefficient);
+                // Gcd(0, n) is n, so seeding with zero makes the first term the running answer
+                // without a special case for it, and Gcd is never negative.
+                content = content.Gcd(coefficient);
+            }
+
+            // One is not a factor worth taking out, and zero cannot be: every coefficient being
+            // zero means every term is, and the sum is already going to collapse without help.
+            if (content.CompareTo(EInteger.One) <= 0)
+                return expr;
+
+            var reduced = Reduced(terms[0].Term, coefficients[0], content);
+            for (var i = 1; i < terms.Count; i++)
+                reduced += Reduced(terms[i].Term, coefficients[i], content);
+            // InvertNegativeMultipliers afterwards, because a negated term inside the bracket is
+            // what taking a
+            // positive content out of a difference leaves: `2x - 4a` rebuilds as
+            // `2 * (x + (-2) * a)`, and `a + c * b = a - (-c) * b` for a negative real c is what
+            // writes it as `2 * (x - 2 * a)`. It is the
+            // last step of Factorize, so nothing else would.
+            return Core.Transformations.RewriteRules.InvertNegativeMultipliers.ApplyOnce(
+                (Integer.Create(content) * reduced).InnerSimplified);
+        }
+
+        /// <summary>
+        /// One term with the content divided out of it, written without the <c>1 *</c> that
+        /// dividing a term by its own coefficient otherwise leaves.
+        /// </summary>
+        private static Entity Reduced(Entity term, EInteger coefficient, EInteger content)
+        {
+            var scaled = coefficient / content;
+            var rest = WithoutCoefficient(term);
+            return scaled.Equals(EInteger.One) ? rest : Integer.Create(scaled) * rest;
+        }
+
+        /// <summary>
+        /// The terms of a chain of sums and differences, each carrying the sign it is under.
+        /// </summary>
+        /// <remarks>
+        /// <c>Sumf.LinearChildren</c> descends sums only, so <c>2x - 4a</c> came back as one term
+        /// and the content of a difference was never taken. Carrying the sign down instead makes
+        /// <c>a - b</c> the pair <c>a</c> and <c>-b</c>, which is what it is, and a chain of any
+        /// depth follows without a special case.
+        /// </remarks>
+        private static void Terms(Entity expr, bool negated, List<(Entity, bool)> into)
+        {
+            switch (expr)
+            {
+                case Sumf(var left, var right):
+                    Terms(left, negated, into);
+                    Terms(right, negated, into);
+                    return;
+                case Minusf(var left, var right):
+                    Terms(left, negated, into);
+                    Terms(right, !negated, into);
+                    return;
+                default:
+                    into.Add((expr, negated));
+                    return;
+            }
+        }
+
+        /// <summary>
+        /// The whole number this term is a multiple of, or <see langword="null"/> where it is not a
+        /// whole multiple of anything — which is the answer that stops the whole sum.
+        /// </summary>
+        /// <remarks>
+        /// Null rather than one, deliberately. A term with no whole coefficient does not contribute
+        /// a 1 to the gcd, it makes the question unanswerable: the content of <c>2x + a/3</c> is
+        /// not 1, it is a thing this does not compute, and returning 1 would say the sum has no
+        /// content when what is true is that this cannot tell.
+        /// </remarks>
+        private static EInteger? CoefficientOf(Entity term) => term switch
+        {
+            Integer whole => whole.EInteger,
+            Mulf(Integer whole, _) => whole.EInteger,
+            Mulf(_, Integer whole) => whole.EInteger,
+            // Anything else is its own coefficient of one: a bare variable, a function, a power.
+            // A Rational or a Real is not, and falls through to null.
+            Number => null,
+            _ => EInteger.One,
+        };
+
+        /// <summary>What is left of the term once its whole coefficient is taken off.</summary>
+        private static Entity WithoutCoefficient(Entity term) => term switch
+        {
+            Integer => Integer.One,
+            Mulf(Integer, var rest) => rest,
+            Mulf(var rest, Integer) => rest,
+            _ => term,
+        };
+    }
+}

--- a/Sources/Tests/UnitTests/Common/PublicApi.txt
+++ b/Sources/Tests/UnitTests/Common/PublicApi.txt
@@ -262,6 +262,7 @@ AngouriMath.Core.Transformations.Transformation.Integration(AngouriMath.Entity+V
 AngouriMath.Core.Transformations.Transformation.LimitAt(AngouriMath.Entity+Variable, AngouriMath.Entity, AngouriMath.Core.ApproachFrom) : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Name { } : System.String
 AngouriMath.Core.Transformations.Transformation.Normalization { } : AngouriMath.Core.Transformations.Transformation
+AngouriMath.Core.Transformations.Transformation.NumericContentExtraction { } : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.PolynomialFactorization { } : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.RationalCanonicalization { } : AngouriMath.Core.Transformations.Transformation
 AngouriMath.Core.Transformations.Transformation.Rationalization { } : AngouriMath.Core.Transformations.Transformation

--- a/Sources/Tests/UnitTests/Core/Transformations/NumericContentTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/NumericContentTest.cs
@@ -1,0 +1,127 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath.Core.Transformations;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// The whole number every term of a sum divides by, taken out in front of it —
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/195">#195</a>'s "forcefully".
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The issue asks for <c>2x + 2a</c> to be collected "forcefully… but not peacefully", and that
+    /// half stopped being true some time ago: an <i>identical</i> factor comes out under plain
+    /// <see cref="Entity.Simplify(int)"/>. What is forceful is a common <b>divisor</b>, because
+    /// <c>2 * (x + 2 * a)</c> is a node larger than <c>4 * a + 2 * x</c> and the cost model will
+    /// not choose it.
+    /// </para>
+    /// <para>
+    /// So it runs in <see cref="Entity.Factorize(int)"/> and not in <c>Simplify</c>. Both halves of
+    /// that are asserted here — the second is the one that would go wrong quietly.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class NumericContentTest
+    {
+        [Theory]
+        [InlineData("2 * x + 4 * a", "2 * (x + 2 * a)")]
+        [InlineData("6 * x + 9 * a", "3 * (2 * x + 3 * a)")]
+        [InlineData("2 * x + 4", "2 * (x + 2)")]
+        [InlineData("4 * x + 6 * y + 10 * z", "2 * (2 * x + 3 * y + 5 * z)")]
+        [InlineData("2 * sin(x) + 4 * cos(x)", "2 * (sin(x) + 2 * cos(x))")]
+        public void FactorizeTakesTheContentOut(string expression, string expected)
+            => Assert.Equal(expected.ToEntity(), expression.ToEntity().Factorize());
+
+        /// <summary>
+        /// A difference is a sum of a negated term, and the sign is carried as a sign rather than
+        /// by negating the term.
+        /// </summary>
+        /// <remarks>
+        /// Negating the term changes its shape — <c>-(4 * a)</c> comes back as a product by -1
+        /// wrapping a product by 4, whose coefficient then reads as -1 and takes the content of
+        /// every difference down to 1. That is what the first version did, and every one of these
+        /// came back unchanged.
+        /// </remarks>
+        [Theory]
+        [InlineData("2 * x - 4 * a", "2 * (x - 2 * a)")]
+        [InlineData("-2 * x - 4 * a", "2 * (-x - 2 * a)")]
+        [InlineData("6 * x - 9 * a", "3 * (2 * x - 3 * a)")]
+        public void ADifferenceIsASumOfANegatedTerm(string expression, string expected)
+            => Assert.Equal(expected.ToEntity(), expression.ToEntity().Factorize());
+
+        /// <summary>
+        /// <b>What it leaves alone, which is most things.</b>
+        /// </summary>
+        /// <remarks>
+        /// A content of one is not a factor. A coefficient that is not a whole number makes the
+        /// question unanswerable rather than answering one: the content of <c>2x + a/3</c> is not
+        /// 1, it is a thing this does not compute, and taking 1 out would say there was nothing to
+        /// take.
+        /// </remarks>
+        [Theory]
+        [InlineData("2 * x + 3 * a")]
+        [InlineData("x + a")]
+        [InlineData("x / 2 + a / 3")]
+        [InlineData("2 * x + a / 3")]
+        public void WhereThereIsNoContentNothingMoves(string expression)
+            => Assert.Equal(expression.ToEntity(), expression.ToEntity().Factorize());
+
+        /// <summary>
+        /// <b><c>Simplify</c> is untouched, which is the whole point of putting this in
+        /// <c>Factorize</c>.</b>
+        /// </summary>
+        /// <remarks>
+        /// The peaceful behaviour is asserted as it is: <c>2x + 2a</c> is collected because the
+        /// factor is identical, and <c>2x + 4a</c> is not because it is only a divisor and the
+        /// result is larger. If a later change makes <c>Simplify</c> take the content out, this is
+        /// what says so.
+        /// </remarks>
+        [Theory]
+        [InlineData("2 * x + 4 * a", "4 * a + 2 * x")]
+        [InlineData("6 * x + 9 * a", "9 * a + 6 * x")]
+        [InlineData("4 * x + 6 * y + 10 * z", "4 * x + 6 * y + 10 * z")]
+        [InlineData("2 * x + 2 * a", "2 * (a + x)")]
+        public void SimplifyStaysPeaceful(string expression, string expected)
+            => Assert.Equal(expected.ToEntity(), expression.ToEntity().Simplify());
+
+        /// <summary>
+        /// The transformation on its own, since it is offered as one.
+        /// </summary>
+        [Fact]
+        public void ItIsAlsoATransformationOfItsOwn()
+        {
+            var taken = Transformation.NumericContentExtraction;
+            Assert.Equal("numeric-content", taken.Name);
+            Assert.Equal(TransformationRelation.Equivalence, taken.Relation);
+            Assert.Equal(Soundness.Sound, taken.Soundness);
+            Assert.Equal("2 * (x + 2 * a)".ToEntity(), taken.ApplyOrKeep("2 * x + 4 * a".ToEntity()));
+            // And it steps aside rather than refusing, so that composing it cannot lose the
+            // answer the step before it gave: `Then` reads a null from its second half as the
+            // whole chain having no answer.
+            Assert.Equal("x + a".ToEntity(), taken.ApplyOrKeep("x + a".ToEntity()));
+            Assert.NotNull(taken.Apply("x + a".ToEntity()).Output);
+        }
+
+        /// <summary>
+        /// It is the last step of factorisation, so what it takes out is on top of everything the
+        /// rules and the polynomial layer already did.
+        /// </summary>
+        /// <remarks>
+        /// Compared as printed forms, which is the wrong default and right here: the two are the
+        /// same product associated differently, and what this asserts is that the content came out
+        /// on top of the factorisation rather than which way the resulting chain is nested.
+        /// </remarks>
+        [Fact]
+        public void ItComesAfterTheRestOfFactorization()
+            => Assert.Equal("2 * (x - 1) * (x + 1)",
+                "2 * x ^ 2 - 2".ToEntity().Factorize().Stringize());
+    }
+}

--- a/Sources/Tests/UnitTests/Core/Transformations/TransformationTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/TransformationTest.cs
@@ -105,8 +105,10 @@ namespace AngouriMath.Tests.Core.Transformations
             var factorThenExpand = Transformation.Factorization.Then(Transformation.Expansion);
 
             // Not an inverse pair, and the names say which way round each one is.
-            Assert.Equal("expand[2] then factorize then polynomial-factorization", Shorten(expandThenFactor.Name));
-            Assert.Equal("factorize then polynomial-factorization then expand[2]", Shorten(factorThenExpand.Name));
+            Assert.Equal("expand[2] then factorize then polynomial-factorization then numeric-content",
+                Shorten(expandThenFactor.Name));
+            Assert.Equal("factorize then polynomial-factorization then numeric-content then expand[2]",
+                Shorten(factorThenExpand.Name));
 
             static string Shorten(string name)
                 => name.Replace("rewrite[PerfectSquare] then rewrite[Factorization] then inner-simplify x2", "factorize");


### PR DESCRIPTION
#195, and the half of it that was still true.

The issue says `2x + 2a` can be collected *"forcefully… but not peacefully"*. **It is collected peacefully now** — the factorisation rules take out a factor appearing *identically* in every term, so that half is obsolete. A factor that is only a common **divisor** is different: `2 * (x + 2 * a)` is a node larger than `4 * a + 2 * x`, so `SimplifiedRate` will not choose it and `Simplify` should not offer it.

So it goes in `Factorize`, which is already the forceful half of the pair — the call a user makes having decided they want the factored form, whatever it rates. No new mode, and `Simplify` untouched.

```csharp
"2 * x + 4 * a".ToEntity().Factorize()          // 2 * (x + 2 * a)
"4 * x + 6 * y + 10 * z".ToEntity().Factorize() // 2 * (2 * x + 3 * y + 5 * z)
"2 * x - 4 * a".ToEntity().Factorize()          // 2 * (x - 2 * a)
"2 * x + 4 * a".ToEntity().Simplify()           // unchanged — asserted, not assumed
```

## Three things the probe caught, each of which would have shipped

**Returning null for "this did not apply" discarded the whole chain.** `SequentialTransformation.ApplyCore` reads a null from its second half as the composite having no answer, so `Factorize` regressed on every input *without* content — `2x + 2a` stopped factoring at all. The step returns its input unchanged instead, which is how the polynomial layer above it already worked and for exactly this reason.

**An eagerly-initialised static field was null when it was read.** `Factorization` is declared above it and calls `FactorizationAtLevel` in its own initialiser; a static field initialiser runs in declaration order, so it read `null` and failed as a `TypeInitializationException` from somewhere else entirely. It lives in a nested class now, which initialises on first use whatever the field order is.

**Negating a term to carry a subtraction changed its shape.** `-(4 * a)` comes back as a product by −1 wrapping a product by 4, whose coefficient then reads as −1 and takes the content of every difference down to 1 — so every subtraction came back unchanged. The sign belongs to the number, so it is applied to the number.

## What it leaves alone

Whole numbers only. `x/2 + a/3` has a common divisor too, but taking `1/6` out puts a *quotient* outside the sum rather than a factor, which is a different rewrite.

The sign stays inside: `-2x - 4a` is `2 * (-x - 2a)` rather than `-2 * (x + 2a)`, because which of those is wanted is a second question.

A term whose coefficient is not whole **stops the sum** rather than contributing a 1 — the content of `2x + a/3` is not 1, it is a thing this does not compute, and answering 1 would say there was nothing to take.

Recorded in `BREAKING-CHANGES.md`, both values measured on a build.

Public surface: one additive property, `Transformation.NumericContentExtraction`. Full suite: **9077 passed, 14 skipped, 0 failed.**

Part of #195. The issue is labelled `Not now` — this was implemented at @Rafael-SOWNet's direction after posting the measurement above; close it if the timing still stands.