### PR TITLE
A system with fewer equations than unknowns is answered, not refused (#212)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -41,6 +41,7 @@ read first.
 | | `"sqrt(x)/(1 + x^2)".Integrate("x")`, and every integrand a fractional power of the variable makes rational | `integral(sqrt(x) / (1 + x ^ 2), x)` — left unevaluated | the antiderivative |
 | | `"sqrt(tan(x))".Integrate("x")`, and every integrand that is a function of `tan(x)` alone and rational in it | `integral(sqrt(tan(x)), x)` — left unevaluated | the antiderivative |
 | | `"x^2/(x + 1)".Integrate("x")`, and every improper quotient of polynomials | `integral(x ^ 2 / (x + 1), x)` — left unevaluated | `x ^ 2 / 2 + -x + ln(x + 1) + C` |
+| | `MathS.Equations("2*x - 4*y - 12").Solve("x", "y")`, and every linear system with fewer equations than unknowns | `WrongNumberOfArgumentsException` | `[[6 + 2 * t_1, t_1]]` — the family of all its solutions |
 | | `Entity.DomainConditionIn(Domain)` | did not exist | the domain of definition for a **stated** reading, through the whole tree |
 | | `MathS.Polynomials.Factor("(y * x3 + 1) * (x4 - y3)", "x")`, and bivariate polynomials whose leading coefficient in the main variable is a polynomial | `null` — a refusal | `(x ^ 4 - y ^ 3) * (x ^ 3 * y + 1)` |
 | | `MathS.Polynomials.Factor("x7 - y7", "x")`, and bivariate polynomials whose substituted image over-factors | `null` — a refusal | `(x - y) * (x ^ 6 + x ^ 5 * y + … + y ^ 6)` |
@@ -2515,6 +2516,55 @@ reason: the leading coefficient there is `1`, but the helper does not divide a p
 other coefficients are symbolic.
 
 [#180](https://github.com/asc-community/AngouriMath/issues/180).
+
+### A system with fewer equations than unknowns is answered, not refused
+
+`Solve` raised `WrongNumberOfArgumentsException` for a system with fewer equations than
+unknowns — a message that says the caller called it wrongly, for a caller who did nothing wrong.
+`2x - 4y = 12` in `x` and `y` is a well-formed question; it simply has infinitely many answers.
+
+```
+MathS.Equations("2*x - 4*y - 12").Solve("x", "y")
+
+was  WrongNumberOfArgumentsException: Number of equations must be equal to that of vars
+is   [[6 + 2 * t_1, t_1]]
+```
+
+which is `x = 6 + 2t, y = t` — the answer the issue asks for in its body.
+
+**The answer type did not change.** A solution has always been a row whose i-th entry is the
+i-th unknown's value, and nothing said those entries may not mention a variable. The unknowns a
+row reduction leaves free become parameters, named the way the constant of integration is named
+in an ODE's answer, and the rest are written in terms of them. The system from the issue thread,
+three equations in five unknowns, comes back with two of them:
+
+```
+{ p + 2q + 4r + s - u = 1, 2p + 4q + 8r + 3s - 4u = 2, p + 3q + 7r + 3u = -2 }
+
+is   [[7 + 2 * t_1 + 3 * t_2, -3 + (-3) * t_1 + (-2) * t_2, t_1, 2 * t_2, t_2]]
+```
+
+**Only the short count is taken this way.** A square system that is rank-deficient still reaches
+the eliminator, which has answered it with a free parameter since
+[#550](https://github.com/asc-community/AngouriMath/issues/550); those answers are unchanged, as
+are every determined and every overdetermined system.
+
+**A contradictory short system is `null`**, the same as a contradictory square one, and that
+continues to mean *there are no solutions* rather than *no answer was found*.
+
+**What still raises.** The system has to be linear in the unknowns, checked rather than assumed
+— `x^2 + y^2 = 1` and `x*y = 1` fail the check — and the coefficients **on the unknowns** must be
+rational, so `a*x + y = 1` raises too. That last is a soundness requirement rather than a
+convenience: a row reduction has to decide whether a pivot is zero, the general test available
+is structural, and choosing a pivot that is zero without being written as `0` produces a wrong
+family rather than no answer. The **constant** term is under no such restriction, being never a
+pivot, so `2x - 4y = k` is answered with `k` symbolic.
+
+**Code that caught `WrongNumberOfArgumentsException` around `Solve`** to detect an
+underdetermined system now gets a matrix for the linear ones, and the exception only for the
+rest.
+
+[#212](https://github.com/asc-community/AngouriMath/issues/212).
 
 ### A polynomial equation that factors is solved through its factors
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -164,3 +164,8 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/ImproperFractionIntegralTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[AngouriMath/Functions/Continuous/Solvers/EquationSolver/LinearSystemSolver.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+[Tests/UnitTests/Algebra/SolveTest/ParametricSystemTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver.cs
@@ -121,6 +121,18 @@ namespace AngouriMath.Functions.Algebra
                 if (Groebner.GroebnerSystemSolver.TrySolve(equations, variables, out var triangularised))
                     return triangularised;
 
+                // Fewer equations than unknowns is not a mistake by the caller, which is what
+                // the exception below says it is. A linear system of that shape has infinitely
+                // many solutions and one family that describes them all, so it is answered as
+                // that family -- the unknowns a row reduction leaves free become parameters.
+                // Only the short count is taken here: a square system that is rank-deficient
+                // reaches the eliminator, which already answers it.
+                // https://github.com/asc-community/AngouriMath/issues/212
+                if (equations.Count < vars.Length
+                    && Functions.Algebra.AnalyticalSolving.LinearSystemSolver.TrySolve(
+                        equations, variables, out var family))
+                    return family;
+
                 if (equations.Count != vars.Length)
                     throw new WrongNumberOfArgumentsException("Number of equations must be equal to that of vars");
                 int initVarCount = vars.Length;

--- a/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/LinearSystemSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Solvers/EquationSolver/LinearSystemSolver.cs
@@ -1,0 +1,232 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using PeterO.Numbers;
+using System.Diagnostics.CodeAnalysis;
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Functions.Algebra.AnalyticalSolving
+{
+    /// <summary>
+    /// A linear system with fewer equations than unknowns, answered as the family of all its
+    /// solutions: the unknowns a row reduction leaves free become parameters, and the rest are
+    /// written in terms of them.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/212">#212</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>2x - 4y = 12</c> for <c>x</c> and <c>y</c> is the issue's own example. It has
+    /// infinitely many solutions and one degree of freedom, so the answer is a single row
+    /// <c>[12/2 + 2t, t]</c> rather than a list of them, and the <c>t</c> in it is a variable
+    /// the caller did not name.
+    /// </para>
+    /// <para>
+    /// <b>The answer type did not need changing, which is why this is small.</b> A solution is a
+    /// row of <see cref="Matrix"/> whose i-th entry is the i-th unknown's value, and nothing
+    /// says those entries may not mention a variable. The same device already carries the
+    /// constant of integration out of the ODE solver, and
+    /// <see cref="EquationSolver.InSolveSystem"/> already mints one <c>t</c> for the single case
+    /// where its recursion bottoms out unconstrained
+    /// (<a href="https://github.com/asc-community/AngouriMath/issues/550">#550</a>).
+    /// </para>
+    /// <para>
+    /// <b>Reached only where the count is short</b>, which is the one shape that had no answer
+    /// at all — <c>SolveSystem</c> threw <c>WrongNumberOfArgumentsException</c> for it before
+    /// reaching any elimination. A square system that is rank-deficient is left to the
+    /// eliminator, which already answers it; taking those here as well would change answers that
+    /// are not wrong.
+    /// </para>
+    /// <para>
+    /// <b>Rational coefficients on the unknowns, and that is a soundness requirement rather than
+    /// a convenience.</b> Row reduction has to decide whether a pivot is zero, and the general
+    /// test available here is structural — <c>Matrix.ReducedRowEchelonForm</c> asks
+    /// <c>a == 0</c>, which an expression that is zero everywhere without being written as
+    /// <c>0</c> fails. Choosing such a pivot divides by zero and produces a wrong family rather
+    /// than no answer. Over the rationals the question is decidable, so it is asked there. The
+    /// <b>constant</b> term is under no such restriction: it is never a pivot, so
+    /// <c>2x - 4y = k</c> is answered with <c>k</c> symbolic.
+    /// </para>
+    /// </remarks>
+    internal static class LinearSystemSolver
+    {
+        /// <summary>
+        /// The family of solutions of <paramref name="equations"/> in <paramref name="variables"/>,
+        /// or <see langword="false"/> where this does not apply. A <see langword="true"/> with a
+        /// <see langword="null"/> matrix is the answer that the system has no solutions at all.
+        /// </summary>
+        internal static bool TrySolve(
+            IReadOnlyList<Entity> equations, IReadOnlyList<Variable> variables, out Matrix? solution)
+        {
+            solution = null;
+            if (variables.Count == 0 || equations.Count == 0 || equations.Count >= variables.Count)
+                return false;
+
+            var width = variables.Count;
+            var coefficients = new ERational[equations.Count][];
+            var constants = new Entity[equations.Count];
+            for (var row = 0; row < equations.Count; row++)
+            {
+                if (!TryReadLinear(equations[row], variables, out var read, out var offset))
+                    return false;
+                coefficients[row] = read;
+                constants[row] = offset;
+            }
+
+            // Ax = b, with b the constant moved across. The coefficients are exact rationals and
+            // the right-hand side is whatever the equations had in them.
+            for (var row = 0; row < constants.Length; row++)
+                constants[row] = (-constants[row]).InnerSimplified;
+
+            var pivotOfRow = new int[equations.Count];
+            for (var row = 0; row < pivotOfRow.Length; row++)
+                pivotOfRow[row] = -1;
+            var rank = Reduce(coefficients, constants, width, pivotOfRow);
+
+            // A row that reduced to 0 = c with c not zero says the system is inconsistent, and
+            // that is an answer -- no solutions -- rather than a failure to find one.
+            for (var row = rank; row < equations.Count; row++)
+                if (constants[row].Evaled is not Integer { IsZero: true })
+                {
+                    if (constants[row].Evaled is Number { IsExact: true })
+                        return true;
+                    // A constant that cannot be decided either way is not evidence of
+                    // inconsistency, and answering "no solutions" on it would be a wrong answer
+                    // rather than an absent one.
+                    return false;
+                }
+
+            var isPivot = new bool[width];
+            for (var row = 0; row < rank; row++)
+                isPivot[pivotOfRow[row]] = true;
+
+            // One parameter per free column. Each is minted against the equations *and* the
+            // parameters already minted, since CreateUnique compares whole names in use and
+            // would otherwise hand back the same name twice.
+            var nameSource = Sumf.Sum(equations);
+            var values = new Entity[width];
+            for (var column = 0; column < width; column++)
+                if (!isPivot[column])
+                {
+                    var parameter = Variable.CreateUnique(nameSource, "t");
+                    values[column] = parameter;
+                    nameSource += parameter;
+                }
+
+            // Back-substitution is a lookup rather than a sweep: the reduction leaves each pivot
+            // alone in its column, so a pivot's value is its own row's constant less the free
+            // columns of that row.
+            for (var row = 0; row < rank; row++)
+            {
+                var column = pivotOfRow[row];
+                Entity value = constants[row];
+                for (var other = column + 1; other < width; other++)
+                    if (!isPivot[other] && !coefficients[row][other].IsZero)
+                        // The coefficient is negated rather than the term subtracted, so that a
+                        // negative one reads as `6 + 2 * t_1` and not as `6 - (-2) * t_1`.
+                        value += Rational.Create(coefficients[row][other].Negate()) * values[other];
+                values[column] = value.InnerSimplified;
+            }
+
+            var builder = new MatrixBuilder(width);
+            builder.Add(new List<Entity>(values));
+            solution = builder.ToMatrix();
+            return solution is not null;
+        }
+
+        /// <summary>
+        /// <paramref name="equation"/> read as <c>c_1 v_1 + ... + c_n v_n + constant</c>, or
+        /// <see langword="false"/> where it is not linear in <paramref name="variables"/> with
+        /// rational coefficients.
+        /// </summary>
+        /// <remarks>
+        /// Linearity is checked rather than assumed, the way
+        /// <see cref="OrdinaryDifferentialEquation"/> checks it: the coefficients are read off by
+        /// differentiating, which is only valid if the equation really is linear in them, so the
+        /// reading is put back together and compared with what it came from. <c>x * y</c> and
+        /// <c>x ^ 2</c> both survive the differentiation and both fail the comparison.
+        /// </remarks>
+        private static bool TryReadLinear(
+            Entity equation, IReadOnlyList<Variable> variables,
+            [NotNullWhen(true)] out ERational[]? coefficients, [NotNullWhen(true)] out Entity? constant)
+        {
+            coefficients = null;
+            constant = null;
+
+            var read = new ERational[variables.Count];
+            Entity reassembled = Integer.Create(0);
+            for (var i = 0; i < variables.Count; i++)
+            {
+                var derivative = equation.Differentiate(variables[i]).Simplify();
+                if (derivative.Evaled is not Rational ratio || derivative.Vars.Any())
+                    return false;
+                read[i] = ratio.ERational;
+                reassembled += Rational.Create(ratio.ERational) * variables[i];
+            }
+
+            var withoutVariables = equation;
+            foreach (var variable in variables)
+                withoutVariables = withoutVariables.Substitute(variable, Integer.Create(0));
+            var offset = withoutVariables.Simplify();
+            if (variables.Any(variable => offset.ContainsNode(variable)))
+                return false;
+
+            if ((reassembled + offset - equation).Simplify() is not Integer { IsZero: true })
+                return false;
+
+            coefficients = read;
+            constant = offset;
+            return true;
+        }
+
+        /// <summary>
+        /// Reduced row echelon form of <paramref name="coefficients"/>, carrying
+        /// <paramref name="constants"/> along, and the rank it came to.
+        /// <paramref name="pivotOfRow"/> receives the pivot column of each row below the rank.
+        /// </summary>
+        private static int Reduce(ERational[][] coefficients, Entity[] constants, int width, int[] pivotOfRow)
+        {
+            var rank = 0;
+            for (var column = 0; column < width && rank < coefficients.Length; column++)
+            {
+                var pivot = -1;
+                for (var row = rank; row < coefficients.Length; row++)
+                    if (!coefficients[row][column].IsZero)
+                    {
+                        pivot = row;
+                        break;
+                    }
+                if (pivot < 0)
+                    continue;
+
+                (coefficients[rank], coefficients[pivot]) = (coefficients[pivot], coefficients[rank]);
+                (constants[rank], constants[pivot]) = (constants[pivot], constants[rank]);
+
+                var head = coefficients[rank][column];
+                for (var other = column; other < width; other++)
+                    coefficients[rank][other] = coefficients[rank][other].Divide(head);
+                constants[rank] = (constants[rank] / Rational.Create(head)).InnerSimplified;
+
+                for (var row = 0; row < coefficients.Length; row++)
+                {
+                    if (row == rank || coefficients[row][column].IsZero)
+                        continue;
+                    var factor = coefficients[row][column];
+                    for (var other = column; other < width; other++)
+                        coefficients[row][other] =
+                            coefficients[row][other].Subtract(factor.Multiply(coefficients[rank][other]));
+                    constants[row] =
+                        (constants[row] - Rational.Create(factor) * constants[rank]).InnerSimplified;
+                }
+
+                pivotOfRow[rank] = column;
+                rank++;
+            }
+            return rank;
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Algebra/GroebnerSystemTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/GroebnerSystemTest.cs
@@ -210,13 +210,28 @@ namespace AngouriMath.Tests.Algebra
         /// <summary>
         /// A free variable means infinitely many solutions, which is not something a
         /// triangular basis enumerates — the ideal is not zero-dimensional, so there is no
-        /// finite set of standard monomials and the conversion declines. Fewer equations
-        /// than unknowns therefore still reaches the old refusal, unchanged.
+        /// finite set of standard monomials and the conversion declines. What this path hands
+        /// on is therefore unchanged; what happens after it is not.
         /// </summary>
+        /// <remarks>
+        /// This used to assert a <c>WrongNumberOfArgumentsException</c>, which is what the whole
+        /// call raised for a system with fewer equations than unknowns. Such a system is now
+        /// answered as the family of all its solutions where it is linear
+        /// (<a href="https://github.com/asc-community/AngouriMath/issues/212">#212</a>), so the
+        /// assertion here is only that this path declines and not that the call fails.
+        /// </remarks>
         [Fact]
-        public void AnUnderDeterminedSystemIsStillRefused()
-            => Assert.Throws<WrongNumberOfArgumentsException>(
-                () => MathS.Equations(new Entity[] { "x + y - 3" }).Solve("x", "y"));
+        public void AnUnderDeterminedSystemIsNotTriangularised()
+        {
+            Assert.False(Functions.Algebra.Groebner.GroebnerSystemSolver.TrySolve(
+                new List<Entity> { "x + y - 3" }, new Entity.Variable[] { "x", "y" }, out _));
+
+            // And the call as a whole answers it, rather than raising as it used to.
+            var solutions = MathS.Equations(new Entity[] { "x + y - 3" }).Solve("x", "y");
+            Assert.NotNull(solutions);
+            Assert.Equal(1, solutions!.RowCount);
+            Assert.Equal(2, solutions.ColumnCount);
+        }
 
         /// <summary>
         /// Eight unknowns is the ceiling of the packed representation; nine has to fall

--- a/Sources/Tests/UnitTests/Algebra/SolveTest/ParametricSystemTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/SolveTest/ParametricSystemTest.cs
@@ -1,0 +1,177 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Core.Exceptions;
+using AngouriMath.Extensions;
+using System.Linq;
+using Xunit;
+
+namespace AngouriMath.Tests.Algebra
+{
+    /// <summary>
+    /// Systems with fewer equations than unknowns, which have infinitely many solutions and are
+    /// answered as the one family that describes them all.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/212">#212</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A system of that shape used to raise <c>WrongNumberOfArgumentsException</c> — which reads
+    /// as "you called this wrongly" for a caller who did nothing wrong. <c>2x - 4y = 12</c> for
+    /// <c>x</c> and <c>y</c> is a well-formed question with an infinite answer set, and the
+    /// answer is now that set: one row, with a parameter where the system leaves a degree of
+    /// freedom.
+    /// </para>
+    /// <para>
+    /// Every case here is checked by substituting the answer back into every equation and
+    /// simplifying to zero, with the parameter left symbolic — a family that satisfies the
+    /// system only at particular values of its parameter is not a family.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Algebra")]
+    public sealed class ParametricSystemTest
+    {
+        /// <summary>
+        /// Substitutes the answer back with the parameters still symbolic, so what is checked is
+        /// the whole family and not one member of it.
+        /// </summary>
+        private static Entity.Matrix Satisfies(string[] equations, params string[] variables)
+        {
+            var solutions = MathS.Equations(equations.Select(e => e.ToEntity()).ToArray())
+                .Solve(variables.Select(v => (Entity.Variable)v).ToArray());
+            Assert.NotNull(solutions);
+            Assert.Equal(variables.Length, solutions!.ColumnCount);
+
+            for (var row = 0; row < solutions.RowCount; row++)
+                foreach (var text in equations)
+                {
+                    Entity residual = text.ToEntity();
+                    for (var column = 0; column < variables.Length; column++)
+                        residual = residual.Substitute(variables[column], solutions[row, column]);
+                    Assert.Equal(Entity.Number.Integer.Create(0), residual.Simplify());
+                }
+            return solutions;
+        }
+
+        /// <summary>The example in the issue's own body, and the shape it asks for.</summary>
+        [Fact]
+        public void TheExampleTheIssueNames()
+        {
+            var solutions = Satisfies(new[] { "2*x - 4*y - 12" }, "x", "y");
+            Assert.Equal(1, solutions.RowCount);
+            // y is the free one and x is written in terms of it, which is `x = 6 + 2t, y = t`.
+            Assert.Single(solutions[0, 1].Vars);
+            Assert.Equal(solutions[0, 1].Vars.Single(), solutions[0, 0].Vars.Single());
+        }
+
+        /// <summary>
+        /// The five-unknown system Happypig375 worked out by hand in the thread, whose answer
+        /// was <c>x1 = 2s + 3t + 7</c>, <c>x2 = -3s - 2t - 3</c>, <c>x3 = s</c>, <c>x4 = 2t</c>,
+        /// <c>x5 = t</c>. Renamed, since a digit suffix does not parse as a variable.
+        /// </summary>
+        [Fact]
+        public void TheFiveUnknownSystemFromTheThread()
+        {
+            var solutions = Satisfies(
+                new[]
+                {
+                    "p + 2*q + 4*r + s - u - 1",
+                    "2*p + 4*q + 8*r + 3*s - 4*u - 2",
+                    "p + 3*q + 7*r + 3*u + 2",
+                },
+                "p", "q", "r", "s", "u");
+            Assert.Equal(1, solutions.RowCount);
+            // Three equations of rank three over five unknowns leaves two degrees of freedom.
+            var parameters = new System.Collections.Generic.HashSet<Entity.Variable>();
+            for (var column = 0; column < solutions.ColumnCount; column++)
+                foreach (var variable in solutions[0, column].Vars)
+                    parameters.Add(variable);
+            Assert.Equal(2, parameters.Count);
+        }
+
+        /// <summary>One equation short, two short, and several equations with several unknowns.</summary>
+        [Theory]
+        [InlineData(new[] { "x + y - 3" }, new[] { "x", "y" })]
+        [InlineData(new[] { "x + y + z - 1" }, new[] { "x", "y", "z" })]
+        [InlineData(new[] { "x + y + z - 1", "x - y" }, new[] { "x", "y", "z" })]
+        [InlineData(new[] { "2*x + 3*y - 5*z - 7" }, new[] { "x", "y", "z" })]
+        [InlineData(new[] { "x/2 - y/3 - 1" }, new[] { "x", "y" })]
+        public void AFamilySatisfiesEveryEquation(string[] equations, string[] variables)
+            => Satisfies(equations, variables);
+
+        /// <summary>
+        /// The constant term may be anything free of the unknowns, since it is never a pivot and
+        /// so never has to be tested for zero. Only the coefficients must be rational.
+        /// </summary>
+        [Fact]
+        public void ASymbolicConstantIsCarriedThrough()
+        {
+            var solutions = Satisfies(new[] { "2*x - 4*y - k" }, "x", "y");
+            Assert.Contains((Entity.Variable)"k", solutions[0, 0].Vars);
+        }
+
+        /// <summary>
+        /// A short system whose equations contradict each other has no solutions, and that is an
+        /// answer rather than a failure to find one — <see langword="null"/>, the same as for a
+        /// contradictory square system.
+        /// </summary>
+        [Fact]
+        public void AContradictoryShortSystemHasNoSolutions()
+            => Assert.Null(MathS.Equations(new Entity[] { "x + y - 1", "2*x + 2*y - 3" })
+                .Solve("x", "y", "z"));
+
+        /// <summary>
+        /// What is not taken here, and still reaches the old refusal. Linearity is checked rather
+        /// than assumed, so a product or a power of the unknowns fails the check; and a
+        /// coefficient that is not rational is refused because a row reduction has to decide
+        /// whether a pivot is zero, which is not decidable for a symbol.
+        /// </summary>
+        [Theory]
+        [InlineData(new[] { "x^2 + y^2 - 1" }, new[] { "x", "y" })]
+        [InlineData(new[] { "x*y - 1" }, new[] { "x", "y" })]
+        [InlineData(new[] { "a*x + y - 1" }, new[] { "x", "y" })]
+        [InlineData(new[] { "sin(x) + y" }, new[] { "x", "y" })]
+        public void WhatIsNotLinearInTheUnknownsIsRefused(string[] equations, string[] variables)
+            => Assert.Throws<WrongNumberOfArgumentsException>(
+                () => MathS.Equations(equations.Select(e => e.ToEntity()).ToArray())
+                    .Solve(variables.Select(v => (Entity.Variable)v).ToArray()));
+
+        /// <summary>
+        /// The neighbours must answer exactly as they did: a determined system, an
+        /// overdetermined but consistent one, and a contradictory one. Only the short count
+        /// reaches the new path.
+        /// </summary>
+        [Fact]
+        public void TheOtherShapesAreUnchanged()
+        {
+            var determined = MathS.Equations(new Entity[] { "x + y - 3", "x - y - 1" }).Solve("x", "y");
+            Assert.NotNull(determined);
+            Assert.Equal(Entity.Number.Integer.Create(2), determined![0, 0].Simplify());
+            Assert.Equal(Entity.Number.Integer.Create(1), determined[0, 1].Simplify());
+
+            var overdetermined = MathS.Equations(new Entity[] { "x + y - 3", "x - y - 1", "2*x - 4" })
+                .Solve("x", "y");
+            Assert.NotNull(overdetermined);
+            Assert.Equal(Entity.Number.Integer.Create(2), overdetermined![0, 0].Simplify());
+
+            Assert.Null(MathS.Equations(new Entity[] { "x - 1", "x - 2" }).Solve("x"));
+        }
+
+        /// <summary>
+        /// A square system that is rank-deficient is left to the eliminator, which has answered
+        /// it since <a href="https://github.com/asc-community/AngouriMath/issues/550">#550</a>.
+        /// Taking those here too would change answers that are not wrong.
+        /// </summary>
+        [Fact]
+        public void ARankDeficientSquareSystemIsLeftAlone()
+        {
+            var solutions = MathS.Equations(new Entity[] { "x + y - 3", "x + y - 3" }).Solve("x", "y");
+            Assert.NotNull(solutions);
+            Assert.NotEmpty(solutions![0, 0].Vars);
+        }
+    }
+}


### PR DESCRIPTION
`Solve` raised `WrongNumberOfArgumentsException` for a system with fewer equations than
unknowns — a message that says the caller called it wrongly, for a caller who did nothing
wrong. `2x - 4y = 12` in `x` and `y` is a well-formed question; it simply has infinitely many
answers.

```
MathS.Equations("2*x - 4*y - 12").Solve("x", "y")

was  WrongNumberOfArgumentsException: Number of equations must be equal to that of vars
is   [[6 + 2 * t_1, t_1]]
```

which is `x = 6 + 2t, y = t` — the answer #212 asks for in its body.

## It reproduces the working in the thread

Happypig375 wrote out a three-equation, five-unknown system by hand in 2020:

```
x₁ = 2s + 3t + 7      x₂ = -3s - 2t - 3      x₃ = s      x₄ = 2t      x₅ = t
```

Renamed (a digit suffix does not parse as a variable), the library now answers:

```
[[7 + 2 * t_1 + 3 * t_2, -3 + (-3) * t_1 + (-2) * t_2, t_1, 2 * t_2, t_2]]
```

Term for term, with `t_1` for `s` and `t_2` for `t`.

## The answer type did not change

A solution has always been a row of `Matrix` whose i-th entry is the i-th unknown's value, and
nothing said those entries may not mention a variable. The unknowns a row reduction leaves free
become parameters; the rest are written in terms of them.

That device is already in the library twice: the ODE solver's constant of integration, and
`InSolveSystem`, which already mints one `t` for the single case where its recursion bottoms out
unconstrained (#550). This reuses its `nameSource` idiom so a parameter cannot collide with a
name in the system — and mints each successive parameter against the ones already minted, since
`Variable.CreateUnique` compares whole names in use and would otherwise hand back `t_1` twice.

## Only the short count is taken here

`equations.Count < vars.Length` is precisely the shape that threw before reaching any
elimination, so this **cannot regress anything**: every input it accepts previously raised.

A square system that is rank-deficient still goes to the eliminator, which has answered it with a
free parameter since #550. Taking those here as well would change answers that are not wrong,
and there is a test asserting they are untouched.

## Rational coefficients on the unknowns, and why that is soundness

A row reduction has to decide whether a pivot is zero. The general test available is
**structural** — `Matrix.ReducedRowEchelonForm` asks `a == 0`, and its own comment records that
"an expression that happens to be zero everywhere is not recognised as one". Choosing such a
pivot divides by zero and produces a **wrong family** rather than no answer, which is the failure
mode worth refusing over. Over the rationals the question is decidable, so it is asked there.

The **constant** term is under no such restriction, being never a pivot, so `2x - 4y = k` is
answered with `k` symbolic.

Linearity is likewise checked rather than assumed, the way `OrdinaryDifferentialEquation` checks
it: coefficients are read off by differentiating — only valid if the system really is linear — so
the reading is reassembled and compared with what it came from. `x*y` and `x^2` both survive the
differentiation and both fail the comparison.

## What still raises, and what returns null

| input | result |
|---|---|
| `x^2 + y^2 = 1`, `x*y = 1`, `sin(x) + y` | raises — not linear |
| `a*x + y = 1` | raises — coefficient on an unknown is not rational |
| `{x + y = 1, 2x + 2y = 3}` for `x, y, z` | **`null`** — contradictory, so no solutions |

`null` goes on meaning *there are no solutions*, not *no answer was found* — the distinction the
repo cares about between an unevaluated result and a definite one.

## One test changed its verdict

`GroebnerSystemTest.AnUnderDeterminedSystemIsStillRefused` pinned the exception. Its subject is
the triangularisation, not the exception, so it now asserts what it was actually about — that
`GroebnerSystemSolver.TrySolve` declines a non-zero-dimensional ideal — and that the call as a
whole answers. Renamed to `AnUnderDeterminedSystemIsNotTriangularised`.

The Budget suite asserts an exact ledger count per solve; this opens no ledger of its own and
that count is unchanged.

## Verification

Full suite **9371 passed, 0 failed**, 14 skipped.

Every family is checked by substituting the answer back into every equation with the parameters
left **symbolic**, and simplifying to exactly zero — a family that satisfies the system only at
particular values of its parameter is not a family.

## Not in this change

The exception is still what an underdetermined system gets when this path declines it. Whether
that should become a refusal of some other kind is a question about what the API promises, and I
have left it as it was rather than decide it here.

Part of #212 — the issue also asks for the free variables to be *named* in the result, which this
does not do: they are discoverable only by looking at which variables appear in the answer.
