### PR TITLE
Common terminates, and an interval bounded by its own element is decided (#1056)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -27,6 +27,8 @@ read first.
 | | `"3^(x+1) - 2^(x-1)".ToEntity().SolveEquation("x")`, and every equation between two powers of numeric bases | `{ ln(0.04674569822628630438865471319331845734268426895141601562 ^ (1 / ln(2))) }` — a `double` promoted to a decimal | `{ -(ln(3) + ln(2)) / (ln(3) + -ln(2)) }` |
 | **Silent** | `MathS.Abs("x").WithCodomain(Domain.Any).Stringize()`, and every node widened to `Any` from a narrower default | `abs(x)` — reads back as `Real`, losing the widening | `domain(abs(x), Any)` |
 | **Silent** | `"domain(1/2, CC)".ToEntity()`, and every quotient of two integer literals annotated with the codomain its node type does not default to | `1/2` — the annotation dropped, equal to the unannotated literal | `1/2` carrying `Codomain = Complex`, which prints and reads back as `domain(1/2, CC)` |
+| | `"a in (a / 3; 3a)".ToEntity().Simplify()`, and every denominator but 2 | `a in (a / 3; 3 * a)` — left as written | `a > 0` |
+| | `"a in (a / 2; 0)".ToEntity().Simplify()`, and every interval demanding both signs | left as written | `False provided a in RR` |
 | | `new Entity[0].SumAll()`, and `Sumf.Sum` on an empty list | `AngouriBugException: At least 1 child required` | `0` |
 | | `new Entity[0].MultiplyAll()`, and `Mulf.Multiply` on an empty list | `AngouriBugException` | `1` |
 | | `MathS.Vector()` and `new Entity[0].ToVector()` | `IndexOutOfRangeException` — outside the documented hierarchy | `InvalidMatrixOperationException` |
@@ -740,6 +742,56 @@ This was the second of the two gaps
 `CodomainSurvivesPrintingTest.StillUnparseable`. That dictionary is now empty and still asserted in
 both directions, so every writable domain on every node type reads back as itself, and a gap added
 to it later fails the day it closes.
+
+### An interval bounded by its own element is decided, and `Common` terminates
+
+`a in (a / 2; 2 * a)` was `a > 0` and `a in (a / 3; 3 * a)` was left as written. The difference was
+not the mathematics — it was which candidate survived `Simplify`'s pruning.
+
+`ParaphraseInterval` writes a membership out as two comparisons with zero, and the difference it
+compares was left as a two-term sum: `a - a / 3` came back as `a + -a / 3`, which no rule about a
+sign can read. It is collected now, and the positive factor is divided out where the comparison is
+built rather than later — because `Simplify` prunes by `SimplifiedRate`, and
+`2/3 * a > 0 and 2 * a > 0` rates **26** against the membership's **25**, one point worse, so it was
+discarded before anything could take it to `a > 0`, which rates **8**. The `n = 2` case answered
+only because `1/2 * a > 0 and a > 0` happens to rate **24**.
+
+| | before | now |
+|---|---|---|
+| `"a in (a / 2; 2a)".Simplify()` | `a > 0` | unchanged |
+| `"a in (a / 3; 3a)".Simplify()` | `a in (a / 3; 3 * a)` | `a > 0` |
+| `"a in (a / 4; 4a)".Simplify()`, and every denominator through 8 | left as written | `a > 0` |
+| `"a in (a / 2; 3a)".Simplify()` | `a in (a / 2; 3 * a)` | `a > 0` |
+| `"a in (a / 7; 5a)".Simplify()` | left as written | `a > 0` |
+| `"a in (a / 2; 0)".Simplify()` | `a in (a / 2; 0)` | `False provided a in RR` |
+| `"a in (-2a; -a/2)".Simplify()` | left as written | `False provided a in RR` |
+| `"a in (a / 2; 2a + 1)".Simplify()` | `a > 0 and 1 + a > 0` | unchanged |
+| `"a in (1; 2)".Simplify()`, `"3 in (1; 5)"`, `"x in [0; 1]"`, `"a in (b; c)"` | unchanged | unchanged |
+
+The two `False` rows are answers where there were none: `a / 2 < a < 0` wants `a > 0` and `a < 0` at
+once, and so does `-2a < a < -a / 2`. The condition is there because the ordering is a claim about
+reals.
+
+**And `RewriteRules.Common` reaches a fixed point.** It was the library's only non-terminating rule
+set: a three-cycle on `-x * 1/2`, `Mulf(-1/2, x)` to `Mulf(-1, Divf(x, 2))` to `Divf(Mulf(-1, x), 2)`
+and back — three trees printing as two strings. Two of the three rules turning it are exact inverses
+on that shape: one reads `(-1 * x) / 2` as a numeric factor to collect, giving `-1/2 * x`, and the
+other reads that back as `-(x / 2)`. The first now declines a factor of `-1`, which is the sign
+rather than a number to collect.
+
+The positive case never cycled, and the reason says why the guard is where it is: `x / 2` is a
+quotient over a *leaf*, so it does not re-enter the collection rule's pattern at all. The loop
+existed only because a negation is spelled as a product.
+
+`Simplify` bounded its own iteration and never hung, so no caller saw the cycle — but a rule set is
+public, a caller may apply one by itself, and `Common` did not terminate when applied that way.
+`RuleSetTerminationTest.NeverSettle` is now empty and still asserted in both directions.
+
+**Nothing else moved.** `-x * 1/2` is `-1/2 * x` and `x * 1/2` is `x / 2`, both as before; the guard
+changes which rewrites are available, not which answer wins. The two halves of this entry ship
+together because the first is what makes the second free: the guard alone cost three interval shapes
+that were being answered by coincidence, and the collection restores them along with the rest of the
+family ([#1056](https://github.com/asc-community/AngouriMath/issues/1056)).
 
 ### A fold over an empty sequence answers instead of throwing
 

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -2903,10 +2903,17 @@ namespace AngouriMath.Core.Transformations.Matching
                 description: "(a / b) * c = (a * c) / b"),
             new MatchedRule(
                 "a-numeric-quotient-of-a-numeric-multiple-collects-its-numbers",
-                MatchPattern.Node<Divf>(MatchPattern.Node<Mulf>(MatchPattern.Any<Number>("c"), MatchPattern.Any("a")), MatchPattern.Any<Number>("d")),
+                // Not for c = -1. That is not a numeric factor to collect but the sign, which the
+                // language spells as a product -- and collecting it is exactly undone by
+                // `a-negated-reciprocal-rational-factor-is-a-negated-division`, which is Sound
+                // where this is SoundUnderAssumptions. The two were the cycle in #1056.
+                MatchPattern.Node<Divf>(
+                    MatchPattern.Node<Mulf>(
+                        MatchPattern.Any<Number>("c", number => number != -1), MatchPattern.Any("a")),
+                    MatchPattern.Any<Number>("d")),
                 bound => (Number)bound["c"] / (Number)bound["d"] * bound["a"],
                 Soundness.SoundUnderAssumptions,
-                description: "(c * a) / d = (c / d) * a, for numeric c and d"),
+                description: "(c * a) / d = (c / d) * a, for numeric c and d other than -1"),
             new MatchedRule(
                 "dividing-twice-divides-by-the-product",
                 MatchPattern.Node<Divf>(MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("b")), MatchPattern.Any("c")),

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Common.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Common.cs
@@ -95,7 +95,15 @@ namespace AngouriMath.Functions
             Mulf(Divf(var any1, var any2), var any3) => any1 * any3 / any2,
 
             // a * {1} / b
-            Divf(Mulf(Number const1, var any1), Number const2) => const1 / const2 * any1,
+            //
+            // Not for const1 = -1, which is not a numeric factor to collect but the sign, spelled
+            // as a product because that is how the language spells a negation. Collecting it turns
+            // -x / 2 into -1/2 * x, and `a-negated-reciprocal-rational-factor-is-a-negated-division`
+            // turns that straight back -- the two are exact inverses on this shape, and the pair
+            // is what made this set the one rule set with no fixed point.
+            // https://github.com/asc-community/AngouriMath/issues/1056
+            Divf(Mulf(Number const1, var any1), Number const2) when const1 != -1
+                => const1 / const2 * any1,
 
             // a / b / c = a / (b * c)
             Divf(Divf(var any1, var any2), var any3) => any1 / (any2 * any3),

--- a/Sources/AngouriMath/Functions/Simplification/Simplificator.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Simplificator.cs
@@ -398,8 +398,55 @@ namespace AngouriMath.Functions
             return leftCon & rightCon;
         }
 
