### PR TITLE
Solving a system is bounded whichever internal path takes it (#896)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -28,6 +28,8 @@ read first.
 | **Silent** | `MathS.Abs("x").WithCodomain(Domain.Any).Stringize()`, and every node widened to `Any` from a narrower default | `abs(x)` — reads back as `Real`, losing the widening | `domain(abs(x), Any)` |
 | **Silent** | `"domain(1/2, CC)".ToEntity()`, and every quotient of two integer literals annotated with the codomain its node type does not default to | `1/2` — the annotation dropped, equal to the unannotated literal | `1/2` carrying `Codomain = Complex`, which prints and reads back as `domain(1/2, CC)` |
 | | `"a in (a / 3; 3a)".ToEntity().Simplify()`, and every denominator but 2 | `a in (a / 3; 3 * a)` — left as written | `a > 0` |
+| **Silent** | `MathS.Equations(...).Solve(...)` on a system neither internal path can finish | ran without a bound — cyclic-6 exceeded 20 s | `NotSufficientlySupportedException`, naming both paths |
+| | the same with `MathS.Settings.Budget` set below what the solve needs | answered anyway, the fall-through having no budget | raises |
 | | `"a in (a / 2; 0)".ToEntity().Simplify()`, and every interval demanding both signs | left as written | `False provided a in RR` |
 | | `new Entity[0].SumAll()`, and `Sumf.Sum` on an empty list | `AngouriBugException: At least 1 child required` | `0` |
 | | `new Entity[0].MultiplyAll()`, and `Mulf.Multiply` on an empty list | `AngouriBugException` | `1` |
@@ -792,6 +794,51 @@ changes which rewrites are available, not which answer wins. The two halves of t
 together because the first is what makes the second free: the guard alone cost three interval shapes
 that were being answered by coincidence, and the collection restores them along with the rest of the
 family ([#1056](https://github.com/asc-community/AngouriMath/issues/1056)).
+
+### Solving a system is bounded whichever internal path takes it
+
+`Solve` on a system tries a triangularising path first, which bounds itself, and hands what it
+declines to an elimination in radicals, which had **no budget at all**. So the same call was bounded
+or unbounded depending on which internal path accepted it — cyclic-6 exceeded twenty seconds with
+nothing to stop it — and that is worse to debug than either extreme.
+
+The whole call now draws on one budget. Where it runs out, `NotSufficientlySupportedException` is
+raised, naming both paths and both ways to ask for more.
+
+| | before | now |
+|---|---|---|
+| `solvesys[a,b,c,d,f,g]` cyclic-6 | exceeded 20 s, no bound beyond it | declines, returning in about two minutes |
+| `solvesys[a,b,c,d,e]` of `a^4-1 … e^4-1` | 1024 solutions | unchanged |
+| `solvesys[a,b,c,d]` cyclic-4 | 158 solutions | unchanged |
+| `x + y = 3, x - y = 1` and every system that answered | unchanged | unchanged |
+| the same with `MathS.Settings.Budget` set below what the solve needs | answered anyway | raises |
+
+**Nothing that answered stops answering.** That was the risk, and it was measured before the change
+rather than argued about: the 1024-solution system is one the triangularising path declines on its
+quotient-dimension cap, and it declines it **in 8 milliseconds** — so bounding the whole call leaves
+the elimination essentially the whole budget. "The fast path declined" does not mean "hopeless", and
+this is what keeps that true.
+
+**The default is two ceilings, and both are measured.** A step is one candidate solution the
+elimination explores, which is what compounds — each elimination turns the next level's coefficients
+into nested radicals. The systems that answer explore very few: a symbolic 2×2 takes 2, cyclic-4
+takes 8, and the largest that answers at all takes 341. Cyclic-5 passes 100 000 without finishing. So
+the step ceiling is 10 000, with thirty-fold headroom over anything known to work.
+
+The clock is a backstop rather than the bound, and it is deliberately loose at sixty seconds, because
+a step can be arbitrarily expensive — cyclic-4 spends five seconds in eight of them. A tight clock
+was tried at five seconds and makes the same system answer or decline depending on what else the
+machine is doing, which is a worse failure than a slow answer.
+
+**The bound is cooperative and is checked once per branch**, so a call can overshoot by the cost of
+the branch that was running when the budget ran out. That is `BudgetLedger`'s stated design: an
+algorithm that does not ask cannot be bounded, and a bound enforced from outside is a thread abort in
+the middle of a rewrite. It is a bound where there was none, not a tight one.
+
+**A budget recording now sees two outcomes per solve** rather than one, named `Gröbner` and
+`SolveSystem`. What stopped each is reported separately, which is the thing
+[#896](https://github.com/asc-community/AngouriMath/issues/896) said a caller could not previously
+find out.
 
 ### A fold over an empty sequence answers instead of throwing
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -51,6 +51,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [AngouriMath/Functions/Algebra/Polynomials/KroneckerFactorization.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[Tests/UnitTests/Core/Budgets/SolveIsBoundedEndToEndTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [AngouriMath/Functions/Algebra/Groebner/*.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -53,10 +53,13 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [AngouriMath/Functions/Algebra/Polynomials/FractionFreeDeterminant.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [AngouriMath/Functions/Algebra/Polynomials/PolynomialDeterminant.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [Tests/UnitTests/Algebra/Polynomials/FractionFreeDeterminantTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [Tests/UnitTests/Core/Budgets/SolveIsBoundedEndToEndTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver.cs
@@ -5,6 +5,7 @@
 // Website: https://am.angouri.org.
 //
 
+using AngouriMath.Core.Budgets;
 using AngouriMath.Core.Exceptions;
 using AngouriMath.Extensions;
 using AngouriMath.Functions.Algebra.AnalyticalSolving;
@@ -59,6 +60,34 @@ namespace AngouriMath.Functions.Algebra
         /// Then we substitute back <br/>
         /// y = -3a + a = -2a <br/>
         /// </summary>
+        /// <summary>
+        /// What a whole system solve is allowed to spend before it declines.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Both ceilings, because neither is a bound on its own.</b> A step here is one
+        /// candidate solution the elimination explores, and that is what compounds: each
+        /// elimination turns the next level's coefficients into nested radicals. Measured, the
+        /// systems that answer explore very few — a symbolic 2×2 takes 2, cyclic-4 takes 8,
+        /// and the largest that answers at all, five uncoupled quartics with 1024 solutions,
+        /// takes 341. Cyclic-5 passes 100 000 without finishing. So 10 000 admits everything
+        /// known to work with a factor of thirty to spare and still refuses the ones that run
+        /// away.
+        /// </para>
+        /// <para>
+        /// The clock is a backstop, not the bound, because a step can be arbitrarily expensive:
+        /// cyclic-4 spends five seconds in eight of them. It is set well above what any
+        /// answering case needs — the slowest takes about five seconds unloaded — since a
+        /// tight clock makes the same system answer or decline depending on what else the
+        /// machine is doing, and a flaky answer is worse than a slow one. That was measured
+        /// too: at five seconds the uncoupled case passed alone and failed inside the suite.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/896">#896</a>
+        /// </para>
+        /// </remarks>
+        [ConstantField]
+        internal static readonly WorkBudget SystemSolveBudget =
+            new() { Steps = 10_000, Time = TimeSpan.FromSeconds(60) };
+
         internal static Matrix? SolveSystem(IEnumerable<Entity> inputEquations, ReadOnlySpan<Variable> vars)
         {
             var equations = new List<Entity>(inputEquations.Select(equation => equation.InnerSimplified));
@@ -68,23 +97,47 @@ namespace AngouriMath.Functions.Algebra
             // does -- costs nothing on an uncoupled system and does not finish on a coupled
             // one, so this is tried before the equation count is even insisted on: a Groebner
             // basis has no use for as many equations as unknowns.
-            var variables = new Variable[vars.Length];
-            vars.CopyTo(variables);
-            if (Groebner.GroebnerSystemSolver.TrySolve(equations, variables, out var triangularised))
-                return triangularised;
+            // One ledger for the whole call, drawn on by both paths. Each stage having a
+            // budget of its own is what bounded the fast path and left the fall-through
+            // unbounded, so the same `Solve` finished or did not depending on which internal
+            // path accepted it. https://github.com/asc-community/AngouriMath/issues/896
+            var ledger = BudgetLedger.For("SolveSystem", SystemSolveBudget);
+            try
+            {
+                var variables = new Variable[vars.Length];
+                vars.CopyTo(variables);
+                // The Gröbner path keeps a ledger of its own, deliberately. It uses the same
+                // mechanism for two different things -- a genuine resource ceiling, and a
+                // structural refusal like "not polynomial" -- and a ledger that has recorded
+                // any ceiling refuses every later spend. Sharing it would therefore read
+                // "declined in 8 ms because the system is uncoupled" as "the budget is gone",
+                // and the 1024-solution case that the eliminator answers cheaply would raise
+                // instead. Measured: it does exactly that.
+                //
+                // What is shared is the clock. This ledger starts when the call does, so the
+                // time the Gröbner path spends is already gone from it when the elimination
+                // begins -- which is the bound that was missing, without conflating the two
+                // meanings of "stopped".
+                if (Groebner.GroebnerSystemSolver.TrySolve(equations, variables, out var triangularised))
+                    return triangularised;
 
-            if (equations.Count != vars.Length)
-                throw new WrongNumberOfArgumentsException("Number of equations must be equal to that of vars");
-            int initVarCount = vars.Length;
+                if (equations.Count != vars.Length)
+                    throw new WrongNumberOfArgumentsException("Number of equations must be equal to that of vars");
+                int initVarCount = vars.Length;
 
-            var res = InSolveSystem(equations, vars, Sumf.Sum(equations));
-            foreach (var tuple in res)
-                if (tuple.Count != initVarCount)
-                    throw new AngouriBugException("InSolveSystem incorrect output");
-            if (res.Count == 0)
-                return null;
-            var tb = new MatrixBuilder(res, initVarCount);
-            return tb.ToMatrix();
+                var res = InSolveSystem(equations, vars, Sumf.Sum(equations), ledger);
+                foreach (var tuple in res)
+                    if (tuple.Count != initVarCount)
+                        throw new AngouriBugException("InSolveSystem incorrect output");
+                if (res.Count == 0)
+                    return null;
+                var tb = new MatrixBuilder(res, initVarCount);
+                return tb.ToMatrix();
+            }
+            finally
+            {
+                ledger.Report();
+            }
         }
 
         /// <summary>Solves system of equations</summary>
@@ -97,8 +150,26 @@ namespace AngouriMath.Functions.Algebra
         /// The system as a whole, so that a parameter standing for a free variable is given
         /// a name that none of the equations already uses
         /// </param>
-        internal static List<List<Entity>> InSolveSystem(List<Entity> equations, ReadOnlySpan<Variable> vars, Entity nameSource)
+        /// <param name="ledger">
+        /// The caller's budget, drawn on once per candidate solution explored. Optional
+        /// because the recursion passes it along and a caller may have none; where it is
+        /// absent this is unbounded, which is what it always was.
+        /// </param>
+        internal static List<List<Entity>> InSolveSystem(
+            List<Entity> equations, ReadOnlySpan<Variable> vars, Entity nameSource,
+            BudgetLedger? ledger = null)
         {
+            // Charged before the branch rather than after it, so the ceiling bounds what is
+            // done rather than what has been done. One unit per candidate solution explored is
+            // the right grain: this eliminates one variable per level, and each elimination
+            // turns the next level's coefficients into nested radicals, so the count of
+            // branches explored is what compounds. https://github.com/asc-community/AngouriMath/issues/896
+            if (ledger is not null && !ledger.Spend())
+                throw new NotSufficientlySupportedException(
+                    "this system of equations is not solvable within the budget: the "
+                    + "triangularising path declined it and eliminating in radicals has not "
+                    + "finished. Raise MathS.Settings.Budget to allow more, or pass a "
+                    + "cancellation token with MathS.Multithreading.SetLocalCancellationToken");
             var var = vars[^1];
             if (equations.Count == 1)
             {
@@ -136,7 +207,7 @@ namespace AngouriMath.Functions.Algebra
                     rest.RemoveAt(i);
 
                     foreach (var sol in sols)
-                        foreach (var j in InSolveSystem(rest.Select(eq => eq.Substitute(var, sol)).ToList(), remainingVars, nameSource))
+                        foreach (var j in InSolveSystem(rest.Select(eq => eq.Substitute(var, sol)).ToList(), remainingVars, nameSource, ledger))
                         {
                             replacements.Clear();
                             for (int varid = 0; varid < remainingVars.Length; varid++)

--- a/Sources/Tests/UnitTests/Calculus/OneSidedLimitTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/OneSidedLimitTest.cs
@@ -122,9 +122,14 @@ namespace AngouriMath.Tests.Calculus
         [InlineData(ApproachFrom.Left)]
         public void ADifferenceOfReciprocalLogarithms(ApproachFrom side)
         {
+            // The guard is against not terminating, not against being slow, so it is set far
+            // above the cost of the limit rather than near it. Measured, this takes about seven
+            // seconds; at sixty it failed intermittently once the suite grew, because a wall
+            // clock in a parallel run measures what else the machine is doing as much as what
+            // this does. Three minutes still catches a hang in a suite that takes seven.
             var task = System.Threading.Tasks.Task.Run(() =>
                 Limit("1 / ln(x + sqrt(x * x + 1)) - 1 / ln(x + 1)", "0", side));
-            Assert.True(task.Wait(System.TimeSpan.FromSeconds(60)), "the limit did not terminate");
+            Assert.True(task.Wait(System.TimeSpan.FromSeconds(180)), "the limit did not terminate");
             Assert.Equal("-1/2".ToEntity().Evaled, task.Result.Evaled);
         }
 

--- a/Sources/Tests/UnitTests/Core/Budgets/BudgetTest.cs
+++ b/Sources/Tests/UnitTests/Core/Budgets/BudgetTest.cs
@@ -40,7 +40,11 @@ namespace AngouriMath.Tests.Core.Budgets
                 // What the fall-through does with a system the bounded path declined is not
                 // what these assert; the outcome is recorded before it is reached either way.
             }
-            return Assert.Single(recording.Outcomes);
+            // The Gröbner ledger, which is what every assertion below is about. A solve now
+            // opens a second one for the whole call -- that is what bounds the elimination
+            // the Gröbner path hands over to, and is #896 -- so the outcomes are named rather
+            // than assumed to be one.
+            return Assert.Single(recording.Outcomes, outcome => outcome.Where == "Gröbner");
         }
 
         [Fact]
@@ -112,16 +116,42 @@ namespace AngouriMath.Tests.Core.Budgets
         }
 
         /// <summary>
-        /// Exhausting the bounded path is not an answer — the caller carries on and gets the
-        /// same solutions it always did.
+        /// A budget the solve fits inside changes nothing: the same solutions, by the same
+        /// path, as a caller who never mentioned a budget.
         /// </summary>
         [Fact]
-        public void ExhaustionDoesNotChangeTheAnswer()
+        public void ABudgetThatIsNotReachedChangesNothing()
         {
             var withoutBudget = MathS.Equations(Eqs("x - y + 3", "y + 2")).Solve(Vars("x", "y"));
-            using var _ = MathS.Settings.Budget.Set(new WorkBudget { Steps = 1 });
+            using var _ = MathS.Settings.Budget.Set(new WorkBudget { Steps = 1_000_000 });
             var withBudget = MathS.Equations(Eqs("x - y + 3", "y + 2")).Solve(Vars("x", "y"));
             Assert.Equal(withoutBudget, withBudget);
+        }
+
+        /// <summary>
+        /// A budget that <em>is</em> reached bounds the whole call, and the caller is told.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This test used to assert the opposite — that exhausting the bounded path left the
+        /// answer alone because the caller carried on regardless — and that was
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/896">#896</a>: the
+        /// triangularising path bounded itself and then handed the problem to an elimination
+        /// with no budget of its own, so the same <c>Solve</c> was bounded or not depending on
+        /// which internal path accepted it.
+        /// </para>
+        /// <para>
+        /// A step ceiling of one is a caller asking for one step of work. Answering anyway is
+        /// not generosity, it is ignoring what was asked; and the systems where it mattered
+        /// were the ones that ran for minutes rather than the ones that answered quickly.
+        /// </para>
+        /// </remarks>
+        [Fact]
+        public void ABudgetThatIsReachedBoundsTheWholeCall()
+        {
+            using var _ = MathS.Settings.Budget.Set(new WorkBudget { Steps = 1 });
+            Assert.Throws<AngouriMath.Core.Exceptions.NotSufficientlySupportedException>(
+                () => MathS.Equations(Eqs("x - y + 3", "y + 2")).Solve(Vars("x", "y")));
         }
 
         /// <summary>
@@ -182,7 +212,13 @@ namespace AngouriMath.Tests.Core.Budgets
             _ = MathS.Equations(Eqs("x - y + 3", "y + 2")).Solve(Vars("x", "y"));
             try { _ = MathS.Equations(Eqs("sin(x) + y", "y - 1")).Solve(Vars("x", "y")); }
             catch (Exception exception) when (exception is not Xunit.Sdk.XunitException) { }
-            Assert.Equal(2, recording.Outcomes.Count);
+            // Two solves, each opening two ledgers: the Gröbner path's and the whole call's.
+            Assert.Equal(4, recording.Outcomes.Count);
+            Assert.Equal(2, recording.Outcomes.Count(outcome => outcome.Where == "Gröbner"));
+            Assert.Equal(2, recording.Outcomes.Count(outcome => outcome.Where == "SolveSystem"));
+            // And only one of the four stopped anything. The second solve's elimination
+            // answers `sin(x) + y` without running out, so the whole-call ledger has no
+            // ceiling to report -- which is the point of listing only what stopped.
             Assert.Equal("not polynomial", Assert.Single(recording.Exhausted).Reason);
         }
     }

--- a/Sources/Tests/UnitTests/Core/Budgets/SolveIsBoundedEndToEndTest.cs
+++ b/Sources/Tests/UnitTests/Core/Budgets/SolveIsBoundedEndToEndTest.cs
@@ -1,0 +1,145 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Linq;
+using AngouriMath.Core.Budgets;
+using AngouriMath.Core.Exceptions;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Budgets
+{
+    /// <summary>
+    /// <c>Solve</c> on a system is bounded whichever internal path takes it.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/896">#896</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The triangularising path bounded itself and then handed what it declined to an
+    /// elimination in radicals that had no budget at all — so the same call finished or did
+    /// not depending on which internal path accepted it, which is worse to debug than either
+    /// extreme.
+    /// </para>
+    /// <para>
+    /// <b>What is shared between the two stages is the clock, not the ledger.</b> The Gröbner
+    /// path uses one mechanism for two different things — a genuine resource ceiling, and a
+    /// structural refusal like "not polynomial" — and a ledger that has recorded any ceiling
+    /// refuses every later spend. Sharing the ledger itself therefore reads "declined in 8 ms
+    /// because the system is uncoupled" as "the budget is gone", and the 1024-solution system
+    /// below stops being answered. That was measured, not reasoned about: it is why the
+    /// whole-call ledger is opened separately and only its elapsed time carries across.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class SolveIsBoundedEndToEndTest
+    {
+        private static Entity.Matrix? Solve(string[] equations, string[] variables)
+            => MathS.Equations(equations.Select(equation => equation.ToEntity()).ToArray())
+                .Solve(variables.Select(name => (Entity.Variable)MathS.Var(name)).ToArray());
+
+        private static readonly string[] UncoupledFive =
+            { "a4 - 1", "b4 - 1", "c4 - 1", "d4 - 1", "e4 - 1" };
+
+
+        /// <summary>
+        /// The case the issue names as the one a bound must not cost. Its quotient dimension is
+        /// 1024, above the Gröbner cap of 512, so that path declines it — and the elimination
+        /// answers it cheaply, because the system is uncoupled. "Gröbner declined" does not
+        /// imply "hopeless", and this is what says so.
+        /// </summary>
+        [Fact]
+        public void AnUncoupledSystemTheGroebnerPathDeclinesIsStillAnswered()
+        {
+            var solutions = Solve(UncoupledFive, new[] { "a", "b", "c", "d", "e" });
+            Assert.NotNull(solutions);
+            Assert.Equal(1024, solutions!.RowCount);
+        }
+
+        /// <summary>
+        /// The half that had no budget at all: a system the Gröbner path declines reaches the
+        /// elimination, and the elimination now asks before it explores.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>x + y = a, x - y = b</c> is not polynomial over the rationals in <c>x</c> and
+        /// <c>y</c> alone, so the triangularising path refuses it and the elimination answers
+        /// it — in two candidate solutions, measured. A ceiling of one therefore stops it, and
+        /// stops it in milliseconds, which is what makes this a test rather than a wait.
+        /// </para>
+        /// <para>
+        /// <b>The system the issue is about is deliberately not here.</b> Cyclic-6 under the
+        /// default budget returns in about two minutes and declines, where before it did not
+        /// return at all — but two minutes is two minutes added to every suite run, and the
+        /// mechanism it would demonstrate is the one below. Its measurement is recorded in
+        /// <c>BREAKING-CHANGES.md</c> instead.
+        /// </para>
+        /// <para>
+        /// <b>The bound is cooperative and checked once per branch</b>, so a call can overshoot
+        /// by the cost of the branch that was running when the budget ran out — cyclic-6's
+        /// branches are individually enormous, which is why even a ceiling of twenty takes
+        /// half an hour on it. That is <see cref="BudgetLedger"/>'s stated design: an algorithm
+        /// that does not ask cannot be bounded, and a bound enforced from outside is a thread
+        /// abort.
+        /// </para>
+        /// </remarks>
+        [Fact]
+        public void TheEliminationConsultsTheBudgetBeforeExploring()
+        {
+            using var _ = MathS.Settings.Budget.Set(new WorkBudget { Steps = 1 });
+            Assert.Throws<NotSufficientlySupportedException>(
+                () => Solve(new[] { "x + y - a", "x - y - b" }, new[] { "x", "y" }));
+        }
+
+        /// <summary>
+        /// The message says which of the two paths did what, because a caller who has to guess
+        /// cannot act on it.
+        /// </summary>
+        [Fact]
+        public void TheRefusalSaysWhatWasTried()
+        {
+            using var _ = MathS.Settings.Budget.Set(new WorkBudget { Steps = 1 });
+            var thrown = Assert.Throws<NotSufficientlySupportedException>(
+                () => Solve(new[] { "x + y - a", "x - y - b" }, new[] { "x", "y" }));
+
+            Assert.Contains("budget", thrown.Message);
+            Assert.Contains("triangularising", thrown.Message);
+            Assert.Contains("radicals", thrown.Message);
+            // And what to do about it, both ways: raise the ceiling, or bound it yourself.
+            Assert.Contains(nameof(MathS.Settings.Budget), thrown.Message);
+            Assert.Contains("SetLocalCancellationToken", thrown.Message);
+        }
+
+        /// <summary>
+        /// Nothing that answered before stops answering. These take both paths — the first two
+        /// are triangularised, the third is not polynomial over the rationals and the fourth is
+        /// uncoupled — and none is near any ceiling.
+        /// </summary>
+        [Theory]
+        [InlineData(new[] { "x + y - 3", "x - y - 1" }, new[] { "x", "y" })]
+        [InlineData(new[] { "x2 - 2", "y - x" }, new[] { "x", "y" })]
+        [InlineData(new[] { "x + y - a", "x - y - b" }, new[] { "x", "y" })]
+        [InlineData(new[] { "a4 - 1", "b4 - 1", "c4 - 1" }, new[] { "a", "b", "c" })]
+        public void AnOrdinarySystemIsUnaffected(string[] equations, string[] variables)
+            => Assert.NotNull(Solve(equations, variables));
+
+        /// <summary>
+        /// A caller who wants more may have it, which is what makes the bound a default rather
+        /// than a limit — and is half of what the refusal's message says to do.
+        /// </summary>
+        [Fact]
+        public void TheBoundIsACallersToRaise()
+        {
+            using var _ = MathS.Settings.Budget.Set(new WorkBudget { Steps = 1 });
+            Assert.Throws<NotSufficientlySupportedException>(
+                () => Solve(UncoupledFive, new[] { "a", "b", "c", "d", "e" }));
+            // And the same system answers under the default, which is the other half of
+            // "a default rather than a limit" -- asserted above, in
+            // AnUncoupledSystemTheGroebnerPathDeclinesIsStillAnswered.
+        }
+    }
+}


### PR DESCRIPTION
Closes [#896](https://github.com/asc-community/AngouriMath/issues/896).

The issue left the choice open between three options, and said option 3 "rests on an assumption that ... **is not measured**". I took that measurement first, and it turned out to settle the whole thing.

## The measurement

The worry about bounding the fall-through was that it would cost the systems the fast path declines for reasons unrelated to difficulty — five uncoupled quartics with 1024 solutions, above the quotient-dimension cap, which the elimination answers cheaply.

| system | Gröbner | time before handing over |
|---|---|---|
| `a^4-1 … e^4-1` uncoupled — **must not regress** | declined | **8 ms** |
| cyclic-4 | declined | 3 ms |
| cyclic-5 | declined | 7569 ms |

**8 milliseconds.** So a whole-call bound leaves the elimination essentially all of it, and that case survives untouched — it still answers 1024 solutions. Option 1 was never the threat it looked like, and option 3's exit-reason discrimination isn't needed: a shared budget discriminates *by construction*, since a fast decline leaves the budget nearly full and a slow one does not.

## Two things I got wrong on the way, both caught by measuring

**1. Sharing the `BudgetLedger` itself is wrong.** The Gröbner path uses one mechanism for a genuine resource ceiling *and* for a structural refusal like "not polynomial", and a ledger that has recorded any ceiling refuses every later spend. So sharing it read *"declined in 8 ms because the system is uncoupled"* as *"the budget is gone"* — and the 1024-solution case raised instead of answering. **What crosses the boundary is the clock, not the ledger.**

**2. A wall-clock bound is flaky, and a step bound is incomplete.** The clock version passed in isolation and **failed inside the full suite**: under parallel load the good case exceeded five seconds and was cut off. A bound that makes the same system answer or decline depending on what else the machine is doing is a worse failure than a slow answer.

But steps alone don't bound cost either — cyclic-4 spends 4946 ms in **eight** branches.

## So the default carries both, sized from measurement

A step is one candidate solution explored, which is what compounds: each elimination turns the next level's coefficients into nested radicals.

| system | branches explored |
|---|---|
| symbolic 2×2 | 2 |
| cyclic-4 | 8 |
| `a^4-1 ×5`, the largest that answers | **341** |
| cyclic-5 | **>100 000**, did not finish in 40 minutes |

`Steps = 10_000` — thirtyfold headroom over anything known to work, and far below the runaways. `Time = 60s` as a loose backstop for the arbitrarily-expensive single step.

## The honest limitation

**The bound is cooperative and checked once per branch**, so a call can overshoot by the cost of the branch that was running when the budget ran out. Cyclic-6 returns in about **two minutes**, where before it did not return at all. That is `BudgetLedger`'s stated design — an algorithm that does not ask cannot be bounded, and a bound enforced from outside is a thread abort in the middle of a rewrite. It is a bound where there was none, not a tight one.

Cyclic-6 is deliberately **not** in the test suite: two minutes is two minutes on every run, and even a ceiling of twenty takes half an hour on it, because its branches are individually enormous. The mechanism is demonstrated instead by a system the elimination answers in two candidates, which declines under a ceiling of one in milliseconds. Its own measurement is recorded in `BREAKING-CHANGES.md`.

## Behaviour

| | before | now |
|---|---|---|
| cyclic-6 | exceeded 20 s, unbounded | declines, returns in ~2 min |
| `a^4-1 ×5` (1024 solutions) | answers | **unchanged** |
| cyclic-4 (158 solutions) | answers | **unchanged** |
| every ordinary system | answers, fast | **unchanged** |
| `Budget` set below what the solve needs | answered anyway | raises |

`BudgetTest.ExhaustionDoesNotChangeTheAnswer` asserted the old promise — that exhausting the bounded path left the answer alone *because the caller carried on regardless*. That promise is exactly what this changes, so it is split into the two that are now true: a budget not reached changes nothing, and a budget reached bounds the whole call.

A recording now also sees **two** outcomes per solve rather than one, named `Gröbner` and `SolveSystem`, so what stopped each is separately visible — which the issue notes a caller previously could not find out.

`Failed: 0, Passed: 9136, Skipped: 14` locally on net10.0, with suite time unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
