### PR TITLE
An analytical solver for first-order linear ODEs (#241)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -4826,6 +4826,14 @@ And what cannot be compiled is named rather than failing obscurely.
 
 Not behavioural changes, listed so that a reader working through this file has the whole picture.
 
+- **An analytical solver for first-order linear ordinary differential equations.**
+  `MathS.SolveOde(equation, function, variable)`, by the integrating factor. The unknown is written
+  as an application — `apply(y, x)` — rather than a bare variable, because `derivative(y, x)` is
+  `0`: a variable does not depend on `x`. `y' + y = 1` comes back as `1 + C_1 * e ^ (-x)`, and
+  `y' + y/x = 1` as `C_1 / x + x / 2`. It returns `null` where the equation is not linear in the
+  unknown and its derivative, and where either of the two integrals has no closed form, which is
+  why `y' + y = e^(x^2)` is declined. Nothing existed before it; there is no behaviour to compare.
+  [#241](https://github.com/asc-community/AngouriMath/issues/241).
 - **A modulus node.** `Modf`, `MathS.Mod`, the `%` operator on `Entity` in C# and F#, the `mod`
   keyword in the parser, evaluation, simplification, differentiation, limits, both compilers, LaTeX
   and SymPy export. `a % b` on `Entity` is *not* `int`'s `%` — it is floored, and its documentation

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -51,6 +51,12 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [AngouriMath/Functions/Algebra/Polynomials/KroneckerFactorization.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[AngouriMath/Functions/Continuous/Solvers/OrdinaryDifferentialEquation.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/OrdinaryDifferentialEquationTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [AngouriMath/Functions/Algebra/Polynomials/FractionFreeDeterminant.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 

--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -193,6 +193,49 @@ namespace AngouriMath
         public static Set SolveEquation(Entity equation, Variable var) => EquationSolver.Solve(equation, var);
 
         /// <summary>
+        /// Solves a first-order linear ordinary differential equation
+        /// <a href="https://en.wikipedia.org/wiki/Linear_differential_equation"/> by its
+        /// integrating factor, or returns <see langword="null"/> where it cannot.
+        /// </summary>
+        /// <param name="equation">
+        /// The equation, read as equal to zero, written in terms of the unknown function applied
+        /// to its variable. The unknown has to be an application — <c>apply(y, x)</c> — rather
+        /// than a bare variable, because <c>derivative(y, x)</c> is <c>0</c>: a variable does not
+        /// depend on <c>x</c>, and the library is right about that.
+        /// </param>
+        /// <param name="function">The name of the unknown function, <c>y</c> above.</param>
+        /// <param name="variable">The name it is a function of, <c>x</c> above.</param>
+        /// <returns>
+        /// The general solution, carrying one arbitrary constant, or <see langword="null"/> where
+        /// the equation is not first-order linear in the unknown, or where either of the two
+        /// integrals the method needs has no closed form.
+        /// </returns>
+        /// <example>
+        /// <code>
+        /// using System;
+        /// using AngouriMath;
+        /// using AngouriMath.Extensions;
+        ///
+        /// // y' + y = 1
+        /// var equation = "derivative(apply(y, x), x) + apply(y, x) - 1".ToEntity();
+        /// Console.WriteLine(MathS.SolveOde(equation, "y", "x"));
+        /// </code>
+        /// Prints
+        /// <code>
+        /// 1 + C_1 * e ^ (-x)
+        /// </code>
+        /// </example>
+        /// <remarks>
+        /// Declining is a legitimate answer here and a common one: the method is exact where it
+        /// applies, and where either integral does not come out there is no approximation to
+        /// offer in its place. <c>y' + y = e^(x^2)</c> is declined for exactly that reason.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/241">#241</a>
+        /// </remarks>
+        public static Entity? SolveOde(Entity equation, Variable function, Variable variable)
+            => Functions.Algebra.OrdinaryDifferentialEquation
+                .SolveFirstOrderLinear(equation, function, variable);
+
+        /// <summary>
         /// Solves a boolean expression. That is, finds all values for
         /// <paramref name="variables"/> such that the expression turns into True when evaluated
         /// Uses a simple table of truth

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/OrdinaryDifferentialEquation.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/OrdinaryDifferentialEquation.cs
@@ -1,0 +1,193 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath.Core.Transformations;
+using static AngouriMath.Entity;
+
+namespace AngouriMath.Functions.Algebra
+{
+    /// <summary>
+    /// The first-order linear ordinary differential equation, solved by its integrating factor.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/241">#241</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// For <c>y' + f(x) y = g(x)</c>, multiplying through by <c>m = e^(int f dx)</c> makes the left
+    /// side the derivative of <c>m y</c> — which is the whole method, since integrating both sides
+    /// then gives <c>m y = int (m g) dx</c>. Nothing here is a heuristic: where the two integrals
+    /// come out, the answer is exact, and where either does not this declines.
+    /// </para>
+    /// <para>
+    /// <b>The unknown is an <see cref="Application"/>.</b> A bare <see cref="Variable"/> cannot
+    /// stand for a function of <c>x</c>: <c>derivative(y, x)</c> is <c>0</c>, because <c>y</c> does
+    /// not contain <c>x</c> and the library is right about that. Written <c>apply(y, x)</c> it is
+    /// an application that does not reduce, and its derivative stays symbolic — which is exactly
+    /// what an equation about an unknown function needs.
+    /// </para>
+    /// <para>
+    /// <b>Linearity is checked, not assumed.</b> The coefficients are read off by differentiating
+    /// with respect to the unknown and its derivative, which is only valid if the equation really
+    /// is linear in them — so the reading is put back together and compared with what it came
+    /// from. An equation that is not linear fails that comparison and is declined rather than
+    /// answered wrongly.
+    /// </para>
+    /// </remarks>
+    internal static class OrdinaryDifferentialEquation
+    {
+        /// <summary>
+        /// The general solution of <paramref name="equation"/> read as equal to zero, or
+        /// <see langword="null"/> where this method does not apply.
+        /// </summary>
+        /// <param name="equation">
+        /// An expression in <c>apply(<paramref name="function"/>, <paramref name="variable"/>)</c>
+        /// and its derivative, equal to zero.
+        /// </param>
+        /// <param name="function">The name of the unknown function.</param>
+        /// <param name="variable">The name it is a function of.</param>
+        internal static Entity? SolveFirstOrderLinear(
+            Entity equation, Variable function, Variable variable)
+        {
+            var unknown = new Application(function, LList.Of<Entity>(variable));
+            var derivative = new Derivativef(unknown, variable, 1);
+
+            // Stand-ins, so that the coefficients can be read by differentiating with respect to
+            // them. Unique against the whole equation, since `y` and `x` are the caller's names
+            // and anything else in it is the caller's too.
+            var atDerivative = Variable.CreateUnique(equation, "yPrime");
+            var atUnknown = Variable.CreateUnique(equation, "yValue");
+            var linear = equation
+                .Substitute(derivative, atDerivative)
+                .Substitute(unknown, atUnknown);
+
+            // Nothing to solve if the equation never mentions the unknown's derivative: that is
+            // an algebraic equation, and answering it here would be answering a different
+            // question from the one asked.
+            if (!linear.ContainsNode(atDerivative))
+                return null;
+
+            var coefficientOfDerivative = Coefficient(linear.Differentiate(atDerivative));
+            var coefficientOfUnknown = Coefficient(linear.Differentiate(atUnknown));
+            var rest = Coefficient(linear
+                .Substitute(atDerivative, Number.Integer.Zero)
+                .Substitute(atUnknown, Number.Integer.Zero));
+
+            // The check that makes the three readings above legitimate. If the equation is linear
+            // in the two, this reassembles it exactly; if it is not -- y' * y, or y ^ 2, or
+            // sin(y') -- the difference does not vanish and this declines.
+            var reassembled = coefficientOfDerivative * atDerivative
+                + coefficientOfUnknown * atUnknown
+                + rest;
+            if (Coefficient(reassembled - linear) != Number.Integer.Zero)
+                return null;
+
+            // And a coefficient that still mentions either stand-in means the equation was not
+            // linear after all, in a way the subtraction above can miss when the simplifier
+            // cannot decide it.
+            foreach (var coefficient in new[] { coefficientOfDerivative, coefficientOfUnknown, rest })
+                if (coefficient.ContainsNode(atDerivative) || coefficient.ContainsNode(atUnknown))
+                    return null;
+
+            if (coefficientOfDerivative.Evaled == Number.Integer.Zero)
+                return null;
+
+            // y' + f y = g, having divided through.
+            var f = (coefficientOfUnknown / coefficientOfDerivative).InnerSimplified;
+            var g = (-rest / coefficientOfDerivative).InnerSimplified;
+
+            if (Antiderivative(f, variable) is not { } integralOfF)
+                return null;
+            var factor = ExponentialOf(integralOfF);
+
+            if (Antiderivative((factor * g).InnerSimplified, variable) is not { } integralOfFactorTimesG)
+                return null;
+
+            // The one constant of integration the answer keeps, and it belongs to this integral
+            // rather than to the factor: a constant in the exponent of the factor would multiply
+            // the whole solution by a constant, which is the same family written less clearly.
+            var constant = Variable.CreateUnique(equation + integralOfFactorTimesG + factor, "C");
+            return ((integralOfFactorTimesG + constant) / factor).InnerSimplified;
+        }
+
+        /// <summary>
+        /// A coefficient read off the equation, simplified and with its domain condition set
+        /// aside.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Both halves are needed and both were found by measuring rather than expected.
+        /// Differentiating <c>y / x</c> with respect to <c>y</c> gives <c>x / x^2</c>, which is
+        /// <c>1/x</c> and is not written that way, and the integrator has no antiderivative for
+        /// the unsimplified form — so <c>y' + y/x = 1</c> was declined while
+        /// <c>x y' + y = x</c>, the same equation multiplied through, was solved.
+        /// </para>
+        /// <para>
+        /// And the quotient rule attaches a <see cref="Providedf"/>: the coefficient came back as
+        /// <c>1 provided not x^2 = 0</c>. A condition travelling into the integrand stops it
+        /// integrating, and it says nothing the answer does not already say — the solution of an
+        /// equation with <c>y/x</c> in it is undefined at zero however it is derived, and the
+        /// answers here carry that condition of their own accord.
+        /// </para>
+        /// </remarks>
+        private static Entity Coefficient(Entity expression)
+        {
+            var simplified = expression.Simplify();
+            while (simplified is Providedf(var inner, _))
+                simplified = inner;
+            return simplified;
+        }
+
+        /// <summary>
+        /// <c>e</c> to the power of <paramref name="exponent"/>, written without the exponential
+        /// where the exponent is a logarithm.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is not tidying, it is the difference between answering and not. The integrating
+        /// factor for <c>y' + y/x = 1</c> is <c>e^(int dx/x)</c>, which is <c>e^ln(x)</c> — and
+        /// <b><c>e^ln(x)</c> is not simplified to <c>x</c> by anything in the library</b>, neither
+        /// by <c>InnerSimplified</c> nor by <c>Simplify</c>. The factor then stays an exponential
+        /// of a logarithm, the second integral has no antiderivative for it, and the whole
+        /// equation is declined. Measured, which is how it was found: every step but that one
+        /// came out.
+        /// </para>
+        /// <para>
+        /// Done here rather than as a simplification rule because a rule for <c>e^ln(a) = a</c>
+        /// reaches every expression in the library and wants deciding on its own terms. Filed
+        /// separately; this is the local reading, which is sound because the exponent was built
+        /// here and is known to be an antiderivative.
+        /// </para>
+        /// </remarks>
+        private static Entity ExponentialOf(Entity exponent)
+            => exponent switch
+            {
+                // e^ln(u) is u.
+                Logf(var logBase, var antilog) when logBase == MathS.e => antilog,
+                // e^(k ln u) is u^k, which is what an antiderivative of k/x gives.
+                Mulf(var scale, Logf(var logBase, var antilog)) when logBase == MathS.e
+                    => MathS.Pow(antilog, scale).InnerSimplified,
+                Mulf(Logf(var logBase, var antilog), var scale) when logBase == MathS.e
+                    => MathS.Pow(antilog, scale).InnerSimplified,
+                _ => MathS.Pow(MathS.e, exponent).InnerSimplified,
+            };
+
+        /// <summary>
+        /// The antiderivative with <b>no</b> constant of integration, or <see langword="null"/>
+        /// where the integral did not come out.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Entity.Integrate(Variable)"/> appends one, which is right for a caller
+        /// asking for an antiderivative and wrong here twice over: the integrating factor would
+        /// carry an arbitrary constant into an exponent, and the answer would end up with two
+        /// constants standing for one family of solutions.
+        /// </remarks>
+        private static Entity? Antiderivative(Entity expression, Variable variable)
+            => Transformation.Integration(variable).Apply(expression).Output is { } antiderivative
+                && !antiderivative.Nodes.Any(node => node is Integralf)
+                ? antiderivative.InnerSimplified
+                : null;
+    }
+}

--- a/Sources/Tests/UnitTests/Calculus/OrdinaryDifferentialEquationTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/OrdinaryDifferentialEquationTest.cs
@@ -1,0 +1,181 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Linq;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// The first-order linear ordinary differential equation.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/241">#241</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every solution here is checked by <b>putting it back into the equation it came from</b> —
+    /// substituting the answer for the unknown and its derivative for the unknown's derivative,
+    /// then evaluating the residual at sampled points and for two values of the arbitrary
+    /// constant. A general solution is a family, so an answer that satisfies the equation for one
+    /// constant and not another is wrong in a way its printed form does not show.
+    /// </para>
+    /// <para>
+    /// Numerically rather than symbolically, because the residual routinely simplifies to
+    /// <c>0 provided ...</c> rather than to <c>0</c>, and a symbolic comparison would then have
+    /// to decide what to make of the condition. At a point, either it vanishes or it does not.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class OrdinaryDifferentialEquationTest
+    {
+        private static readonly Entity Unknown = "apply(y, x)".ToEntity();
+        private static readonly Entity UnknownDerivative = "derivative(apply(y, x), x)".ToEntity();
+
+        private static void Satisfies(string equation)
+        {
+            var solution = MathS.SolveOde(equation.ToEntity(), "y", "x");
+            Assert.NotNull(solution);
+
+            var residual = equation.ToEntity()
+                .Substitute(UnknownDerivative, solution!.Differentiate("x"))
+                .Substitute(Unknown, solution)
+                .Simplify();
+
+            var compared = 0;
+            foreach (var at in new[] { 0.4, 1.3, 2.2, 3.1 })
+                foreach (var constant in new[] { 0.0, 1.5 })
+                {
+                    var here = residual;
+                    // The arbitrary constant is whatever unique name the solver gave it, so it is
+                    // found rather than named: pinning `C_1` would make this test about how the
+                    // constant is spelled.
+                    foreach (var free in residual.Vars.Where(v => v.Name.StartsWith("C")))
+                        here = here.Substitute(free, constant);
+                    var value = here.Substitute("x", at).EvalNumerical();
+                    if (value.IsNaN)
+                        continue;
+                    compared++;
+                    Assert.True(Math.Abs((double)value.RealPart) < 1e-9,
+                        $"{solution} does not satisfy {equation}: the residual is {value} "
+                        + $"at x = {at} with the constant {constant}");
+                }
+
+            Assert.True(compared >= 4,
+                $"only {compared} points were comparable for {equation}, so this asserts little");
+        }
+
+        /// <summary>
+        /// The homogeneous and the separable cases, where the integrating factor is an
+        /// exponential.
+        /// </summary>
+        [Theory]
+        [InlineData("derivative(apply(y, x), x)")]
+        [InlineData("derivative(apply(y, x), x) - apply(y, x)")]
+        [InlineData("derivative(apply(y, x), x) + apply(y, x)")]
+        [InlineData("derivative(apply(y, x), x) - 3*apply(y, x)")]
+        [InlineData("derivative(apply(y, x), x) - apply(y, x) * x")]
+        [InlineData("derivative(apply(y, x), x) - x")]
+        public void HomogeneousAndSeparable(string equation) => Satisfies(equation);
+
+        /// <summary>With a right-hand side, so the second integral does real work.</summary>
+        [Theory]
+        [InlineData("derivative(apply(y, x), x) + apply(y, x) - 1")]
+        [InlineData("derivative(apply(y, x), x) + 2*x*apply(y, x) - x")]
+        [InlineData("derivative(apply(y, x), x) - apply(y, x) - e^x")]
+        [InlineData("derivative(apply(y, x), x) + apply(y, x) - sin(x)")]
+        public void WithARightHandSide(string equation) => Satisfies(equation);
+
+        /// <summary>
+        /// Where the integrating factor is a power rather than an exponential, because the
+        /// coefficient integrates to a logarithm. <c>y' + y/x = 1</c> is the textbook first
+        /// example and was the last of these to work.
+        /// </summary>
+        [Theory]
+        [InlineData("derivative(apply(y, x), x) + apply(y, x)/x - 1")]
+        [InlineData("derivative(apply(y, x), x) + 2*apply(y, x)/x - x")]
+        [InlineData("derivative(apply(y, x), x) + apply(y, x)/x - x^2")]
+        [InlineData("x * derivative(apply(y, x), x) + apply(y, x) - x")]
+        public void WhereTheFactorIsAPower(string equation) => Satisfies(equation);
+
+        /// <summary>
+        /// An equation and the same equation multiplied through by <c>x</c> are one equation, and
+        /// must come back with one answer. They did not: the multiplied form was solved while the
+        /// divided form was declined, because differentiating <c>y/x</c> gives <c>x/x^2</c> under
+        /// a domain condition and neither the unsimplified quotient nor the condition would
+        /// integrate.
+        /// </summary>
+        [Fact]
+        public void TheSameEquationWrittenTwoWaysHasOneSolution()
+        {
+            var divided = MathS.SolveOde(
+                "derivative(apply(y, x), x) + apply(y, x)/x - 1".ToEntity(), "y", "x");
+            var multiplied = MathS.SolveOde(
+                "x * derivative(apply(y, x), x) + apply(y, x) - x".ToEntity(), "y", "x");
+
+            Assert.NotNull(divided);
+            Assert.NotNull(multiplied);
+            Assert.Equal(multiplied!.Simplify(), divided!.Simplify());
+        }
+
+        /// <summary>
+        /// What it declines. The first four are not linear in the unknown and its derivative, so
+        /// the method does not apply at all; the last is linear and declined because
+        /// <c>int e^(x^2) dx</c> has no closed form, which is a fact about the integral rather
+        /// than about this solver.
+        /// </summary>
+        /// <remarks>
+        /// Declining is the right answer to each. The alternative — reading a nonlinear equation
+        /// as though it were linear, by taking coefficients that do not exist — is a wrong answer
+        /// that looks entirely plausible, which is why the solver reassembles what it read and
+        /// compares it with what it was given.
+        /// </remarks>
+        [Theory]
+        [InlineData("derivative(apply(y, x), x) * apply(y, x) - 1")]
+        [InlineData("derivative(apply(y, x), x) + apply(y, x)^2")]
+        [InlineData("sin(derivative(apply(y, x), x)) - 1")]
+        [InlineData("derivative(apply(y, x), x)^2 - apply(y, x)")]
+        [InlineData("derivative(apply(y, x), x) + apply(y, x) - e^(x^2)")]
+        public void WhatItDeclines(string equation)
+            => Assert.Null(MathS.SolveOde(equation.ToEntity(), "y", "x"));
+
+        /// <summary>
+        /// An equation with no derivative in it is algebraic, and answering it here would be
+        /// answering a different question from the one asked.
+        /// </summary>
+        [Fact]
+        public void AnAlgebraicEquationIsNotAnOde()
+            => Assert.Null(MathS.SolveOde("apply(y, x) - x".ToEntity(), "y", "x"));
+
+        /// <summary>
+        /// The answer the issue's own worked example gives, asserted as a form rather than only
+        /// as a residual: a solution off by a constant factor still satisfies a homogeneous
+        /// equation.
+        /// </summary>
+        [Fact]
+        public void TheGeneralSolutionCarriesOneArbitraryConstant()
+        {
+            var solution = MathS.SolveOde(
+                "derivative(apply(y, x), x) + apply(y, x) - 1".ToEntity(), "y", "x");
+            Assert.NotNull(solution);
+            var constants = solution!.Vars.Where(v => v.Name.StartsWith("C")).ToList();
+            Assert.Single(constants);
+            // y = 1 + C e^(-x): at the constant zero it is the particular solution y = 1.
+            //
+            // Read at a point rather than compared as a tree. The answer comes back as
+            // `1 provided not e ^ x = 0`, a condition that is never false for real x but is
+            // carried anyway, and asserting the tree would be asserting that noise. Whether a
+            // vacuous condition should survive simplification is a question about Providedf
+            // rather than about this solver.
+            var particular = solution.Substitute(constants[0], 0);
+            foreach (var at in new[] { 0.5, 2.0, 3.5 })
+                Assert.True(
+                    Math.Abs((double)(particular.Substitute("x", at).EvalNumerical() - 1).RealPart) < 1e-9,
+                    $"the particular solution is {particular}, which is not 1 at x = {at}");
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Common/PublicApi.txt
+++ b/Sources/Tests/UnitTests/Common/PublicApi.txt
@@ -2465,6 +2465,7 @@ AngouriMath.MathS.Signum(AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.MathS.Sin(AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.MathS.SolveBooleanTable(AngouriMath.Entity, AngouriMath.Entity+Variable[]) : AngouriMath.Entity+Matrix
 AngouriMath.MathS.SolveEquation(AngouriMath.Entity, AngouriMath.Entity+Variable) : AngouriMath.Entity+Set
+AngouriMath.MathS.SolveOde(AngouriMath.Entity, AngouriMath.Entity+Variable, AngouriMath.Entity+Variable) : AngouriMath.Entity
 AngouriMath.MathS.Sqr(AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.MathS.Sqrt(AngouriMath.Entity) : AngouriMath.Entity
 AngouriMath.MathS.Sum(AngouriMath.Entity, AngouriMath.Entity, AngouriMath.Entity, AngouriMath.Entity) : AngouriMath.Entity


### PR DESCRIPTION
Closes [#241](https://github.com/asc-community/AngouriMath/issues/241).

`MathS.SolveOde(equation, function, variable)`, by the integrating factor the issue sets out. Nothing existed before this — the library had no notion of an ODE at all.

## The unknown had to be an application

A bare variable cannot stand for a function of `x`: `derivative(y, x)` is `0`, because `y` does not contain `x` and the library is right about that. Written `apply(y, x)` it is an `Application` that does not reduce, and its derivative stays symbolic — exactly what an equation about an unknown function needs, and already there.

```csharp
var equation = "derivative(apply(y, x), x) + apply(y, x) - 1".ToEntity();
MathS.SolveOde(equation, "y", "x");   // 1 + C_1 * e ^ (-x)
```

## Solved

| | |
|---|---|
| `y' + y = 1` | `1 + C_1 * e ^ (-x)` |
| `y' + y/x = 1` | `C_1 / x + x / 2` |
| `y' + 2xy = x` | `1/2 + C_1 * e ^ (-x^2)` |
| `y' - y = e^x` | `(C_1 + x) * e ^ x` |
| `y' + y = sin(x)` | `(sin(x) - cos(x)) / 2 + e ^ (-x) * C_1` |
| `y' + 2y/x = x` | `(x^4/4 + C_1) / x^2` |

Thirteen in all, each checked by **substituting the answer back into the equation it came from** and evaluating the residual at four points for **two values of the arbitrary constant**. A general solution is a family, and an answer that satisfies the equation for one constant and not another is wrong in a way its printed form does not show.

## Declined, and why that matters

`y' * y = 1`, `y' + y^2`, `sin(y') = 1`, `y'^2 = y` — not linear in the unknown and its derivative, so the method does not apply. `y' + y = e^(x^2)` **is** linear and is declined because `int e^(x^2) dx` has no closed form, which is a fact about the integral rather than about this solver.

**Linearity is checked, not assumed.** The coefficients are read by differentiating with respect to the unknown and its derivative, which is only valid if the equation is linear in them — so the reading is reassembled and compared with what it came from. Reading a nonlinear equation as though it were linear is a wrong answer that looks entirely plausible, and it is the one failure mode worth designing against here.

## Two things found by measuring

**`y' + y/x = 1` was declined while `x y' + y = x` was solved** — the same equation, multiplied through. Differentiating `y / x` gives `x / x^2` under a domain condition, and neither the unsimplified quotient nor the `Providedf` would integrate. Coefficients are now simplified and their conditions set aside, and a test asserts directly that the two forms give one answer.

**`e^ln(x)` is not simplified to `x`** by anything in the library, `Simplify` included. The integrating factor for that same equation is `e^(int dx/x)`, so it stayed an exponential of a logarithm and the second integral had nothing to work with. Read locally here — a rule for `e^ln(a) = a` reaches every expression in the library and wants deciding on its own terms — and filed separately.

## Surface

One member added, `PublicApi.txt` regenerated with `AM_UPDATE_PUBLIC_API=1`. **Nothing removed:**

```
+AngouriMath.MathS.SolveOde(AngouriMath.Entity, Entity+Variable, Entity+Variable) : AngouriMath.Entity
```

`Failed: 0, Passed: 9243` on net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
