### PR TITLE
A pattern reaches inside a binder, and only one node type needed it (#1074)

### DIFF
--- a/Sources/AngouriMath/Core/Entity/Entity.Definition.cs
+++ b/Sources/AngouriMath/Core/Entity/Entity.Definition.cs
@@ -132,6 +132,30 @@ namespace AngouriMath
         public IReadOnlyList<Entity> DirectChildren => directChildren.GetValue(static @this => @this.InitDirectChildren(), this);
         private LazyPropertyA<IReadOnlyList<Entity>> directChildren;
 
+        /// <summary>
+        /// The parts a <see cref="Core.Transformations.Matching.MatchPattern"/> takes this node
+        /// apart into. <see cref="DirectChildren"/> for every node but one.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The two differ only where a node's traversal shape is not its written shape, and
+        /// <see cref="Set.ConditionalSet"/> is the only node where that is so — measured across
+        /// every binder the language has. A summation, a product, an integral, a derivative, a
+        /// limit and a lambda all publish the name they bind as an ordinary child, un-renamed, so
+        /// a pattern can already name it and a repeated hole already says "the same variable". A
+        /// set builder publishes its predicate alone, with the bound name replaced by a
+        /// placeholder invented per traversal, so a pattern could reach neither.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1074">#1074</a>
+        /// </para>
+        /// <para>
+        /// This is the same split <see cref="VarsAndConsts"/> and <see cref="FreeVariables"/>
+        /// already make, and for the same reason: what a set builder <em>is</em> is read off its
+        /// declared parts, and what it publishes for traversal is a capture-avoiding rewriting of
+        /// them. Anything asking a question about the written expression has to ask the first.
+        /// </para>
+        /// </remarks>
+        internal virtual IReadOnlyList<Entity> MatchableChildren => DirectChildren;
+
         /// <remarks>A depth-first enumeration is required by
         /// <see cref="AngouriMath.Functions.TreeAnalyzer.GetMinimumSubtree"/></remarks>
         /// <summary>

--- a/Sources/AngouriMath/Core/Entity/Omni/Entity.Omni.Classes.cs
+++ b/Sources/AngouriMath/Core/Entity/Omni/Entity.Omni.Classes.cs
@@ -492,6 +492,21 @@ namespace AngouriMath
                 protected override Entity[] InitDirectChildren() =>
                     new[] { Predicate.Substitute(Var, Variable.CreateTemp(Predicate.Vars)) };
 
+                /// <summary>
+                /// The written parts, which is what a pattern has to be able to say. The rename
+                /// above is what makes traversal alpha-invariant and it is exactly what puts the
+                /// bound name out of a pattern's reach, so matching reads the pair as declared.
+                /// <a href="https://github.com/asc-community/AngouriMath/issues/1074">#1074</a>
+                /// </summary>
+                /// <remarks>
+                /// A pattern that reads these still cannot tell <c>{ x : x &gt; 0 }</c> from
+                /// <c>{ y : y &gt; 0 }</c>, because the only pattern allowed in the name position
+                /// is a hole — <see cref="Core.Transformations.Matching.MatchPattern"/>'s
+                /// <c>Binder</c> refuses anything else. It is the hole being repeated in the body
+                /// that says "the same variable", and that reads the same under either name.
+                /// </remarks>
+                internal override IReadOnlyList<Entity> MatchableChildren => new[] { Var, Predicate };
+
                 /// <inheritdoc/>
                 public override bool IsSetFinite => false;
                 /// <inheritdoc/>

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchPattern.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchPattern.cs
@@ -601,6 +601,55 @@ namespace AngouriMath.Core.Transformations.Matching
             => new NodePattern(typeof(T), children, commutative: false);
 
         /// <summary>
+        /// Matches a binder — a node that declares a name and puts a body under it — binding the
+        /// declared name to <paramref name="varName"/> and matching the body against
+        /// <paramref name="body"/>. Repeating <paramref name="varName"/> inside
+        /// <paramref name="body"/> is how a rule says <i>the same variable</i>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>{ x : x in S }</c> is <c>S</c>, and the <c>switch</c> said so by deconstructing
+        /// <c>ConditionalSet(var v, Inf(var v, var s))</c> — reading the node's <i>stored</i>
+        /// parts. A pattern could not: the matcher walked <c>DirectChildren</c>, and a set builder
+        /// publishes one child there, its predicate, with the bound name already replaced by a
+        /// placeholder invented per traversal. So a two-child pattern over it never matched, and
+        /// no pattern could name the bound variable at all.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1074">#1074</a>
+        /// </para>
+        /// <para>
+        /// <b>One node type needs this, not six.</b> The issue expected every binder to be in the
+        /// same position; measuring them says otherwise. A summation, a product, an integral, a
+        /// derivative, a limit and a lambda each publish the name they bind as an ordinary child,
+        /// un-renamed, so an ordinary <see cref="Node{T}"/> already reaches it —
+        /// <c>Summationf</c> offers four children and the second is the index. Only
+        /// <see cref="Entity.Set.ConditionalSet"/> hides and renames, and only it has an
+        /// <see cref="Entity.MatchableChildren"/> override.
+        /// </para>
+        /// <para>
+        /// <b>The name position is a hole, and cannot be anything else.</b> Matching a bound name
+        /// against a written one would make the pattern read <c>{ x : … }</c> and
+        /// <c>{ y : … }</c> as different expressions, which they are not, so this refuses
+        /// anything but <see cref="Any(string)"/> there. Alpha-invariance then holds for the same
+        /// reason it holds of the <c>switch</c> arm: what is asserted is that two occurrences are
+        /// the same name, never which name.
+        /// </para>
+        /// <para>
+        /// <b>What a rule owes in return.</b> Reading inside a binder means the body arrives with
+        /// its bound name written, so a replacement that lifts part of that body out of the
+        /// binder frees an occurrence that was bound — capture, in reverse. Nothing here can check
+        /// that, because the replacement is arbitrary. <c>{ x : x in S }</c> is safe because
+        /// <c>S</c> is a sibling of the bound occurrence rather than under it; a rule taking out
+        /// something that mentions <paramref name="varName"/> would not be.
+        /// </para>
+        /// </remarks>
+        internal static MatchPattern Binder<T>(string varName, MatchPattern body) where T : Entity
+            => new NodePattern(
+                typeof(T),
+                new[] { Any(varName), body ?? throw new ArgumentNullException(nameof(body)) },
+                commutative: false,
+                binder: true);
+
+        /// <summary>
         /// Matches a two-child node of the given type whose children match <b>in either
         /// order</b>. One of these replaces the four arms a <c>switch</c> needs to say the same
         /// thing about a commutative operator.
@@ -885,7 +934,8 @@ namespace AngouriMath.Core.Transformations.Matching
             private readonly MatchPattern[] children;
             private readonly bool commutative;
 
-            internal NodePattern(Type nodeType, MatchPattern[] children, bool commutative)
+            internal NodePattern(
+                Type nodeType, MatchPattern[] children, bool commutative, bool binder = false)
             {
                 this.nodeType = nodeType;
                 this.children = children;
@@ -897,7 +947,13 @@ namespace AngouriMath.Core.Transformations.Matching
                     && children.All(child => child.IsBuildable);
                 deterministic = !commutative && children.All(child => child.IsDeterministic);
                 nodeCount = 1 + children.Sum(child => child.NodeCount);
-                canEMatch = children.All(child => child.CanEMatch);
+                // A binder's matchable shape is not the shape an e-node has -- the e-graph is
+                // built from DirectChildren and has no notion of binding at all, which is why
+                // `constructors` has no entry for one. So this reports what is true rather than
+                // relying on never being asked: an e-class holding a set builder offers no node
+                // this could match, and saying so here is the difference between a limit and an
+                // accident.
+                canEMatch = !binder && children.All(child => child.CanEMatch);
             }
 
             /// <summary>Settled here because it depends on nothing that changes afterwards.</summary>
@@ -1013,7 +1069,7 @@ namespace AngouriMath.Core.Transformations.Matching
 
             private protected override IEnumerable<Bindings> MatchCore(Entity expr, Bindings bindings)
             {
-                var actual = expr.DirectChildren;
+                var actual = expr.MatchableChildren;
                 if (actual.Count != children.Length) yield break;
 
                 foreach (var solution in MatchInOrder(actual, bindings, 0))
@@ -1054,7 +1110,7 @@ namespace AngouriMath.Core.Transformations.Matching
                 Entity expr, Bindings bindings, out Bindings result)
             {
                 result = bindings;
-                var actual = expr.DirectChildren;
+                var actual = expr.MatchableChildren;
                 if (actual.Count != children.Length) return false;
                 // Left to right, threading the bindings through. No backtracking is needed
                 // because no child offers a second answer -- that is what IsDeterministic means.
@@ -1102,7 +1158,7 @@ namespace AngouriMath.Core.Transformations.Matching
                 Entity expr, Bindings bindings, int choice, out Bindings result)
             {
                 result = bindings;
-                var actual = expr.DirectChildren;
+                var actual = expr.MatchableChildren;
                 if (actual.Count != children.Length) return false;
 
                 // `MatchCore` yields every solution in the written order first and then, for a

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -1747,21 +1747,22 @@ namespace AngouriMath.Core.Transformations.Matching
         /// anyway, because its replacement wants the node rather than its parts.
         /// </para>
         /// <para>
-        /// The other <b>was real, and is the first limitation of the matcher this file has had to
+        /// The other <b>was real, and was the first limitation of the matcher this file had to
         /// work around.</b> <c>{ x : x in S }</c> is <c>S</c>, and the <c>switch</c> says that by
         /// deconstructing <c>ConditionalSet(var v, Inf(var v, var s))</c> — a record
         /// deconstruction, which reads the <i>stored</i> <c>Var</c> and <c>Predicate</c>. The
-        /// matcher walks <c>DirectChildren</c>, and a <see cref="Set.ConditionalSet"/> has
+        /// matcher walked <c>DirectChildren</c>, and a <see cref="Set.ConditionalSet"/> has
         /// <b>one</b> child there, its predicate, with the bound variable already renamed to a
         /// placeholder: <c>{ x : x in [0; 1] }</c> offers <c>%1 in [0; 1]</c> and nothing else.
-        /// A two-child node pattern over it cannot match, and no pattern can name the bound
-        /// variable at all.
+        /// So the rule bound the whole set and took it apart in its replacement — honest rather
+        /// than clever, but a rule whose shape was code again.
         /// </para>
         /// <para>
-        /// So that rule binds the whole set and takes it apart in its replacement, which is
-        /// honest rather than clever: the pattern says what the matcher can say, and the
-        /// condition says the rest. Reaching into a binder is
-        /// <a href="https://github.com/asc-community/AngouriMath/issues/1074">#1074</a>.
+        /// It is data now. <c>MatchPattern.Binder</c> reads a binder's declared parts, and the
+        /// repeated hole is what the <c>switch</c> wrote as <c>when v1 == v1a</c>. Only this node
+        /// type needed it: every other binder in the language publishes the name it binds as an
+        /// ordinary child.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1074">#1074</a>
         /// </para>
         /// </remarks>
         internal static MatchedRuleSet SetOperator { get; } = new(
@@ -1816,13 +1817,12 @@ namespace AngouriMath.Core.Transformations.Matching
                 Soundness.Sound,
                 description: "A \\ A = {}"),
 
-            // { x : x in S } = S. Bound whole and taken apart in the replacement, because a
-            // node pattern cannot reach inside a binder -- see the remark on this set.
+            // { x : x in S } = S. The repeated "v" is what the switch wrote as `when v1 == v1a`.
             new MatchedRule(
                 "a-conditional-set-whose-condition-is-its-own-membership-is-that-set",
-                MatchPattern.Any<Set.ConditionalSet>(
-                    "cs", set => set.Predicate is Set.Inf(var member, _) && member == set.Var),
-                bound => ((Set.Inf)((Set.ConditionalSet)bound["cs"]).Predicate).SupSet,
+                MatchPattern.Binder<Set.ConditionalSet>(
+                    "v", MatchPattern.Node<Set.Inf>(MatchPattern.Any("v"), MatchPattern.Any("s"))),
+                MatchPattern.Any("s"),
                 Soundness.Sound,
                 description: "{ x : x in S } = S"),
 

--- a/Sources/AngouriMath/Docs/Contributing/WritingARule.md
+++ b/Sources/AngouriMath/Docs/Contributing/WritingARule.md
@@ -121,18 +121,19 @@ matches and silently builds nothing. `BuildableNodeTypesTest` is the list.
 
 ## Replacement: a pattern, or code
 
-**33** of the 322 rules have a pattern on both sides. The rest build their answer in code, and both
+**34** of the 322 rules have a pattern on both sides. The rest build their answer in code, and both
 are legitimate — but the choice costs two things, so make it deliberately.
 
 A pattern replacement gets:
 
-- **a direction.** `MatchedRule.Reversed` is the rule read the other way, and **32** of the 33
-  two-sided rules have one. (The thirty-third is the Pythagorean identity: `sin²+cos² = 1` forgets the
-  angle, so there is nothing to read back. See [ReversibleRules.md](ReversibleRules.md).)
+- **a direction.** `MatchedRule.Reversed` is the rule read the other way, and **32** of the 34
+  two-sided rules have one. The other two forget something: `sin²+cos² = 1` forgets the angle, and
+  `{ x : x in S } = S` forgets the name the set builder bound, so neither has anything to read back.
+  See [ReversibleRules.md](ReversibleRules.md).
 - **an exact growth**, counted from the two patterns rather than declared.
 
 A code replacement gets neither, and its growth is `Unknown` unless you declare one. That is the
-honest default — **261** rules sit at `Unknown` — but declare it where you can justify it:
+honest default — **260** rules sit at `Unknown` — but declare it where you can justify it:
 
 ```csharp
 // The Chebyshev expansion of sin(n * a) is a sum of n terms where the pattern is one node,

--- a/Sources/Tests/UnitTests/Core/Transformations/BinderMatchingTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/BinderMatchingTest.cs
@@ -1,0 +1,172 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Core.Transformations;
+using AngouriMath.Core.Transformations.Matching;
+using AngouriMath.Extensions;
+using Xunit;
+using static AngouriMath.Entity;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// A pattern reaching inside a binder:
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/1074">#1074</a>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The bound name of a <see cref="Set.ConditionalSet"/> is not among its
+    /// <see cref="Entity.DirectChildren"/>, and the body published there has it replaced by a
+    /// placeholder invented per traversal — so a pattern could reach neither, and
+    /// <c>{ x : x in S } = S</c> had to be written as code. <c>MatchPattern.Binder</c> reads the
+    /// declared pair instead.
+    /// </para>
+    /// <para>
+    /// Everything here compares entities rather than printed forms, and the placeholder is
+    /// exactly the kind of thing a printed comparison would hide.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class BinderMatchingTest
+    {
+        private static MatchPattern MembershipInItsOwnSet =>
+            MatchPattern.Binder<Set.ConditionalSet>(
+                "v", MatchPattern.Node<Set.Inf>(MatchPattern.Any("v"), MatchPattern.Any("s")));
+
+        /// <summary>
+        /// The defect itself: a two-child pattern over a set builder used to match nothing,
+        /// because the node offered one child.
+        /// </summary>
+        [Theory]
+        [InlineData("{ x : x in [0; 1] }", "[0; 1]")]
+        [InlineData("{ y : y in RR }", "RR")]
+        [InlineData("{ k : k in {1, 2, 3} }", "{1, 2, 3}")]
+        [InlineData("{ x : x in A \\/ B }", "A \\/ B")]
+        public void ABinderPatternReachesTheBoundNameAndTheBody(string source, string supset)
+        {
+            var bindings = Bindings.Empty;
+            var solutions = MembershipInItsOwnSet.Match(source.ToEntity(), bindings).ToList();
+
+            var solution = Assert.Single(solutions);
+            Assert.Equal(supset.ToEntity(), solution["s"]);
+        }
+
+        /// <summary>
+        /// The repeated hole is the <c>when v1 == v1a</c> the <c>switch</c> wrote: a predicate
+        /// about some <em>other</em> name is a different statement and must not match.
+        /// </summary>
+        [Theory]
+        [InlineData("{ x : y in [0; 1] }")]
+        [InlineData("{ x : x > 0 }")]
+        [InlineData("{ x : x in [0; 1] and x > 0 }")]
+        public void APredicateThatIsNotMembershipOfTheBoundNameDoesNotMatch(string source)
+            => Assert.Empty(MembershipInItsOwnSet.Match(source.ToEntity(), Bindings.Empty));
+
+        /// <summary>
+        /// Alpha-invariance: the name position is a hole, so the pattern says <em>the same
+        /// name</em> and never <em>which</em> name, and two set builders differing only in their
+        /// bound name are matched alike.
+        /// </summary>
+        [Fact]
+        public void TheBoundNameIsNotWhatIsMatchedOn()
+        {
+            var underX = MembershipInItsOwnSet.Match("{ x : x in [0; 1] }".ToEntity(), Bindings.Empty).ToList();
+            var underQ = MembershipInItsOwnSet.Match("{ q : q in [0; 1] }".ToEntity(), Bindings.Empty).ToList();
+
+            Assert.Single(underX);
+            Assert.Single(underQ);
+            Assert.Equal(underX[0]["s"], underQ[0]["s"]);
+            // And the two sets are one expression to begin with, which is what the rename in
+            // DirectChildren is for and what reading the declared pair must not undo.
+            Assert.Equal("{ x : x in [0; 1] }".ToEntity(), "{ q : q in [0; 1] }".ToEntity());
+        }
+
+        /// <summary>
+        /// A set builder offers two matchable children where it offers one direct child, and
+        /// nothing but a pattern over its own type may have them. Otherwise the widening would
+        /// hand every two-child pattern in the library a new node to match.
+        /// </summary>
+        /// <remarks>
+        /// The node type is checked before matching on all three entry points —
+        /// <c>Match</c>, <c>TryMatchOnce</c> and <c>TryMatchChoice</c> — so all three are asked
+        /// here rather than just the one a rewrite pass happens to use.
+        /// </remarks>
+        [Fact]
+        public void ATwoChildPatternOfAnotherTypeStillDoesNotMatchASetBuilder()
+        {
+            var set = "{ x : x in [0; 1] }".ToEntity();
+            Assert.Single(set.DirectChildren);
+            Assert.Equal(2, ((Entity)set).MatchableChildren.Count);
+
+            foreach (var pattern in new[]
+            {
+                MatchPattern.Node<Sumf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
+                MatchPattern.Node<Set.Inf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
+                MatchPattern.Commutative<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("b")),
+            })
+            {
+                Assert.Empty(pattern.Match(set, Bindings.Empty));
+                Assert.False(pattern.TryMatchOnce(set, Bindings.Empty, out _));
+                Assert.False(pattern.TryMatchChoice(set, Bindings.Empty, 0, out _));
+            }
+        }
+
+        /// <summary>
+        /// The rule that needed this, end to end, through the set it belongs to.
+        /// </summary>
+        [Theory]
+        [InlineData("{ x : x in [0; 1] }", "[0; 1]")]
+        [InlineData("{ x : x in RR }", "RR")]
+        public void TheRuleFiresThroughItsSet(string source, string expected)
+        {
+            var rule = RewriteRules.SetOperator.Rules.Single(
+                r => r.Name == "a-conditional-set-whose-condition-is-its-own-membership-is-that-set");
+            Assert.Equal(expected.ToEntity(), rule.TryApply(source.ToEntity()));
+        }
+
+        /// <summary>
+        /// <b>One node type needs the binder pattern, not six.</b> The issue expected every binder
+        /// to hide its bound name; this is the measurement that says otherwise, and the reason
+        /// there is one <see cref="Entity.MatchableChildren"/> override rather than a family of
+        /// them.
+        /// </summary>
+        /// <remarks>
+        /// A summation offers four children and the second is the index, a limit three and the
+        /// second is the variable, and so on — un-renamed in every case, so an ordinary
+        /// <c>Node&lt;T&gt;</c> already reaches them. Asserted as the shapes rather than as
+        /// "they are fine", so that a binder that starts hiding its name fails here.
+        /// </remarks>
+        [Fact]
+        public void EveryOtherBinderPublishesTheNameItBinds()
+        {
+            var hiding = new List<string>();
+            foreach (var source in new[]
+            {
+                "lambda(x, x + 1)", "sum(x, x, 1, 3)", "product(x, x, 1, 3)",
+                "integral(x, x)", "integral(x, x, 0, 1)", "derivative(x, x)", "limit(x, x, 0)",
+            })
+            {
+                var binder = source.ToEntity();
+                if (!binder.DirectChildren.Contains((Entity)MathS.Var("x")))
+                    hiding.Add($"{source} offers [{string.Join(" | ", binder.DirectChildren)}]");
+            }
+
+            Assert.True(hiding.Count == 0,
+                "these binders no longer publish the name they bind, so a pattern can no longer "
+                + "name it and each wants a MatchableChildren override of its own:\n  "
+                + string.Join("\n  ", hiding));
+
+            // And the one that does hide it, stated the same way round.
+            var set = "{ x : x in [0; 1] }".ToEntity();
+            Assert.DoesNotContain((Entity)MathS.Var("x"), set.DirectChildren);
+            Assert.Single(MembershipInItsOwnSet.Match(set, Bindings.Empty));
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
@@ -113,8 +113,13 @@ namespace AngouriMath.Tests.Core.Transformations
             // Named one by one and with the reason, so that a rule losing or gaining a direction
             // fails rather than moving a number. Almost all of these are one-way because their
             // replacement is arithmetic on a binding rather than a tree built around it -- see
-            // RuleReversal.ReplacementIsCode -- and exactly one is one-way for a mathematical
-            // reason: 1 does not say which angle it came from.
+            // RuleReversal.ReplacementIsCode -- and two are one-way for a mathematical reason:
+            // 1 does not say which angle it came from, and S does not say which name a set
+            // builder over it would bind, which is what dropping the binder's hole means.
+            //
+            // The second of those was ReplacementIsCode until MatchPattern.Binder let it be
+            // written as data (#1074). Its reason got *better* rather than going away: it is now
+            // one-way because of what it says, rather than because of how it was written.
             Assert.Equal(
                 new[]
                 {
@@ -123,7 +128,7 @@ namespace AngouriMath.Tests.Core.Transformations
                     "a-common-factor-is-collected-out-of-a-whole-sum: ReplacementIsCode",
                     "a-common-factor-of-two-added-products-comes-out: ReplacementIsCode",
                     "a-common-factor-of-two-subtracted-products-comes-out: ReplacementIsCode",
-                    "a-conditional-set-whose-condition-is-its-own-membership-is-that-set: ReplacementIsCode",
+                    "a-conditional-set-whose-condition-is-its-own-membership-is-that-set: ReplacementDropsHoles",
                     "a-conjunction-absorbs-a-disjunction-it-shares-an-operand-with: ReplacementIsCode",
                     "a-conjunction-chain-is-sorted-and-grouped: ReplacementIsCode",
                     "a-conjunction-drops-a-negated-copy-of-its-other-operand: ReplacementIsCode",
@@ -610,9 +615,17 @@ namespace AngouriMath.Tests.Core.Transformations
                         continue;
                     }
                     Assert.True(rule.Right.IsBuildable, $"{set.Name}/{rule.Name}: right");
-                    // The left decides only whether it reads backwards, and the type says which.
-                    Assert.Equal(rule.Left.IsBuildable,
-                        rule.Reversal is not RuleReversal.PatternCannotBeBuilt);
+                    // The left decides only whether it reads backwards. Stated as the two
+                    // implications rather than as an equivalence: `Classify` returns the *first*
+                    // reason a rule is one-way, so a rule that both drops a hole and has an
+                    // unbuildable left is reported as dropping the hole, and reading
+                    // PatternCannotBeBuilt as "exactly the unbuildable ones" fails on it.
+                    // MatchPattern.Binder made that shape real -- { x : x in S } = S has a
+                    // ConditionalSet pattern, which is not buildable, and drops the bound name.
+                    if (rule.Reversal is RuleReversal.Reversible)
+                        Assert.True(rule.Left.IsBuildable, $"{set.Name}/{rule.Name}: left");
+                    if (rule.Reversal is RuleReversal.PatternCannotBeBuilt)
+                        Assert.False(rule.Left.IsBuildable, $"{set.Name}/{rule.Name}: left");
                 }
         }
 

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
@@ -80,20 +80,33 @@ namespace AngouriMath.Tests.Core.Transformations
         public void ReplacementAPatternOrCode()
         {
             var rules = MatchedRules.All.SelectMany(set => set.Rules).ToList();
-            Stated(33, rules.Count(rule => rule.Right is not null),
+            Stated(34, rules.Count(rule => rule.Right is not null),
                 "how many rules have a pattern on both sides");
             Stated(32, rules.Count(rule => rule.Reversed is not null),
                 "how many two-sided rules have a direction");
-            Stated(261, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
+            Stated(260, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
                 "how many rules sit at Unknown growth");
 
-            // And the thirty-third is the one the document names. Asserted by its own name rather
-            // than by the one the documentation calls it: the rule is
-            // `squared-sine-and-cosine-of-one-argument-sum-to-one` and the prose calls it the
-            // Pythagorean identity, which is right and is not what to match on.
-            var oneWay = rules.Single(rule => rule.Right is not null && rule.Reversed is null);
-            Assert.Equal(RuleReversal.ReplacementDropsHoles, oneWay.Reversal);
-            Assert.Equal("squared-sine-and-cosine-of-one-argument-sum-to-one", oneWay.Name);
+            // And the two the document names. By their own names rather than by what the prose
+            // calls them: the first is `squared-sine-and-cosine-of-one-argument-sum-to-one` and
+            // the prose calls it the Pythagorean identity, which is right and is not what to
+            // match on. Both forget something the backwards direction would have to invent -- the
+            // angle, and the name the set builder bound.
+            var oneWay = rules
+                .Where(rule => rule.Right is not null && rule.Reversed is null)
+                .Select(rule => rule.Name)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+            Assert.Equal(
+                new[]
+                {
+                    "a-conditional-set-whose-condition-is-its-own-membership-is-that-set",
+                    "squared-sine-and-cosine-of-one-argument-sum-to-one",
+                },
+                oneWay);
+            Assert.All(
+                rules.Where(rule => oneWay.Contains(rule.Name) && rule.Right is not null),
+                rule => Assert.Equal(RuleReversal.ReplacementDropsHoles, rule.Reversal));
         }
 
         [Fact]


### PR DESCRIPTION
Closes [#1074](https://github.com/asc-community/AngouriMath/issues/1074).

## The defect

`{ x : x in S }` is `S`, and the `switch` said so by deconstructing `ConditionalSet(var v, Inf(var v, var s))` — reading the node's **stored** parts. A pattern could not. The matcher walked `DirectChildren`, where a set builder publishes one child, its predicate, with the bound name already replaced by a placeholder invented per traversal:

```
{ x : x in [0; 1] }   ->   DirectChildren: [ %1 in [0; 1] ]
```

So a two-child pattern over it never matched, and no pattern could name the bound variable at all. That rule bound the whole set and took it apart in its replacement — honest, but a rule whose shape was code again, so it could not be read backwards or checked the way its neighbours are.

The rename is load-bearing: it is what makes traversal alpha-invariant, and #1008 was about that placeholder escaping into `Vars`/`FreeVariables`. So the fix is not to stop renaming.

## The fix

Matching reads the declared pair, through a new internal `Entity.MatchableChildren` — `DirectChildren` for every node but one. This is the same split `VarsAndConsts` and `FreeVariables` already make, and for the same reason: what a set builder *is* is read off its declared parts, and what it publishes for traversal is a capture-avoiding rewriting of them.

`MatchPattern.Binder<T>(varName, body)` is the spelling, and the rule becomes:

```csharp
MatchPattern.Binder<Set.ConditionalSet>(
    "v", MatchPattern.Node<Set.Inf>(MatchPattern.Any("v"), MatchPattern.Any("s"))),
MatchPattern.Any("s"),
```

The repeated `"v"` is what the `switch` wrote as `when v1 == v1a`.

## The issue's premise was wrong, and that shrank the fix

#1074 said *"Every binder is in the same position: `sum`, `product`, `integral`, `derivative`, `limit`, `ConditionalSet`"* and expected a `Binder<T>` family. Measured, that is false — I had generalised from the one case I had opened:

| | `DirectChildren` |
|---|---|
| `{ x : x in [0; 1] }` | **[1]** `%1 in [0; 1]` |
| `lambda(x, x + 1)` | [2] `x` \| `x + 1` |
| `sum(x, x, 1, 3)` | [4] `x` \| `x` \| `1` \| `3` |
| `product(x, x, 1, 3)` | [4] `x` \| `x` \| `1` \| `3` |
| `integral(x, x)` | [2] `x` \| `x` |
| `integral(x, x, 0, 1)` | [4] `x` \| `x` \| `0` \| `1` |
| `derivative(x, x)` | [3] `x` \| `x` \| `1` |
| `limit(x, x, 0)` | [3] `x` \| `x` \| `0` |

Every binder but the set builder publishes the name it binds as an ordinary child, un-renamed — so a plain `Node<T>` already reaches it and a repeated hole already says "the same variable". **One override, not six.** `EveryOtherBinderPublishesTheNameItBinds` puts that measurement in the build, so a binder that starts hiding its name fails here rather than going quiet.

## Alpha-invariance

The name position is a hole and cannot be anything else — matching a bound name against a written one would make `{ x : … }` and `{ y : … }` different expressions, which they are not. What is asserted is that two occurrences are *the same* name, never *which*. Pinned by `TheBoundNameIsNotWhatIsMatchedOn`.

The widening also must not hand every two-child pattern in the library a new node to match. All three matching entry points check the node type first, and `ATwoChildPatternOfAnotherTypeStillDoesNotMatchASetBuilder` asks all three rather than the one a rewrite pass happens to use.

A binder pattern reports `CanEMatch` **false** rather than relying on never being asked: the e-graph is built from `DirectChildren` and has no notion of binding, which is why `MatchPattern.Construct` has no entry for a binder to begin with.

## One test assertion was wrong in general

`EveryDataRuleIsBuildableOnBothSides` asserted `Left.IsBuildable == (Reversal is not PatternCannotBeBuilt)`. `Classify` returns the **first** reason a rule is one-way, so a rule that both drops a hole *and* has an unbuildable left is reported as dropping the hole. This rule is the first of that shape. Stated as the two true implications instead.

Its reason for being one-way got better rather than going away: `ReplacementIsCode` → `ReplacementDropsHoles` — one-way because `S` does not say which name a set builder over it would bind, rather than because of how it was written.

## Measured

No answer changes: `MatchableChildren` is internal and only the node pattern reads it, and the rule fires on exactly what it fired on before — `MatchedRulesAgreeWithTheSwitchTest` compares the data rules against the original `switch` and is unchanged. No `BREAKING-CHANGES.md` entry is owed.

`Failed: 0, Passed: 9097, Skipped: 14` locally on net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
