### PR TITLE
A generated file is checked against its generator, and two had stopped matching (#1034)

### DIFF
--- a/.github/workflows/GeneratedFilesUpToDate.yml
+++ b/.github/workflows/GeneratedFilesUpToDate.yml
@@ -1,0 +1,73 @@
+name: 'Generated Files Up To Date'
+
+# Several files in this repository are generated and checked in, and nothing rebuilt them and
+# compared -- so a template could stop matching its output and the build stayed green. The file was
+# then only discovered to be unregenerable the next time somebody actually tried.
+#
+# That had happened twice by the time this was written. `EquationSystemFunctionPattern.txt` still
+# said `Tensor?` long after the type was renamed to `Matrix?` (repaired by #1029), and
+# `TupleToIntervalTest.txt` still said `MathS.Matrices.Interval`, which does not exist -- so
+# regenerating that test file produced eighteen CS0117 errors. Both were found by hand, years apart,
+# which is the argument for this job.
+#
+# The ANTLR parser has its own job, GrammarUpToDate.yml, because it needs a Java runtime where this
+# needs a dotnet tool. Keeping them apart means neither goes red for the other's reason.
+# https://github.com/asc-community/AngouriMath/issues/1034
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "Sources/AngouriMath/**/*.tt"
+      - "Sources/AngouriMath/Convenience/CompilationExtensions.cs"
+      - "Sources/AngouriMath/Functions/Compilation/**"
+      - "Sources/Utils/**"
+      - "Sources/Tests/UnitTests/Convenience/TupleToIntervalTest.cs"
+      - "Sources/AngouriMath/AngouriMath.csproj"
+      - ".github/workflows/GeneratedFilesUpToDate.yml"
+  pull_request:
+    branches:
+      - '*'
+    paths:
+      - "Sources/AngouriMath/**/*.tt"
+      - "Sources/AngouriMath/Convenience/CompilationExtensions.cs"
+      - "Sources/AngouriMath/Functions/Compilation/**"
+      - "Sources/Utils/**"
+      - "Sources/Tests/UnitTests/Convenience/TupleToIntervalTest.cs"
+      - "Sources/AngouriMath/AngouriMath.csproj"
+      - ".github/workflows/GeneratedFilesUpToDate.yml"
+
+jobs:
+  Regenerate:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup .NET 10
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '10.x'
+        dotnet-quality: 'preview'
+
+    # The one tool this needs beyond the SDK the other jobs already install.
+    - name: 'Install the T4 processor'
+      run: dotnet tool install -g dotnet-t4
+
+    - name: 'Regenerate every generated file'
+      run: bash Sources/Utils/regenerate_all.sh
+
+    # No exclusions. The templates emit the copyright header themselves, so the generated file is
+    # the committed file byte for byte and there is nothing here that could quietly grow to hide a
+    # real difference. Two of the three T4 templates did not emit it until this issue, which meant
+    # regenerating them produced files that failed the build outright -- IDE0073 is an error here.
+    - name: 'Fail if a committed generated file is not what its generator produces'
+      run: |
+        if ! git diff --exit-code --stat; then
+          echo "::error::A checked-in generated file does not match its generator."
+          echo "::error::Run Sources/Utils/regenerate_all.sh and commit the result."
+          echo "--- the difference ---"
+          git --no-pager diff
+          exit 1
+        fi

--- a/Sources/AngouriMath/Convenience/CompilationExtensions.cs
+++ b/Sources/AngouriMath/Convenience/CompilationExtensions.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) 2019-2022 Angouri.
 // AngouriMath is licensed under MIT.
 // Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.

--- a/Sources/AngouriMath/Convenience/CompilationExtensions.tt
+++ b/Sources/AngouriMath/Convenience/CompilationExtensions.tt
@@ -1,4 +1,10 @@
-﻿
+﻿//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
 using static AngouriMath.Entity;
 using AngouriMath.Core.Compilation.IntoLinq;
 using System.Collections.Generic;

--- a/Sources/AngouriMath/Functions/Compilation/Compile.Linq.Definition.cs
+++ b/Sources/AngouriMath/Functions/Compilation/Compile.Linq.Definition.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) 2019-2022 Angouri.
 // AngouriMath is licensed under MIT.
 // Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.

--- a/Sources/AngouriMath/Functions/Compilation/Compile.Linq.Definition.tt
+++ b/Sources/AngouriMath/Functions/Compilation/Compile.Linq.Definition.tt
@@ -1,4 +1,11 @@
-﻿using System;
+﻿//
+// Copyright (c) 2019-2022 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;

