### PR TITLE
Domain.Any is a codomain and not the universal set (#996)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -57,6 +57,8 @@ read first.
 | **Silent** | `"-1 * (y mod z)".ToEntity().Stringize()` | `-y mod z` | `-(y mod z)` |
 | | any expression mixing a number with a `Complex` argument, `Compile`d in a NativeAOT app — `"x + 1".Compile<Complex, Complex>("x")` | `UncompilableNodeException: ... The binary operator Add is not defined for the types 'System.Numerics.Complex' and 'System.Numerics.Complex'` | the compiled function, answering as it does under the JIT |
 | | `Compile` to a nullable integral return type in a NativeAOT app | `AngouriBugException: IsNaN method expected for type System.Double`, which took the process down | the compiled function |
+| **Silent** | `"(x = 1) implies (x = 2)".ToEntity().Solve("x")`, and every implication | `{ 2 } \/ BB` — truth values in the solution set of a numeric question | `{ x : not x = 1 }` |
+| | `"domain((-oo; +oo), Any) = RR".ToEntity().Solve("x")`, and every unbounded interval widened to `Any` | `NotSufficientlySupportedException: There is no special set for domain Any` | `{  }` |
 | **Silent** | an app publishing with `PublishTrimmed` or NativeAOT | `AngouriMath.dll` was copied in whole, being unmarked | it is trimmed with the rest, since the assembly now declares `IsTrimmable` |
 | **Silent** | `"domain(x, ZZ)".ToEntity().Stringize()`, and `ToString`, and `EntityJsonConverter` | `x`, which reads back with `Codomain = Any` | `domain(x, ZZ)`, which reads back narrowed |
 | **Silent** | `"domain(sqrt(-1), RR)".ToEntity().Stringize()` | `sqrt(-1)`, which evaluates to `i` when read back | `domain(sqrt(-1), RR)`, which evaluates to `NaN` |
@@ -302,6 +304,59 @@ was nothing to take.
 
 `Transformation.NumericContentExtraction` is the step on its own, and `Transformation.Factorization`'s
 `Name` gains it — a chain names its parts.
+
+### An implication is solved without naming a universe
+
+`Solve` answered `a implies b` with `Codomain \ solve(a) \/ solve(b)`, taking the complement
+inside the **statement node's** codomain. That is `Boolean` for every implication, so a numeric
+question came back with a solution set containing `True` and `False`
+([#996](https://github.com/asc-community/AngouriMath/issues/996)). A `TODO` on the line asked for a
+universal set to subtract from instead; neither is needed, because *the values of `x` where `a`
+does not hold* is `{ x : not a }`, which names no universe at all.
+
+**Was** — the domain in the answer is the codomain of the `implies` node, not anything the question
+was asked over:
+
+```
+"(x = 1) implies (x = 2)".ToEntity().Solve("x")     { 2 } \/ BB
+"x > 1 implies x > 0".ToEntity().Solve("x")         BB \ (1; +oo) \/ (0; +oo)
+"A implies B".ToEntity().Solve("A")                 BB \ { True }
+```
+
+**Is** — a set-builder for the antecedent's complement, united with what the consequent settles:
+
+```
+"(x = 1) implies (x = 2)".ToEntity().Solve("x")     { x : not x = 1 }
+"x > 1 implies x > 0".ToEntity().Solve("x")         { x : not x > 1 } \/ (0; +oo)
+"A implies B".ToEntity().Solve("A")                 { A : not A }
+```
+
+The boolean row carries the same information it did before — `BB \ { True }` and `{ A : not A }`
+are the same set — without asserting that `A` ranges over `BB`. The implication solver is no more
+complete than it was: `solve(b, x)` is still empty where `b` does not mention `x`, so
+`A implies True` is `{ A : not A }` rather than `BB`, as it was before.
+
+### An unbounded interval over no constraint is left as written
+
+`(-oo; +oo)` simplifies to the domain it is an interval of. Widened to `Domain.Any` there is no such
+domain — `Any` is a codomain and not a set — and asking for one threw out of `Solve` on input a
+caller can write ([#996](https://github.com/asc-community/AngouriMath/issues/996)).
+
+**Was**
+
+```
+"domain((-oo; +oo), Any) = RR".ToEntity().Solve("x")
+    NotSufficientlySupportedException: There is no special set for domain Any
+```
+
+**Is** — the interval is left alone, and the statement is solved:
+
+```
+"domain((-oo; +oo), Any) = RR".ToEntity().Solve("x")    {  }
+"domain((-oo; +oo), Any)".ToEntity().Simplify()         domain((-oo; +oo), Any)
+"(-oo; +oo)".ToEntity().Simplify()                      RR                        unchanged
+"domain((-oo; +oo), CC)".ToEntity().Simplify()          CC                        unchanged
+```
 
 ### An equation nothing settled is no longer answered with the empty set
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -122,3 +122,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [Tests/UnitTests/Core/ExceptionMessageNamesTheExpressionTest.cs]
 [Tests/UnitTests/Core/UnknownDomainIsNotABugTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Core/Sets/DomainAnyIsNotAUniversalSetTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Core/Domains.cs
+++ b/Sources/AngouriMath/Core/Domains.cs
@@ -10,8 +10,32 @@ using static AngouriMath.Entity.Set;
 namespace AngouriMath.Core
 {
     /// <summary>
-    /// Specify the domain used within a record 
+    /// The codomain an <see cref="Entity"/> node is read over: the values it is allowed to take
+    /// before it is <see cref="MathS.NaN"/>.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A member of this enum is a <b>constraint on a node</b>, not a mathematical object. Five of
+    /// them also name a set — <see cref="Entity.Set.SpecialSet.Create(Domain)"/> maps those five
+    /// to <c>BB</c>, <c>ZZ</c>, <c>QQ</c>, <c>RR</c> and <c>CC</c> — and <see cref="Any"/> does not,
+    /// because "no constraint" is not a collection of values. Sets are
+    /// <see cref="Entity.Set"/>s and are reasoned about with membership, union and difference;
+    /// a domain is not, and the two are deliberately different types.
+    /// </para>
+    /// <para>
+    /// The members are ordered from narrowest to widest and are compared as such — evaluation
+    /// asks <c>Codomain &lt; Domain.Complex</c> to mean "narrower than the complex plane", and
+    /// <see cref="Entity.DomainConditionIn(Domain)"/> narrows a node whose codomain is
+    /// <i>wider</i> than the reading it is asked in. <see cref="Any"/> is the top of that order,
+    /// which is what makes it the identity for narrowing rather than a set of everything.
+    /// </para>
+    /// <para>
+    /// Distinct from <see cref="MathS.Settings.Codomain"/>, which is the <b>ambient</b> reading a
+    /// question is asked in and applies to nodes that do not constrain themselves. A node's own
+    /// codomain says what that node is declared over; the ambient one says what the library
+    /// should take an unconstrained node to be.
+    /// </para>
+    /// </remarks>
     public enum Domain
     {
         /// <summary>
@@ -40,13 +64,49 @@ namespace AngouriMath.Core
         Complex,
 
         /// <summary>
-        /// The domain of all values (might be removed in the future)
+        /// No constraint: this node is not declared over any narrower codomain, so whatever
+        /// reading the question is asked in applies to it.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Not a set, and not the universal set.</b> It is the widest member of the order
+        /// above and the one <see cref="Entity.Set.SpecialSet.Create(Domain)"/> has no set for,
+        /// on purpose: it says that a node imposes no restriction, which is a statement about the
+        /// node rather than a claim that some collection contains every value. Nothing may read
+        /// it as "the set of everything" — the solution set of an equation is never this, and a
+        /// code path that needs a set has to name one.
+        /// </para>
+        /// <para>
+        /// A mathematical set that constrains nothing is already expressible, as a set-builder
+        /// whose predicate holds everywhere: <c>{ x : True }</c> parses, prints, round-trips,
+        /// compares and answers membership. That is why there is no <c>AA</c>/<c>UU</c>
+        /// <see cref="Entity.Set.SpecialSet"/> and why this member is staying.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/996">#996</a>
+        /// </para>
+        /// <para>
+        /// It is the default codomain of a <see cref="Entity.Variable"/>, a
+        /// <see cref="Entity.Matrix"/>, a <see cref="Entity.Set.ConditionalSet"/>, a
+        /// <see cref="Entity.Lambda"/> and the set operators — every node whose value is not
+        /// confined to numbers. It is written as <c>domain(x, Any)</c>, which is a keyword in
+        /// that one position and not a set literal.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1048">#1048</a>
+        /// </para>
+        /// </remarks>
         Any
     }
 
     internal static class DomainsFunctional
     {
+        /// <summary>
+        /// Whether a value is not ruled out by a codomain.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Domain.Any"/> is answered here rather than by asking for its set, because
+        /// it has none: a node that constrains nothing rules nothing out, which is a shortcut
+        /// past <see cref="Entity.Set.SpecialSet.Create(Domain)"/> and not a membership test
+        /// against a universal set.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/996">#996</a>
+        /// </remarks>
         public static bool FitsDomainOrNonNumeric(Entity entity, Domain domain)
             => domain == Domain.Any || SpecialSet.Create(domain).MayContain(entity);
 

--- a/Sources/AngouriMath/Core/Entity/Omni/Entity.Set.cs
+++ b/Sources/AngouriMath/Core/Entity/Omni/Entity.Set.cs
@@ -81,9 +81,18 @@ namespace AngouriMath
         public Set SetSubtract(Entity anotherSet) => new SetMinusf(this, anotherSet);
 
         /// <summary>
-        /// The domain as the set of all its values — <see cref="Domain.Real"/> becomes the set
-        /// of reals — so a domain can be written wherever an expression is expected.
+        /// The set a domain names — <see cref="Domain.Real"/> becomes the set of reals — so one
+        /// of the five domains that name a set can be written wherever an expression is expected.
         /// </summary>
+        /// <remarks>
+        /// <b>Partial, and deliberately so.</b> <see cref="Domain.Any"/> names no set, and this
+        /// throws <see cref="Core.Exceptions.NotSufficientlySupportedException"/> for it rather
+        /// than inventing one: a codomain that constrains nothing is a statement about a node,
+        /// and there is no collection of values it corresponds to. Where a domain is used as a
+        /// constraint rather than as a set — a guard, a narrowing, a reading — ask
+        /// <see cref="Domain"/> directly and do not convert.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/996">#996</a>
+        /// </remarks>
         public static implicit operator Entity(Domain domain) => Set.SpecialSet.Create(domain);
 
     }

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -1861,12 +1861,18 @@ namespace AngouriMath.Core.Transformations.Matching
                 Soundness.Sound,
                 description: "{ True, False } = the boolean domain"),
 
-            // (-oo; +oo) is the domain it is an interval of
+            // (-oo; +oo) is the domain it is an interval of, where that domain names a set.
+            // The Any case is refused in the condition rather than left to the replacement:
+            // MatchedRule.Build swallows what the right-hand side throws, so without this the
+            // rule declined by accident on an interval widened to "no constraint" -- which is
+            // the right answer arrived at by an exception. There is no set of Domain.Any.
+            // https://github.com/asc-community/AngouriMath/issues/996
             new MatchedRule(
                 "an-unbounded-interval-is-a-whole-domain",
                 MatchPattern.Any<Set.Interval>(
                     "i", interval => interval.Left == Real.NegativeInfinity
-                                     && interval.Right == Real.PositiveInfinity),
+                                     && interval.Right == Real.PositiveInfinity
+                                     && interval.Codomain is not Domain.Any),
                 bound => Set.SpecialSet.Create(((Set.Interval)bound["i"]).Codomain),
                 Soundness.Sound,
                 description: "(-oo; +oo) = the domain it is an interval of"));

--- a/Sources/AngouriMath/Docs/Usage/Syntax.md
+++ b/Sources/AngouriMath/Docs/Usage/Syntax.md
@@ -21,13 +21,19 @@ something, so the ordinary expression is unchanged — and the default is not th
 a variable and a matrix default to `Any`, `abs` and an interval to `RR`, every boolean node to `BB`,
 each numeric literal to its own type's domain, and everything else to `CC`.
 
-Two annotations still do not survive, and both are the grammar's limit rather than the printer's.
-There is no way to write **`Any`**, because the second argument of `domain(...)` has to be one of
-the five special sets and none of them means "no restriction" — so a node *widened* to `Any` from a
-narrower default prints as though it had not been. And no input at all yields a rational literal
-whose codomain is `CC`: the pass that reads `1/2` as a rational rather than a quotient
+**`Any` is written too, and it is not a set.** `domain(abs(x), Any)` is how a node widened from a
+narrower default prints, and it reads back widened
+([#1048](https://github.com/asc-community/AngouriMath/issues/1048)). `Any` is a keyword in that one
+position and nowhere else — `Any + 1` is arithmetic on a variable called `Any`, and there is no
+`Entity` it denotes: `SpecialSet.Create(Domain.Any)` throws, deliberately. It says that a node
+imposes no restriction, which is a fact about the node and not a collection of values
+([#996](https://github.com/asc-community/AngouriMath/issues/996)).
+
+One annotation still does not survive, and it is the parser's rather than the printer's: no input
+at all yields a rational literal whose codomain is `CC`, because the pass that reads `1/2` as a
+rational rather than a quotient
 ([#873](https://github.com/asc-community/AngouriMath/issues/873)) treats `CC` as "nobody annotated
-this", because that is what an un-annotated `/` carries.
+this", which is what an un-annotated `/` carries.
 
 **LaTeX output has a round trip too, and it is checked in someone else's repository.**
 [CSharpMath.Evaluation](https://github.com/verybadcat/CSharpMath/blob/master/CSharpMath.Evaluation/Evaluation.cs)
@@ -138,6 +144,11 @@ with an operator parses.
 | special | `RR` `CC` `ZZ` `QQ` `BB` |
 | operations | `unite` `/\` … see the table above |
 
+There is **no universal set** and no literal for one. A set that constrains nothing is the
+conditional set `{ x : True }`, which prints, reads back, compares and answers membership like any
+other; `Domain.Any` is a codomain and not a candidate for the job
+([#996](https://github.com/asc-community/AngouriMath/issues/996)).
+
 ## Matrices and vectors
 
 `[1, 2, 3]` is a column vector (3 by 1), `[[1, 2], [3, 4]]` a matrix, `[1, 2, 3]T` a transpose
@@ -207,9 +218,10 @@ range in [#657](https://github.com/asc-community/AngouriMath/pull/657).
 **Structural** — `piecewise(a provided p, b provided q)`, `lambda(param, body)`,
 `apply(f, arg, ...)`, `domain(expr, set)`.
 
-`domain` takes a special set — `CC` `RR` `QQ` `ZZ` `BB` — and narrows the *codomain* of whatever
-node it wraps, which is what makes the expression evaluate to `NaN` outside it. It applies to any
-node, not only a variable, and it is what `Stringize` prints for one.
+`domain` takes a special set — `CC` `RR` `QQ` `ZZ` `BB` — or the keyword `Any`, and sets the
+*codomain* of whatever node it wraps, which is what makes the expression evaluate to `NaN` outside
+it. It applies to any node, not only a variable, and it is what `Stringize` prints for one. `Any`
+is the one spelling here that is not a set: it removes the restriction rather than naming values.
 
 **Refused by name** — `trunc` `lcm` `erf` `conjugate`. AngouriMath has none of these, and each is
 what some other CAS calls a function, so a caller reaches for it. Left alone they would be read as

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/SolveStatement.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/SolveStatement.cs
@@ -149,6 +149,39 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
         }
 
         /// <summary>
+        /// <c>a implies b</c> holds where <c>a</c> fails or where <c>b</c> holds, and the first
+        /// half of that is a set-builder rather than a complement.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This used to read <c>expr.Codomain \ Solve(a) \/ Solve(b)</c>, taking the
+        /// complement inside the <b>statement node's</b> codomain. That is
+        /// <see cref="Domain.Boolean"/> for every <see cref="Impliesf"/>, so
+        /// <c>(x = 1) implies (x = 2)</c> was answered <c>{ 2 } \/ BB</c> — a solution set for
+        /// a numeric question containing <c>True</c> and <c>False</c>. That is exactly the
+        /// confusion between a codomain and a set that
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/996">#996</a> is about,
+        /// and a <c>TODO</c> here asked for a universal set to subtract from instead.
+        /// </para>
+        /// <para>
+        /// <b>Neither is needed.</b> "The values of <c>x</c> where <c>a</c> does not hold" is
+        /// <c>{ x : not a }</c>, which names no universe at all — a set-builder is already this
+        /// library's unconstrained set, and a complement written that way is right whatever
+        /// <c>x</c> ranges over. Which is #996's answer: what the solver wanted was the
+        /// difference, and the difference is expressible without the universe.
+        /// </para>
+        /// <para>
+        /// It does not make the implication solver complete. <c>Solve(b, x)</c> is still
+        /// <see cref="Set.Empty"/> where <c>b</c> does not mention <c>x</c>, so
+        /// <c>A implies True</c> comes back as <c>{ A : not A }</c> and not as <c>BB</c> — as it
+        /// did before, where the answer was <c>BB \ { True }</c>. What this stops is answering
+        /// with a set the question was never asked over.
+        /// </para>
+        /// </remarks>
+        private static Set Implication(Entity left, Entity right, Variable x)
+            => (Set)MathS.Union(new ConditionalSet(x, !left), Solve(right, x));
+
+        /// <summary>
         /// Where both sides of a conjunction were settled, its solution set is the
         /// intersection of theirs.
         /// </summary>
@@ -182,10 +215,8 @@ namespace AngouriMath.Functions.Algebra.AnalyticalSolving
                     Conjunction(Solve(left, x), Solve(right, x), expr, x),
                 Orf(var left, var right) => 
                     MathS.Union(Solve(left, x), Solve(right, x)),
-                Impliesf(var left, var right) => 
-                    MathS.Union(MathS.SetSubtraction(expr.Codomain, Solve(left, x)), Solve(right, x)),
+                Impliesf(var left, var right) => Implication(left, right, x),
 
-                // TODO: there should be universal set to subtract from when inverting
                 Greaterf(var left, var right) => 
                     AnalyticalInequalitySolver.Solve(Minus(left, right), x),
                 LessOrEqualf(var left, var right) => 

--- a/Sources/AngouriMath/Functions/Output/ToSympy/ToSympy.Omni.Classes.cs
+++ b/Sources/AngouriMath/Functions/Output/ToSympy/ToSympy.Omni.Classes.cs
@@ -29,10 +29,16 @@ namespace AngouriMath
             {
                 // A set builder's Codomain is Domain.Any, which SpecialSet.Create has no
                 // member for and throws on -- so every set builder threw an AngouriBugException
-                // out of the exporter. SymPy names that set: S.UniversalSet is the one it
-                // prints ConditionSet without a third argument for, which is what "no
-                // restriction beyond the predicate" means here too.
+                // out of the exporter.
                 // https://github.com/asc-community/AngouriMath/issues/985
+                //
+                // S.UniversalSet is what SymPy prints a ConditionSet without a third argument
+                // over, so it is the right thing to emit for a predicate under no further
+                // restriction. It is a choice about the target language and not a claim about
+                // this one: SymPy has a universal set and AngouriMath does not, and an exporter
+                // to a system without one (or with a typed one, as Lean and SMT have) picks
+                // differently. Nothing here may be read back as "Domain.Any is a set".
+                // https://github.com/asc-community/AngouriMath/issues/996
                 internal override string ToSymPy()
                     => $"sympy.ConditionSet({Var.ToSymPy()}, {Predicate.ToSymPy()}, {CodomainToSymPy()})";
 

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Sets.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Sets.cs
@@ -37,7 +37,14 @@ namespace AngouriMath.Functions
             Simplificator.ParaphraseInterval(var, left, leftClosed, right, rightClosed),
 
             FiniteSet potentialBB when potentialBB == FullBooleanSet => SpecialSet.Create(Domain.Boolean),
-            Interval(var left, _, var right, _) interval when left == Real.NegativeInfinity && right == Real.PositiveInfinity => SpecialSet.Create(interval.Codomain),
+            // (-oo; +oo) is the domain it is an interval of -- where that domain names a set.
+            // An interval widened to Domain.Any is left as written: "no constraint" has no set,
+            // and asking SpecialSet.Create for one threw out of `solve` on valid input.
+            // https://github.com/asc-community/AngouriMath/issues/996
+            Interval(var left, _, var right, _) interval
+                when left == Real.NegativeInfinity && right == Real.PositiveInfinity
+                     && interval.Codomain is not AngouriMath.Core.Domain.Any
+                => SpecialSet.Create(interval.Codomain),
 
             _ => x
         };

--- a/Sources/Tests/UnitTests/Convenience/SyntaxDocumentedTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/SyntaxDocumentedTest.cs
@@ -230,6 +230,46 @@ namespace AngouriMath.Tests.Convenience
             Assert.Equal("abs(x)", "(|x|)".ToEntity().Stringize());
         }
 
+        /// <summary>
+        /// The page says there is no universal set and no literal for one, and that a set
+        /// constraining nothing is written <c>{ x : True }</c>.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/996">#996</a>
+        /// </summary>
+        [Fact]
+        public void ThereIsNoUniversalSetLiteral()
+        {
+            Assert.IsType<Entity.Variable>("AA".ToEntity());
+            Assert.IsType<Entity.Variable>("UU".ToEntity());
+
+            var unconstrained = Assert.IsType<Entity.Set.ConditionalSet>("{ x : true }".ToEntity().Simplify());
+            Assert.True(unconstrained.TryContains(3, out var number) && number);
+            Assert.True(unconstrained.TryContains(Entity.Boolean.True, out var truth) && truth);
+        }
+
+        /// <summary>
+        /// The page says <c>domain(...)</c> takes the five special sets or the keyword
+        /// <c>Any</c>, that the annotation reads back, and that <c>Any</c> is a keyword in that
+        /// one position rather than a set.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1048">#1048</a>,
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/996">#996</a>
+        /// </summary>
+        [Fact]
+        public void DomainTakesTheFiveSpecialSetsOrTheKeywordAny()
+        {
+            foreach (var (name, domain) in new[]
+                     {
+                         ("CC", AngouriMath.Core.Domain.Complex), ("RR", AngouriMath.Core.Domain.Real),
+                         ("QQ", AngouriMath.Core.Domain.Rational), ("ZZ", AngouriMath.Core.Domain.Integer),
+                         ("BB", AngouriMath.Core.Domain.Boolean),
+                     })
+                Assert.Equal(domain, $"domain(x, {name})".ToEntity().Codomain);
+
+            Assert.Equal(AngouriMath.Core.Domain.Any, "domain(abs(x), Any)".ToEntity().Codomain);
+            Assert.Equal(AngouriMath.Core.Domain.Real, "abs(x)".ToEntity().Codomain);
+            Assert.IsType<Entity.Variable>("Any".ToEntity());
+            Assert.Equal("Any + 1".ToEntity(), MathS.Var("Any") + 1);
+        }
+
         // ------------------------------------------------------------ functions
 
         /// <summary>One argument to <c>log</c> is base 10, and two more names say a base outright.</summary>

--- a/Sources/Tests/UnitTests/Core/Sets/DomainAnyIsNotAUniversalSetTest.cs
+++ b/Sources/Tests/UnitTests/Core/Sets/DomainAnyIsNotAUniversalSetTest.cs
@@ -1,0 +1,266 @@
+﻿//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Core;
+using AngouriMath.Core.Exceptions;
+using AngouriMath.Extensions;
+using Xunit;
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Set;
+
+namespace UnitTests.Core.Sets
+{
+    /// <summary>
+    /// The boundary between a mathematical set, the ambient domain a question is asked in, and a
+    /// node's codomain. <a href="https://github.com/asc-community/AngouriMath/issues/996">#996</a>
+    /// asked whether there should be a universal set and whether <see cref="Domain.Any"/> is it;
+    /// the answer is that <c>Any</c> is a codomain and not a set, and that a set constraining
+    /// nothing is already written <c>{ x : True }</c>.
+    /// </summary>
+    /// <remarks>
+    /// These pin the invariant rather than the implementation: each one would have to be argued
+    /// against before a universal set could be added, which is the point of writing them down.
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class DomainAnyIsNotAUniversalSetTest
+    {
+        private static readonly ConditionalSet Unconstrained = new(MathS.Var("x"), Boolean.True);
+
+        #region A set-builder with a true predicate is the unconstrained set
+
+        /// <summary>
+        /// A predicate that holds everywhere reduces to <c>{ x : True }</c> and not to a special
+        /// set — there is none to reduce to. It used to throw
+        /// <see cref="AngouriBugException"/> instead
+        /// (<a href="https://github.com/asc-community/AngouriMath/issues/878">#878</a>).
+        /// </summary>
+        [Theory]
+        [InlineData("{ x : 1 = 1 }")]
+        [InlineData("{ x : x = x }")]
+        [InlineData("{ x : true }")]
+        public void APredicateThatHoldsEverywhereIsTheUnconstrainedSet(string source)
+            => Assert.Equal(Unconstrained, source.ToEntity().Simplify());
+
+        /// <summary>
+        /// And it admits values of every sort, which is what a caller wanting a universal set
+        /// wants of one: a number, a truth value and a matrix are each decided members.
+        /// </summary>
+        [Theory]
+        [InlineData("3")]
+        [InlineData("-1/2")]
+        [InlineData("i")]
+        [InlineData("true")]
+        [InlineData("[1, 2]")]
+        [InlineData("{ 1, 2 }")]
+        public void TheUnconstrainedSetAdmitsValuesOfEverySort(string element)
+        {
+            Assert.True(Unconstrained.TryContains(element.ToEntity(), out var contains),
+                "membership of { x : True } is decidable");
+            Assert.True(contains);
+        }
+
+        /// <summary>It prints, reads back as itself, and simplifying it again changes nothing.</summary>
+        [Fact]
+        public void TheUnconstrainedSetRoundTripsAndIsStable()
+        {
+            var printed = Unconstrained.Stringize();
+            Assert.Equal(Unconstrained, printed.ToEntity());
+            Assert.Equal(Unconstrained, Unconstrained.Simplify());
+            Assert.Equal(Unconstrained, Unconstrained.Simplify().Simplify());
+        }
+
+        /// <summary>
+        /// The bound name is not part of it, so two spellings of the same set are one set. A
+        /// <see cref="SpecialSet"/> would give that for free; a set-builder gives it too, which
+        /// is one fewer reason to want one.
+        /// </summary>
+        [Fact]
+        public void TheUnconstrainedSetDoesNotDependOnItsBoundName()
+            => Assert.Equal(Unconstrained, "{ y : true }".ToEntity().Simplify());
+
+        #endregion
+
+        #region Domain.Any is a codomain, and there is no set of it
+
+        /// <summary>
+        /// The five domains that name a set convert to it; <see cref="Domain.Any"/> does not, and
+        /// says so rather than inventing one. This is the load-bearing assertion of #996: the
+        /// moment <c>Any</c> answers here it has become a universal set by accident.
+        /// </summary>
+        [Theory]
+        [InlineData(Domain.Boolean)]
+        [InlineData(Domain.Integer)]
+        [InlineData(Domain.Rational)]
+        [InlineData(Domain.Real)]
+        [InlineData(Domain.Complex)]
+        public void EveryDomainThatNamesASetConvertsToOne(Domain domain)
+            => Assert.IsAssignableFrom<SpecialSet>((Entity)domain);
+
+        /// <inheritdoc cref="EveryDomainThatNamesASetConvertsToOne"/>
+        [Fact]
+        public void TheUnconstrainedCodomainNamesNoSet()
+        {
+            Assert.Throws<NotSufficientlySupportedException>(() => SpecialSet.Create(Domain.Any));
+            Assert.Throws<NotSufficientlySupportedException>(() => (Entity)Domain.Any);
+        }
+
+        /// <summary>
+        /// <c>{ x : True }</c> carries <see cref="Domain.Any"/> as its codomain, and that is a
+        /// statement about the node rather than about its members: the codomain of the node
+        /// naming the set and the set itself are different things, and the first cannot be turned
+        /// into the second.
+        /// </summary>
+        [Fact]
+        public void TheUnconstrainedSetHasTheUnconstrainedCodomainAndIsStillNotIt()
+        {
+            Assert.Equal(Domain.Any, Unconstrained.Codomain);
+            Assert.Throws<NotSufficientlySupportedException>(
+                () => SpecialSet.Create(Unconstrained.Codomain));
+        }
+
+        /// <summary>
+        /// There is no spelling for a universal set, and the two that have been suggested for one
+        /// — <c>AA</c> and <c>UU</c> — are ordinary variables. Introducing either is a decision
+        /// this issue declined to take, so it should fail here first.
+        /// </summary>
+        [Theory]
+        [InlineData("AA")]
+        [InlineData("UU")]
+        public void ThereIsNoLiteralForAUniversalSet(string source)
+            => Assert.IsType<Variable>(source.ToEntity());
+
+        /// <summary>
+        /// <c>Any</c> is read as the unconstrained codomain in the second argument of
+        /// <c>domain(...)</c> and is an ordinary variable everywhere else — it is a keyword in
+        /// that one position and never a set literal.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1048">#1048</a>
+        /// </summary>
+        [Fact]
+        public void AnyIsACodomainKeywordAndNotASetLiteral()
+        {
+            Assert.IsType<Variable>("Any".ToEntity());
+            var widened = "abs(x)".ToEntity().WithCodomain(Domain.Any);
+            Assert.Equal(Domain.Any, widened.Codomain);
+            Assert.Equal(widened, widened.Stringize().ToEntity());
+        }
+
+        #endregion
+
+        #region The ambient domain is not the solution set
+
+        /// <summary>
+        /// #996's own example. <c>x - x</c> is not defined for arbitrary values — <c>true - true</c>
+        /// is <see cref="MathS.NaN"/> — so the solution set is the domain the question was asked
+        /// in and not everything that could be written in place of <c>x</c>.
+        /// </summary>
+        [Fact]
+        public void ATautologyAnswersTheDomainTheQuestionWasAskedInAndNotAUniversalSet()
+        {
+            var solutions = "x - x = 0".ToEntity().Solve("x");
+            Assert.Equal(MathS.Sets.C, solutions);
+            Assert.IsType<SpecialSet.Complexes>(solutions);
+        }
+
+        /// <summary>
+        /// And that answer is a real restriction rather than a permissive one: <c>CC</c> decides
+        /// against a truth value and against a matrix, which is what makes it different from a
+        /// universal set. <a href="https://github.com/asc-community/AngouriMath/issues/995">#995</a>
+        /// </summary>
+        [Theory]
+        [InlineData("true")]
+        [InlineData("false")]
+        [InlineData("[1, 2]")]
+        public void TheDomainAnEquationIsSolvedInExcludesWhatItDoesNotContain(string element)
+        {
+            var solutions = "x - x = 0".ToEntity().Solve("x");
+            Assert.True(solutions.TryContains(element.ToEntity(), out var contains));
+            Assert.False(contains);
+        }
+
+        /// <summary>
+        /// The ambient codomain is a setting on the question, so it is not something an
+        /// expression carries: reading over the reals does not turn the solution set into a
+        /// different kind of object, and nothing about it produces a universal set.
+        /// </summary>
+        [Fact]
+        public void TheAmbientCodomainIsAPropertyOfTheQuestion()
+        {
+            Assert.Equal(Domain.Complex, MathS.Settings.Codomain.Value);
+            using var _ = MathS.Settings.Codomain.Set(Domain.Real);
+            var solutions = "x - x = 0".ToEntity().Solve("x");
+            Assert.IsAssignableFrom<SpecialSet>(solutions);
+            Assert.True(solutions.TryContains("true".ToEntity(), out var contains));
+            Assert.False(contains);
+        }
+
+        #endregion
+
+        #region A complement needs no universe
+
+        /// <summary>
+        /// <c>a implies b</c> is solved as <c>{ x : not a } \/ solve(b)</c>. The complement is a
+        /// set-builder and names no universe, which is what the <c>TODO</c> asking for "a
+        /// universal set to subtract from" turned out to need. Taking it in the statement node's
+        /// codomain instead answered <c>{ 2 } \/ BB</c> — truth values in the solution set of a
+        /// numeric question.
+        /// </summary>
+        [Fact]
+        public void AnImplicationIsSolvedWithoutNamingAUniverse()
+        {
+            var solutions = "(x = 1) implies (x = 2)".ToEntity().Solve("x");
+
+            Assert.True(solutions.TryContains(2, out var two));
+            Assert.True(two, "2 satisfies the implication");
+            Assert.True(solutions.TryContains(1, out var one));
+            Assert.False(one, "1 makes the antecedent true and the consequent false");
+            Assert.True(solutions.TryContains(3, out var three));
+            Assert.True(three, "3 makes the antecedent false");
+        }
+
+        /// <summary>
+        /// And the answer is a set-builder rather than a domain: nothing in it asserts what
+        /// <c>x</c> ranges over, which the previous answer did by naming <c>BB</c>.
+        /// </summary>
+        [Fact]
+        public void AnImplicationsAnswerAssertsNoDomain()
+        {
+            var solutions = "(x = 1) implies (x = 2)".ToEntity().Solve("x");
+            Assert.False(solutions is SpecialSet, "the answer names no domain");
+            Assert.DoesNotContain("BB", solutions.Stringize());
+        }
+
+        #endregion
+
+        #region An unbounded interval over no constraint is not a domain
+
+        /// <summary>
+        /// <c>(-oo; +oo)</c> is the domain it is an interval of, where that domain names a set.
+        /// Widened to <see cref="Domain.Any"/> it names none, so it is left as written — asking
+        /// for the set of <c>Any</c> here threw <see cref="NotSufficientlySupportedException"/>
+        /// out of <c>Solve</c> on input a caller could write.
+        /// </summary>
+        [Fact]
+        public void AnUnboundedIntervalBecomesADomainOnlyWhereThereIsOne()
+        {
+            Assert.Equal(MathS.Sets.R, "(-oo; +oo)".ToEntity().Simplify());
+            Assert.Equal(MathS.Sets.C, "domain((-oo; +oo), CC)".ToEntity().Simplify());
+
+            var unconstrained = "domain((-oo; +oo), Any)".ToEntity();
+            Assert.Equal(Domain.Any, unconstrained.Codomain);
+            Assert.Equal(unconstrained, unconstrained.Simplify());
+        }
+
+        /// <inheritdoc cref="AnUnboundedIntervalBecomesADomainOnlyWhereThereIsOne"/>
+        [Fact]
+        public void SolvingOverAnUnboundedIntervalOverNoConstraintDoesNotThrow()
+            => Assert.Null(Record.Exception(
+                () => "domain((-oo; +oo), Any) = RR".ToEntity().Solve("x")));
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Answers [#996](https://github.com/asc-community/AngouriMath/issues/996) — *should there be a
universal set, and is `Domain.Any` it?* — from the repository rather than from the question, and
corrects the three places that had already answered it the other way.

## The conclusion

**`Domain.Any` is a codomain. It is not a set, and there is no universal set to add.**

Three things in the code say so, none of them the comment on the enum member:

- Every one of the twelve nodes that declares `Any` — `Variable`, `Matrix`, `ConditionalSet`,
  `Lambda`, the set operators, the providers — means *this node imposes no restriction*. That is a
  statement about a node, not a claim that a collection contains every value.
- The enum is an **order**, narrowest to widest, and that is how it is read: evaluation asks
  `Codomain < Domain.Complex` for "narrower than the complex plane", and `DomainConditionIn`
  narrows a node whose codomain is *wider* than the reading. `Any` is the top of that order, which
  makes it the identity for narrowing — not a set of everything.
- The five domains that name a set are exactly the five `SpecialSet.Create` answers. `Any` throws,
  and every internal caller answers it before asking.

And the thing a universal set would be for is already there: `{ x : True }` parses, prints,
round-trips, compares up to its bound name, and decides membership for a number, a truth value and
a matrix alike. Set-difference, intersection, union and `Filter` all work on it. Nothing in the
repository asked for `AA`, so none is introduced.

`solve x in (x - x = 0)` is `CC`, unchanged — and `CC` still decides *against* `true` and against
`[1, 2]` (#995), which is what makes it an answer rather than a universal set in disguise.

## What was wrong

**1. `solve(a implies b)` put truth values in the solution set of a numeric question.**

The arm took the complement inside `expr.Codomain` — the *statement node's* codomain, which is
`Boolean` for every `Impliesf`. A `TODO` beside it asked for a universal set to subtract from.

```
"(x = 1) implies (x = 2)".ToEntity().Solve("x")     { 2 } \/ BB          was
                                                    { x : not x = 1 }    is
"x > 1 implies x > 0".ToEntity().Solve("x")         BB \ (1; +oo) \/ (0; +oo)
                                                    { x : not x > 1 } \/ (0; +oo)
"A implies B".ToEntity().Solve("A")                 BB \ { True }
                                                    { A : not A }
```

Neither the codomain nor a universal set was needed. *The values of `x` where `a` does not hold*
is `{ x : not a }`, which names no universe at all and is right whatever `x` ranges over. **That is
#996's answer**: what the solver wanted was the difference, and the difference is expressible
without the universe — which is the case *against* adding one.

It does not make the implication solver complete. `Solve(b, x)` is still empty where `b` does not
mention `x`, so `A implies True` is `{ A : not A }` rather than `BB` — as it was before, where the
answer was `BB \ { True }`. What stops is answering with a set the question was never asked over.

**2. An unbounded interval widened to `Any` threw out of `solve`.**

```
"domain((-oo; +oo), Any) = RR".ToEntity().Solve("x")
    NotSufficientlySupportedException: There is no special set for domain Any     was
    {  }                                                                          is
```

`(-oo; +oo)` becomes the domain it is an interval of; widened to `Any` there is no such domain, so
it is now left as written. Its data twin in `MatchedRules` declined the same case **only because
`MatchedRule.Build` swallows what a replacement throws** — the right answer arrived at by an
exception — so the condition says it instead.

**3. The implicit `Domain` → `Entity` conversion read as "a domain is a set".**

Kept for compatibility, now documented as partial: it is the map from the five domains that name a
set, and it throws for `Any` rather than inventing one.

## Documentation

The enum member said *"the domain of all values (might be removed in the future)"* — the reading
this issue exists to rule out, and an open question in a place that looks like an answer. It now
says what `Any` is, what it is not, that the unconstrained *set* is `{ x : True }`, and that the
ambient `MathS.Settings.Codomain` is a third thing again: a parameter of the question, not a
property of an expression and not a solution set.

`Syntax.md` still said `Any` cannot be written, which #1048 made false. Corrected, along with the
`domain(...)` entry, and the Sets table now records that there is no universal set and no literal
for one.

The SymPy exporter maps a set-builder's `Any` to `S.UniversalSet`. That stays — it is what SymPy
prints a `ConditionSet` without a third argument over — with a comment that it is a choice about
the *target* language, since SymPy has a universal set and this library does not, and an exporter
to Lean or SMT picks differently.

## Tests

32 new tests, in `DomainAnyIsNotAUniversalSetTest` and `SyntaxDocumentedTest`. They pin the
invariant rather than the implementation: `{ x : True }` as the unconstrained set (membership,
round-trip, stability, bound-name independence), the five domains converting to sets and `Any` not,
no literal for `AA` or `UU`, `Any` as a codomain keyword and not a set literal, `x - x = 0`
answering the domain it was asked in and that domain excluding a truth value and a matrix, an
implication asserting no domain, and the widened interval. Three of them fail against the previous
behaviour; the rest would fail the day a universal set is added by accident.

## Measured

- Unit suite **9159 passed, 0 failed**, 14 skipped.
- `casbench` 116/119, **0 wrong, 0 error, 0 timeout**.
- `crashcheck` 1834 cases, **0 crashed**, 0 unexpected.
- `rulecheck` 30 sets, 17532 applications, **0 value changes**, 0 never settle.
- `confluence` `SetOperator` 0 nodes with several arms, 0 disagreeing.
- Two entries in `BREAKING-CHANGES.md`, both measured on a build.

## Deliberately not in this PR

- `AnalyticalEquationSolver` answers a tautology with a hardcoded `MathS.Sets.C` rather than the
  ambient `MathS.Settings.Codomain`, so `solve x in (x - x = 0)` is `CC` even under
  `Codomain.Set(Domain.Real)`. Conservative and correct at the default; making the tautology answer
  follow the ambient reading is a solver change with its own blast radius.
- `Solve` has no `Notf` arm, so `not (x = 1)` answers `{  }` — the empty set as a positive claim,
  which is the defect #1036 fixed for equations, unfixed for negation. Filed as #1127.

Neither is a domain-versus-set confusion, which is what this one is about.

