### PR TITLE
An annotated rational literal keeps its annotation, CC included (#1048)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -26,6 +26,7 @@ read first.
 | | `"2 * x3 - 2".ToEntity().Factorize()`, and every polynomial whose content the rules take out | `2 * (x ^ 3 - 1)` — the remainder left whole | `2 * (x - 1) * (x ^ 2 + x + 1)` |
 | | `"3^(x+1) - 2^(x-1)".ToEntity().SolveEquation("x")`, and every equation between two powers of numeric bases | `{ ln(0.04674569822628630438865471319331845734268426895141601562 ^ (1 / ln(2))) }` — a `double` promoted to a decimal | `{ -(ln(3) + ln(2)) / (ln(3) + -ln(2)) }` |
 | **Silent** | `MathS.Abs("x").WithCodomain(Domain.Any).Stringize()`, and every node widened to `Any` from a narrower default | `abs(x)` — reads back as `Real`, losing the widening | `domain(abs(x), Any)` |
+| **Silent** | `"domain(1/2, CC)".ToEntity()`, and every quotient of two integer literals annotated with the codomain its node type does not default to | `1/2` — the annotation dropped, equal to the unannotated literal | `1/2` carrying `Codomain = Complex`, which prints and reads back as `domain(1/2, CC)` |
 | | `new Entity[0].SumAll()`, and `Sumf.Sum` on an empty list | `AngouriBugException: At least 1 child required` | `0` |
 | | `new Entity[0].MultiplyAll()`, and `Mulf.Multiply` on an empty list | `AngouriBugException` | `1` |
 | | `MathS.Vector()` and `new Entity[0].ToVector()` | `IndexOutOfRangeException` — outside the documented hierarchy | `InvalidMatrixOperationException` |
@@ -697,6 +698,48 @@ it stays an ordinary variable.
 
 `Latexize` renders the subscript as `\mathrm{Any}` rather than a `\mathbb`, since there is no set
 to render ([#1048](https://github.com/asc-community/AngouriMath/issues/1048)).
+
+### An annotated rational literal keeps the annotation, `CC` included
+
+A codomain is a property of a node rather than a node of its own, so `domain(1/2, CC)` has to become
+one `Rational` carrying `Complex` — and it did not. The pass that reads a quotient of two integer
+literals as the rational it denotes ([#873](https://github.com/asc-community/AngouriMath/issues/873))
+ran over the **finished** tree, by which point `Complex` means two things at once: it is what an
+unannotated `Divf` carries by default, and it is what `domain(x, CC)` asks for. The pass read it as
+the first and dropped it.
+
+| | before | now |
+|---|---|---|
+| `"domain(1/2, CC)".ToEntity().Codomain` | `Rational` — the annotation gone | `Complex` |
+| `"domain(1/2, CC)".ToEntity() == "1/2".ToEntity()` | `true` | `false` |
+| `(1/2).WithCodomain(Complex).Stringize().ToEntity()` | `1/2`, `Rational` — printed one node, read back another | round-trips |
+| `"domain(1/2, RR)".ToEntity()` | `Real`, correct | unchanged |
+| `"1/2".ToEntity()` | a `Rational`, `Codomain = Rational` | unchanged |
+| `"domain(4/2, CC)".ToEntity()` | a `Divf`, `Codomain = Complex` | unchanged |
+| `"domain(1/2, CC)".ToEntity().Evaled` | `1/2` — the annotation erased by evaluating | `domain(1/2, CC)`, carried through |
+| the same, `.Simplify()` | `1/2` | `domain(1/2, CC)` |
+| the same, `.Latexize()` | `\frac{1}{2}` | `{\left(\frac{1}{2}\right)}_{\mathbb{C}}` |
+| `"domain(1/2, CC) + 1".ToEntity().Evaled` | `3/2` | unchanged |
+
+**The fix is where the fold happens, not what it reads.** `domain(...)`'s own parser rule now folds
+its argument before annotating it, so the two meanings of `Complex` never meet: an annotation lands
+on a node that is already the right shape, and the sweep over the rest of the tree — which is the
+only other place the fold runs — can hand back a bare `Rational` and read no codomain at all. It is
+sound to do so because those two are the only routes, `domain(...)` being the one syntax that
+annotates anything and the sweep meeting only what it did not annotate.
+
+`Complex` on a rational literal is a **widening** — a rational is a complex number — so nothing that
+was defined becomes `NaN` and no value changes: `domain(1/2, CC) + 1` evaluates to `3/2` as before,
+and `domain(1/2, ZZ)` is still `NaN`. What changes is equality, and everything that follows from the
+node genuinely carrying the annotation now — `Evaled` and `Simplify` hand it back instead of erasing
+it, and `Latexize` writes the subscript. That is the point: an annotation the caller wrote is no
+longer indistinguishable from one they did not.
+
+This was the second of the two gaps
+[#1048](https://github.com/asc-community/AngouriMath/issues/1048) recorded, and the last entry in
+`CodomainSurvivesPrintingTest.StillUnparseable`. That dictionary is now empty and still asserted in
+both directions, so every writable domain on every node type reads back as itself, and a gap added
+to it later fails the day it closes.
 
 ### A fold over an empty sequence answers instead of throwing
 

--- a/Sources/AngouriMath/Core/Antlr/AngouriMath.g
+++ b/Sources/AngouriMath/Core/Antlr/AngouriMath.g
@@ -441,12 +441,19 @@ atom returns[Entity value]
             // SpecialSet.Create(Domain). Reading it in this one position commits to a spelling
             // without deciding whether there is a universal *set*, which is #996.
             // https://github.com/asc-community/AngouriMath/issues/1048
+            // The argument is folded to a rational literal first. A codomain is a property of a
+            // node rather than a node of its own, so `1/2` annotated here and `1/2` written bare
+            // have to become the same shape before the annotation lands -- otherwise the sweep
+            // that folds the rest of the tree meets an annotated quotient it cannot tell from an
+            // unannotated one, and `domain(1/2, CC)` loses what it was asked for.
+            // https://github.com/asc-community/AngouriMath/issues/1048
+            var annotated = ParsingHelpers.RationalLiteral($args.list[0]);
             if ($args.list[1] is Variable { Name: "Any" })
-                $value = $args.list[0].WithCodomain(AngouriMath.Core.Domain.Any);
+                $value = annotated.WithCodomain(AngouriMath.Core.Domain.Any);
             else if ($args.list[1] is not SpecialSet ss)
                 throw new InvalidArgumentParseException($"Unrecognized special set {$args.list[1].Stringize()}");
             else
-                $value = $args.list[0].WithCodomain(ss.ToDomain());
+                $value = annotated.WithCodomain(ss.ToDomain());
         }
     | 'piecewise(' args = function_arguments ')'
         {

--- a/Sources/AngouriMath/Core/Antlr/AngouriMathParser.cs
+++ b/Sources/AngouriMath/Core/Antlr/AngouriMathParser.cs
@@ -3240,12 +3240,19 @@ internal partial class AngouriMathParser : Parser {
 				            // SpecialSet.Create(Domain). Reading it in this one position commits to a spelling
 				            // without deciding whether there is a universal *set*, which is #996.
 				            // https://github.com/asc-community/AngouriMath/issues/1048
+				            // The argument is folded to a rational literal first. A codomain is a property of a
+				            // node rather than a node of its own, so `1/2` annotated here and `1/2` written bare
+				            // have to become the same shape before the annotation lands -- otherwise the sweep
+				            // that folds the rest of the tree meets an annotated quotient it cannot tell from an
+				            // unannotated one, and `domain(1/2, CC)` loses what it was asked for.
+				            // https://github.com/asc-community/AngouriMath/issues/1048
+				            var annotated = ParsingHelpers.RationalLiteral(_localctx.args.list[0]);
 				            if (_localctx.args.list[1] is Variable { Name: "Any" })
-				                _localctx.value =  _localctx.args.list[0].WithCodomain(AngouriMath.Core.Domain.Any);
+				                _localctx.value =  annotated.WithCodomain(AngouriMath.Core.Domain.Any);
 				            else if (_localctx.args.list[1] is not SpecialSet ss)
 				                throw new InvalidArgumentParseException($"Unrecognized special set {_localctx.args.list[1].Stringize()}");
 				            else
-				                _localctx.value =  _localctx.args.list[0].WithCodomain(ss.ToDomain());
+				                _localctx.value =  annotated.WithCodomain(ss.ToDomain());
 				        
 				}
 				break;

--- a/Sources/AngouriMath/Core/Antlr/ParsingHelpers.cs
+++ b/Sources/AngouriMath/Core/Antlr/ParsingHelpers.cs
@@ -30,5 +30,47 @@ namespace AngouriMath.Core.Antlr
             }
             return tb.ToMatrix() ?? throw new AngouriBugException("Should've been checked already");
         }
+
+        /// <summary>
+        /// The <see cref="Number.Rational"/> that a quotient of two integer literals denotes, or
+        /// the node unchanged where it denotes none.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// A <see cref="Number.Rational"/> prints as <c>7/2</c> and there is no rational literal
+        /// in the grammar, so re-parsing gave a <see cref="Divf"/> and the round trip was not an
+        /// identity — the value survived and the node did not. That is
+        /// https://github.com/asc-community/AngouriMath/issues/946's neighbour,
+        /// https://github.com/asc-community/AngouriMath/issues/873, answered there with "if you
+        /// have two integers on both sides of the division, it is reasonable to try to parse it
+        /// as a rational".
+        /// </para>
+        /// <para>
+        /// <b>A quotient that reduces to an integer is left alone</b>, deliberately. Parsing is
+        /// not simplification: turning <c>4/2</c> into <c>2</c> would discard what the caller
+        /// wrote, and <c>4/2</c> already round-trips, being a <see cref="Divf"/> before and after.
+        /// Only the non-integer case is what a <see cref="Number.Rational"/> can print as, so only
+        /// it is what the round trip needs.
+        /// </para>
+        /// <para>
+        /// This agrees with the normalisation rather than anticipating it:
+        /// <c>Divf(1, 2).InnerSimplified</c> was already a <see cref="Number.Rational"/>, so the
+        /// parser was the one step that disagreed.
+        /// </para>
+        /// <para>
+        /// The codomain is not read here and not carried. Every caller either has no codomain to
+        /// carry — the sweep over a finished tree, where an annotation cannot have reached a
+        /// quotient — or is <c>domain(...)</c> itself, which applies its own afterwards.
+        /// </para>
+        /// </remarks>
+        internal static Entity RationalLiteral(Entity node)
+        {
+            if (node is not Divf(Number.Integer numerator, Number.Integer denominator))
+                return node;
+            if (denominator.EInteger.IsZero)
+                return node;
+            var value = Number.Rational.Create(numerator.EInteger, denominator.EInteger);
+            return value is Number.Integer ? node : value;
+        }
     }
 }

--- a/Sources/AngouriMath/Core/Parser.cs
+++ b/Sources/AngouriMath/Core/Parser.cs
@@ -184,48 +184,25 @@ namespace AngouriMath.Core
         /// </summary>
         /// <remarks>
         /// <para>
-        /// A <see cref="Rational"/> prints as <c>7/2</c> and there is no rational literal in the
-        /// grammar, so re-parsing gave a <see cref="Entity.Divf"/> and the round trip was not an
-        /// identity — the value survived and the node did not. That is
-        /// https://github.com/asc-community/AngouriMath/issues/946's neighbour,
-        /// https://github.com/asc-community/AngouriMath/issues/873, answered there with "if you
-        /// have two integers on both sides of the division, it is reasonable to try to parse it
-        /// as a rational".
+        /// The rewrite itself is <see cref="Antlr.ParsingHelpers.RationalLiteral"/>, which the
+        /// <c>domain(...)</c> rule also calls — on its argument, before annotating it. That is what
+        /// lets this sweep hand back a bare <see cref="Rational"/> and read no codomain at all: a
+        /// quotient reaching here has never been annotated, because the only syntax that annotates
+        /// anything has already folded what it was given.
         /// </para>
         /// <para>
-        /// <b>A quotient that reduces to an integer is left alone</b>, deliberately. Parsing is
-        /// not simplification: turning <c>4/2</c> into <c>2</c> would discard what the caller
-        /// wrote, and <c>4/2</c> already round-trips, being a <see cref="Entity.Divf"/> before and
-        /// after. Only the non-integer case is what a <see cref="Rational"/> can print as, so only
-        /// it is what the round trip needs.
-        /// </para>
-        /// <para>
-        /// This agrees with the normalisation rather than anticipating it:
-        /// <c>Divf(1, 2).InnerSimplified</c> was already a <see cref="Rational"/>, so the parser
-        /// was the one step that disagreed.
+        /// Reading one would be wrong as well as unnecessary. An unannotated quotient carries the
+        /// default, <see cref="Domain.Complex"/>, and a rational literal the tighter
+        /// <see cref="Domain.Rational"/>, so copying it across would make <c>7/2</c> and <c>3.5</c>
+        /// structurally unequal — the round trip this exists to fix, broken from the other end.
+        /// Telling that default apart from a <c>domain(x, CC)</c> somebody wrote is what no reader
+        /// of a finished tree can do, and it cost <c>domain(1/2, CC)</c> its annotation until
+        /// the fold moved to where the annotation is applied.
+        /// https://github.com/asc-community/AngouriMath/issues/1048
         /// </para>
         /// </remarks>
         private static Entity RationalLiterals(Entity parsed)
-            => parsed.Replace(static node =>
-            {
-                if (node is not Entity.Divf(Entity.Number.Integer numerator,
-                                            Entity.Number.Integer denominator))
-                    return node;
-                if (denominator.EInteger.IsZero)
-                    return node;
-                var value = Entity.Number.Rational.Create(numerator.EInteger, denominator.EInteger);
-                if (value is Entity.Number.Integer)
-                    return node;
-                // The codomain travels with the node, and `domain(1/2, ZZ)` has already put one on
-                // the quotient by the time this runs -- so handing back a bare Rational would drop
-                // it and the domain check would silently start passing. Caught by Domains.CheckNaN.
-                //
-                // Only a codomain somebody asked for is carried. A quotient that nobody annotated
-                // has the default, Complex, while a rational literal takes the tighter Rational --
-                // so copying it unconditionally would make `7/2` and `3.5` structurally unequal,
-                // which is the round trip this change exists to fix, broken from the other end.
-                return node.Codomain == Domain.Complex ? value : value.WithCodomain(node.Codomain);
-            });
+            => parsed.Replace(static node => Antlr.ParsingHelpers.RationalLiteral(node));
 
         internal static Entity Parse(string source)
             => ParseSilent(source)

--- a/Sources/Tests/UnitTests/Common/CodomainSurvivesPrintingTest.cs
+++ b/Sources/Tests/UnitTests/Common/CodomainSurvivesPrintingTest.cs
@@ -51,22 +51,23 @@ namespace AngouriMath.Tests.Common
         /// fails the test rather than sitting here describing something that stopped being true.
         /// </summary>
         /// <remarks>
-        /// The one entry is a <em>parser</em> gap, not a printing one. No input string at all
-        /// yields a <see cref="Entity.Number.Rational"/> whose codomain is
-        /// <see cref="Domain.Complex"/>: the pass that reads a quotient of two integer literals
-        /// as the rational it denotes
-        /// (<a href="https://github.com/asc-community/AngouriMath/issues/873">#873</a>) uses
-        /// <see cref="Domain.Complex"/> as its "nobody annotated this" sentinel, because that is
-        /// what an un-annotated <see cref="Entity.Divf"/> carries, and drops it. So
-        /// <c>domain(1/2, CC)</c> parses to the same node <c>1/2</c> does, and there is nothing
-        /// the printer can emit instead.
+        /// <para>
+        /// <b>Empty, and kept.</b> Its one entry was <c>domain(1/2, CC)</c>: the pass that reads a
+        /// quotient of two integer literals as the rational it denotes
+        /// (<a href="https://github.com/asc-community/AngouriMath/issues/873">#873</a>) ran over the
+        /// finished tree, where <see cref="Domain.Complex"/> is both what an un-annotated
+        /// <see cref="Entity.Divf"/> carries and what <c>domain(x, CC)</c> asks for — so it could
+        /// not tell them apart, and dropped the annotation somebody had written.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1048">#1048</a>
+        /// </para>
+        /// <para>
+        /// The fold now happens where the annotation is applied rather than after it, so no reader
+        /// has to distinguish those two, and every writable domain reads back on every node type.
+        /// The dictionary stays because the shape of the assertion is what matters: a gap recorded
+        /// here fails the day it closes, and this one did.
+        /// </para>
         /// </remarks>
-        private static readonly Dictionary<string, string> StillUnparseable = new(StringComparer.Ordinal)
-        {
-            ["domain(1/2, CC)"] =
-                "the parser's integer-quotient-to-rational pass reads Complex as `not annotated`, "
-                + "so no input produces a Rational whose codomain is Complex",
-        };
+        private static readonly Dictionary<string, string> StillUnparseable = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Every node type there is, narrowed to every domain that can be written down, prints
@@ -150,6 +151,55 @@ namespace AngouriMath.Tests.Common
                     + "Domains.Classes.cs and have to name the same domain.");
                 Assert.Equal(subnode.DefaultCodomain, subnode.Codomain);
             }
