### PR TITLE
An improper quotient is divided out before it is decomposed (#180)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -40,6 +40,7 @@ read first.
 | | `"x^2/(x^4 + 1)".Integrate("x")`, and every quotient whose denominator is a biquadratic irreducible over `Q` | `integral(x ^ 2 / (x ^ 4 + 1), x)` — left unevaluated | the antiderivative, over the real quadratic factors |
 | | `"sqrt(x)/(1 + x^2)".Integrate("x")`, and every integrand a fractional power of the variable makes rational | `integral(sqrt(x) / (1 + x ^ 2), x)` — left unevaluated | the antiderivative |
 | | `"sqrt(tan(x))".Integrate("x")`, and every integrand that is a function of `tan(x)` alone and rational in it | `integral(sqrt(tan(x)), x)` — left unevaluated | the antiderivative |
+| | `"x^2/(x + 1)".Integrate("x")`, and every improper quotient of polynomials | `integral(x ^ 2 / (x + 1), x)` — left unevaluated | `x ^ 2 / 2 + -x + ln(x + 1) + C` |
 | | `Entity.DomainConditionIn(Domain)` | did not exist | the domain of definition for a **stated** reading, through the whole tree |
 | | `MathS.Polynomials.Factor("(y * x3 + 1) * (x4 - y3)", "x")`, and bivariate polynomials whose leading coefficient in the main variable is a polynomial | `null` — a refusal | `(x ^ 4 - y ^ 3) * (x ^ 3 * y + 1)` |
 | | `MathS.Polynomials.Factor("x7 - y7", "x")`, and bivariate polynomials whose substituted image over-factors | `null` — a refusal | `(x - y) * (x ^ 6 + x ^ 5 * y + … + y ^ 6)` |
@@ -2471,6 +2472,49 @@ reach. The gate reached the same verdict independently, by differentiating the a
 than by comparing it with anything.
 
 [#233](https://github.com/asc-community/AngouriMath/issues/233).
+
+### An improper quotient is divided out before it is decomposed
+
+Every step of the rational integrator wants a **proper** fraction — a numerator of lower degree
+than the denominator — and each of the three declines an improper one rather than dividing it out.
+So `x^2/(x + 1)` had no antiderivative, although it is `x - 1 + 1/(x + 1)` and every piece of that
+has been integrable throughout.
+
+```
+"x^2/(x + 1)".Integrate("x")
+
+was  integral(x ^ 2 / (x + 1), x)
+is   x ^ 2 / 2 + -x + ln(x + 1) + C
+```
+
+**The division is not new code.** `TreeAnalyzer.PolynomialLongDivision` has done it all along, for
+the simplifier's own `PolynomialLongDivision` rule set; the integrator simply never asked it. What
+changed is one call, placed before the three decompositions rather than after them.
+
+New with it, as written: `x^3/(1 + x^2)`, `x^4/(x^2 + 1)`, `(x^5 + 2)/(x^2 + 1)`,
+`(x^2 + 3x + 5)/(x + 2)`, and the exact-division cases `(x^3 + 1)/(x + 1)` and `(x^2 - 1)/(x - 1)`,
+whose proper part is zero.
+
+New with it **through a substitution**, which is where it matters more, since the substitution
+produces the improper fraction rather than the user writing one: `tan(x)^2`, `tan(x)^3` and
+`sqrt(x)/(x + 1)` were all declined for this and no other reason, each having been named as such
+in the tests that recorded the boundary. `int tan(x)^2` comes back as
+`tan(x) - arctan(tan(x)) + C` rather than the textbook `tan(x) - x`, which is the same function on
+the principal branch and is what the rewrite has to say without an assumption about which branch
+`x` is on.
+
+**A proper fraction is untouched.** The helper answers nothing for one, so the three steps below
+see exactly what they saw before: `int 1/(x + 1)` is still `ln(x + 1) + C` and `int x/(x^2 + 1)`
+still `ln(x^2 + 1)/2 + C`.
+
+**A symbolic leading coefficient is still declined.** `x^2/(a + b*x)` —
+[#180](https://github.com/asc-community/AngouriMath/issues/180)'s item 18 — would have the division
+divide by `b`, which is not decidably non-zero, and at `b = 0` the quotient is `x^2/a`, whose
+antiderivative is not the limit of the divided form. `x^2/(x + a)` is declined too, for a narrower
+reason: the leading coefficient there is `1`, but the helper does not divide a polynomial whose
+other coefficients are symbolic.
+
+[#180](https://github.com/asc-community/AngouriMath/issues/180).
 
 ### A polynomial equation that factors is solved through its factors
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -161,3 +161,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/TangentSubstitutionIntegralTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/ImproperFractionIntegralTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -54,11 +54,29 @@ namespace AngouriMath.Functions.Algebra
         /// introduces a radical, and a denominator that factors over Q should be taken apart in
         /// exact arithmetic by one of the two above.
         /// </para>
+        /// <para>
+        /// <b>All three of those want a proper fraction</b>, and each declines an improper one
+        /// rather than dividing it out — so <c>x^2/(x + 1)</c> had no antiderivative although
+        /// it is <c>x - 1 + 1/(x + 1)</c> and every piece of that is read. The division is the
+        /// first step here for that reason, and it is not new code:
+        /// <see cref="TreeAnalyzer.PolynomialLongDivision"/> has done it all along for the
+        /// simplifier's own rule set, and the integrator simply never asked it.
+        /// </para>
         /// </remarks>
         internal static Entity? SolveByPartialFractions(Entity expr, Entity.Variable x, bool integrateByParts)
         {
             if (expr is not Entity.Divf(var numerator, var denominator))
                 return null;
+
+            // The helper answers null for a fraction that is already proper, so this cannot
+            // fire on one and recurse into the problem it started from. The check on the
+            // quotient is the second half of that guarantee: a division that came back with
+            // nothing taken out would hand the same fraction on and not terminate.
+            if (TreeAnalyzer.PolynomialLongDivision(numerator, denominator) is var (quotient, properPart)
+                && quotient.Evaled != Entity.Number.Integer.Create(0)
+                && Integration.ComputeIndefiniteIntegral(quotient, x, integrateByParts) is { } wholePart
+                && Integration.ComputeIndefiniteIntegral(properPart, x, integrateByParts) is { } fractionPart)
+                return wholePart + fractionPart;
 
             if (Functions.PolynomialFactoring.TrySplitOffRationalRoot(
                     numerator, denominator, x, out var simple, out var restNumerator, out var restDenominator)

--- a/Sources/Tests/UnitTests/Calculus/ImproperFractionIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ImproperFractionIntegralTest.cs
@@ -1,0 +1,118 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// Quotients of polynomials whose numerator is of no lower degree than the denominator, which
+    /// every step of the rational integrator wanted divided out first and none of them did.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>x^2/(x + 1)</c> is <c>x - 1 + 1/(x + 1)</c>, and each piece of that has been integrable
+    /// throughout; the quotient itself had no antiderivative because the split at a rational root,
+    /// the split at a coprime pair, and the split over the reals all require a <b>proper</b>
+    /// fraction and decline otherwise.
+    /// </para>
+    /// <para>
+    /// The division was not written for this — <c>TreeAnalyzer.PolynomialLongDivision</c> has done
+    /// it all along for the simplifier's own <c>PolynomialLongDivision</c> rule set. The integrator
+    /// never asked it.
+    /// </para>
+    /// <para>
+    /// Checked by differentiating the answer back and comparing at points, never by comparing
+    /// printed forms.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class ImproperFractionIntegralTest
+    {
+        private static void DifferentiatesBack(string integrand, params double[] points)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 3,
+                $"only {compared} of {points.Length} points were comparable for {integrand}");
+        }
+
+        /// <summary>The degree of the numerator above the denominator's, by one and by more.</summary>
+        [Theory]
+        [InlineData("x^2/(x + 1)", new[] { 0.3, 1.7, 5.0, -2.4 })]
+        [InlineData("x^2/(1 + x)", new[] { 0.3, 1.7, 5.0, -2.4 })]
+        [InlineData("x^3/(1 + x^2)", new[] { 0.3, 1.7, 5.0, -2.4 })]
+        [InlineData("x^4/(x^2 + 1)", new[] { 0.3, 1.7, 5.0, -2.4 })]
+        [InlineData("(x^5 + 2)/(x^2 + 1)", new[] { 0.3, 1.7, 5.0, -2.4 })]
+        [InlineData("(x^2 + 3*x + 5)/(x + 2)", new[] { 0.3, 1.7, 5.0, -2.4 })]
+        public void AnImproperQuotientIsDividedOutFirst(string integrand, double[] points)
+            => DifferentiatesBack(integrand, points);
+
+        /// <summary>
+        /// A numerator the denominator divides exactly, where the proper part is zero and the
+        /// answer is the polynomial alone.
+        /// </summary>
+        [Theory]
+        [InlineData("(x^3 + 1)/(x + 1)", new[] { 0.3, 1.7, 5.0, -2.4 })]
+        [InlineData("(x^2 - 1)/(x - 1)", new[] { 0.3, 1.7, 5.0, -2.4 })]
+        public void ADenominatorThatDividesExactly(string integrand, double[] points)
+            => DifferentiatesBack(integrand, points);
+
+        /// <summary>
+        /// What reaches this through a substitution rather than as written: the tangent
+        /// substitution and the fractional power both produce improper fractions, and both were
+        /// declined for it.
+        /// </summary>
+        [Theory]
+        [InlineData("tan(x) ^ 2", new[] { 0.3, 0.9, 1.3 })]
+        [InlineData("tan(x) ^ 3", new[] { 0.3, 0.9, 1.3 })]
+        [InlineData("sqrt(x)/(x + 1)", new[] { 0.3, 1.7, 5.0 })]
+        public void ReachedThroughASubstitution(string integrand, double[] points)
+            => DifferentiatesBack(integrand, points);
+
+        /// <summary>
+        /// A proper fraction must be untouched by this: the division declines one, so the steps
+        /// below it see exactly what they saw before and answer it the same way.
+        /// </summary>
+        [Theory]
+        [InlineData("1/(x + 1)", "ln(x + 1) + C")]
+        [InlineData("x/(x^2 + 1)", "1/2 * ln(x ^ 2 + 1) + C")]
+        public void AProperFractionIsUnchanged(string integrand, string expected)
+            => Assert.Equal(expected.ToEntity(), integrand.ToEntity().Integrate("x"));
+
+        /// <summary>
+        /// A denominator whose leading coefficient is symbolic is still declined. The division
+        /// would have to divide by <c>b</c>, which is not decidably non-zero — and at <c>b = 0</c>
+        /// the quotient is <c>x^2/a</c>, whose antiderivative is not the limit of the divided
+        /// form. <see href="https://github.com/asc-community/AngouriMath/issues/180"/> item 18.
+        /// </summary>
+        [Theory]
+        [InlineData("x^2/(a + b*x)")]
+        [InlineData("x^2/(x + a)")]
+        public void ASymbolicLeadingCoefficientIsDeclined(string integrand)
+            => Assert.Contains("integral(", integrand.ToEntity().Integrate("x").Stringize());
+    }
+}

--- a/Sources/Tests/UnitTests/Calculus/PowerSubstitutionIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/PowerSubstitutionIntegralTest.cs
@@ -90,19 +90,23 @@ namespace AngouriMath.Tests.Calculus
         [InlineData("1/(sqrt(x) * (1 + x))")]
         [InlineData("1/(sqrt(x) * (1 + x^2))")]
         [InlineData("1/(sqrt(x) + x)")]
+        // Becomes 2u^2/(1 + u^2), which is improper; answered once the rational integrator
+        // divides an improper fraction out before decomposing it.
+        [InlineData("sqrt(x)/(x + 1)")]
         public void AFractionalPowerIsAlsoASubstitution(string integrand)
             => DifferentiatesBack(integrand);
 
         /// <summary>
         /// Where a fractional substitution reaches and the rest of the chain does not, recorded
         /// so the boundary is visible. <c>sqrt(x)/(1 + x^4)</c> becomes <c>2u^2/(1 + u^8)</c>,
-        /// whose denominator is neither factorable over the rationals nor a biquadratic; and
-        /// <c>sqrt(x)/(x + 1)</c> becomes <c>2u^2/(1 + u^2)</c>, which is improper, and dividing
-        /// an improper fraction out is not something the rational integrator does.
+        /// whose denominator is neither factorable over the rationals nor a biquadratic.
         /// </summary>
+        /// <remarks>
+        /// <c>sqrt(x)/(x + 1)</c> was here too, for becoming an improper fraction that nothing
+        /// divided out. It is answered above now that the rational integrator divides first.
+        /// </remarks>
         [Theory]
         [InlineData("sqrt(x)/(1 + x^4)")]
-        [InlineData("sqrt(x)/(x + 1)")]
         public void WhereTheChainStops(string integrand)
             => Assert.Contains("integral(", integrand.ToEntity().Integrate("x").Stringize());
 

--- a/Sources/Tests/UnitTests/Calculus/TangentSubstitutionIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/TangentSubstitutionIntegralTest.cs
@@ -83,6 +83,17 @@ namespace AngouriMath.Tests.Calculus
         public void AFunctionOfTheTangentAlone(string integrand) => DifferentiatesBack(integrand);
 
         /// <summary>
+        /// A power of the tangent, which the rewrite turns into an <b>improper</b> rational
+        /// function — <c>u^2/(1 + u^2)</c> and <c>u^3/(1 + u^2)</c>. These were declined while
+        /// nothing divided an improper fraction out; they are answered now that the rational
+        /// integrator does that first.
+        /// </summary>
+        [Theory]
+        [InlineData("tan(x) ^ 2")]
+        [InlineData("tan(x) ^ 3")]
+        public void APowerOfTheTangent(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
         /// What the neighbours still answer, and must go on answering the same way: the tangent
         /// itself has a rule, which is reached before this and gives the shorter form.
         /// </summary>
@@ -110,18 +121,17 @@ namespace AngouriMath.Tests.Calculus
         /// <list type="bullet">
         /// <item><c>sqrt(cotan(x))</c> — <c>cotan</c> is its own node rather than a reciprocal of
         /// the tangent, so the rewrite finds nothing to replace and this never starts.</item>
-        /// <item><c>tan(x)^2</c> and <c>tan(x)^3</c> become <c>u^2/(1 + u^2)</c> and
-        /// <c>u^3/(1 + u^2)</c>, which are <b>improper</b> — a polynomial plus a proper fraction
-        /// — and dividing that out is not something the rational integrator does.</item>
         /// <item><c>1/(1 + tan(x)^2)</c> becomes <c>1/(1 + u^2)^2</c>, a repeated irreducible
         /// quadratic, which the partial fraction step declines because there is no rule for a
         /// numerator over one.</item>
         /// </list>
+        /// <c>tan(x)^2</c> and <c>tan(x)^3</c> were on this list, for becoming improper rational
+        /// functions that nothing divided out. They are answered above now that the rational
+        /// integrator divides first, which is why a list like this is worth keeping as tests
+        /// rather than as prose: it fails when the boundary moves.
         /// </remarks>
         [Theory]
         [InlineData("sqrt(cotan(x))")]
-        [InlineData("tan(x) ^ 2")]
-        [InlineData("tan(x) ^ 3")]
         [InlineData("1/(1 + tan(x)^2)")]
         public void WhatIsStillDeclined(string integrand)
             => Assert.Contains("integral(", integrand.ToEntity().Integrate("x").Stringize());


### PR DESCRIPTION
Every step of the rational integrator wants a **proper** fraction — a numerator of lower
degree than the denominator — and each of the three declines an improper one rather than
dividing it out. So `x^2/(x + 1)` had no antiderivative, although it is `x - 1 + 1/(x + 1)`
and every piece of that has been integrable throughout.

```
"x^2/(x + 1)".Integrate("x")

was  integral(x ^ 2 / (x + 1), x)
is   x ^ 2 / 2 + -x + ln(x + 1) + C
```

## The division was already written

`TreeAnalyzer.PolynomialLongDivision` has done this all along, for the simplifier's own
`PolynomialLongDivision` rule set. The integrator never asked it. The diff to the library is
one call, placed before the three decompositions rather than after them — no new algorithm,
and nothing about the division itself changed.

That is worth saying plainly because the gap read like a missing capability from the outside:
three separate places in the code say an improper fraction "has to be divided out first, which
is not done here", and the thing they describe existed one namespace away.

## What it delivers

As written:

| integrand | now |
|---|---|
| `x^2/(x + 1)` | `x^2/2 - x + ln(x + 1) + C` |
| `x^3/(1 + x^2)` | answered |
| `x^4/(x^2 + 1)` | answered |
| `(x^5 + 2)/(x^2 + 1)` | answered |
| `(x^2 + 3x + 5)/(x + 2)` | answered |
| `(x^3 + 1)/(x + 1)`, `(x^2 - 1)/(x - 1)` | answered — exact division, proper part zero |

Through a substitution, which is where it matters more, because there the improper fraction is
*produced* rather than written by anyone:

| integrand | becomes | now |
|---|---|---|
| `tan(x)^2` | `u^2/(1 + u^2)` | `tan(x) - arctan(tan(x)) + C` |
| `tan(x)^3` | `u^3/(1 + u^2)` | answered |
| `sqrt(x)/(x + 1)` | `2u^2/(1 + u^2)` | answered |

`int tan(x)^2` comes back as `tan(x) - arctan(tan(x)) + C` rather than the textbook
`tan(x) - x`. Those are the same function on the principal branch, and the second is what the
rewrite would have to assert about which branch `x` is on, so the first is the honest form.

## The declined lists caught this, which is what they are for

All three of `tan(x)^2`, `tan(x)^3` and `sqrt(x)/(x + 1)` were on "what is still declined"
theories added earlier today, each naming the improper-fraction gap as its reason. All three
failed the moment this landed, and moved to the positive cases with a note saying where they
came from. A boundary recorded as a test fails when the boundary moves; recorded as prose it
just goes quietly wrong.

## What is still declined

**A proper fraction is untouched** — the helper answers nothing for one, so the three steps
below it see exactly what they saw before. `int 1/(x + 1)` is still `ln(x + 1) + C` and
`int x/(x^2 + 1)` still `ln(x^2 + 1)/2 + C`, both asserted.

**A symbolic leading coefficient**, and this corrects something I wrote on #180 earlier today.
Item 18 there is `x^2/(a + b*x)`, which I said should come with this work. It does not: the
division would have to divide by `b`, which is not decidably non-zero, and at `b = 0` the
quotient is `x^2/a`, whose antiderivative is not the limit of the divided form. `x^2/(x + a)`
is declined too, for the narrower reason that the helper does not divide a polynomial whose
other coefficients are symbolic even when the leading one is `1`. Both are pinned by a test,
and I will correct the comment on #180.

Handling either would want the `Piecewise`-on-the-degenerate-case treatment that
`IntegrateRationalQuadratic` already uses for `a = 0`, which is its own change with its own
soundness argument.

## Verification

Full suite **9356 passed, 0 failed**, 14 skipped. Corpus still 40 of 40.

Every new answer is checked by differentiating it back and comparing at sampled points, through
a helper that first asserts the antiderivative contains no `integral(` — without that guard the
check passes vacuously, since `d/dx` of an unevaluated `integral(f, x)` is `f`.

Part of #180.
