### PR TITLE
The ODE solver's exponential helper is not redundant after all

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -126,8 +126,13 @@ positive reals, on the principal branch: at `a = -3`, `ln(-3)` is `ln(3) + i*pi`
 [#241](https://github.com/asc-community/AngouriMath/issues/241)'s solver its integrating factor. It
 does not: `OrdinaryDifferentialEquation` carries its own `ExponentialOf` helper that already folds
 `e ^ ln(u)`, so the eight first-order linear equations measured across this change come back
-**byte-identical**. The rule makes that helper redundant rather than unlocking anything, and removing
-it is left as its own change.
+**byte-identical**. *An earlier version of this entry went one step further and said the rule makes
+that helper redundant, with removing it left as its own change. It does not, and the removal was
+measured rather than done: the solver asks `InnerSimplified`, which does not carry the rewrite rules,
+so `e ^ ln(x)` reaches it unfolded. Deleting the helper fails three `OrdinaryDifferentialEquationTest`
+cases, deleting only its `e ^ ln(u)` arm fails two, and calling `Simplify` at the call site instead
+still fails one — because nothing in the library folds `e ^ (k ln u)` to `u ^ k`, which is the shape
+an antiderivative of `k/x` gives. The helper stays, and its doc comment now records why.*
 
 [#1138](https://github.com/asc-community/AngouriMath/issues/1138).
 

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/OrdinaryDifferentialEquation.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/OrdinaryDifferentialEquation.cs
@@ -147,18 +147,29 @@ namespace AngouriMath.Functions.Algebra
         /// <remarks>
         /// <para>
         /// This is not tidying, it is the difference between answering and not. The integrating
-        /// factor for <c>y' + y/x = 1</c> is <c>e^(int dx/x)</c>, which is <c>e^ln(x)</c> — and
-        /// <b><c>e^ln(x)</c> is not simplified to <c>x</c> by anything in the library</b>, neither
-        /// by <c>InnerSimplified</c> nor by <c>Simplify</c>. The factor then stays an exponential
-        /// of a logarithm, the second integral has no antiderivative for it, and the whole
-        /// equation is declined. Measured, which is how it was found: every step but that one
-        /// came out.
+        /// factor for <c>y' + y/x = 1</c> is <c>e^(int dx/x)</c>, which is <c>e^ln(x)</c>. If that
+        /// stays an exponential of a logarithm, the second integral has no antiderivative for it
+        /// and the whole equation is declined. Measured, which is how it was found: every step but
+        /// that one came out.
         /// </para>
         /// <para>
-        /// Done here rather than as a simplification rule because a rule for <c>e^ln(a) = a</c>
-        /// reaches every expression in the library and wants deciding on its own terms. Filed
-        /// separately; this is the local reading, which is sound because the exponent was built
-        /// here and is known to be an antiderivative.
+        /// <b>Every arm here is load-bearing, and the general rule does not replace any of them.</b>
+        /// <c>Simplify</c> has folded <c>e^ln(a)</c> to <c>a</c> since
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1138">#1138</a>, which is
+        /// what the paragraph above used to deny — but this method asks
+        /// <see cref="Entity.InnerSimplified"/>, and that pass does not carry the rewrite rules, so
+        /// <c>e^ln(x)</c> reaches it unfolded. Removing the whole method fails three
+        /// <c>OrdinaryDifferentialEquationTest</c> cases; removing only the <c>e^ln(u)</c> arm
+        /// fails two; and calling <c>Simplify</c> at the call site instead still fails one, because
+        /// <b>nothing in the library folds <c>e^(k ln u)</c> to <c>u^k</c></b> — the shape an
+        /// antiderivative of <c>k/x</c> gives, and the reason the two <c>Mulf</c> arms exist.
+        /// </para>
+        /// <para>
+        /// Kept local rather than promoted to a rule for the same reason it was written local: the
+        /// scaled form <c>e^(k ln u) = u^k</c> is a principal-branch identity that reaches every
+        /// expression in the library and wants deciding on its own terms. Here the exponent was
+        /// built by this method and is known to be an antiderivative, which is what makes the
+        /// local reading sound without that argument.
         /// </para>
         /// </remarks>
         private static Entity ExponentialOf(Entity exponent)


### PR DESCRIPTION
#1143 folded `e ^ ln(a)` to `a`. Both that PR's body and the `BREAKING-CHANGES.md`
entry it added went one step past what had been measured, and said the new rule makes
`OrdinaryDifferentialEquation.ExponentialOf` redundant, with the removal left as its
own change.

**It is not redundant.** The removal was measured rather than done:

| what was removed | `OrdinaryDifferentialEquationTest` failures |
|---|---|
| the whole helper | 3 |
| only its `e ^ ln(u)` arm | 2 |
| the helper, calling `Simplify()` at the call site instead | 1 |

Two reasons, both measured rather than reasoned:

1. **The solver asks `InnerSimplified`, which does not carry the rewrite rules.** So
   `e ^ ln(x)` reaches it unfolded however `Simplify` now behaves. This is the same
   fact that made #1143's eight ODEs come back byte-identical — the rule and the
   solver never meet.
2. **Nothing in the library folds `e ^ (k ln u)` to `u ^ k`** — neither
   `InnerSimplified` nor `Simplify`. That is the shape an antiderivative of `k/x`
   gives, and it is what the helper's two `Mulf` arms are for. It survives even the
   `Simplify()` variant, which is the only route that could have removed the helper.

Probed directly, on this branch's build:

```
e ^ ln(x)        inner = e ^ ln(x)        simplify = x
e ^ (2 * ln(x))  inner = e ^ (2 * ln(x))  simplify = e ^ (2 * ln(x))
e ^ (ln(x) * 2)  inner = e ^ (ln(x) * 2)  simplify = e ^ (2 * ln(x))
e ^ (ln(x) / 2)  inner = e ^ (ln(x) / 2)  simplify = e ^ (ln(x) / 2)
```

## What changes

**No behaviour changes.** Two documents, both of which #1143 made false:

- **`OrdinaryDifferentialEquation.ExponentialOf`'s doc comment** asserted in bold that
  `e ^ ln(x)` *"is not simplified to `x` by anything in the library, neither by
  `InnerSimplified` nor by `Simplify`"*. The `Simplify` half stopped being true at
  #1143. Rewritten to say what holds now, and to name which measurement pins each arm,
  so the next reader tempted to delete it has the numbers rather than the inference.
- **`BREAKING-CHANGES.md`** said the rule *"makes that helper redundant … and removing
  it is left as its own change"*. Corrected in place and marked as a correction rather
  than silently rewritten, since that paragraph is the record of what was claimed.

The guard against a future deletion already exists and needed nothing added:
`OrdinaryDifferentialEquationTest.WhereTheFactorIsAPower` and
`TheSameEquationWrittenTwoWaysHasOneSolution` are the cases that fail, which is how
each row of the table above was obtained.

## Verification

Full suite: **9308 passed, 0 failed**, 14 skipped.

Part of #1138.