+        }
+
+        /// <summary>
+        /// An annotated quotient of two integer literals is the rational it denotes, annotated —
+        /// so <c>domain(1/2, D)</c> is <c>(1/2).WithCodomain(D)</c> for every writable
+        /// <see cref="Domain"/>, including the <see cref="Domain.Complex"/> that used to read as
+        /// "nobody annotated this".
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1048">#1048</a>
+        /// </summary>
+        /// <remarks>
+        /// The fold and the annotation happen in one place now (<c>domain(...)</c>'s own parser
+        /// rule, through <c>ParsingHelpers.RationalLiteral</c>), which is what makes the two
+        /// meanings of <see cref="Domain.Complex"/> stop colliding. <see cref="Domain.Rational"/>
+        /// is in the list because it is the node's default and so prints nothing — the assertion
+        /// is on the entity either way.
+        /// </remarks>
+        [Theory]
+        [InlineData(Domain.Complex)]
+        [InlineData(Domain.Real)]
+        [InlineData(Domain.Rational)]
+        [InlineData(Domain.Integer)]
+        [InlineData(Domain.Boolean)]
+        [InlineData(Domain.Any)]
+        public void AnAnnotatedRationalLiteralIsTheRationalAnnotated(Domain domain)
+        {
+            var annotated = MathS.FromString($"1/2").WithCodomain(domain);
+            var parsed = MathS.FromString(annotated.Stringize());
+
+            Assert.IsAssignableFrom<Entity.Number.Rational>(parsed);
+            Assert.Equal(domain, parsed.Codomain);
+            Assert.Equal(annotated, parsed);
+        }
+
+        /// <summary>
+        /// And a quotient that denotes no rational literal is still a quotient, annotation or
+        /// not: parsing is not simplification, so <c>4/2</c> stays a <see cref="Entity.Divf"/>
+        /// and keeps whatever was written on it.
+        /// </summary>
+        [Theory]
+        [InlineData("domain(4/2, RR)", Domain.Real)]
+        [InlineData("domain(4/2, CC)", Domain.Complex)]
+        [InlineData("4/2", Domain.Complex)]
+        public void AQuotientThatIsNotARationalLiteralKeepsItsShape(string source, Domain expected)
+        {
+            var parsed = MathS.FromString(source);
+
+            Assert.IsAssignableFrom<Entity.Divf>(parsed);
+            Assert.Equal(expected, parsed.Codomain);
+            Assert.Equal(parsed, MathS.FromString(parsed.Stringize()));
         }
 
         /// <summary>


