### PR TITLE
An argument that is the variable is not a chain rule (#1149)

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -164,3 +164,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/ImproperFractionIntegralTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/ApplicationDerivativeTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Differentiation.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Differentiation.cs
@@ -466,8 +466,20 @@ namespace AngouriMath
                 {
                     (Variable v, var args) when args.All(arg => arg.Nodes.Contains(variable) is false)
                         => 0,
-                    // special case f(x) to return a raw Derivativef avoid stack overflowing InnerSimplify
-                    (Variable v, { Head: Variable variable_, Tail : LEmpty<Entity> }) when variable_ == variable => MathS.Derivative(this, variable),
+                    // An argument that *is* the variable has nothing for the chain rule to do:
+                    // its own derivative is one, so the term below would be
+                    // MathS.Derivative(this, variable) -- this very node, inside its own
+                    // expansion. A raw Derivativef is returned instead, which the caller reads
+                    // as "no progress" and leaves alone.
+                    //
+                    // This used to ask whether the *only* argument is the variable
+                    // (`Tail: LEmpty<Entity>`), and with two arguments the expansion below ran:
+                    // d/dx apply(f, x, y) came back as derivative(apply(f, x, y), x) * 1 + ...,
+                    // which is not a Derivativef but contains one, so InnerSimplify's
+                    // "not Derivativef" test read it as progress and simplified its way back
+                    // here. `apply(f, x, y).Differentiate("x")` overflowed the stack.
+                    (Variable v, var args) when args.Any(arg => arg == variable)
+                        => MathS.Derivative(this, variable),
 
                     // d/dx_i f(g_1(x_1, x_2, ..., x_n), g_2(x_1, x_2, ..., x_n), ..., g_n(x_1, x_2, ..., x_n))
                     // becomes

--- a/Sources/Tests/UnitTests/Calculus/ApplicationDerivativeTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ApplicationDerivativeTest.cs
@@ -1,0 +1,120 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// Differentiating an <see cref="Entity.Application"/> — <c>apply(f, x)</c> and its
+    /// several-argument forms.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The two-argument case overflowed the stack.</b> An argument that <em>is</em> the
+    /// variable has nothing for the chain rule to do — its own derivative is one, so its term is
+    /// the derivative node the expansion is inside. That was special-cased for an application of
+    /// exactly one argument, whose comment says it exists to avoid the overflow, and the case was
+    /// written as "the only argument is the variable" rather than "an argument is". With two,
+    /// <c>d/dx apply(f, x, y)</c> expanded to <c>derivative(apply(f, x, y), x) * 1 + ...</c>,
+    /// which is not a <c>Derivativef</c> but contains one — so the "did the derivative come back
+    /// unresolved" test read it as progress and simplified its way back to the same node.
+    /// </para>
+    /// <para>
+    /// A stack overflow is not a failing test: it takes the process down and the run reports
+    /// nothing. These therefore assert the answer rather than merely that a call returns, and if
+    /// the guard is lost the suite aborts rather than going red — which is the loud signal, but
+    /// worth knowing about when one appears.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class ApplicationDerivativeTest
+    {
+        /// <summary>
+        /// The shape that overflowed, at every arity. The answer is the unresolved derivative,
+        /// which is the honest one: nothing is known about <c>f</c>.
+        /// </summary>
+        [Theory]
+        [InlineData("apply(f, x, y)", "derivative(apply(f, x, y), x)")]
+        [InlineData("apply(f, x, y, z)", "derivative(apply(f, x, y, z), x)")]
+        [InlineData("apply(f, y, x)", "derivative(apply(f, y, x), x)")]
+        public void AnArgumentThatIsTheVariableLeavesTheDerivativeUnresolved(string input, string expected)
+            => Assert.Equal(expected.ToEntity(), input.ToEntity().Differentiate("x"));
+
+        /// <summary>The one-argument case, which always worked, and must go on working.</summary>
+        [Fact]
+        public void OneArgumentIsUnchanged()
+            => Assert.Equal("derivative(apply(f, x), x)".ToEntity(),
+                "apply(f, x)".ToEntity().Differentiate("x"));
+
+        /// <summary>
+        /// Nothing varies with a name the application does not mention, so the derivative is
+        /// zero rather than an unresolved node.
+        /// </summary>
+        [Theory]
+        [InlineData("apply(f, x, y)", "z")]
+        [InlineData("apply(f, x)", "y")]
+        public void AVariableTheApplicationDoesNotMentionGivesZero(string input, string variable)
+            => Assert.Equal(Entity.Number.Integer.Create(0), input.ToEntity().Differentiate(variable));
+
+        /// <summary>
+        /// Where no argument <em>is</em> the variable the chain rule still runs, which is what
+        /// the guard must not cost: each argument contributes a partial times its own derivative.
+        /// </summary>
+        [Fact]
+        public void TheChainRuleStillRunsWhereNoArgumentIsTheVariable()
+        {
+            var derivative = "apply(f, sin(x), y)".ToEntity().Differentiate("x");
+            // The partial with respect to the first argument survives, and it is multiplied by
+            // that argument's own derivative rather than by one.
+            Assert.Contains("cos(x)", derivative.Stringize());
+            Assert.Contains("derivative(apply(f, sin(x), y), sin(x))", derivative.Stringize());
+        }
+
+        /// <summary>
+        /// The product rule over two applications, which is the shape
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/286">#286</a> asks for —
+        /// written with <c>apply</c>, since <c>f(x)</c> still parses as a product.
+        /// </summary>
+        [Fact]
+        public void TheProductRuleOverTwoApplications()
+        {
+            var derivative = "apply(f, x) * apply(g, x)".ToEntity().Differentiate("x").Stringize();
+            Assert.Contains("derivative(apply(f, x), x)", derivative);
+            Assert.Contains("derivative(apply(g, x), x)", derivative);
+            Assert.Contains("apply(f, x)", derivative);
+            Assert.Contains("apply(g, x)", derivative);
+        }
+
+        /// <summary>
+        /// Repeated differentiation terminates too — the second pass asks the same question of
+        /// the node the first one produced.
+        /// </summary>
+        [Fact]
+        public void DifferentiatingTwiceTerminates()
+        {
+            var twice = "apply(f, x, y)".ToEntity().Differentiate("x").Differentiate("x");
+            Assert.Contains("derivative(", twice.Stringize());
+        }
+
+        /// <summary>
+        /// The neighbouring passes over the same node, none of which should recurse either.
+        /// </summary>
+        [Theory]
+        [InlineData("apply(f, x, y)")]
+        [InlineData("derivative(apply(f, x, y), x)")]
+        public void TheUsualPassesTerminate(string input)
+        {
+            var entity = input.ToEntity();
+            Assert.NotNull(entity.InnerSimplified);
+            Assert.NotNull(entity.Simplify());
+            Assert.NotNull(entity.Evaled);
+        }
+    }
+}


### PR DESCRIPTION
`apply(f, x, y).Differentiate("x")` overflowed the stack and took the process down with it.
Full detail in #1149; the short version and the reasoning are below.

```csharp
"apply(f, x, y)".ToEntity().Differentiate("x")   // Stack overflow, host process dies
```

## The guard existed and was one notch too narrow

`Application.InnerDifferentiate` already special-cased this, and its comment names the failure
mode it is there to prevent:

```csharp
// special case f(x) to return a raw Derivativef avoid stack overflowing InnerSimplify
(Variable v, { Head: Variable variable_, Tail : LEmpty<Entity> }) when variable_ == variable
    => MathS.Derivative(this, variable),
```

`Tail : LEmpty<Entity>` matches an argument list of **exactly one**. With two, the chain-rule arm
below runs instead, and for `d/dx apply(f, x, y)` its first term is `MathS.Derivative(this, x) * 1`
— **the very node being simplified, inside its own expansion**.

`Derivativef.InnerSimplify` decides whether differentiating made progress with

```csharp
when expr.InnerDifferentiate(var, asInt) is var res and not Derivativef
```

and the expansion is a `Sumf` that *contains* a `Derivativef` rather than being one. So the test
passes, `res.InnerSimplified` collapses the sum back to that same node, and round it goes.

The fix asks the question the comment intended — whether **an** argument is the variable, rather
than whether the **only** one is:

```csharp
(Variable v, var args) when args.Any(arg => arg == variable) => MathS.Derivative(this, variable),
```

That is correct for every arity, and it is the honest answer: an argument that *is* the variable
has nothing for the chain rule to do, its own derivative being one.

## What the guard must not cost

A guard that bought termination by refusing the chain rule would be the wrong fix, so the case
where it still applies is asserted: `apply(f, sin(x), y)` differentiated by `x` still expands to a
partial times `cos(x)`. Only the self-referential term is declined, and only when an argument is
literally the variable.

| input, differentiated by `x` | before | after |
|---|---|---|
| `apply(f, x, y)` | **stack overflow** | `derivative(apply(f, x, y), x)` |
| `apply(f, x, y, z)` | **stack overflow** | `derivative(apply(f, x, y, z), x)` |
| `apply(f, y, x)` | **stack overflow** | `derivative(apply(f, y, x), x)` |
| `apply(f, x)` | `derivative(apply(f, x), x)` | unchanged |
| `apply(f, sin(x), y)` | chain rule | unchanged |
| `apply(f, x, y)` by `z` | `0` | unchanged |

Parsing, `InnerSimplified`, `Simplify` and `Evaled` were all fine on the same node before and
after; differentiation was the only route in.

## On testing a crash

A stack overflow is not a failing test — it takes the host down and the run reports nothing, so
this could never have shown up as the suite going red. The tests here therefore assert the
**answers**, not merely that the calls return; if the guard is lost, the suite aborts rather than
going red, which is loud but worth knowing about when it happens. That is recorded in the test
file's remarks so the next person reading an aborted run has somewhere to start.

## Why it went unhit

`f(x, y)` does not parse — it raises `UnhandledParseException` — so an application of two
arguments has to be built through `apply` or the API directly. Anything that made it parse, which
is what #286 asks for, would have met this first. I found it while measuring #286.

## Verification

Full suite **9367 passed, 0 failed**, 14 skipped. 11 new tests.

No `BREAKING-CHANGES.md` entry: nothing that returned a value returns a different one. What
changed is that a call which crashed now answers.

Closes #1149.
