### PR TITLE
The exponential of a natural logarithm folds (#1138)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -100,6 +100,36 @@ read first.
 | | `"2 * x + 4 * a".ToEntity().Factorize()`, and every sum whose whole coefficients share a divisor | `2 * x + 4 * a` — left alone | `2 * (x + 2 * a)` |
 | | `Transformation.Factorization.Name` | `… then polynomial-factorization` | `… then polynomial-factorization then numeric-content` |
 | **Silent** | `"arccotan(-1)".ToEntity().Simplify()`, and every negative argument the inverse-trigonometric table knows | `3/4 * pi` — the textbook range, and **not equal to `arccotan(-1)`**, whose value is `-pi/4` | `-1/4 * pi` |
+| | `"e ^ ln(x)".ToEntity().Simplify()`, and every exponential of a natural logarithm | `e ^ ln(x)` — left as written | `x` |
+
+### The exponential of a natural logarithm folds
+
+`"e ^ ln(x)".ToEntity().Simplify()` was `e ^ ln(x)` and is `x`; so are `e ^ ln(2 * x)`,
+`e ^ ln(x + 1)` and `e ^ ln(sin(x))`. Nothing that had a value changes value.
+
+The identity was not missing. `2 ^ log(2, x)` has simplified to `x` throughout, and the rule that
+does it could not reach `e`: `ln(a)` is stored as `log(e, a)`, `e` is a `Constant` rather than a
+`Number`, and the pattern binds its base with `Any<Number>`, so the base never matched however the
+logarithm was written. That is
+[#994](https://github.com/asc-community/AngouriMath/issues/994) — every logarithm carrying a constant
+it does not mention — showing up as a missing simplification rather than as a printed one.
+
+Nothing is assumed. `b ^ log(b, a) = a` needs `ln(b)` to be non-zero, and `e` is decidably neither
+`0` nor `1`, which is exactly what the numeric arm cannot say about an arbitrary `Number` — so a
+symbolic base stays refused, and `1 ^ log(1, x)` is still `NaN` rather than `x`. It holds off the
+positive reals, on the principal branch: at `a = -3`, `ln(-3)` is `ln(3) + i*pi` and
+`e ^ (ln(3) + i*pi)` is `-3`. At `a = 0` no definedness moves either, since this library reads
+`ln(0)` as `-oo` and `e ^ (-oo)` as `0`, so both sides are `0`. It is labelled
+`SoundUnderAssumptions` rather than `Sound` because that last part is a branch convention.
+
+**No ODE changes.** The issue was filed believing this cost
+[#241](https://github.com/asc-community/AngouriMath/issues/241)'s solver its integrating factor. It
+does not: `OrdinaryDifferentialEquation` carries its own `ExponentialOf` helper that already folds
+`e ^ ln(u)`, so the eight first-order linear equations measured across this change come back
+**byte-identical**. The rule makes that helper redundant rather than unlocking anything, and removing
+it is left as its own change.
+
+[#1138](https://github.com/asc-community/AngouriMath/issues/1138).
 
 ### Every rule set describes the rules it runs
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -155,3 +155,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Common/LimitTermination.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Common/ExponentialOfALogarithmTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -2666,6 +2666,31 @@ namespace AngouriMath.Core.Transformations.Matching
                 Soundness.SoundUnderAssumptions,
                 description: "a ^ log(a, b) = b"),
 
+            // The same identity through `e`, which the rule above cannot reach: `ln(b)` is stored
+            // as log(e, b) and `e` is a Constant, not a Number, so `Any<Number>` never binds it
+            // however the logarithm is written.
+            // https://github.com/asc-community/AngouriMath/issues/994
+            //
+            // Nothing is left to discharge once the base is `e`: b^log_b(a) = a needs ln(b) to be
+            // non-zero, and e is decidably neither 0 nor 1, which is exactly what the numeric arm
+            // above cannot say about an arbitrary Number. It holds off the positive reals too --
+            // at a = -3, ln(-3) is ln(3) + i*pi and e^(ln(3) + i*pi) is -3 -- and at a = 0, where
+            // ln(0) is -oo here and e^(-oo) is 0, so both sides are 0 and no definedness moves.
+            // Labelled under assumptions rather than Sound because it is the principal branch of
+            // the logarithm that makes it true away from the reals, which is a branch convention.
+            // Written with a pattern on the right rather than the `bound => bound["a"]` its
+            // numeric sibling uses, so it is data in both directions: the constructor can then
+            // check the replacement only builds names the pattern binds, and the rule classifies
+            // as Reversible instead of ReplacementIsCode.
+            new MatchedRule(
+                "e-raised-to-a-natural-logarithm-is-the-antilogarithm",
+                MatchPattern.Node<Powf>(
+                    MatchPattern.Exact(Variable.e),
+                    MatchPattern.Node<Logf>(MatchPattern.Exact(Variable.e), MatchPattern.Any("a"))),
+                MatchPattern.Any("a"),
+                Soundness.SoundUnderAssumptions,
+                description: "e ^ ln(b) = b"),
+
             // Four `switch` arms: the power on either side of a product, and the shared base in
             // either position inside it. A commutative pattern says both halves at once.
             new MatchedRule(

--- a/Sources/AngouriMath/Docs/Contributing/WritingARule.md
+++ b/Sources/AngouriMath/Docs/Contributing/WritingARule.md
@@ -18,7 +18,7 @@ effect". This is how to supply those seven things.
 ## Where a rule goes
 
 `Core/Transformations/Matching/MatchedRules.cs`, as a value in a `MatchedRuleSet`. **33** sets and
-**322** rules live there today.
+**323** rules live there today.
 
 The `switch` statements in `Functions/Simplification/Patterns` are the older form. Twenty-seven of
 the thirty registered sets no longer run theirs, and **none of those twenty-seven describes it any
@@ -62,7 +62,7 @@ in a name and putting the identity in brackets after it:
 2. Tangent is sine over cosine (tan(a) = sin(a) / cos(a)), so tan(x) becomes sin(x) / cos(x).
 ```
 
-So the name has to be a clause that survives being read that way. **All 293 distinct rule names are,
+So the name has to be a clause that survives being read that way. **All 294 distinct rule names are,
 and `StepAsASentenceTest` holds them to it** — a name with a capital, a bracket or an underscore
 fails that test rather than degrading the prose quietly.
 
@@ -89,7 +89,7 @@ debugged for an afternoon.
 | `Left.ToString()` | `Divf(var a, Divf(var b, var c))` — how the matcher spells it |
 
 Write the identity with `=`, not `->`: it is an equality, and the arrow belongs to the direction the
-rule happens to be applied in. **292** rules carry one today; a new rule should.
+rule happens to be applied in. **293** rules carry one today; a new rule should.
 
 ## The pattern language
 
@@ -121,12 +121,12 @@ matches and silently builds nothing. `BuildableNodeTypesTest` is the list.
 
 ## Replacement: a pattern, or code
 
-**34** of the 322 rules have a pattern on both sides. The rest build their answer in code, and both
+**35** of the 323 rules have a pattern on both sides. The rest build their answer in code, and both
 are legitimate — but the choice costs two things, so make it deliberately.
 
 A pattern replacement gets:
 
-- **a direction.** `MatchedRule.Reversed` is the rule read the other way, and **32** of the 34
+- **a direction.** `MatchedRule.Reversed` is the rule read the other way, and **33** of the 35
   two-sided rules have one. The other two forget something: `sin²+cos² = 1` forgets the angle, and
   `{ x : x in S } = S` forgets the name the set builder bound, so neither has anything to read back.
   See [ReversibleRules.md](ReversibleRules.md).
@@ -154,7 +154,7 @@ limit, against nothing for handing the node over.
 | `SoundUnderAssumptions` | holds given something the rule does not check |
 | `Heuristic` | usually right |
 
-**181** of the 322 rules are `Sound` and **141** are conditional. Every one of the thirty registered
+**181** of the 323 rules are `Sound` and **142** are conditional. Every one of the thirty registered
 *sets* declares `SoundUnderAssumptions`, because a set's tier is the **minimum** over its rules — so
 the set grain says nothing and the rule grain says everything. A derivation reports the rule's tier
 (`RewriteStep.Soundness`), which is why getting it right matters beyond the label.

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Power.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Power.cs
@@ -133,6 +133,20 @@ namespace AngouriMath.Functions
             // c ^ log(c, a) = a
             Powf(Number const1, Logf(Number const1a, var any1)) when const1 == const1a => any1,
 
+            // e ^ ln(a) = a, which is the same identity and needs its own arm because the one
+            // above cannot reach it: `e` is a Variable rather than a Number, so `ln(a)` -- which
+            // is stored as log(e, a) -- never presents a numeric base however it is written.
+            // https://github.com/asc-community/AngouriMath/issues/994
+            //
+            // Assumptions: none. b^log_b(a) = a needs ln(b) to be non-zero, and e is decidably
+            // neither 0 nor 1, so there is nothing left to discharge. It is not restricted to the
+            // positive reals either, because on the principal branch ln(-3) is ln(3) + i*pi and
+            // e^(ln(3) + i*pi) is -3; and at a = 0 both sides are 0, since ln(0) is -oo here and
+            // e^(-oo) is 0. A symbolic base stays refused -- b != 1 is not decidable for it, and
+            // 1^log(1, a) is 1 rather than a.
+            Powf(var base1, Logf(var base1a, var any1))
+                when base1 == base1a && base1 == Variable.e => any1,
+
             Mulf(Powf(var any1, var any3), Mulf(var any1a, var any2)) when any1 == any1a => new Powf(any1, any3 + 1) * any2,
             Mulf(Powf(var any1, var any3), Mulf(var any2, var any1a)) when any1 == any1a => new Powf(any1, any3 + 1) * any2,
             Mulf(Mulf(var any1, var any2), Powf(var any1a, var any3)) when any1 == any1a => new Powf(any1, any3 + 1) * any2,

--- a/Sources/Tests/UnitTests/Common/ExponentialOfALogarithmTest.cs
+++ b/Sources/Tests/UnitTests/Common/ExponentialOfALogarithmTest.cs
@@ -1,0 +1,87 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Common
+{
+    /// <summary>
+    /// <c>e ^ ln(a) = a</c>. The identity was already written for a numeric base — <c>2 ^ log(2, x)</c>
+    /// has always simplified to <c>x</c> — and could not reach <c>e</c>, because <c>ln(a)</c> is stored
+    /// as <c>log(e, a)</c> and <c>e</c> is a <c>Constant</c> rather than a <c>Number</c>, so the
+    /// pattern's <c>Any&lt;Number&gt;</c> never bound it.
+    /// <see href="https://github.com/asc-community/AngouriMath/issues/1138"/>,
+    /// <see href="https://github.com/asc-community/AngouriMath/issues/994"/>.
+    /// </summary>
+    [Trait("Area", "Common")]
+    public sealed class ExponentialOfALogarithmTest
+    {
+        [Theory]
+        [InlineData("e ^ ln(x)", "x")]
+        [InlineData("e ^ ln(2 * x)", "2 * x")]
+        [InlineData("e ^ ln(x + 1)", "1 + x")]
+        [InlineData("e ^ ln(x ^ 2)", "x ^ 2")]
+        [InlineData("e ^ ln(sin(x))", "sin(x)")]
+        public void TheExponentialUndoesTheLogarithm(string input, string expected)
+            => Assert.Equal(expected.ToEntity(), input.ToEntity().Simplify());
+
+        /// <summary>The numeric base this was modelled on, which already worked.</summary>
+        [Theory]
+        [InlineData("2 ^ log(2, x)", "x")]
+        [InlineData("10 ^ log(10, x + 1)", "1 + x")]
+        public void ANumericBaseStillDoes(string input, string expected)
+            => Assert.Equal(expected.ToEntity(), input.ToEntity().Simplify());
+
+        /// <summary>
+        /// A symbolic base stays refused, and must: <c>b ^ log(b, a) = a</c> needs <c>ln(b)</c> to be
+        /// non-zero, which is not decidable for a symbol, and at <c>b = 1</c> the left side is
+        /// <c>1</c> rather than <c>a</c>. <c>e</c> is decidably neither <c>0</c> nor <c>1</c>, which
+        /// is the whole of what the new rule relies on.
+        /// </summary>
+        [Fact]
+        public void ASymbolicBaseIsNotFolded()
+        {
+            var expr = "a ^ log(a, x)".ToEntity();
+            Assert.Equal(expr, expr.Simplify());
+        }
+
+        /// <summary>And the base it would be wrong for is still answered the way it was.</summary>
+        [Fact]
+        public void TheBaseOneCaseIsUnchanged()
+            => Assert.Equal("NaN".ToEntity().Evaled, "1 ^ log(1, x)".ToEntity().Simplify().Evaled);
+
+        /// <summary>
+        /// The rewrite must not move a value anywhere the original had one, and in particular not on
+        /// the negative reals, where it is the principal branch that makes it true:
+        /// <c>ln(-3)</c> is <c>ln(3) + i*pi</c>, and <c>e ^ (ln(3) + i*pi)</c> is <c>-3</c>.
+        /// </summary>
+        [Theory]
+        [InlineData("e ^ ln(x)", 3.0)]
+        [InlineData("e ^ ln(x)", -3.0)]
+        [InlineData("e ^ ln(x)", 0.25)]
+        [InlineData("e ^ ln(2 * x)", -1.5)]
+        [InlineData("e ^ ln(x + 1)", -4.0)]
+        public void TheValueIsPreserved(string input, double at)
+        {
+            var original = input.ToEntity();
+            var before = original.Substitute("x", at).Evaled;
+            var after = original.Simplify().Substitute("x", at).Evaled;
+            Assert.Equal(before, after);
+        }
+
+        /// <summary>
+        /// At <c>a = 0</c> no definedness moves either, which is what the contract's O4 asks: this
+        /// library reads <c>ln(0)</c> as <c>-oo</c> and <c>e ^ (-oo)</c> as <c>0</c>, so both sides
+        /// are <c>0</c> rather than one being undefined.
+        /// </summary>
+        [Fact]
+        public void NothingBecomesDefinedThatWasNot()
+            => Assert.Equal("0".ToEntity().Evaled, "e ^ ln(0)".ToEntity().Simplify().Evaled);
+    }
+}

--- a/Sources/Tests/UnitTests/Core/Transformations/AddressableRulesTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/AddressableRulesTest.cs
@@ -290,7 +290,7 @@ namespace AngouriMath.Tests.Core.Transformations
 
             Assert.Equal(30, withRules.Count);
 
-            // 313, and it was 407 before the registry started reporting the rules it runs rather
+            // 314, and it was 407 before the registry started reporting the rules it runs rather
             // than the `switch` it no longer runs. The ninety-four that went are not rules lost, they
             // are arms the data form writes once. Boolean's thirty-six are twenty, because a
             // commutative pattern finds a shared operand wherever it sits, so eight arms of
@@ -299,7 +299,7 @@ namespace AngouriMath.Tests.Core.Transformations
             // are thirty-three; NumericNeat's sixteen are eleven, six of them being three rules
             // written once per side a negative factor can sit on; and the two factorial sets are
             // eight arms each written as three. Every other repointed set is one arm for one rule.
-            Assert.Equal(313, withRules.Sum(set => set.Rules.Count));
+            Assert.Equal(314, withRules.Sum(set => set.Rules.Count));
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
@@ -43,7 +43,7 @@ namespace AngouriMath.Tests.Core.Transformations
         public void WhereARuleGoes()
         {
             Stated(33, MatchedRules.All.Count, "the number of rule sets written as data");
-            Stated(322, MatchedRules.All.Sum(set => set.Rules.Count), "the number of rules written as data");
+            Stated(323, MatchedRules.All.Sum(set => set.Rules.Count), "the number of rules written as data");
             Stated(30, RewriteRules.All.Count, "the number of registered sets");
             Stated(27, RewriteRules.All.Count(set =>
                     MatchedRules.All.Any(data => data.Name == set.Name)
@@ -59,7 +59,7 @@ namespace AngouriMath.Tests.Core.Transformations
         {
             var names = MatchedRules.All.SelectMany(set => set.Rules)
                 .Select(rule => rule.Name).Distinct(StringComparer.Ordinal).ToList();
-            Stated(293, names.Count, "the number of distinct rule names");
+            Stated(294, names.Count, "the number of distinct rule names");
 
             var words = names.Select(name => name.Split('-').Length).ToList();
             Stated(4, words.Min(), "the shortest rule name in words");
@@ -68,7 +68,7 @@ namespace AngouriMath.Tests.Core.Transformations
 
         [Fact]
         public void TheIdentityIsNotTheName()
-            => Stated(292,
+            => Stated(293,
                 MatchedRules.All.SelectMany(set => set.Rules).Count(rule => rule.Description is not null),
                 "how many rules carry an identity");
 
@@ -80,9 +80,9 @@ namespace AngouriMath.Tests.Core.Transformations
         public void ReplacementAPatternOrCode()
         {
             var rules = MatchedRules.All.SelectMany(set => set.Rules).ToList();
-            Stated(34, rules.Count(rule => rule.Right is not null),
+            Stated(35, rules.Count(rule => rule.Right is not null),
                 "how many rules have a pattern on both sides");
-            Stated(32, rules.Count(rule => rule.Reversed is not null),
+            Stated(33, rules.Count(rule => rule.Reversed is not null),
                 "how many two-sided rules have a direction");
             Stated(260, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
                 "how many rules sit at Unknown growth");
@@ -115,7 +115,7 @@ namespace AngouriMath.Tests.Core.Transformations
             var rules = MatchedRules.All.SelectMany(set => set.Rules).ToList();
             Stated(181, rules.Count(rule => rule.Soundness is Soundness.Sound),
                 "how many rules are Sound");
-            Stated(141, rules.Count(rule => rule.Soundness is Soundness.SoundUnderAssumptions),
+            Stated(142, rules.Count(rule => rule.Soundness is Soundness.SoundUnderAssumptions),
                 "how many rules are SoundUnderAssumptions");
             Assert.All(RewriteRules.All,
                 set => Assert.Equal(Soundness.SoundUnderAssumptions, set.Soundness));

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleMetadataTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleMetadataTest.cs
@@ -46,7 +46,7 @@ namespace AngouriMath.Tests.Core.Transformations
         /// <c>AsAddressable</c> used to compare the lengths of the two rendered pattern strings,
         /// which is what <c>RuleRegistryGenerator</c> has to do — it reads C# source text and has
         /// no tree to count nodes on. Here there is a tree, and the proxy disagreed with it
-        /// <b>23 times in 322, in both directions</b>:
+        /// <b>23 times in 323, in both directions</b>:
         /// </para>
         /// <list type="bullet">
         /// <item>thirteen <c>Boolean</c> rules that <i>declare</i> <c>Collects</c> on a code-built
@@ -77,7 +77,7 @@ namespace AngouriMath.Tests.Core.Transformations
         /// <remarks>
         /// All thirty registry sets declare <see cref="Soundness.SoundUnderAssumptions"/>, and one
         /// conditional rule is enough to make that true of a set of a hundred. Asked per rule
-        /// instead, <b>181 of the 322 rules written as data are <see cref="Soundness.Sound"/></b> —
+        /// instead, <b>181 of the 323 rules written as data are <see cref="Soundness.Sound"/></b> —
         /// they hold for every complex argument, with nothing assumed. The counts are asserted
         /// rather than the ratio, because the interesting failure is a rule quietly changing tier.
         /// </remarks>
@@ -85,9 +85,9 @@ namespace AngouriMath.Tests.Core.Transformations
         public void SoundnessIsFinerPerRuleThanPerSet()
         {
             var rules = MatchedRules.All.SelectMany(set => set.Rules).ToList();
-            Assert.Equal(322, rules.Count);
+            Assert.Equal(323, rules.Count);
             Assert.Equal(181, rules.Count(rule => rule.Soundness is Soundness.Sound));
-            Assert.Equal(141, rules.Count(rule => rule.Soundness is Soundness.SoundUnderAssumptions));
+            Assert.Equal(142, rules.Count(rule => rule.Soundness is Soundness.SoundUnderAssumptions));
 
             // And every set still reports the weakest of them, which is what makes the set grain
             // uninformative rather than wrong.
@@ -168,7 +168,7 @@ namespace AngouriMath.Tests.Core.Transformations
             var repointed = RewriteRules.All
                 .Where(set => set.Rules.Count > 0 && set.Rules.All(rule => rule.Soundness is not null))
                 .ToList();
-            Assert.Equal(292, repointed.Sum(set => set.Rules.Count));
+            Assert.Equal(293, repointed.Sum(set => set.Rules.Count));
             Assert.All(repointed, set => Assert.All(set.Rules, rule => Assert.NotNull(rule.Description)));
         }
 

--- a/Sources/Tests/UnitTests/Core/Transformations/StepAsASentenceTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/StepAsASentenceTest.cs
@@ -59,7 +59,7 @@ namespace AngouriMath.Tests.Core.Transformations
         {
             var names = MatchedRules.All.SelectMany(set => set.Rules).Select(rule => rule.Name)
                 .Distinct(StringComparer.Ordinal).ToList();
-            Assert.Equal(293, names.Count);
+            Assert.Equal(294, names.Count);
             Assert.All(names, name => Assert.True(Explanation.IsProse(name),
                 $"'{name}' is a rule name that does not read as a phrase in English"));
 


### PR DESCRIPTION
Part of #1138.

`"e ^ ln(x)".ToEntity().Simplify()` was `e ^ ln(x)` and is `x`; so are `e ^ ln(2 * x)`, `e ^ ln(x + 1)` and `e ^ ln(sin(x))`.

## The identity was not missing

`2 ^ log(2, x)` has simplified to `x` throughout. The rule that does it could not reach `e`, because `ln(a)` is stored as `log(e, a)` and **`e` is a `Constant`, not a `Number`** — the pattern binds its base with `Any<Number>`, so the base never matched however the logarithm was written.

That is **#994** — every logarithm carrying a constant it does not mention — showing up as a missing simplification rather than as a printed one.

## The part that a passing unit test would have hidden

I first added the arm to the `switch` in `Patterns.Power.cs`, rebuilt, and **nothing changed** — while calling the rule directly gave `PowerRules(e ^ ln(x)) = x`.

`PowerRules` is one of the sets repointed at its data form, so `Simplify` runs the `MatchedRuleSet` and not the `switch`. Editing the `switch` alone is close to dead code for `Simplify`. Both forms are updated here; the arm is still carried because `FractionedPolynoms` and the rational patterns call `Patterns.PowerRules` directly and should fold it too.

## Data on both sides

Written with a pattern on the right rather than the `bound => bound["a"]` its numeric sibling uses. The constructor can then check the replacement builds only names the pattern binds, and the rule classifies as `Reversible` rather than `ReplacementIsCode`.

## What it assumes

Nothing beyond a branch convention, and the guard is the whole reason the general rule stays refused:

- `b ^ log(b, a) = a` needs `ln(b)` non-zero. **`e` is decidably neither `0` nor `1`** — exactly what the numeric arm cannot say about an arbitrary `Number`.
- A symbolic base is still refused: `a ^ log(a, x)` is unchanged, and `1 ^ log(1, x)` is still `NaN` rather than `x`.
- It holds off the positive reals: at `a = -3`, `ln(-3)` is `ln(3) + i*pi` and `e ^ (ln(3) + i*pi)` is `-3`. Checked at `3`, `-3`, `0.25`, `-1.5` and `-4`.
- At `a = 0` nothing becomes defined that was not: `ln(0)` is `-oo` here and `e ^ (-oo)` is `0`, so both sides are `0`.

Labelled `SoundUnderAssumptions` rather than `Sound` because that fourth point is the principal branch, and `Sound` here means "no choice of branch".

## No ODE changes, contrary to the issue

#1138 was filed believing this cost #241's solver its integrating factor. **It does not.** `OrdinaryDifferentialEquation` carries its own `ExponentialOf` helper that already folds `e ^ ln(u)`, so eight first-order linear equations measured across this change come back **byte-identical**. The rule makes that helper redundant rather than unlocking anything; removing it is left as its own change, and the issue is corrected rather than closed by this.

## Census

Adding one rule moves seven stated numbers, because `WritingARule.md` states the rule population and four tests hold the document to it — *"Update the document, not this test."* The two-sided and reversible counts move too, this rule being data on both sides.

`9308 passed, 0 failed.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura