### PR TITLE
A limit-termination guard is a bound on hanging, not a stopwatch (#1141)

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -145,3 +145,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Algebra/SolveTest/NegationIsNotTheEmptySetTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Common/LimitTermination.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/Tests/UnitTests/Calculus/BoundedTimesVanishingTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/BoundedTimesVanishingTest.cs
@@ -28,7 +28,7 @@ namespace AngouriMath.Tests.Calculus
         {
             var task = Task.Run(() =>
                 expression.ToEntity().Limit("x", destination.ToEntity()).Simplify());
-            Assert.True(task.Wait(TimeSpan.FromSeconds(30)), "the limit did not terminate");
+            Assert.True(task.Wait(LimitTermination.Guard), "the limit did not terminate");
             Assert.Equal(expected.ToEntity().Evaled, task.Result.Evaled);
         }
 
@@ -88,7 +88,7 @@ namespace AngouriMath.Tests.Calculus
         {
             var task = Task.Run(() => expression.ToEntity()
                 .Limit("x", destination.ToEntity(), ApproachFrom.BothSides));
-            Assert.True(task.Wait(TimeSpan.FromSeconds(30)), "the limit did not terminate");
+            Assert.True(task.Wait(LimitTermination.Guard), "the limit did not terminate");
             Assert.Equal(MathS.NaN, task.Result.Evaled);
         }
 
@@ -115,7 +115,7 @@ namespace AngouriMath.Tests.Calculus
         public void AComplexArgumentIsNotBounded(string expression, string destination)
         {
             var task = Task.Run(() => expression.ToEntity().Limit("x", destination.ToEntity()));
-            Assert.True(task.Wait(TimeSpan.FromSeconds(30)), "the limit did not terminate");
+            Assert.True(task.Wait(LimitTermination.Guard), "the limit did not terminate");
             Assert.IsType<Entity.Limitf>(task.Result);
         }
     }

--- a/Sources/Tests/UnitTests/Calculus/DifferenceAtInfinityTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/DifferenceAtInfinityTest.cs
@@ -98,7 +98,7 @@ namespace AngouriMath.Tests.Calculus
         public void ADifferenceOfLikeRadicalsIsSettledByTheSeries(string expression, string expected)
         {
             var task = Task.Run(() => expression.ToEntity().Limit("x", "+oo".ToEntity()).Simplify());
-            Assert.True(task.Wait(TimeSpan.FromSeconds(30)), "the limit did not terminate");
+            Assert.True(task.Wait(LimitTermination.Guard), "the limit did not terminate");
             Assert.Equal(expected.ToEntity().Evaled, task.Result.Evaled);
         }
     }

--- a/Sources/Tests/UnitTests/Calculus/EquivalentInfinitesimalTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/EquivalentInfinitesimalTest.cs
@@ -27,7 +27,7 @@ namespace AngouriMath.Tests.Calculus
         {
             var task = Task.Run(() =>
                 expression.ToEntity().Limit("x", destination.ToEntity(), side).Simplify());
-            Assert.True(task.Wait(TimeSpan.FromSeconds(30)), $"the limit of {expression} did not terminate");
+            Assert.True(task.Wait(LimitTermination.Guard), $"the limit of {expression} did not terminate");
             return task.Result;
         }
 

--- a/Sources/Tests/UnitTests/Calculus/GruntzTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/GruntzTest.cs
@@ -78,7 +78,7 @@ namespace AngouriMath.Tests.Calculus
         public void AnOscillationIsDeclinedRatherThanGuessedAt(string expression)
         {
             var task = Task.Run(() => expression.ToEntity().Limit("x", "+oo".ToEntity()));
-            Assert.True(task.Wait(TimeSpan.FromSeconds(30)), "the limit did not terminate");
+            Assert.True(task.Wait(LimitTermination.Guard), "the limit did not terminate");
             Assert.IsType<Entity.Limitf>(task.Result);
         }
     }

--- a/Sources/Tests/UnitTests/Calculus/LimitAtInfinityTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/LimitAtInfinityTest.cs
@@ -97,7 +97,7 @@ namespace AngouriMath.Tests.Calculus
         public void AFormThatCannotBeSettledTerminatesWithoutClaimingAnAnswer(string expression)
         {
             var task = Task.Run(() => Limit(expression, "+oo"));
-            Assert.True(task.Wait(TimeSpan.FromSeconds(30)), "the limit did not terminate");
+            Assert.True(task.Wait(LimitTermination.Guard), "the limit did not terminate");
             Assert.IsType<Entity.Limitf>(task.Result);
         }
     }