--- a/Sources/Tests/UnitTests/Convenience/TupleToIntervalTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/TupleToIntervalTest.cs
@@ -5,20 +5,6 @@
 // Website: https://am.angouri.org.
 //
 
-/* Copyright (c) 2019-2020 Angourisoft
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy,
- * modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
- * is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
- * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
- * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- */
-
 // This file is auto-generated. Use generate_additional_extensions_tests.bat to re-generate it, do not edit the file itself.
 
 using Xunit;

--- a/Sources/Utils/Utils/AdditionalExtensionsTestGenerator.cs
+++ b/Sources/Utils/Utils/AdditionalExtensionsTestGenerator.cs
@@ -37,7 +37,13 @@ namespace Utils
 
             var com = new SourceGenerator(commonTemplate, "%bat%", "%usings%", "%namespace%", "%classheader%", "%content%");
 
-            var fullText = com.Generate("generate_additional_extensions_tests.bat", "using Xunit;\nusing AngouriMath;\nusing AngouriMath.Extensions;", "UnitTest.Extensions", "public class IntervalExtensionTest", GenerateTupleToInterval());
+            // The namespace and the trait are the committed file's, not this generator's older
+            // guesses at them: `UnitTest.Extensions` is a namespace the test project does not use,
+            // and every test class here carries an Area trait so that `dotnet test --filter` can
+            // select by area. Both had drifted, as had `MathS.Matrices.Interval` in the content
+            // template -- which does not exist, so the file could not be regenerated at all.
+            // https://github.com/asc-community/AngouriMath/issues/1034
+            var fullText = com.Generate("generate_additional_extensions_tests.bat", "using Xunit;\nusing AngouriMath;\nusing AngouriMath.Extensions;", "AngouriMath.Tests.Extensions", "[Trait(\"Area\", \"Convenience\")]\n    public class IntervalExtensionTest", GenerateTupleToInterval());
 
             File.WriteAllText("../Tests/UnitTests/Convenience/TupleToIntervalTest.cs", fullText);
         }

--- a/Sources/Utils/Utils/TupleToIntervalTest.txt
+++ b/Sources/Utils/Utils/TupleToIntervalTest.txt
@@ -1,12 +1,12 @@
         [Fact] public void Test%testid%()
             => Assert.Equal(
-            MathS.Matrices.Interval(%arg1%, %arg2%),
+            MathS.Interval(%arg1%, %arg2%),
             (%arg1%, %arg2%).ToInterval()
             );
 
         [Fact] public void Test%testid%_custom()
             => Assert.Equal(
-            MathS.Matrices.Interval(%arg1%, true, %arg2%, false), 
+            MathS.Interval(%arg1%, true, %arg2%, false), 
             (%arg1%, true, %arg2%, false).ToInterval()
             );
 

--- a/Sources/Utils/regenerate_all.sh
+++ b/Sources/Utils/regenerate_all.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Regenerates every checked-in generated file that is not the ANTLR parser, in place.
+#
+# The parser has its own job, GrammarUpToDate.yml, because regenerating it needs a Java runtime
+# and this needs a dotnet tool -- keeping them apart means neither is red for the other's reason.
+#
+# Run from anywhere; paths are resolved from this script's own location, not from the working
+# directory, because a report that writes where you are not reading goes stale invisibly.
+#
+# https://github.com/asc-community/AngouriMath/issues/1034
+
+set -euo pipefail
+
+sources="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+kernel="$sources/AngouriMath"
+
+# The three T4 templates, read out of the project file rather than listed here -- a list written
+# twice is a list that drifts, and this one would drift silently in the direction of covering
+# less. `None Update="a\b.tt"` is MSBuild's Windows separator, so it is translated on the way out.
+templates=$(
+    grep -o 'None Update="[^"]*\.tt"' "$kernel/AngouriMath.csproj" \
+    | sed 's/None Update="//; s/"$//; s|\\|/|g'
+)
+
+if [ -z "$templates" ]; then
+    echo "no .tt templates found in AngouriMath.csproj -- has the declaration shape changed?" >&2
+    exit 1
+fi
+
+# `dotnet tool install -g dotnet-t4` installs a binary called `t4`, not `dotnet-t4`, so it is not
+# reachable as `dotnet t4` and is only on PATH if the tools directory is. Looked up rather than
+# assumed, because the failure otherwise reads as "you misspelled a built-in dotnet command".
+t4=$(command -v t4 || true)
+if [ -z "$t4" ] && [ -x "$HOME/.dotnet/tools/t4" ]; then
+    t4="$HOME/.dotnet/tools/t4"
+fi
+if [ -z "$t4" ]; then
+    echo "t4 not found. Install it with: dotnet tool install -g dotnet-t4" >&2
+    exit 1
+fi
+
+for template in $templates; do
+    echo "t4: $template"
+    "$t4" "$kernel/$template" -o "$kernel/${template%.tt}.cs"
+done
+
+# And the two hand-written generators, which write their own destinations.
+echo "utils: ExtensionGenerator"
+(cd "$sources/Utils" && dotnet run --project Utils -c Release ExtensionGenerator)
+echo "utils: AdditionalExtensionsTestGenerator"
+(cd "$sources/Utils" && dotnet run --project Utils -c Release AdditionalExtensionsTestGenerator)


### PR DESCRIPTION
Closes [#1034](https://github.com/asc-community/AngouriMath/issues/1034).

## The issue was right, and it had happened again

Nothing rebuilt the checked-in generated files and compared, so a template could stop matching its output and the build stayed green. `EquationSystemFunctionPattern.txt` was the first case, repaired by #1029. There was a second one live on `master`:

`TupleToIntervalTest.txt` still named **`MathS.Matrices.Interval`**, which does not exist. Regenerating `TupleToIntervalTest.cs` produced eighteen `CS0117` errors — measured, not inferred:

```
TupleToIntervalTest.cs(20,28): error CS0117: 'MathS.Matrices' does not contain a definition for 'Interval'
```

The generator had drifted twice more: it wrote namespace `UnitTest.Extensions` where the test project uses `AngouriMath.Tests.Extensions`, and it had lost the `[Trait("Area", …)]` every test class here carries so `dotnet test --filter` can select by area. All three are repaired, and the regenerated file builds and passes its 18 tests.

## Two T4 templates produced files that failed the build

The issue proposed excluding the copyright header when diffing, since no template emitted it. That understates it: **IDE0073 is an error in this repository**, so regenerating either `CompilationExtensions.tt` or `Compile.Linq.Definition.tt` produced a file that would not compile.

```
CompilationExtensions.cs(1,1): error IDE0073: A source file is missing a required header.
```

So they emit it now instead. That is better than an exclusion on two counts: it fixes a real break rather than agreeing to ignore it, and it means **the gate has no exclusions at all** — nothing that could quietly grow to hide a real difference, which is the issue's own acceptance criterion 3. `MathAllMethods.tt` already emitted the header and already reproduced exactly, so this makes the other two match the one that worked. BOM included: that file has none either, and no `.editorconfig` rule asks for one.

## The gate

`Sources/Utils/regenerate_all.sh` regenerates everything in place, and `GeneratedFilesUpToDate.yml` runs it and fails on any difference, printing the diff rather than "files differ".

Three details that are deliberate:

- **The template list is read out of `AngouriMath.csproj`**, not written in the script. A list written twice is a list that drifts, and this one would drift in the direction of covering less.
- **Paths resolve from the script's own location**, not the working directory — four harnesses in the sibling workspace had a bug where a report wrote where nobody was reading, and it hid staleness for months.
- **`t4` is looked up, not assumed.** `dotnet tool install -g dotnet-t4` installs a binary called `t4`, so `dotnet t4` fails with *"You misspelled a built-in dotnet command"* — a message that reads as the caller's typo rather than a missing tool.

ANTLR keeps its own job, `GrammarUpToDate.yml`, because it needs a Java runtime where this needs a dotnet tool — so neither goes red for the other's reason. (That job already exists and already covers the parser, so the issue's fifth row is done.)

## Acceptance criteria

1. **Fails when a template is edited without regenerating** — demonstrated by pushing exactly that, on `demo/generated-files-gate-goes-red`, which edits `TupleToIntervalTest.txt` and nothing else. Locally the same edit gives `exit=1` and names `Sources/Tests/UnitTests/Convenience/TupleToIntervalTest.cs`.
2. **The failure names the file and shows the diff** — the step runs `git --no-pager diff` after the `::error::` lines.
3. **No header exclusion**, because there is nothing to exclude any more.
4. **One tool beyond the SDK** the other jobs already install.

`Failed: 0, Passed: 9098, Skipped: 14` locally on net10.0, with every generated file regenerated from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
