### PR TITLE
The determinant is computed by fraction-free elimination where it can be (#999)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -28,6 +28,8 @@ read first.
 | **Silent** | `MathS.Abs("x").WithCodomain(Domain.Any).Stringize()`, and every node widened to `Any` from a narrower default | `abs(x)` — reads back as `Real`, losing the widening | `domain(abs(x), Any)` |
 | **Silent** | `"domain(1/2, CC)".ToEntity()`, and every quotient of two integer literals annotated with the codomain its node type does not default to | `1/2` — the annotation dropped, equal to the unannotated literal | `1/2` carrying `Codomain = Complex`, which prints and reads back as `domain(1/2, CC)` |
 | | `"a in (a / 3; 3a)".ToEntity().Simplify()`, and every denominator but 2 | `a in (a / 3; 3 * a)` — left as written | `a > 0` |
+| | `MathS.Matrix(...).Determinant` on a symbolic matrix of polynomials | `a * d + -b * c`, Laplace's nested expansion | `a * d - b * c`, expanded — the same value, no larger |
+| | the same on a numeric matrix past 10x10 | did not return | 11x11 in 2 ms, 30x30 in 22 ms |
 | | `"a in (a / 2; 0)".ToEntity().Simplify()`, and every interval demanding both signs | left as written | `False provided a in RR` |
 | | `new Entity[0].SumAll()`, and `Sumf.Sum` on an empty list | `AngouriBugException: At least 1 child required` | `0` |
 | | `new Entity[0].MultiplyAll()`, and `Mulf.Multiply` on an empty list | `AngouriBugException` | `1` |
@@ -792,6 +794,57 @@ changes which rewrites are available, not which answer wins. The two halves of t
 together because the first is what makes the second free: the guard alone cost three interval shapes
 that were being answered by coincidence, and the collection restores them along with the rest of the
 family ([#1056](https://github.com/asc-community/AngouriMath/issues/1056)).
+
+### The determinant is computed by fraction-free elimination where it can be
+
+`Matrix.Determinant` expanded by Laplace, which is `O(n!)`. For a fully symbolic matrix that is
+optimal — the determinant genuinely has `n!` terms, and no algorithm returns it smaller in expanded
+form. For a numeric one it is pure waste: the answer is a single number and `O(n^3)` work suffices.
+
+Bareiss' fraction-free elimination now runs wherever the entries are polynomials over the rationals,
+and Laplace answers everything else. What decides it is not the size but whether the entries can be
+read, settled per matrix by trying.
+
+**The ceiling this removes**, both arms built from source on one machine:
+
+| | before | now |
+|---|---|---|
+| numeric 8×8 | 382 ms | under 1 ms |
+| numeric 10×10 | 14 415 ms | 2 ms |
+| numeric 11×11 | did not return in four minutes | 2 ms |
+| numeric 12×12 | did not return | 3 ms |
+| numeric 20×20 | did not return | 11 ms |
+| numeric 30×30 | did not return | 22 ms |
+
+**The printed form of a symbolic determinant changes**, because an elimination produces an expanded
+polynomial where Laplace produces a nested expansion. The value is the same and the expression is no
+larger in any case measured:
+
+| | before | now |
+|---|---|---|
+| `"[[a, b], [c, d]]"` | `a * d + -b * c` | `a * d - b * c` |
+| `"[[x, 1, 0], [1, x, 1], [0, 1, x]]"` | `x * (x ^ 2 + -1) + -x` | `x ^ 3 - 2 * x` |
+| `"[[a, b, 1], [c, d, 2], [1, 2, 3]]"` | `a * (d * 3 + -4) + -b * (c * 3 + -2) + c * 2 + -d` | `3 * a * d - 4 * a - 3 * b * c + 2 * b + 2 * c - d` |
+| `"[[x, 1], [1, x]]"` | `x ^ 2 + -1` | unchanged |
+| `"[[1/2, 1/3], [1/4, 1/5]]"` | `1/60` | unchanged |
+
+**No condition is introduced, and that is the point.** An ordinary Gaussian elimination leaves its
+pivots as literal divisions, so its answer is undefined wherever a pivot vanishes — at points where
+the determinant is perfectly well defined. That was
+[#992](https://github.com/asc-community/AngouriMath/issues/992), and it is why Laplace was chosen.
+Bareiss divides as well, but each division is by the *previous* pivot and is exact: the quotient is a
+determinant of a minor, so it is back in the ring. Here it is exact **and checked** — the arithmetic
+happens in `MultivariatePolynomial`, which has no quotients to leave behind, and a division that does
+not come out returns null and sends the caller to Laplace.
+
+**What is declined**, and answered by Laplace exactly as before: an entry that is not a polynomial
+over the rationals (`sin(x)`, `1 / x`, `2 ^ x`), a matrix in more than eight indeterminates, and a
+matrix mentioning `e` or `pi` — a constant is a value rather than an indeterminate, and this ring
+cannot hold one.
+
+The two algorithms were compared on 300 generated matrices where both apply, as a difference
+simplified to zero rather than as trees, with **no disagreements**
+([#999](https://github.com/asc-community/AngouriMath/issues/999)).
 
 ### A fold over an empty sequence answers instead of throwing
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -51,6 +51,15 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [AngouriMath/Functions/Algebra/Polynomials/KroneckerFactorization.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[AngouriMath/Functions/Algebra/Polynomials/FractionFreeDeterminant.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[AngouriMath/Functions/Algebra/Polynomials/PolynomialDeterminant.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Algebra/Polynomials/FractionFreeDeterminantTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [AngouriMath/Functions/Algebra/Groebner/*.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 

--- a/Sources/AngouriMath/Core/Entity/Omni/Entity.Matrix.cs
+++ b/Sources/AngouriMath/Core/Entity/Omni/Entity.Matrix.cs
@@ -270,23 +270,37 @@ namespace AngouriMath
             this);
             private LazyPropertyA<Matrix> t;
 
-            // We do not need to use Gaussian elimination here
-            // since we anyway get N! memory use.
-            // Gaussian elimination is also not merely no cheaper, it is wrong here:
-            // it leaves the pivots as literal divisions, so the expression it returns
-            // is undefined wherever a pivot vanishes -- at points where the
-            // determinant itself is perfectly well defined. The determinant of a
-            // matrix over a commutative ring is a polynomial in its entries, and
-            // Laplace expansion never divides, so there is nothing to exclude.
+            // Two algorithms, and which one runs is decided by the entries rather than by the
+            // size. Bareiss' fraction-free elimination is O(n^3) and Laplace expansion is
+            // O(n!), so Bareiss is tried first -- but it needs entries it can read as
+            // polynomials over the rationals, and it says so by declining rather than by
+            // guessing. https://github.com/asc-community/AngouriMath/issues/999
+            //
+            // *Ordinary* Gaussian elimination is not merely no cheaper than Laplace, it is
+            // wrong here: it leaves the pivots as literal divisions, so the expression it
+            // returns is undefined wherever a pivot vanishes -- at points where the
+            // determinant itself is perfectly well defined. The determinant of a matrix over a
+            // commutative ring is a polynomial in its entries, and neither Laplace nor Bareiss
+            // ever leaves a quotient, so there is nothing to exclude either way.
             // https://github.com/asc-community/AngouriMath/issues/992
             /// <summary>
-            /// Finds the symbolical determinant via Laplace's method
+            /// The determinant, by fraction-free elimination where the entries are polynomials
+            /// over the rationals and by Laplace expansion otherwise.
             /// </summary>
+            /// <remarks>
+            /// Both are exact and neither divides in a way that could exclude a point, so the
+            /// two agree wherever both apply; which one ran is a fact about cost, not about the
+            /// answer. Laplace is optimal for a fully symbolic matrix, whose determinant
+            /// genuinely has n! terms.
+            /// </remarks>
             public Entity? Determinant => determinant.GetValue(
-                static @this => 
+                static @this =>
                 {
-                    if (!@this.IsSquare) 
+                    if (!@this.IsSquare)
                         return null;
+                    if (Functions.PolynomialDeterminant.Of(@this.RowCount, (r, c) => @this[r, c])
+                        is { } byElimination)
+                        return byElimination.InnerSimplified;
                     return @this.InnerMatrix.DeterminantLaplace().InnerSimplified;
                 },
                 this

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/FractionFreeDeterminant.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/FractionFreeDeterminant.cs
@@ -1,0 +1,127 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath.Core.Multithreading;
+using PeterO.Numbers;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// Bareiss' fraction-free elimination: the determinant of a square matrix over an
+    /// integral domain, in <c>O(n^3)</c> ring operations and without ever leaving the ring.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Ordinary Gaussian elimination divides by the pivot, so over a ring of polynomials it
+    /// produces quotients — and an expression built from them is undefined wherever a pivot
+    /// vanishes, at points where the determinant itself is perfectly well defined. That is
+    /// what <a href="https://github.com/asc-community/AngouriMath/issues/992">#992</a> was
+    /// about, and why <see cref="Entity.Matrix.Determinant"/> used Laplace expansion rather
+    /// than elimination.
+    /// </para>
+    /// <para>
+    /// Bareiss divides too, and the divisions are the point: each entry is divided by the
+    /// <em>previous</em> pivot, and that division is <b>exact</b> — the quotient is a
+    /// determinant of a minor and therefore back in the ring. So the intermediate entries do
+    /// not swell the way Gaussian elimination's do, and nothing is ever left as a quotient to
+    /// exclude a point.
+    /// </para>
+    /// <para>
+    /// <b>Exactness is a fact about the ring, and is checked here anyway.</b>
+    /// <see cref="MultivariatePolynomial.DivideExact(MultivariatePolynomial, int)"/> returns
+    /// null rather than a remainder, so a division that does not come out — because the term
+    /// ceiling was reached, or because an assumption above is wrong — stops the elimination
+    /// instead of producing an answer that is quietly not the determinant. Every caller reads
+    /// null as "use another method", never as "there is no determinant".
+    /// </para>
+    /// <para>
+    /// Split out of <see cref="PolynomialResultant"/>, where it was written for the Sylvester
+    /// matrix. Shared rather than written twice, deliberately: a sign convention or an
+    /// off-by-one in an elimination is a wrong answer that looks entirely plausible, and one
+    /// implementation exercised by two callers is tested by both.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/999">#999</a>
+    /// </para>
+    /// </remarks>
+    internal static class FractionFreeDeterminant
+    {
+        [ConstantField] private static readonly ERational MinusOne = ERational.One.Negate();
+
+        /// <summary>
+        /// The determinant of <paramref name="matrix"/>, or <see langword="null"/> where the
+        /// elimination could not finish within <paramref name="maxWork"/> or a division came
+        /// back inexact.
+        /// </summary>
+        /// <param name="matrix">
+        /// Square, and <b>modified in place</b> — the caller owns it and must not need it
+        /// afterwards. Elimination is destructive, and copying here would hide the cost of the
+        /// one thing this exists to make cheap.
+        /// </param>
+        /// <param name="variableCount">
+        /// How many variables the entries are over, needed to build the zero and the one of the
+        /// same ring. Not derivable from the entries, since a matrix may be all constants.
+        /// </param>
+        /// <param name="maxWork">
+        /// A ceiling on term-pair multiplications, charged <em>before</em> each multiplication
+        /// rather than after, so that the budget cannot be overshot by the one step that was
+        /// going to be the most expensive of them.
+        /// </param>
+        internal static MultivariatePolynomial? Of(
+            MultivariatePolynomial[][] matrix, int variableCount, long maxWork)
+        {
+            var size = matrix.Length;
+            if (size == 0)
+                return MultivariatePolynomial.One(variableCount);
+
+            var zero = MultivariatePolynomial.Zero(variableCount);
+            var negated = false;
+            var work = 0L;
+            var previous = MultivariatePolynomial.One(variableCount);
+
+            for (var pivot = 0; pivot + 1 < size; pivot++)
+            {
+                MultithreadingFunctional.ExitIfCancelled();
+                if (matrix[pivot][pivot].IsZero)
+                {
+                    var replacement = -1;
+                    for (var row = pivot + 1; row < size && replacement < 0; row++)
+                        if (!matrix[row][pivot].IsZero)
+                            replacement = row;
+                    // Nothing below the pivot to bring up means the column is a combination
+                    // of the ones before it, so the matrix is singular and its determinant
+                    // is zero. That is an answer, not a failure.
+                    if (replacement < 0)
+                        return zero;
+                    (matrix[pivot], matrix[replacement]) = (matrix[replacement], matrix[pivot]);
+                    negated = !negated;
+                }
+                var head = matrix[pivot][pivot];
+                for (var row = pivot + 1; row < size; row++)
+                {
+                    MultithreadingFunctional.ExitIfCancelled();
+                    var leading = matrix[row][pivot];
+                    for (var column = pivot + 1; column < size; column++)
+                    {
+                        work += (long)head.TermCount * matrix[row][column].TermCount
+                            + (long)leading.TermCount * matrix[pivot][column].TermCount;
+                        if (work > maxWork)
+                            return null;
+                        if (head.Multiply(matrix[row][column]) is not { } kept
+                            || leading.Multiply(matrix[pivot][column]) is not { } removed
+                            || kept.Subtract(removed).DivideExact(previous) is not { } reduced)
+                            return null;
+                        matrix[row][column] = reduced;
+                    }
+                    matrix[row][pivot] = zero;
+                }
+                previous = head;
+            }
+
+            var determinant = matrix[size - 1][size - 1];
+            return negated ? determinant.ScaleBy(MinusOne) : determinant;
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialDeterminant.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialDeterminant.cs
@@ -1,0 +1,118 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static AngouriMath.Entity;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// The determinant of a matrix whose entries are polynomials over the rationals, by
+    /// Bareiss' fraction-free elimination — <c>O(n^3)</c> where Laplace expansion is
+    /// <c>O(n!)</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Laplace is not merely slower. For a <b>fully symbolic</b> matrix it is optimal, because
+    /// the determinant genuinely has <c>n!</c> terms and no algorithm returns it smaller in
+    /// expanded form. For a <b>numeric</b> one it is pure waste: the answer is a single number
+    /// and <c>O(n^3)</c> work suffices. That is the split
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/999">#999</a> asks for, and
+    /// what decides it is not the size but whether the entries are polynomials this can read —
+    /// which is settled per matrix, by trying, rather than by a rule about <c>n</c>.
+    /// </para>
+    /// <para>
+    /// <b>Why this cannot introduce a condition.</b> Bareiss divides, and the usual reason to
+    /// distrust an elimination is that its divisions leave quotients excluding the points where
+    /// a pivot vanishes — the defect
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/992">#992</a> was about. Its
+    /// divisions are exact over an integral domain, and here they are exact <em>and checked</em>:
+    /// the arithmetic happens in <see cref="MultivariatePolynomial"/>, which has no quotients to
+    /// leave behind at all, and a division that does not come out returns null and sends the
+    /// caller to Laplace. So the answer is a polynomial in the entries, or it is Laplace's.
+    /// </para>
+    /// <para>
+    /// <b>What it declines.</b> An entry that is not a polynomial over the rationals — anything
+    /// with <c>sin</c>, a symbolic exponent, a genuine <c>1/x</c> — a matrix in more than
+    /// <see cref="MultivariatePolynomial.MaxVariables"/> indeterminates, and a matrix mentioning
+    /// a <see cref="Entity.Constant"/>, since <c>e</c> and <c>pi</c> are values rather than
+    /// indeterminates and this ring cannot hold them. Each is a refusal to try, not a wrong
+    /// answer, and Laplace answers them exactly as before.
+    /// </para>
+    /// </remarks>
+    internal static class PolynomialDeterminant
+    {
+        /// <summary>
+        /// A ceiling on term-pair multiplications, past which this declines and Laplace answers
+        /// instead.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately far above <c>PolynomialResultant</c>'s, and for a different reason.
+        /// There, exceeding the budget means the resultant is not computed at all and a caller
+        /// loses an answer. Here it means falling back to an algorithm that also answers, so a
+        /// generous budget risks only spending longer before choosing the other method — and the
+        /// case this exists for, a large mostly-numeric matrix, is one where Laplace would not
+        /// have finished at all.
+        /// </remarks>
+        private const long MaxEliminationWork = 50_000_000;
+
+        /// <summary>
+        /// The determinant of the <paramref name="size"/>-by-<paramref name="size"/> matrix whose
+        /// entries are <paramref name="at"/>, or <see langword="null"/> where this method does
+        /// not apply and the caller should use another.
+        /// </summary>
+        internal static Entity? Of(int size, Func<int, int, Entity> at)
+        {
+            if (size == 0)
+                return null;
+
+            // The variables of the whole matrix, in a fixed order, so that every entry is read
+            // into the same ring. Ordered by name rather than by encounter: the packed monomial
+            // addresses a variable by index, so two entries disagreeing about which index a name
+            // has would be a wrong answer rather than a failure.
+            //
+            // The Variable objects themselves are kept, not their names: a name is not
+            // guaranteed to parse back to the variable it came from -- `x2` reads as `x ^ 2`,
+            // which is the implicit-power rule the grammar has for a reason -- so going through
+            // MathS.Var would throw on a name a caller is perfectly entitled to have built.
+            var byName = new SortedSet<Variable>(
+                Comparer<Variable>.Create(
+                    (left, right) => string.CompareOrdinal(left.Name, right.Name)));
+            for (var row = 0; row < size; row++)
+                for (var column = 0; column < size; column++)
+                    foreach (var variable in at(row, column).Vars)
+                        byName.Add(variable);
+            if (byName.Count > MultivariatePolynomial.MaxVariables)
+                return null;
+
+            var variables = byName.ToList();
+            var index = new Dictionary<Variable, int>();
+            for (var i = 0; i < variables.Count; i++)
+                index[variables[i]] = i;
+
+            var matrix = new MultivariatePolynomial[size][];
+            for (var row = 0; row < size; row++)
+            {
+                matrix[row] = new MultivariatePolynomial[size];
+                for (var column = 0; column < size; column++)
+                {
+                    if (MultivariatePolynomial.TryParse(at(row, column), index)
+                        is not { } parsed)
+                        return null;
+                    matrix[row][column] = parsed;
+                }
+            }
+
+            if (FractionFreeDeterminant.Of(matrix, variables.Count, MaxEliminationWork)
+                is not { } determinant)
+                return null;
+            return determinant.ToEntity(variables);
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialResultant.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialResultant.cs
@@ -254,54 +254,10 @@ namespace AngouriMath.Functions
                     if (rightCoefficients.TryGetValue(power, out var coefficient))
                         matrix[rightDegree + row][row + rightDegree - power] = coefficient;
 
-            var negated = false;
-            var work = 0L;
-            var previous = MultivariatePolynomial.One(variableCount);
-            for (var pivot = 0; pivot + 1 < size; pivot++)
-            {
-                MultithreadingFunctional.ExitIfCancelled();
-                if (matrix[pivot][pivot].IsZero)
-                {
-                    var replacement = -1;
-                    for (var row = pivot + 1; row < size && replacement < 0; row++)
-                        if (!matrix[row][pivot].IsZero)
-                            replacement = row;
-                    // Nothing below the pivot to bring up means the column is a combination
-                    // of the ones before it, so the matrix is singular and its determinant
-                    // is zero. That is an answer, not a failure: the two polynomials have a
-                    // common factor.
-                    if (replacement < 0)
-                        return zero;
-                    (matrix[pivot], matrix[replacement]) = (matrix[replacement], matrix[pivot]);
-                    negated = !negated;
-                }
-                var head = matrix[pivot][pivot];
-                for (var row = pivot + 1; row < size; row++)
-                {
-                    MultithreadingFunctional.ExitIfCancelled();
-                    var leading = matrix[row][pivot];
-                    for (var column = pivot + 1; column < size; column++)
-                    {
-                        // Charged before the multiplication rather than after it, so that the
-                        // budget cannot be overshot by the one step that was going to be the
-                        // most expensive of them.
-                        work += (long)head.TermCount * matrix[row][column].TermCount
-                            + (long)leading.TermCount * matrix[pivot][column].TermCount;
-                        if (work > MaxEliminationWork)
-                            return null;
-                        if (head.Multiply(matrix[row][column]) is not { } kept
-                            || leading.Multiply(matrix[pivot][column]) is not { } removed
-                            || kept.Subtract(removed).DivideExact(previous) is not { } reduced)
-                            return null;
-                        matrix[row][column] = reduced;
-                    }
-                    matrix[row][pivot] = zero;
-                }
-                previous = head;
-            }
-
-            var determinant = matrix[size - 1][size - 1];
-            return negated ? determinant.ScaleBy(MinusOne) : determinant;
+            // The elimination itself is shared with Entity.Matrix.Determinant, which
+            // wants exactly this over an ordinary square matrix rather than a Sylvester
+            // one. https://github.com/asc-community/AngouriMath/issues/999
+            return FractionFreeDeterminant.Of(matrix, variableCount, MaxEliminationWork);
         }
     }
 }

--- a/Sources/Tests/UnitTests/Algebra/Polynomials/FractionFreeDeterminantTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/Polynomials/FractionFreeDeterminantTest.cs
@@ -1,0 +1,203 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using AngouriMath.Extensions;
+using AngouriMath.Functions;
+using Xunit;
+
+namespace AngouriMath.Tests.Algebra.Polynomials
+{
+    /// <summary>
+    /// The determinant by Bareiss' fraction-free elimination, and its agreement with Laplace
+    /// expansion wherever both apply.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/999">#999</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two algorithms for one quantity is how a library acquires a case where they differ, so
+    /// the agreement is generated rather than listed — and compared as a difference that
+    /// simplifies to zero rather than as trees, because the two group the same polynomial
+    /// differently and that is not a disagreement.
+    /// </para>
+    /// <para>
+    /// The other half is that a matrix this cannot read is <em>declined</em> rather than
+    /// answered wrongly. Both directions are asserted: what it takes, and what it refuses.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Algebra")]
+    public sealed class FractionFreeDeterminantTest
+    {
+        private static Entity.Matrix Parse(string source) => (Entity.Matrix)source.ToEntity();
+
+        private static Entity? ByElimination(Entity.Matrix matrix)
+            => PolynomialDeterminant.Of(matrix.RowCount, (row, column) => matrix[row, column]);
+
+        /// <summary>
+        /// The determinants everybody knows, so that a sign convention cannot be wrong in a way
+        /// only a generated comparison would notice.
+        /// </summary>
+        [Theory]
+        [InlineData("[[1, 2], [3, 4]]", "-2")]
+        [InlineData("[[a, b], [c, d]]", "a * d - b * c")]
+        [InlineData("[[0, 1], [1, 0]]", "-1")]
+        [InlineData("[[1, 1], [1, 1]]", "0")]
+        [InlineData("[[x, 1], [1, x]]", "x ^ 2 - 1")]
+        [InlineData("[[x, 1, 0], [1, x, 1], [0, 1, x]]", "x ^ 3 - 2 * x")]
+        [InlineData("[[1/2, 1/3], [1/4, 1/5]]", "1/60")]
+        [InlineData("[[2, 0, 0], [0, 3, 0], [0, 0, 5]]", "30")]
+        public void TheDeterminantIsWhatItShouldBe(string source, string expected)
+            => Assert.Equal(expected.ToEntity(), Parse(source).Determinant);
+
+        /// <summary>
+        /// A row swap is needed when a pivot vanishes, and getting its sign wrong is the classic
+        /// way to write an elimination that is right on most inputs. The first column here is
+        /// zero at the top, so the swap happens.
+        /// </summary>
+        [Theory]
+        [InlineData("[[0, 1], [1, 0]]", "-1")]
+        [InlineData("[[0, 2], [3, 0]]", "-6")]
+        [InlineData("[[0, 0, 1], [0, 1, 0], [1, 0, 0]]", "-1")]
+        [InlineData("[[0, 1, 0], [0, 0, 1], [1, 0, 0]]", "1")]
+        public void ARowSwapCarriesItsSign(string source, string expected)
+            => Assert.Equal(expected.ToEntity(), Parse(source).Determinant);
+
+        /// <summary>
+        /// A singular matrix is zero rather than a failure — a whole column with nothing to
+        /// bring up is an answer.
+        /// </summary>
+        [Theory]
+        [InlineData("[[0, 0], [0, 0]]")]
+        [InlineData("[[0, 1], [0, 2]]")]
+        [InlineData("[[1, 2], [2, 4]]")]
+        [InlineData("[[a, a], [b, b]]")]
+        public void ASingularMatrixIsZero(string source)
+            => Assert.Equal(Entity.Number.Integer.Zero, Parse(source).Determinant);
+
+        /// <summary>
+        /// What the elimination declines, and why. Each is a refusal to try rather than a wrong
+        /// answer, and <see cref="Entity.Matrix.Determinant"/> still answers all of them by
+        /// Laplace expansion.
+        /// </summary>
+        [Theory]
+        // Not a polynomial over the rationals.
+        [InlineData("[[sin(x), 1], [1, cos(x)]]")]
+        [InlineData("[[1 / x, 1], [1, x]]")]
+        [InlineData("[[2 ^ x, 1], [1, 1]]")]
+        // A constant is a value, not an indeterminate, and this ring cannot hold one.
+        [InlineData("[[e, 1], [1, e]]")]
+        [InlineData("[[pi, 1], [1, 1]]")]
+        public void WhatItCannotReadItDeclines(string source)
+        {
+            var matrix = Parse(source);
+            Assert.Null(ByElimination(matrix));
+            // And the caller still gets an answer, from the other method.
+            Assert.NotNull(matrix.Determinant);
+        }
+
+        /// <summary>
+        /// More indeterminates than the packed monomial has room for is also a decline. Nine
+        /// distinct names, so this is one past the ceiling.
+        /// </summary>
+        [Fact]
+        public void MoreVariablesThanTheRingHoldsIsDeclined()
+        {
+            var cells = new Entity[3, 3];
+            // Single letters, and none of them e, i or pi: a name ending in a digit is not a
+            // variable at all -- `q1` parses as `q ^ 1` -- and a constant would be declined for
+            // the other reason, which would make this test pass for the wrong one.
+            var names = new[] { "q", "r", "s", "t", "u", "v", "w", "y", "z" };
+            for (var row = 0; row < 3; row++)
+                for (var column = 0; column < 3; column++)
+                    cells[row, column] = MathS.Var(names[row * 3 + column]);
+            var matrix = MathS.Matrix(cells);
+
+            Assert.Null(ByElimination(matrix));
+            Assert.NotNull(matrix.Determinant);
+        }
+
+        /// <summary>
+        /// The two algorithms agree on every matrix where both apply. Generated, because the
+        /// disagreements worth finding are the ones nobody thought to write down, and
+        /// deterministic, so a failure reproduces.
+        /// </summary>
+        [Fact]
+        public void EliminationAgreesWithLaplaceWhereverBothApply()
+        {
+            var random = new Random(4242);
+            var names = new[] { "a", "b", "c" };
+            var compared = 0;
+            var disagreements = new List<string>();
+
+            for (var trial = 0; trial < 300; trial++)
+            {
+                var size = 2 + trial % 3;
+                var cells = new Entity[size, size];
+                for (var row = 0; row < size; row++)
+                    for (var column = 0; column < size; column++)
+                        cells[row, column] = random.Next(0, 4) == 0
+                            ? MathS.Var(names[random.Next(0, names.Length)])
+                            : random.Next(-4, 5);
+                var matrix = MathS.Matrix(cells);
+
+                if (ByElimination(matrix) is not { } byElimination)
+                    continue;
+                compared++;
+                var byLaplace = matrix.InnerMatrix.DeterminantLaplace().InnerSimplified;
+                if ((byElimination - byLaplace).Simplify() != 0)
+                    disagreements.Add($"{matrix.Stringize()}: "
+                        + $"{byElimination.Stringize()} vs {byLaplace.Stringize()}");
+            }
+
+            Assert.True(disagreements.Count == 0,
+                $"of {compared} matrices where both apply, these disagree:\n  "
+                + string.Join("\n  ", disagreements));
+            // Not an assertion about the generator's luck -- an assertion that it generated
+            // anything at all, so that a change making the elimination decline everything would
+            // fail here rather than pass vacuously.
+            Assert.True(compared > 100,
+                $"only {compared} of 300 generated matrices were read by the elimination");
+        }
+
+        /// <summary>
+        /// The size the issue is about. Laplace is <c>O(n!)</c>, so a 10×10 took about fourteen
+        /// seconds and an 11×11 did not return; this is the same work in milliseconds.
+        /// </summary>
+        /// <remarks>
+        /// A timing is not asserted — this machine is not that machine. What is asserted is the
+        /// answer, at a size where the previous algorithm could not produce one at all, which is
+        /// the claim that matters and does not depend on a clock.
+        /// </remarks>
+        [Theory]
+        [InlineData(11)]
+        [InlineData(14)]
+        [InlineData(20)]
+        public void ALargeNumericMatrixHasADeterminant(int size)
+        {
+            var cells = new Entity[size, size];
+            for (var row = 0; row < size; row++)
+                for (var column = 0; column < size; column++)
+                    cells[row, column] = row == column ? 2 : 1;
+            // A matrix of ones with 2 on the diagonal has determinant n + 1.
+            Assert.Equal((Entity)(size + 1), MathS.Matrix(cells).Determinant);
+        }
+
+        /// <summary>
+        /// And the elimination is what answered it, rather than Laplace having got quick.
+        /// </summary>
+        [Fact]
+        public void ALargeNumericMatrixIsTheEliminationsToAnswer()
+        {
+            var cells = new Entity[11, 11];
+            for (var row = 0; row < 11; row++)
+                for (var column = 0; column < 11; column++)
+                    cells[row, column] = row == column ? 2 : 1;
+            Assert.NotNull(ByElimination(MathS.Matrix(cells)));
+        }
+    }
+}


### PR DESCRIPTION
Closes [#999](https://github.com/asc-community/AngouriMath/issues/999).

## The ceiling, removed

Both arms built from source on one machine:

| | before | now |
|---|---|---|
| numeric 8×8 | 382 ms | under 1 ms |
| numeric 10×10 | 14 415 ms | 2 ms |
| numeric 11×11 | **did not return in four minutes** | 2 ms |
| numeric 12×12 | did not return | 3 ms |
| numeric 20×20 | did not return | 11 ms |
| numeric 30×30 | did not return | 22 ms |

Bareiss' fraction-free elimination runs wherever the entries are polynomials over the rationals; Laplace answers everything else. **The switch is decided by the entries, not by `n`** — as the issue asks, since a 12×12 with two variables and a 4×4 with sixteen are different problems. It is settled per matrix, by trying.

## The elimination was already in the repository

`PolynomialResultant.SylvesterDeterminant` is a Bareiss elimination over `MultivariatePolynomial`, written for the Sylvester matrix and already carrying exact division, row swaps, sign tracking, a work budget and a cancellation check. It is split out into `FractionFreeDeterminant` and shared rather than written twice.

That is worth stating rather than doing quietly: a sign convention or an off-by-one in an elimination is a wrong answer that looks entirely plausible, and one implementation exercised by two callers is tested by both.

## The condition question, which is the one the issue says to check rather than argue

> exactness is a fact about the ring, not something `Entity` division notices: `(a * b) / a` stays written as a quotient unless something cancels it

Right — and the answer is that this arithmetic never touches `Entity` division. It happens in `MultivariatePolynomial`, which has no quotients to leave behind at all, and `DivideExact` returns **null rather than a remainder**. So a division that does not come out stops the elimination and sends the caller to Laplace. The answer is a polynomial in the entries, or it is Laplace's; there is no third outcome in which a quotient survives to exclude a point.

That is the property #992 was about, and it is why `Determinant` used Laplace in the first place: an *ordinary* Gaussian elimination leaves its pivots as literal divisions, so its answer is undefined wherever a pivot vanishes — at points where the determinant is perfectly well defined.

## What it declines

Each is a refusal to try, not a wrong answer, and Laplace answers all of them exactly as before:

- an entry that is not a polynomial over the rationals — `sin(x)`, `1 / x`, `2 ^ x`
- more than eight indeterminates, which is what the packed monomial holds
- a matrix mentioning `e` or `pi`: a constant is a **value**, not an indeterminate, and this ring cannot hold one

## Measured

**The two algorithms agree on 300 generated matrices where both apply, with no disagreements** — compared as a difference that simplifies to zero rather than as trees, since they group the same polynomial differently and that is not a disagreement. The test also asserts it read more than a third of what it generated, so a change that made the elimination decline everything fails here rather than passing vacuously.

The printed form of a symbolic determinant changes, because an elimination produces an expanded polynomial where Laplace produces a nested one. Recorded in `BREAKING-CHANGES.md` with both arms measured. The expression is **no larger in any case measured**:

| | before | now |
|---|---|---|
| `[[a, b], [c, d]]` | `a * d + -b * c` | `a * d - b * c` |
| `[[x, 1, 0], [1, x, 1], [0, 1, x]]` | `x * (x ^ 2 + -1) + -x` | `x ^ 3 - 2 * x` |
| `[[x, 1], [1, x]]`, `[[1/2, 1/3], [1/4, 1/5]]` | | unchanged |

`Failed: 0, Passed: 9154, Skipped: 14` locally on net10.0.

## One thing found on the way

Collecting the matrix's variables by *name* and rebuilding them with `MathS.Var` throws on names a caller is entitled to have built — `x2` parses back as `x ^ 2`, which is the implicit-power rule the grammar has for a reason. The `Variable` objects are kept instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