--- a/Sources/Tests/UnitTests/Calculus/LimitTerminatesOnEveryNodeTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/LimitTerminatesOnEveryNodeTest.cs
@@ -104,7 +104,7 @@ namespace AngouriMath.Tests.Calculus
                 foreach (var destination in new Entity[] { 0, "+oo".ToEntity(), "-oo".ToEntity() })
                     foreach (var side in new[] { ApproachFrom.BothSides, ApproachFrom.Left, ApproachFrom.Right })
                         node.Limit(MathS.Var("x"), destination, side);
-            }).Wait(TimeSpan.FromSeconds(30));
+            }).Wait(LimitTermination.Guard);
 
             Assert.True(finished, $"a limit over {node.Stringize()} did not terminate");
         }

--- a/Sources/Tests/UnitTests/Calculus/LinearityBeforeByPartsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/LinearityBeforeByPartsTest.cs
@@ -31,7 +31,7 @@ namespace AngouriMath.Tests.Calculus
         /// regression here is a hang, and a hang would otherwise wedge the run instead of
         /// failing it.
         /// </summary>
-        private static readonly TimeSpan Budget = TimeSpan.FromSeconds(15);
+        private static readonly TimeSpan Budget = LimitTermination.Guard;
 
         private static Entity IntegrateWithinBudget(string integrand)
         {

--- a/Sources/Tests/UnitTests/Calculus/OneSidedLimitTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/OneSidedLimitTest.cs
@@ -129,7 +129,7 @@ namespace AngouriMath.Tests.Calculus
             // this does. Three minutes still catches a hang in a suite that takes seven.
             var task = System.Threading.Tasks.Task.Run(() =>
                 Limit("1 / ln(x + sqrt(x * x + 1)) - 1 / ln(x + 1)", "0", side));
-            Assert.True(task.Wait(System.TimeSpan.FromSeconds(180)), "the limit did not terminate");
+            Assert.True(task.Wait(LimitTermination.Guard), "the limit did not terminate");
             Assert.Equal("-1/2".ToEntity().Evaled, task.Result.Evaled);
         }
 

--- a/Sources/Tests/UnitTests/Calculus/PiecewiseLimitTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/PiecewiseLimitTest.cs
@@ -103,7 +103,7 @@ namespace AngouriMath.Tests.Calculus
             var task = Task.Run(() =>
                 "piecewise(1 / x provided x < -1, x ^ 2 provided x < 0, sin(x) / x provided x < 1, ln(x), 7)"
                     .ToEntity().Limit("x", 0, ApproachFrom.Right));
-            Assert.True(task.Wait(TimeSpan.FromSeconds(30)), "the limit of a piecewise did not terminate");
+            Assert.True(task.Wait(LimitTermination.Guard), "the limit of a piecewise did not terminate");
         }
     }
 }

--- a/Sources/Tests/UnitTests/Calculus/SignumLimitTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/SignumLimitTest.cs
@@ -54,7 +54,7 @@ namespace AngouriMath.Tests.Calculus
         public void AtZeroItIsLeftUnevaluatedAndTerminates(string expression, string destination)
         {
             var task = Task.Run(() => Limit(expression, destination));
-            Assert.True(task.Wait(TimeSpan.FromSeconds(30)), "the limit did not terminate");
+            Assert.True(task.Wait(LimitTermination.Guard), "the limit did not terminate");
             Assert.IsType<Entity.Limitf>(task.Result);
         }
 
@@ -64,7 +64,7 @@ namespace AngouriMath.Tests.Calculus
         public void OneSidedAtZeroTerminatesToo(ApproachFrom side)
         {
             var task = Task.Run(() => "signum(x)".ToEntity().Limit("x", 0, side).Simplify());
-            Assert.True(task.Wait(TimeSpan.FromSeconds(30)), "the limit did not terminate");
+            Assert.True(task.Wait(LimitTermination.Guard), "the limit did not terminate");
             Assert.IsType<Entity.Limitf>(task.Result);
         }
 

--- a/Sources/Tests/UnitTests/Calculus/VanishingTimesDivergingTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/VanishingTimesDivergingTest.cs
@@ -29,7 +29,7 @@ namespace AngouriMath.Tests.Calculus
         {
             var task = Task.Run(() =>
                 expression.ToEntity().Limit("x", 0, ApproachFrom.Right).Simplify());
-            Assert.True(task.Wait(TimeSpan.FromSeconds(30)), "the limit did not terminate");
+            Assert.True(task.Wait(LimitTermination.Guard), "the limit did not terminate");
             Assert.Equal(expected.ToEntity().Evaled, task.Result.Evaled);
         }
 