### PR DESCRIPTION
Closes the second of the two gaps [#1048](https://github.com/asc-community/AngouriMath/issues/1048) recorded. The first shipped in #1098.

## The defect

`domain(1/2, CC)` parsed to the same node `1/2` does — the annotation was dropped.

A codomain is a property of a node rather than a node of its own. The pass that reads a quotient of two integer literals as the rational it denotes (#873) ran over the **finished** tree, and by that point `Complex` means two things at once: it is what an unannotated `Divf` carries by default, and it is what `domain(x, CC)` asks for. The pass read it as the first.

It could not have done better from there. Reading the codomain unconditionally is not available either — copying the default across would make `7/2` and `3.5` structurally unequal, which is the round trip #873 exists to fix, broken from the other end.

## The fix

The fold moves to where the annotation is applied. `domain(...)`'s own parser rule folds its argument *before* annotating it, so an annotation lands on a node that is already the right shape and the two meanings of `Complex` never meet. The sweep over the rest of the tree is then free to hand back a bare `Rational` and read no codomain at all.

That is sound because those are the only two routes: `domain(...)` is the one syntax that annotates anything, and both `WithCodomain` calls in the whole parsing path are inside that one rule. The sweep therefore meets only what it did not annotate.

## Measured

Both arms built and run; `domain(4/2, CC)` and `domain(1/2, RR)` are in the table because they are what a fix in the wrong place would have disturbed.

| | before | now |
|---|---|---|
| `"domain(1/2, CC)".ToEntity().Codomain` | `Rational` — the annotation gone | `Complex` |
| `"domain(1/2, CC)".ToEntity() == "1/2".ToEntity()` | `true` | `false` |
| `(1/2).WithCodomain(Complex).Stringize().ToEntity()` | printed one node, read back another | round-trips |
| `"domain(1/2, CC)".ToEntity().Evaled` | `1/2` | `domain(1/2, CC)` |
| the same, `.Latexize()` | `\frac{1}{2}` | `{\left(\frac{1}{2}\right)}_{\mathbb{C}}` |
| `"domain(1/2, CC) + 1".ToEntity().Evaled` | `3/2` | unchanged |
| `"domain(1/2, ZZ)".ToEntity().Evaled` | `NaN` | unchanged |
| `"domain(1/2, RR)".ToEntity().Codomain` | `Real` | unchanged |
| `"domain(4/2, CC)".ToEntity()` | a `Divf`, `Codomain = Complex` | unchanged |
| `"1/2".ToEntity()` | a `Rational`, `Codomain = Rational` | unchanged |

`Complex` on a rational literal is a widening, so no value changes and nothing defined becomes `NaN`. What changes is equality and everything that follows from the node genuinely carrying the annotation — recorded in `BREAKING-CHANGES.md`.

## Tests

`CodomainSurvivesPrintingTest.StillUnparseable` held this as its one entry, asserted in **both** directions — so the fix made that test fail with *"reads back as itself now — drop it"*, which is what the dictionary is for. It is now empty and still asserted both ways: every writable domain on every node type reads back as itself, and a gap added to it later fails the day it closes.

Two new theories pin the behaviour rather than the absence of the gap: `domain(1/2, D)` is `(1/2).WithCodomain(D)` for all six domains, and a quotient that denotes no rational literal keeps its shape and its annotation.

`Failed: 0, Passed: 9086, Skipped: 14` locally on net10.0.

## The generated parser

`AngouriMathParser.cs` is regenerated from the grammar with `Sources/Utils/antlr_rerun.bat`. Regenerating it **beforehand**, with no grammar change, reproduced the committed file byte for byte — so the diff here is this change and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
