### PR TITLE
The Terminal's compiler service is checked rather than warned about (#1100)

### DIFF
--- a/Sources/Terminal/AngouriMath.Terminal.Lib/AngouriMath.Terminal.Lib.fsproj
+++ b/Sources/Terminal/AngouriMath.Terminal.Lib/AngouriMath.Terminal.Lib.fsproj
@@ -22,6 +22,26 @@
     https://github.com/asc-community/AngouriMath/issues/542
     -->
     <IsPackable>false</IsPackable>
+
+    <!--
+    NU1608: FSharp.Compiler.Service 43.9.300 requires FSharp.Core (= 9.0.300), and what is
+    resolved is the 10.1 that the F# SDK references implicitly for every F# project. Sixteen
+    occurrences in the publish run for 2.3.0 and sixteen in the one for 2.4.0, so it is neither
+    new nor going away on its own: the constraint can only be met by pinning FSharp.Core two
+    majors back, against the SDK, for every project in the graph.
+
+    Suppressed because it was measured rather than because it was noisy. A kernel built on this
+    pair runs generic inference, records, unions, sequences, async, units of measure, object
+    expressions, inline constraints, active patterns, classes and string interpolation, and
+    reports a type error and a syntax error with the right positions — sixteen of sixteen, in
+    CompilerServiceWorksTest, which is what now carries the claim. A warning nobody reads is not
+    a check; a test that runs the compiler is.
+
+    If FSharp.Core or FSharp.Compiler.Service moves, that test is what should be believed, and
+    this comment is what should be rewritten.
+    https://github.com/asc-community/AngouriMath/issues/1100
+    -->
+    <NoWarn>$(NoWarn);NU1608</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Sources/Terminal/AngouriMath.Terminal/AngouriMath.Terminal.fsproj
+++ b/Sources/Terminal/AngouriMath.Terminal/AngouriMath.Terminal.fsproj
@@ -14,6 +14,13 @@
     <Description>F#-based command line interface for symbolic algebra library AngouriMath</Description>
 
     <PackageTags>$(PackageTags), cli, terminal</PackageTags>
+
+    <!--
+    The same NU1608 as AngouriMath.Terminal.Lib's, reaching here through the project reference,
+    and suppressed on the same measurement. Its comment is the one to read.
+    https://github.com/asc-community/AngouriMath/issues/1100
+    -->
+    <NoWarn>$(NoWarn);NU1608</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Sources/Tests/TerminalUnitTests/CompilerServiceWorksTest.fs
+++ b/Sources/Tests/TerminalUnitTests/CompilerServiceWorksTest.fs
@@ -1,0 +1,84 @@
+/// The Terminal bundles FSharp.Compiler.Service beside an FSharp.Core two majors above the one
+/// it declares it needs, and NU1608 has said so on every publish since 2.3.0. This is what
+/// settles whether that matters: the pair is asked to compile F#, and told to.
+/// https://github.com/asc-community/AngouriMath/issues/1100
+module AngouriMath.Terminal.CompilerServiceWorksTest
+
+open Xunit
+open AngouriMath.Terminal.Lib.FSharpInteractive
+open AngouriMath.Terminal.Lib.PreRunCode
+open AngouriMath.Terminal.Lib.Consts
+
+/// A kernel with nothing loaded into it, so what is under test is the compiler rather than
+/// AngouriMath's own bindings. The Terminal opens AggressiveOperators over the top, which
+/// deliberately rebinds the comparison operators to build expressions — that is the tool's whole
+/// point and it is not what this asks about.
+let private bareKernel () =
+    match createKernel () with
+    | Result.Error _ ->
+        Assert.True(false, "the kernel did not load at all")
+        raise (System.Exception())
+    | Result.Ok kernel -> kernel
+
+let private evaluates (code: string) (expected: string) =
+    match execute (bareKernel ()) code with
+    | ExecutionResult.PlainTextSuccess actual -> Assert.Equal(expected, actual)
+    | other ->
+        Assert.True(false, $"expected {expected}, and the kernel answered {other}")
+
+/// Each of these is a language feature the compiler service has to implement rather than a
+/// value the parser can fold, so a mismatched FSharp.Core would show here rather than in
+/// arithmetic. Sixteen of sixteen pass on the shipped pair.
+[<Theory>]
+// Inference and generics.
+[<InlineData("let twice f x = f (f x)\ntwice (fun n -> n * 2) 5", "20")>]
+[<InlineData("let inline add a b = a + b\nadd 2 3", "5")>]
+// Type definitions of every shape.
+[<InlineData("type P = { X: int; Y: int }\nlet p = { X = 1; Y = 2 }\np.X + p.Y", "3")>]
+[<InlineData("type T = A of int | B\nmatch A 7 with A n -> n | B -> 0", "7")>]
+[<InlineData("type C(x: int) =\n    member _.Doubled = x * 2\nC(21).Doubled", "42")>]
+[<InlineData("[<Measure>] type m\nlet d = 5.0<m>\nfloat d", "5")>]
+// Computation expressions and the library that backs them.
+[<InlineData("async { return 1 + 1 } |> Async.RunSynchronously", "2")>]
+[<InlineData("seq { 1..100 } |> Seq.filter (fun x -> x % 7 = 0) |> Seq.length", "14")>]
+[<InlineData("[ for i in 1..10 -> i * i ] |> List.sum", "385")>]
+// Pattern matching, including one the compiler generates code for.
+[<InlineData("let (|Even|Odd|) n = if n % 2 = 0 then Even else Odd\nmatch 4 with Even -> \"e\" | Odd -> \"o\"", "e")>]
+[<InlineData("[(1,2);(3,4)] |> List.map (fun (a,b) -> a + b)", "[3; 7]")>]
+[<InlineData("let f x = if x > 0 then Some x else None\nOption.defaultValue 0 (f 5)", "5")>]
+// Recursion, formatting, interpolation, and an object expression over an interface.
+[<InlineData("let rec fib n = if n < 2 then n else fib (n-1) + fib (n-2)\nfib 20", "6765")>]
+[<InlineData("sprintf \"%d %s %.2f\" 42 \"x\" 3.14159", "42 x 3.14")>]
+[<InlineData("let n = 6\n$\"n is {n}\"", "n is 6")>]
+[<InlineData("let c = { new System.IComparable<int> with member _.CompareTo o = 0 }\nc.CompareTo 1", "0")>]
+let ``The compiler service compiles F#`` (code: string) (expected: string) =
+    evaluates code expected
+
+/// And it still refuses what it should, with a position — a compiler that accepted everything
+/// would pass the theory above and be useless.
+[<Theory>]
+[<InlineData("let x: int = \"not an int\"", "typecheck error")>]
+[<InlineData("let =", "parse error")>]
+let ``The compiler service reports errors`` (code: string) (expected: string) =
+    match execute (bareKernel ()) code with
+    | ExecutionResult.Error message ->
+        Assert.Contains(expected, message)
+        // A position, not just a complaint: the Terminal shows these to whoever typed them.
+        Assert.Contains("input.fsx (1,", message)
+    | other ->
+        Assert.True(false, $"expected an error and the kernel answered {other}")
+
+/// The pairing the warning is about, doing the work the Terminal exists for.
+[<Theory>]
+[<InlineData("solutions \"x\" \"x2 - 5x + 6 = 0\"", "{ 2, 3 }")>]
+[<InlineData("derivative \"x\" \"x3 + sin(x)\"", "3 * x ^ 2 + cos(x)")>]
+[<InlineData("integral \"x\" \"x2\"", "x ^ 3 / 3 + C")>]
+let ``AngouriMath works through the compiler service`` (code: string) (expected: string) =
+    let kernel = bareKernel ()
+    match enableAngouriMath kernel with
+    | ExecutionResult.Error reason -> Assert.True(false, $"AngouriMath did not load: {reason}")
+    | _ -> ()
+    match execute kernel code with
+    | ExecutionResult.LatexSuccess (_, actual) -> Assert.Equal(expected, actual)
+    | ExecutionResult.PlainTextSuccess actual -> Assert.Equal(expected, actual)
+    | other -> Assert.True(false, $"expected {expected}, and the kernel answered {other}")

--- a/Sources/Tests/TerminalUnitTests/TerminalUnitTests.fsproj
+++ b/Sources/Tests/TerminalUnitTests/TerminalUnitTests.fsproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <Compile Include="Tests.fs" />
+    <Compile Include="CompilerServiceWorksTest.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
Closes [#1100](https://github.com/asc-community/AngouriMath/issues/1100), which asked for "an hour of someone running the Terminal against something non-trivial" rather than a fix.

## The answer: it is benign

A kernel built on the shipped pair — `FSharp.Compiler.Service 43.9.300` beside `FSharp.Core 10.1` — compiles **sixteen of sixteen** language features that the compiler service has to implement rather than the parser fold:

| | |
|---|---|
| generic functions, inference, `inline` constraints | ✅ |
| records, discriminated unions, classes with members, units of measure | ✅ |
| `async`, sequence expressions, list comprehensions | ✅ |
| active patterns, tuple destructuring, `Option` | ✅ |
| recursion, `sprintf`, string interpolation, object expression over an interface | ✅ |

And it still **refuses** what it should — a type error and a syntax error, each with the position the Terminal shows to whoever typed it. A compiler that accepted everything would pass the first sixteen and be useless, so that half is asserted too.

## What changed, and why it is not just a suppression

The warning is suppressed, and the claim it was making now lives in `CompilerServiceWorksTest`. **That is the point of the change rather than a side effect.** A warning nobody reads is not a check, and this one had been passing through CI unread for two releases at sixteen occurrences a run. If `FSharp.Core` or `FSharp.Compiler.Service` moves and the pair really does come apart, a test fails — where before a sixteen-line warning would have scrolled past again.

`InteractiveTest.yml` already runs `TerminalUnitTests`, so this gates on every PR touching it.

**Suppressing rather than pinning, because the constraint cannot be met.** The 10.1 is the `FSharp.Core` the F# SDK references implicitly for every F# project; satisfying `FSharp.Compiler.Service`'s `= 9.0.300` would mean pinning two majors back, against the SDK, across the whole graph.

The `.fsproj` comment records what was measured and says the test is what to believe if the versions move.

## Measured

| | before | now |
|---|---|---|
| `dotnet pack`, NU1608 | 16 | **0** |
| `dotnet pack`, NuGet warnings of any kind | 16 | **0** |
| `TerminalUnitTests` | 7 pass | **28 pass** |

## One thing found on the way, filed separately

The tests use a **bare** kernel deliberately. The Terminal opens `AngouriMath.Interactive.AggressiveOperators` over the top, which rebinds `< > <= >= = <>` to build expressions — that is the tool's whole point, and it means ordinary F# containing a comparison does not typecheck once AngouriMath is enabled:

```
let rec fib n = if n < 2 then n else fib (n-1) + fib (n-2)
  -> typecheck error: expected 'bool' but here has type 'Entity'
```

Same for `if 1 < 2 then …` and `List.filter (fun x -> x > 1)`. That is a deliberate design trade-off rather than a defect of this pairing, so it is filed as its own issue rather than smuggled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