--- a/Sources/Tests/UnitTests/Common/AlreadyFixedIssuesTest.cs
+++ b/Sources/Tests/UnitTests/Common/AlreadyFixedIssuesTest.cs
@@ -21,7 +21,7 @@ namespace AngouriMath.Tests.Common
     [Trait("Area", "Common")]
     public sealed class AlreadyFixedIssuesTest
     {
-        private static readonly System.TimeSpan Budget = System.TimeSpan.FromSeconds(30);
+        private static readonly System.TimeSpan Budget = LimitTermination.Guard;
 
         /// <summary>
         /// Runs work that used to hang or overflow the stack, and fails if it does not

--- a/Sources/Tests/UnitTests/Common/EveryNodeSurvivesEveryPipelineTest.cs
+++ b/Sources/Tests/UnitTests/Common/EveryNodeSurvivesEveryPipelineTest.cs
@@ -168,7 +168,7 @@ namespace AngouriMath.Tests.Common
                     catch (AngouriMath.Core.Exceptions.AngouriMathBaseException) { /* the library's own, and legitimate */ }
                     catch (NotSupportedException) { /* documented refusal, e.g. uncompilable shapes */ }
                     catch (Exception e) { failure = e.GetType().FullName + ": " + e.Message.Split('\n')[0]; }
-                }).Wait(TimeSpan.FromSeconds(30));
+                }).Wait(LimitTermination.Guard);
 
                 if (!finished)
                     broken.Add($"{name} did not terminate");

--- a/Sources/Tests/UnitTests/Common/LimitTermination.cs
+++ b/Sources/Tests/UnitTests/Common/LimitTermination.cs
@@ -1,0 +1,50 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+
+namespace AngouriMath.Tests
+{
+    /// <summary>
+    /// How long a test waits before it is willing to call a limit non-terminating.
+    /// </summary>
+    /// <remarks>
+    /// These guards exist because several limits used to run forever, and a test that hangs is
+    /// worse than one that fails. What they are <b>not</b> for is measuring how long a limit
+    /// takes: a non-terminating limit exceeds any bound, so the bound only has to be past the
+    /// slowest honest answer, and every second below that buys nothing while costing a false
+    /// failure whenever the machine is busy.
+    ///
+    /// The bound used to be 30 seconds, which is not past it on a loaded CI runner. The whole
+    /// guarded set — 171 cases across nine classes — runs in about 9 seconds on a developer
+    /// machine, yet on 2026-09-01 a macOS runner twice failed
+    /// <c>x * ln(x) / cos(x)</c> at 30 seconds on library code that master had already run green
+    /// on the same platform, in a suite whose own duration moved between 19 and 26 minutes with
+    /// load. Two runs of the same binary disagreeing is what makes it the clock and not the code.
+    ///
+    /// A genuine regression to non-termination still fails, three minutes later than it used to.
+    /// That is the trade this constant makes, and it is the right way round: a real regression is
+    /// rare and its slower report costs one CI run, while a false failure blocks every merge that
+    /// happens to land on a busy runner.
+    ///
+    /// Two wall clocks in this suite deliberately do <b>not</b> use it, because for them the bound
+    /// is not arbitrary:
+    /// <list type="bullet">
+    /// <item><c>CorpusGateTest</c>'s budget decides <c>Verdict.Timeout</c>, which is a recorded
+    /// verdict the gate compares against expectations — widening it would rewrite results rather
+    /// than stabilise them.</item>
+    /// <item><c>BooleanMinimisationTest.ParityIsNotSearchedAndTerminatesQuickly</c> asserts that
+    /// the engine declines instead of searching. There the tightness <i>is</i> the assertion: at
+    /// three minutes it would pass while the engine searched for two.</item>
+    /// </list>
+    /// </remarks>
+    internal static class LimitTermination
+    {
+        /// <summary>The wall clock a limit is given before a test declares it non-terminating.</summary>
+        internal static readonly TimeSpan Guard = TimeSpan.FromSeconds(180);
+    }
+}

--- a/Sources/Tests/UnitTests/Common/PowerQuotientGatheringTest.cs
+++ b/Sources/Tests/UnitTests/Common/PowerQuotientGatheringTest.cs
@@ -83,7 +83,7 @@ namespace AngouriMath.Tests.Common
         public void AQuotientOfPowersIsStillAnsweredAsALimit(string expr)
         {
             var limit = Task.Run(() => expr.ToEntity().Limit("x", "+oo").Simplify());
-            Assert.True(limit.Wait(System.TimeSpan.FromSeconds(30)), $"{expr} did not terminate");
+            Assert.True(limit.Wait(LimitTermination.Guard), $"{expr} did not terminate");
             Assert.False(limit.Result.Nodes.Any(node => node is Entity.Limitf),
                 $"{expr} came back unevaluated: {limit.Result.Stringize()}");
         }