+        /// <summary>
+        /// <paramref name="left"/> exceeds <paramref name="right"/>, stated as a comparison of
+        /// their difference against zero — which is the form the inequality rules can decide.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <see cref="SimplifyChildren"/> alone is not enough to reach that form. It simplifies
+        /// the operands and leaves the sum standing, so <c>a - a / 3</c> comes back as
+        /// <c>a + -a / 3</c> — two terms in one variable, which no rule about a sign can read.
+        /// <see cref="Transformation.RationalCanonicalization"/> collects them into
+        /// <c>2/3 * a</c>, and a rational multiple of something is positive exactly when that
+        /// something is, so <c>a in (a / 3; 3 * a)</c> is <c>a &gt; 0</c>.
+        /// </para>
+        /// <para>
+        /// It was <c>a in (a / 2; 2 * a)</c> alone that answered before, and by coincidence
+        /// rather than by this route: nothing collected the terms, and the answer came out of
+        /// <see cref="Entity.Simplify(int)"/>'s candidate search happening to reach it for that
+        /// one denominator. Three, four, five and six were all left as written.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1056">#1056</a>
+        /// </para>
+        /// <para>
+        /// Then the comparison itself is normalised, and that is what makes the answer reachable
+        /// rather than merely correct. <c>Simplify</c> prunes a candidate by
+        /// <c>SimplifiedRate</c> at each step, and <c>2/3 * a &gt; 0 and 2 * a &gt; 0</c> rates 26
+        /// where the membership it came from rates 25 — one point worse, so it was discarded
+        /// before anything could reduce it to <c>a &gt; 0</c>, which rates 8. The <c>n = 2</c> case
+        /// answered only because <c>1/2 * a &gt; 0 and a &gt; 0</c> happens to rate 24. Dividing
+        /// out the positive factor here, with the rule set that already knows how, means the
+        /// candidate is born at its best rate instead of having to survive on the way there.
+        /// </para>
+        /// <para>
+        /// Two named transformations rather than a call back into <see cref="Entity.Simplify(int)"/>,
+        /// deliberately: this runs inside a rewrite rule that <c>Simplify</c> itself applies, and
+        /// the full simplifier here would be a cycle through the interval rule rather than a
+        /// deeper answer.
+        /// </para>
+        /// </remarks>
         internal static Entity ConditionallyGreater(Entity left, Entity right)
-            => SimplifyChildren(left - right) > 0;
+            => decideSign.ApplyOrKeep(
+                Transformation.RationalCanonicalization.ApplyOrKeep(SimplifyChildren(left - right)) > 0);
+
+        /// <summary>
+        /// Divides a decidably-signed numeric factor out of a comparison with zero, which is what
+        /// takes <c>2/3 * a &gt; 0</c> to <c>a &gt; 0</c>. Held as a field so the chain is built
+        /// once rather than per interval end.
+        /// </summary>
+        [ConstantField]
+        private static readonly Transformation decideSign =
+            Transformation.Rewriting(RewriteRules.InequalityEquality);
 
         /// <summary>
         /// Divides the given expression by the divisor.

--- a/Sources/Tests/UnitTests/Core/Transformations/CommonTerminatesTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/CommonTerminatesTest.cs
@@ -1,0 +1,91 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Collections.Generic;
+using AngouriMath.Core.Transformations;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// The cycle that made <c>Common</c> the one rule set with no fixed point, written down as the
+    /// shapes it went through. <a href="https://github.com/asc-community/AngouriMath/issues/1056">#1056</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="RuleSetTerminationTest"/> holds the general claim over a generated corpus; this
+    /// holds the particular one, because the corpus that finds a cycle is not the thing that says
+    /// which rewrite closed it. Printed forms are not enough — two of the three trees printed the
+    /// same string — so every assertion here is against a tree.
+    /// </para>
+    /// <para>
+    /// The cycle was
+    /// <c>Mulf(-1/2, x)</c> → <c>Mulf(-1, Divf(x, 2))</c> → <c>Divf(Mulf(-1, x), 2)</c> → back,
+    /// turned by three rules of which two are exact inverses on this shape. The positive case
+    /// never cycled: <c>x / 2</c> is a quotient over a leaf and so does not re-enter the
+    /// collection rule's pattern at all. The loop existed only because a negation is spelled as a
+    /// product.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class CommonTerminatesTest
+    {
+        /// <summary>
+        /// Iterated on its own, with no normalisation to lean on, the set reaches a fixed point.
+        /// </summary>
+        [Theory]
+        [InlineData("-x * 1/2")]
+        [InlineData("-1/2 * x")]
+        [InlineData("-x / 2")]
+        [InlineData("-2 * x / 4")]
+        [InlineData("-x * 1/3")]
+        [InlineData("x * 1/2")]
+        public void CommonReachesAFixedPoint(string source)
+        {
+            var current = source.ToEntity();
+            var seen = new List<Entity> { current };
+            for (var pass = 0; pass < 32; pass++)
+            {
+                var applied = RewriteRules.Common.ApplyOnce(current);
+                if (applied.Equals(current))
+                    return;
+                Assert.DoesNotContain(applied, seen);
+                seen.Add(applied);
+                current = applied;
+            }
+
+            Assert.True(false, "no fixed point in 32 passes: "
+                + string.Join(" -> ", seen.ConvertAll(e => e.Stringize())));
+        }
+
+        /// <summary>
+        /// The rule that gave way, at the shape it gives way on and at the shape it does not. It
+        /// collects a numeric factor out of a quotient's numerator, and <c>-1</c> is the sign
+        /// rather than a factor to collect — so that one case is declined and every other
+        /// coefficient still collects.
+        /// </summary>
+        [Theory]
+        [InlineData("(-1 * x) / 2", null)]
+        [InlineData("(-2 * x) / 4", "-1/2 * x")]
+        [InlineData("(2 * x) / 4", "1/2 * x")]
+        [InlineData("(1 * x) / 2", "1/2 * x")]
+        [InlineData("(-3 * x) / 2", "-3/2 * x")]
+        public void TheCollectionRuleDeclinesTheSignAndNothingElse(string source, string? expected)
+        {
+            var rule = System.Linq.Enumerable.Single(
+                RewriteRules.Common.Rules,
+                r => r.Name == "a-numeric-quotient-of-a-numeric-multiple-collects-its-numbers");
+            var applied = rule.TryApply(source.ToEntity());
+
+            if (expected is null)
+                Assert.Null(applied);
+            else
+                Assert.Equal(expected.ToEntity(), applied);
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Core/Transformations/IntervalMembershipOfItsOwnBoundTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/IntervalMembershipOfItsOwnBoundTest.cs
@@ -1,0 +1,105 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// <c>a in (a / n; m * a)</c> is <c>a &gt; 0</c>, for every whole <c>n</c> and <c>m</c> above
+    /// one — and it was answered for <c>n = 2</c> alone.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/1056">#1056</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Not a rule about intervals. <c>ParaphraseInterval</c> writes the membership out as two
+    /// comparisons with zero, and the difference it compares was left as a two-term sum:
+    /// <c>a - a / 3</c> came back as <c>a + -a / 3</c>, which no rule about a sign can read.
+    /// Collecting it gives <c>2/3 * a</c>, and a positive rational multiple of something is
+    /// positive exactly when that something is.
+    /// </para>
+    /// <para>
+    /// Collecting alone was not enough, and the reason is worth writing down: <c>Simplify</c>
+    /// prunes candidates by <c>SimplifiedRate</c>, and <c>2/3 * a &gt; 0 and 2 * a &gt; 0</c>
+    /// rates <b>26</b> against the membership's <b>25</b> — one point worse, so it was thrown away
+    /// before anything could take it to <c>a &gt; 0</c>, which rates <b>8</b>. The <c>n = 2</c>
+    /// case answered because <c>1/2 * a &gt; 0 and a &gt; 0</c> happens to rate <b>24</b>. So the
+    /// positive factor is divided out where the comparison is built, and the candidate is born at
+    /// its best rate rather than having to survive on the way there.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class IntervalMembershipOfItsOwnBoundTest
+    {
+        /// <summary>
+        /// Every denominator, because the one that worked worked by coincidence. Three through
+        /// eight were all left as written.
+        /// </summary>
+        [Theory]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        public void MembershipBetweenItsOwnFractionAndItsOwnMultipleIsPositivity(int n)
+            => Assert.Equal(
+                "a > 0".ToEntity(),
+                $"a in (a / {n}; {n} * a)".ToEntity().Simplify());
+
+        /// <summary>
+        /// And the two bounds need not agree, which is what says the answer comes from the
+        /// mathematics rather than from the pair cancelling.
+        /// </summary>
+        [Theory]
+        [InlineData("a in (a / 2; 3 * a)")]
+        [InlineData("a in (a / 3; 2 * a)")]
+        [InlineData("a in (a / 7; 5 * a)")]
+        [InlineData("a in (0; 2 * a)")]
+        public void TheTwoBoundsNeedNotAgree(string source)
+            => Assert.Equal("a > 0".ToEntity(), source.ToEntity().Simplify());
+
+        /// <summary>
+        /// An interval that demands both signs at once is <b>False</b>, not merely unsimplified.
+        /// Both of these were left as written before, so this is an answer where there was none.
+        /// </summary>
+        /// <remarks>
+        /// <c>a / 2 &lt; a &lt; 0</c> wants <c>a &gt; 0</c> and <c>a &lt; 0</c>; <c>-2a &lt; a</c>
+        /// wants <c>a &gt; 0</c> and <c>a &lt; -a/2</c> wants <c>a &lt; 0</c>. The condition is
+        /// there because the ordering is a claim about reals.
+        /// </remarks>
+        [Theory]
+        [InlineData("a in (a / 2; 0)")]
+        [InlineData("a in (-2 * a; -a / 2)")]
+        public void AnIntervalDemandingBothSignsIsEmpty(string source)
+            => Assert.Equal("false provided a in RR".ToEntity(), source.ToEntity().Simplify());
+
+        /// <summary>
+        /// A bound that is not a multiple of the element keeps its own condition rather than
+        /// being folded into the sign one.
+        /// </summary>
+        [Fact]
+        public void AnUnrelatedBoundKeepsItsOwnCondition()
+            => Assert.Equal(
+                "a > 0 and 1 + a > 0".ToEntity(),
+                "a in (a / 2; 2 * a + 1)".ToEntity().Simplify());
+
+        /// <summary>
+        /// And nothing that was already right has moved: a numeric membership is decided, and one
+        /// with nothing to decide is left alone rather than guessed at.
+        /// </summary>
+        [Theory]
+        [InlineData("3 in (1; 5)", "true")]
+        [InlineData("a in (1; 2)", "a in (1; 2)")]
+        [InlineData("x in [0; 1]", "x in [0; 1]")]
+        [InlineData("a in (b; c)", "a in (b; c)")]
+        public void TheOrdinaryCasesAreUnchanged(string source, string expected)
+            => Assert.Equal(expected.ToEntity(), source.ToEntity().Simplify());
+    }
+}

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleSetTerminationTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleSetTerminationTest.cs
@@ -137,15 +137,30 @@ namespace AngouriMath.Tests.Core.Transformations
         /// which is how the simplifier runs them.
         /// </summary>
         /// <remarks>
-        /// <c>Common</c> has a three-cycle on <c>-x * 1/2</c>:
-        /// <c>Mulf(-1/2, x)</c> to <c>Mulf(-1, Divf(x, 2))</c> to <c>Divf(Mulf(-1, x), 2)</c> and
-        /// back — three trees printing as two strings, which is why it wants writing down as
-        /// shapes. Two rules disagree about whether <c>c * x</c> or <c>(c * x) / d</c> is the
-        /// destination. <c>Simplify</c> bounds its own iteration and does not hang, so this is a
-        /// property of the set rather than a defect a caller sees today
-        /// (<a href="https://github.com/asc-community/AngouriMath/issues/1056">#1056</a>).
+        /// <para>
+        /// <b>Empty, and kept.</b> <c>Common</c> was the one entry: a three-cycle on
+        /// <c>-x * 1/2</c>, <c>Mulf(-1/2, x)</c> to <c>Mulf(-1, Divf(x, 2))</c> to
+        /// <c>Divf(Mulf(-1, x), 2)</c> and back — three trees printing as two strings, which is
+        /// why the remark wrote them as shapes.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1056">#1056</a>
+        /// </para>
+        /// <para>
+        /// The pair that turned it were exact inverses on one shape:
+        /// <c>a-numeric-quotient-of-a-numeric-multiple-collects-its-numbers</c> reads
+        /// <c>(-1 * x) / 2</c> as a numeric factor to collect, giving <c>-1/2 * x</c>, and
+        /// <c>a-negated-reciprocal-rational-factor-is-a-negated-division</c> reads that back as
+        /// <c>-(x / 2)</c>. The first now declines a factor of <c>-1</c>, which is the sign rather
+        /// than a number to collect. The positive case never cycled, because <c>x / 2</c> is a
+        /// <c>Divf</c> over a leaf and so does not re-enter the first rule's pattern at all — the
+        /// loop existed only because a negation is spelled as a product.
+        /// </para>
+        /// <para>
+        /// The list stays because the shape of the assertion is what matters: it is held in both
+        /// directions, so a set that starts cycling fails and a set that stops cycling has to
+        /// leave it, which is how this one was found to have stopped.
+        /// </para>
         /// </remarks>
-        private static readonly HashSet<string> NeverSettle = new() { "Common" };
+        private static readonly HashSet<string> NeverSettle = new();
 
         /// <summary>
         /// With the normalisation between passes — how the simplifier runs them — every set


### PR DESCRIPTION
Closes [#1056](https://github.com/asc-community/AngouriMath/issues/1056), and answers a family of interval memberships that turned out to be the same story.

## The cycle is three rules, two of them exact inverses

```
Mulf(-1/2, x)          -1/2 * x   a-negated-reciprocal-rational-factor-is-a-negated-division
Mulf(-1, Divf(x, 2))   -x / 2     a-thing-times-a-quotient-keeps-the-divisor-outermost
Divf(Mulf(-1, x), 2)   -x / 2     a-numeric-quotient-of-a-numeric-multiple-collects-its-numbers
                                  → back to the start
```

The issue said "two rules disagree about whether `c * x` or `(c * x) / d` is the destination". It is narrower than that: **the collection rule and the negated-reciprocal rule are exact inverses on this one shape**, and the third rule is the reshaping step between them.

**Why only the negative case cycles.** `1/2 * x` becomes `x / 2` = `Divf(x, 2)` — a quotient over a *leaf*, which does not re-enter the collection rule's pattern. But `-x / 2` is `Divf(Mulf(-1, x), 2)`, because a negation is spelled as a product. That is the whole asymmetry, and it is what says which edge to cut.

The collection rule now declines a factor of `-1`, which is the sign rather than a number to collect.

## All three edges were cut and measured before choosing

| | breaks cycle | cost, full suite |
|---|---|---|
| **collection declines `c = -1`** ← this PR | ✅ | 3 interval shapes |
| drop `a * (-1/c) = -(a/c)` | ✅ | 2 integration answers (`∫x²-x`, `∫eˣsin x`) |
| `a * (b/c)` declines `a = -1` | ✅ | ~8: limits, arcsecant/arccosecant derivatives, sets |

No orientation is free — every edge is load-bearing somewhere. This is the cheapest, and its cost is the second half of the PR.

## The three "lost" shapes were a coincidence, and following that fixed the family

`a in (a / 2; 2a)` was `a > 0`. Every other denominator, **on master, before any of this**:

```
a in (a / 2; 2a) = a > 0            a in (a / 3; 3a) = a in (a / 3; 3 * a)
a in (a / 4; 4a) = a in (a/4; 4*a)  a in (a / 5; 5a) = a in (a / 5; 5 * a)
```

Two causes, both needed:

1. **`ParaphraseInterval` never collected its terms.** It writes a membership out as two comparisons with zero, and `SimplifyChildren(a - a/3)` leaves `a + -a / 3` — two terms in one variable, which no rule about a sign can read. `RationalCanonicalization` collects them into `2/3 * a`.

2. **`SimplifiedRate` pruned the candidate before it could reduce.** Collecting alone still did not answer `n ≥ 3`:

   | candidate | rate |
   |---|---|
   | `a in (a/3; 3a)` | 25 |
   | `2/3 * a > 0 and 2 * a > 0` | **26** → one point worse, discarded |
   | `a in (a/2; 2a)` | 25 |
   | `1/2 * a > 0 and a > 0` | **24** → kept, reaches `a > 0` |
   | `a > 0` | 8 |

   So `n = 2` answered because its intermediate happened to rate one point *better* than the input. The fix is to divide the positive factor out where the comparison is built — with `RewriteRules.InequalityEquality`, which already knows `(k * a > 0) = (a > 0)` — so the candidate is born at its best rate instead of having to survive on the way there.

Two named transformations rather than a call back into `Simplify`: this runs inside a rule that `Simplify` applies, so the full simplifier here would be a cycle through the interval rule.

## Measured

| | before | now |
|---|---|---|
| `a in (a / 2; 2a)` | `a > 0` | unchanged |
| `a in (a / n; n·a)`, n = 3…8 | left as written | `a > 0` |
| `a in (a / 2; 3a)`, `a in (a / 7; 5a)` | left as written | `a > 0` |
| `a in (a / 2; 0)` | left as written | `False provided a in RR` |
| `a in (-2a; -a/2)` | left as written | `False provided a in RR` |
| `a in (a / 2; 2a + 1)` | `a > 0 and 1 + a > 0` | unchanged |
| `a in (1; 2)`, `3 in (1; 5)`, `x in [0; 1]`, `a in (b; c)` | | unchanged |
| `-x * 1/2` → `-1/2 * x`, `x * 1/2` → `x / 2` | | unchanged |

The two `False` rows are **answers where there were none**: `a/2 < a < 0` wants `a > 0` and `a < 0` at once, and so does `-2a < a < -a/2`. The condition is there because the ordering is a claim about reals.

The two halves ship together because the first is what makes the second free.

## Tests

`RuleSetTerminationTest.NeverSettle` is now **empty** and still asserted in both directions — it is what reported the fix, with *"these sets terminate now and should leave the list: Common"*.

Two new files: `CommonTerminatesTest` holds the particular cycle as shapes (two of the three trees print alike, so every assertion is against a tree) and pins that the collection rule declines the sign and nothing else; `IntervalMembershipOfItsOwnBoundTest` holds the family, every denominator, with the rate figures in its remarks so the reason is not lost.

`Failed: 0, Passed: 9115, Skipped: 14` locally on net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