@@ -109,7 +109,7 @@ namespace AngouriMath.Tests.Common
         public void TheQuotientFormIsAnsweredAsTheSinglePowerFormIs(string expr)
         {
             var limit = Task.Run(() => expr.ToEntity().Limit("x", "+oo").Simplify());
-            Assert.True(limit.Wait(System.TimeSpan.FromSeconds(30)), $"{expr} did not terminate");
+            Assert.True(limit.Wait(LimitTermination.Guard), $"{expr} did not terminate");
             Assert.Equal(Entity.Number.Integer.Create(1), limit.Result);
         }
 

--- a/Sources/Tests/UnitTests/Common/SimplificationRegressionTest.cs
+++ b/Sources/Tests/UnitTests/Common/SimplificationRegressionTest.cs
@@ -140,7 +140,7 @@ namespace AngouriMath.Tests.Common
         public void IntegrationTerminates(string integrand)
         {
             var task = System.Threading.Tasks.Task.Run(() => integrand.ToEntity().Integrate("x"));
-            Assert.True(task.Wait(System.TimeSpan.FromSeconds(30)),
+            Assert.True(task.Wait(LimitTermination.Guard),
                 $"integrating {integrand} did not terminate");
         }
 

--- a/Sources/Tests/UnitTests/Convenience/FloorCeilTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/FloorCeilTest.cs
@@ -188,7 +188,7 @@ namespace AngouriMath.Tests.Convenience
         {
             var task = System.Threading.Tasks.Task.Run(
                 () => input.ToEntity().Limit("x", destination.ToEntity()));
-            Assert.True(task.Wait(System.TimeSpan.FromSeconds(20)),
+            Assert.True(task.Wait(LimitTermination.Guard),
                 $"limit({input}, x, {destination}) did not finish");
             Assert.NotNull(task.Result);
         }

--- a/Sources/Tests/UnitTests/Convenience/ModulusTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/ModulusTest.cs
@@ -161,7 +161,7 @@ namespace AngouriMath.Tests.Convenience
         {
             var task = System.Threading.Tasks.Task.Run(
                 () => expression.ToEntity().Limit("x", destination.ToEntity()).Simplify());
-            Assert.True(task.Wait(TimeSpan.FromSeconds(30)), "the limit did not terminate");
+            Assert.True(task.Wait(LimitTermination.Guard), "the limit did not terminate");
             Assert.IsType<Entity.Limitf>(task.Result);
         }
 


### PR DESCRIPTION
Closes #1141.

The tests that assert a limit terminates wrap the call in a `Task` and fail it if it has not finished within a wall clock -- 15, 20 or 30 seconds, written separately at twenty-one call sites. They exist because several of these limits used to run forever, and a test that hangs is worse than one that fails.

## The bound was below the slowest honest answer

`Test (macos-latest)` failed twice on #1140 at `x * ln(x) / cos(x)`. That PR adds four files -- a workflow, a text list, two scripts -- and **none is compiled**, so the code under test was master's:

| | |
|---|---|
| master, macOS, 09:46 | green, suite 19 min |
| master, macOS, 12:09 | green, suite 22 min |
| #1140, macOS, 11:46 | **red**, suite 20 min |
| #1140, macOS, 12:28 | **red**, suite 26 min |

Both #1140 attempts re-ran the same merge commit. One binary, passing and failing by load -- which is what makes it the clock rather than the code. The guarded set is 171 cases in about 9 seconds here; the full suite is 6 minutes.

`OneSidedLimitTest` had already been widened to 180 s by hand for the same reason. This makes that one constant instead of one file's private decision.

## The trade, stated

A non-terminating limit exceeds any bound, so the bound only has to sit past the slowest honest answer; every second below that buys nothing and costs a false failure whenever the machine is busy. A regression to non-termination still fails, three minutes later than before. That is the right way round: a real regression is rare and costs one CI run, while a false failure blocks whatever merge happens to land on a busy runner. The job has no explicit timeout, so 360 minutes against a 26-minute suite leaves the slower path free.

## Two that deliberately keep their own bounds

Not everything with a wall clock is the same kind of thing, and both exclusions are recorded on the constant next to the reason the others share it:

- **`CorpusGateTest`** -- its budget decides `Verdict.Timeout`, a **recorded verdict** the gate compares against expectations. Widening it would rewrite results rather than stabilise them.
- **`BooleanMinimisationTest.ParityIsNotSearchedAndTerminatesQuickly`** -- asserts the engine **declines instead of searching**. There the tightness *is* the assertion: at three minutes it would pass while the engine searched for two.

## Measured

`9264 passed, 0 failed, 6 m 13 s` locally on the full unit suite. No library code is touched; the diff is tests plus the `.editorconfig` header entry the new file needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura