### PR TITLE
A polynomial summand is summed in closed form (#717)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -107,6 +107,53 @@ read first.
 | **Silent** | `"arccotan(-1)".ToEntity().Simplify()`, and every negative argument the inverse-trigonometric table knows | `3/4 * pi` — the textbook range, and **not equal to `arccotan(-1)`**, whose value is `-pi/4` | `-1/4 * pi` |
 | | `"e ^ ln(x)".ToEntity().Simplify()`, and every exponential of a natural logarithm | `e ^ ln(x)` — left as written | `x` |
 | | `"a => a + 3".ToEntity()`, and every lambda written with an arrow | `UnhandledParseException` | `lambda(a, a + 3)` |
+| | `"sum(k, k, 1, n)".ToEntity().Simplify()`, and every summation whose body is a polynomial in the index | `sum(k, k, 1, n)` — carried | `piecewise((n + n ^ 2) / 2 provided n >= 0, 0)` |
+| | `"sum(k, k, 1, 100000)".ToEntity().Simplify()`, and every concrete range past a hundred terms | `sum(k, k, 1, 100000)` — carried | `5000050000` |
+
+### A polynomial summand is summed in closed form
+
+A summation wrote itself out term by term where the bounds were concrete and there were fewer
+than a hundred terms, and was carried otherwise. So a symbolic bound had no answer, and neither
+did a long concrete range — both now do, where the body is a polynomial in the index.
+
+```
+"sum(k, k, 1, n)".Simplify()        was  sum(k, k, 1, n)
+                                    is   piecewise((n + n ^ 2) / 2 provided n >= 0, 0)
+
+"sum(k, k, 1, 100000)".Simplify()   was  sum(k, k, 1, 100000)
+                                    is   5000050000
+```
+
+`sum(k^2, k, 1, n)` and `sum(k^3, k, 1, n)` come with it, as does any polynomial summand by
+linearity, a coefficient that does not mention the index — `sum(a*k^2 + b*k + c, k, 1, n)` — and a
+symbolic *lower* bound, `sum(k, k, m, n)` being `S(n) - S(m - 1)` like any other.
+
+**The condition is the entry.** `sum(k, k, 1, n)` is **not** `(n + n^2)/2` for every `n`. At
+`n = -2` the range is empty, and this library answers an empty range with the operator's identity
+— `sum(k, k, 5, 1)` is `0`, which has its own test — while the polynomial there is `1`. The
+identity holds exactly where `to >= from - 1`, so that is what is attached, with the empty-range
+value as the other branch. Where the bounds are concrete the condition is decidable and the whole
+thing collapses to a number, which is why the long range above is an integer and not a piecewise.
+
+SymPy prints the bare polynomial for the same input and is not making a mistake: it reads a
+reversed range as the negated sum over the flipped one, under which the identity needs no
+condition. The condition is what this library's different convention costs, and **code that
+expected a bare polynomial from `Simplify` gets a `Piecewise`.**
+
+**A bound that is a number and not a whole one is still carried.** The index runs over the
+integers, so `sum(k, k, 1, 5/2)` is `1 + 2`; the polynomial continued to `5/2` is `35/8`, which
+answers a different question. `+oo` is refused the same way, so an infinite series is untouched.
+
+**A product is unchanged, whatever its body.** `product(k, k, 1, n)` is still carried, and
+`factorial(n)` would be a wrong answer for it rather than a missing one: the empty product is `1`
+at every `n < 1`, and `factorial` is undefined at the negative integers. Answering it needs the
+same kind of condition the sum now carries, and is not done here.
+
+No Bernoulli numbers are involved. The sum of a degree-`d` polynomial is a polynomial of degree
+`d + 1`, so `d + 2` of its values determine it, and those values are short sums computed directly;
+interpolating them recovers the coefficients exactly in rational arithmetic.
+
+[#717](https://github.com/asc-community/AngouriMath/issues/717).
 
 ### A lambda is written with an arrow as well as a call
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -176,3 +176,8 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/ApplicationDerivativeTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[AngouriMath/Functions/Algebra/Polynomials/PolynomialSummation.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+[Tests/UnitTests/Core/ClosedFormSummationTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -6963,12 +6963,20 @@ namespace AngouriMath
         /// <param name="to">The last value of the index, inclusive.</param>
         /// <returns>
         /// The sum written out where the bounds are concrete integers and there are not too many
-        /// terms, and an unevaluated <see cref="Entity.Summationf"/> otherwise — so a symbolic
-        /// bound is carried rather than refused.
+        /// terms; a closed form where the body is a polynomial in the index, whatever the bounds;
+        /// and an unevaluated <see cref="Entity.Summationf"/> otherwise — so a body this cannot
+        /// read is carried rather than refused.
         /// </returns>
         /// <remarks>
+        /// <para>
         /// An empty range sums to <c>0</c>, which is stated rather than left to fall out of the
         /// loop. <a href="https://github.com/asc-community/AngouriMath/issues/248">#248</a>
+        /// </para>
+        /// <para>
+        /// That convention is why a closed form carries a condition: <c>sum(k, k, 1, n)</c> is
+        /// <c>(n + n^2)/2</c> only where <c>n >= 0</c>, the range being empty and the sum
+        /// <c>0</c> below that while the polynomial is not.
+        /// </para>
         /// </remarks>
         /// <example>
         /// <code>

--- a/Sources/AngouriMath/Docs/Usage/Comparison.md
+++ b/Sources/AngouriMath/Docs/Usage/Comparison.md
@@ -248,6 +248,21 @@ Long answers are truncated in the table below at 64 characters, with `…`.
 | holonomic | holonomic functions | `expr_to_holonomic exists: True` | `<no member at all matching "Holonomic">` | absent |
 | codegen | compile to a callable | `9` | `9` | answers |
 
+### One row has moved since the run
+
+**concrete / symbolic summation** was measured as `declines` at `6b93b401` and is answered now:
+`sum(k, k, 1, n)` is `(n + n^2)/2`, carrying the condition `n >= 0` that this library's
+empty-range convention requires and SymPy's reversed-range convention does not. The row is left
+as it was measured rather than edited, because the table is a record of one run at one commit and
+a hand-corrected cell would be a measurement nobody took; it will read `answers` when
+`sympyparity` is next run.
+
+The two rows either side of it have **not** moved. *Infinite series* is still declined —
+`sum(1 / k ^ 2, k, 1, +oo)` needs the zeta function, which the row four below records as absent.
+*Symbolic product* is still declined, and deliberately: `factorial(n)` is undefined at the
+negative integers where the empty product is `1`, so answering it needs a condition of the same
+kind the sum now carries.
+
 ### Implemented, but not reachable from outside
 
 The gap in these five is a public entry point, not an algorithm.

--- a/Sources/AngouriMath/Docs/Usage/Syntax.md
+++ b/Sources/AngouriMath/Docs/Usage/Syntax.md
@@ -247,7 +247,16 @@ name being declared and the first is the body it runs over, so `sum(i, i, 1, 10)
 
 Both bounds are inclusive and the step is one. An empty range is the operator's identity —
 `sum(k, k, 5, 1)` is `0` and `product(k, k, 5, 1)` is `1` — and the range is written out only when
-both bounds are integers, so `sum(k, k, 1, n)` and `sum(k, k, 1, 5/2)` stay as they are written.
+both bounds are integers and there are not too many terms.
+
+A `sum` whose body is a **polynomial in the index** is answered in closed form instead of being
+written out, so `sum(k, k, 1, n)` is `(n + n^2)/2` and `sum(k, k, 1, 100000)` is `5000050000`
+rather than a hundred thousand terms. The answer carries the condition it needs — `to >= from - 1`
+— because below that the range is empty and the polynomial is not zero; where the bounds are
+concrete that condition is decidable and the answer is a number. A bound that is a number and not
+a whole one still stays as written, since the index runs over the integers and
+`sum(k, k, 1, 5/2)` is `1 + 2` rather than the polynomial at `5/2`. A `product` stays as written
+whatever its body.
 
 **The declared name means the name, and only inside the operator that declares it.** Two names
 show this, because both mean something else in this language:

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialSummation.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialSummation.cs
@@ -1,0 +1,217 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using PeterO.Numbers;
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// A summation whose summand is a polynomial in the index, written as a polynomial in the
+    /// bounds: <c>sum(k, k, 1, n)</c> is <c>n^2/2 + n/2</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The operator writes itself out term by term where the bounds are concrete and few, and
+    /// otherwise stayed as written — so a symbolic bound had no answer at all, and neither did a
+    /// concrete range past a hundred terms. Both are the same gap: a sum of a polynomial has a
+    /// closed form, and computing it is cheaper than the expansion it replaces.
+    /// </para>
+    /// <para>
+    /// <b>No Bernoulli numbers.</b> The sum of a degree-<c>d</c> polynomial in the index is a
+    /// polynomial of degree <c>d + 1</c> in the bound, which is the whole of what is needed: a
+    /// polynomial of that degree is determined by <c>d + 2</c> of its values, and those values
+    /// are sums of <c>d + 2</c> terms each, computed directly. Interpolating them recovers the
+    /// coefficients exactly, in rational arithmetic, with no table to carry and no identity to
+    /// get subtly wrong. Faulhaber's formula would give the same answer by a shorter route that
+    /// needs Bernoulli numbers, which the library does not have.
+    /// </para>
+    /// <para>
+    /// <b>The condition is not decoration.</b> <c>sum(k, k, 1, n)</c> is <em>not</em>
+    /// <c>n^2/2 + n/2</c> for every <c>n</c>: at <c>n = -2</c> the range is empty and this
+    /// library answers an empty range with <c>0</c>, while the polynomial gives <c>1</c>. The
+    /// identity holds exactly when <c>to >= from - 1</c>, so that is what is attached, with the
+    /// empty-range value as the other branch. Where the bounds are concrete the condition is
+    /// decidable and the piecewise collapses to a number.
+    /// </para>
+    /// <para>
+    /// SymPy answers the same input with the bare polynomial and is not making a mistake: it
+    /// reads a reversed range as the negated sum over the flipped one, under which the identity
+    /// is unconditional. This library defines an empty range as the operator's identity instead,
+    /// and the condition is what that choice costs.
+    /// </para>
+    /// </remarks>
+    internal static class PolynomialSummation
+    {
+        /// <summary>
+        /// The degree of summand this will take. The work is cubic in it and the coefficients
+        /// carry factorials of it, so the ceiling is about the size of the answer rather than
+        /// about the method, which has no upper bound of its own.
+        /// </summary>
+        private const int MaxDegree = 16;
+
+        /// <summary>
+        /// <c>sum(expression, index, from, to)</c> written in closed form, or
+        /// <see langword="null"/> where the summand is not a polynomial in the index.
+        /// </summary>
+        internal static Entity? ClosedForm(Entity expression, Entity var, Entity from, Entity to)
+        {
+            if (var is not Variable index)
+                return null;
+            // A bound that is a number and not a whole one is not a bound this identity is about.
+            // The index runs over the integers, so `sum(k, k, 1, 5/2)` is 1 + 2 = 3, while the
+            // polynomial continued to 5/2 is 35/8 -- a different question, confidently answered.
+            // `+oo` fails the same test, and so does every other non-integer number.
+            if (!IsWholeOrSymbolic(from) || !IsWholeOrSymbolic(to))
+                return null;
+            if (!TreeAnalyzer.TryGetPolynomial(expression, index, out var monomials))
+                return null;
+
+            var degree = 0;
+            foreach (var monomial in monomials)
+            {
+                if (monomial.Key.Sign < 0 || !monomial.Key.CanFitInInt32())
+                    return null;
+                var power = monomial.Key.ToInt32Checked();
+                if (power > MaxDegree)
+                    return null;
+                // A coefficient that still mentions the index means the reading did not separate
+                // them, and summing it as a constant would be answering a different question.
+                if (monomial.Value.ContainsNode(index))
+                    return null;
+                if (power > degree)
+                    degree = power;
+            }
+
+            // S(m) = sum over k from 1 to m of the summand, as a polynomial in m. One power sum
+            // per power present, weighted by that power's coefficient.
+            Entity AtBound(Entity bound)
+            {
+                Entity total = Integer.Create(0);
+                foreach (var monomial in monomials)
+                    total += monomial.Value * Evaluate(PowerSum(monomial.Key.ToInt32Checked()), bound);
+                return total;
+            }
+
+            // sum from a to b is S(b) - S(a - 1), which holds for every pair of integers with
+            // b >= a - 1 -- at b = a - 1 both sides are zero, and below it the range is empty
+            // while the polynomial is not.
+            var closed = (AtBound(to) - AtBound(from - 1)).InnerSimplified;
+            var nonEmpty = new GreaterOrEqualf(to, from - 1);
+            return MathS.Piecewise(new[]
+            {
+                new Providedf(closed, nonEmpty),
+                new Providedf(Integer.Create(0), Entity.Boolean.True),
+            }).InnerSimplified;
+        }
+
+        /// <summary>
+        /// Whether a bound is one this identity can speak about: a whole number, or a name, of
+        /// which the second is read as standing for a whole number because that is what the
+        /// index of a summation ranges over.
+        /// </summary>
+        /// <remarks>
+        /// Only a bound that <em>evaluates to a number</em> and is not whole is refused. That
+        /// covers <c>5/2</c>, <c>+oo</c> and <c>1.5</c>, and leaves both a literal integer and
+        /// anything symbolic to go through — the symbolic case being the one the closed form
+        /// exists for.
+        /// </remarks>
+        private static bool IsWholeOrSymbolic(Entity bound)
+            => bound.Evaled is Integer || bound.Evaled is not Number;
+
+        /// <summary>
+        /// The coefficients of <c>sum of k^power for k from 1 to m</c> as a polynomial in
+        /// <c>m</c>, lowest power first.
+        /// </summary>
+        /// <remarks>
+        /// A polynomial of degree <c>power + 1</c>, so <c>power + 2</c> of its values determine
+        /// it. They are taken at <c>m = 0, 1, ..., power + 1</c>, where each is a sum of at most
+        /// <c>power + 1</c> whole numbers, and Lagrange's formula turns them back into
+        /// coefficients.
+        /// </remarks>
+        private static ERational[] PowerSum(int power)
+        {
+            var points = power + 2;
+            var values = new ERational[points];
+            var running = EInteger.Zero;
+            for (var m = 0; m < points; m++)
+            {
+                if (m > 0)
+                    running = running.Add(EInteger.FromInt32(m).Pow(power));
+                values[m] = ERational.Create(running, EInteger.One);
+            }
+            return Interpolate(values);
+        }
+
+        /// <summary>
+        /// The polynomial through <c>(i, values[i])</c> for each <c>i</c>, by Lagrange's formula,
+        /// as coefficients lowest power first.
+        /// </summary>
+        private static ERational[] Interpolate(ERational[] values)
+        {
+            var result = new ERational[values.Length];
+            for (var i = 0; i < result.Length; i++)
+                result[i] = ERational.Zero;
+
+            for (var i = 0; i < values.Length; i++)
+            {
+                // The basis polynomial for node i: the product of (x - j) over every other node,
+                // divided by the same product evaluated at i.
+                // Zeroed rather than left default: ERational is a class, so an unassigned entry
+                // is null and the multiplication below reads every one of them.
+                var basis = new ERational[values.Length];
+                for (var k = 0; k < basis.Length; k++)
+                    basis[k] = ERational.Zero;
+                basis[0] = ERational.One;
+                var filled = 1;
+                var denominator = ERational.One;
+                for (var j = 0; j < values.Length; j++)
+                {
+                    if (j == i)
+                        continue;
+                    // Multiply by (x - j), in place and from the top down so that a coefficient
+                    // is read before it is overwritten.
+                    for (var k = filled; k > 0; k--)
+                        basis[k] = basis[k - 1].Subtract(basis[k].Multiply(ERational.FromInt32(j)));
+                    basis[0] = basis[0].Multiply(ERational.FromInt32(-j));
+                    filled++;
+                    denominator = denominator.Multiply(ERational.FromInt32(i - j));
+                }
+
+                var scale = values[i].Divide(denominator);
+                for (var k = 0; k < result.Length; k++)
+                    result[k] = result[k].Add(basis[k].Multiply(scale));
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// A rational-coefficient polynomial evaluated at <paramref name="at"/>, as a flat sum of
+        /// terms rather than by Horner: the answer is read by a person, and
+        /// <c>n / 2 + n ^ 2 / 2</c> is the form this sum is known by, where the nested one is the
+        /// same number written as nobody writes it.
+        /// </summary>
+        private static Entity Evaluate(ERational[] coefficients, Entity at)
+        {
+            Entity total = Integer.Create(0);
+            for (var power = 0; power < coefficients.Length; power++)
+            {
+                if (coefficients[power].IsZero)
+                    continue;
+                var coefficient = Rational.Create(coefficients[power]);
+                total += power switch
+                {
+                    0 => coefficient,
+                    1 => coefficient * at,
+                    _ => coefficient * MathS.Pow(at, Integer.Create(power)),
+                };
+            }
+            return total;
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
@@ -178,8 +178,17 @@ namespace AngouriMath
             internal const int MaxExpandedTerms = 100;
 
             /// <inheritdoc/>
+            /// <remarks>
+            /// The expansion first, because it answers any summand at all where the range is
+            /// short, and the closed form only a polynomial one. What the closed form then
+            /// reaches is the two cases the expansion declines: a symbolic bound, and a concrete
+            /// range too long to write out — where it is not a fallback but the better answer,
+            /// since it computes rather than expands.
+            /// </remarks>
             protected override Entity InnerSimplify(bool isExact) =>
-                Expanded(this, Expression, Var, From, To, static (a, b) => a + b, 0, isExact) ?? this;
+                Expanded(this, Expression, Var, From, To, static (a, b) => a + b, 0, isExact)
+                ?? Functions.PolynomialSummation.ClosedForm(Expression, Var, From, To)
+                ?? this;
 
             /// <summary>
             /// Writes the operator out where its bounds are concrete integers and there are few

--- a/Sources/Tests/UnitTests/Convenience/SyntaxDocumentedTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/SyntaxDocumentedTest.cs
@@ -350,13 +350,26 @@ namespace AngouriMath.Tests.Convenience
         public void AnInclusiveRangeAndItsIdentity(string written, string expected) =>
             Assert.Equal(expected.ToEntity(), written.ToEntity().Simplify());
 
-        /// <summary>Written out only when both bounds are integers.</summary>
+        /// <summary>
+        /// A bound that is a number and not a whole one is left as written. The index runs over
+        /// the integers, so <c>sum(k, k, 1, 5/2)</c> is <c>1 + 2</c>; the closed form continued
+        /// to <c>5/2</c> would be <c>35/8</c>, which answers a different question.
+        /// </summary>
         [Theory]
-        [InlineData("sum(k, k, 1, n)")]
         [InlineData("sum(k, k, 1, 5/2)")]
         [InlineData("sum(k, k, 1, +oo)")]
+        [InlineData("sum(2 ^ k, k, 1, n)")]
         public void ARangeThatIsNotAnIntegerOneStaysAsWritten(string written) =>
             Assert.Equal(written.ToEntity(), written.ToEntity().Simplify());
+
+        /// <summary>
+        /// A symbolic bound is read as standing for a whole number, which is what the index of a
+        /// summation ranges over — so a polynomial summand is answered in closed form rather
+        /// than left as written.
+        /// </summary>
+        [Fact]
+        public void ASymbolicBoundOverAPolynomialIsAnswered() =>
+            Assert.NotEqual("sum(k, k, 1, n)".ToEntity(), "sum(k, k, 1, n)".ToEntity().Simplify());
 
         /// <summary>
         /// The declared name means the name inside the operator, and what it usually means

--- a/Sources/Tests/UnitTests/Core/ClosedFormSummationTest.cs
+++ b/Sources/Tests/UnitTests/Core/ClosedFormSummationTest.cs
@@ -1,0 +1,192 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Core
+{
+    /// <summary>
+    /// A summation whose summand is a polynomial in the index, answered as a polynomial in the
+    /// bounds rather than carried: <c>sum(k, k, 1, n)</c> is <c>(n + n^2)/2</c>.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/717">#717</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Almost every case here is checked by <b>agreeing with the expansion</b> at several
+    /// concrete bounds rather than against a printed form. The closed form and the term-by-term
+    /// sum are two routes to one number, and that they meet is the property worth asserting; the
+    /// shape the answer prints in is not.
+    /// </para>
+    /// <para>
+    /// The exception is <see cref="TheEmptyRangeIsWhereTheConditionEarnsItsPlace"/>, which is
+    /// about the condition attached to the closed form and would pass vacuously if it only
+    /// compared the two routes.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class ClosedFormSummationTest
+    {
+        /// <summary>
+        /// The closed form agrees with writing the sum out, at bounds on both sides of the
+        /// empty-range boundary.
+        /// </summary>
+        private static void AgreesWithTheExpansion(string expression, params int[] bounds)
+        {
+            var closed = expression.ToEntity().Simplify();
+            Assert.IsNotType<Entity.Summationf>(closed);
+            foreach (var at in bounds)
+            {
+                var expanded = expression.ToEntity().Substitute("n", at).Simplify().Evaled;
+                var fromClosedForm = closed.Substitute("n", at).Simplify().Evaled;
+                Assert.Equal(expanded, fromClosedForm);
+            }
+        }
+
+        /// <summary>The sums whose closed forms have names.</summary>
+        [Theory]
+        [InlineData("sum(1, k, 1, n)")]
+        [InlineData("sum(k, k, 1, n)")]
+        [InlineData("sum(k ^ 2, k, 1, n)")]
+        [InlineData("sum(k ^ 3, k, 1, n)")]
+        [InlineData("sum(k ^ 4, k, 1, n)")]
+        public void ThePowerSums(string expression)
+            => AgreesWithTheExpansion(expression, 0, 1, 2, 3, 7, 12);
+
+        /// <summary>Any polynomial summand, by linearity over its terms.</summary>
+        [Theory]
+        [InlineData("sum(2 * k + 1, k, 1, n)")]
+        [InlineData("sum(k ^ 2 - 3 * k + 5, k, 1, n)")]
+        [InlineData("sum((k + 1) * (k + 2), k, 1, n)")]
+        [InlineData("sum(k * (k - 1) / 2, k, 1, n)")]
+        public void AnyPolynomialSummand(string expression)
+            => AgreesWithTheExpansion(expression, 0, 1, 2, 3, 7, 12);
+
+        /// <summary>
+        /// A coefficient that does not mention the index may be anything, since it is carried
+        /// through by linearity and never has to be decided.
+        /// </summary>
+        [Theory]
+        [InlineData("sum(c, k, 1, n)")]
+        [InlineData("sum(c * k, k, 1, n)")]
+        [InlineData("sum(a * k ^ 2 + b * k + c, k, 1, n)")]
+        [InlineData("sum(sin(x) * k, k, 1, n)")]
+        public void ACoefficientFreeOfTheIndexIsCarried(string expression)
+            => AgreesWithTheExpansion(expression, 0, 1, 2, 5);
+
+        /// <summary>
+        /// A symbolic lower bound too — the identity is <c>S(to) - S(from - 1)</c> and neither
+        /// bound has to be concrete for that.
+        /// </summary>
+        [Fact]
+        public void ASymbolicLowerBound()
+        {
+            var closed = "sum(k, k, m, n)".ToEntity().Simplify();
+            Assert.IsNotType<Entity.Summationf>(closed);
+            foreach (var (from, to) in new[] { (1, 5), (2, 7), (3, 3), (4, 3), (-2, 2) })
+                Assert.Equal(
+                    "sum(k, k, m, n)".ToEntity().Substitute("m", from).Substitute("n", to).Simplify().Evaled,
+                    closed.Substitute("m", from).Substitute("n", to).Simplify().Evaled);
+        }
+
+        /// <summary>
+        /// <b>Why the answer carries a condition.</b> This library answers an empty range with the
+        /// operator's identity, so <c>sum(k, k, 1, -2)</c> is <c>0</c> — while the polynomial
+        /// <c>(n + n^2)/2</c> is <c>1</c> there. The closed form therefore holds only where
+        /// <c>to >= from - 1</c>, and says so; without that it would be a wrong answer below the
+        /// boundary rather than an absent one.
+        /// </summary>
+        [Theory]
+        [InlineData(-5)]
+        [InlineData(-2)]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void TheEmptyRangeIsWhereTheConditionEarnsItsPlace(int bound)
+            => Assert.Equal(
+                "sum(k, k, 1, n)".ToEntity().Substitute("n", bound).Simplify().Evaled,
+                "sum(k, k, 1, n)".ToEntity().Simplify().Substitute("n", bound).Simplify().Evaled);
+
+        /// <summary>
+        /// A concrete range longer than the expansion will write out is now answered rather than
+        /// carried, which is the same capability seen from the other side: the closed form
+        /// computes the value where writing the terms was refused.
+        /// </summary>
+        [Theory]
+        [InlineData("sum(k, k, 1, 100000)", "5000050000")]
+        [InlineData("sum(k, k, 1, 1000)", "500500")]
+        [InlineData("sum(k ^ 2, k, 1, 1000)", "333833500")]
+        public void ARangeTooLongToWriteOutIsStillAnswered(string expression, string expected)
+            => Assert.Equal(expected.ToEntity().Evaled, expression.ToEntity().Simplify().Evaled);
+
+        /// <summary>
+        /// <b>A bound that is a number and not a whole one is left alone</b>, which is the other
+        /// place this could answer a different question confidently. The index runs over the
+        /// integers, so <c>sum(k, k, 1, 5/2)</c> is <c>1 + 2 = 3</c>; the polynomial continued to
+        /// <c>5/2</c> is <c>35/8</c>. Neither is a rounding of the other.
+        /// </summary>
+        [Theory]
+        [InlineData("sum(k, k, 1, 5/2)")]
+        [InlineData("sum(k, k, 1, 1.5)")]
+        [InlineData("sum(k, k, 1, +oo)")]
+        [InlineData("sum(k, k, -oo, n)")]
+        public void ABoundThatIsNotAWholeNumberIsLeftAlone(string expression)
+            => Assert.IsType<Entity.Summationf>(expression.ToEntity().Simplify());
+
+        /// <summary>
+        /// What is not a polynomial in the index is carried, as it was. Each of these has a
+        /// closed form in the literature and none of them is this method's.
+        /// </summary>
+        [Theory]
+        [InlineData("sum(2 ^ k, k, 1, n)")]
+        [InlineData("sum(1 / k, k, 1, n)")]
+        [InlineData("sum(1 / k ^ 2, k, 1, n)")]
+        [InlineData("sum(sin(k), k, 1, n)")]
+        [InlineData("sum(k ^ k, k, 1, n)")]
+        [InlineData("sum(factorial(k), k, 1, n)")]
+        public void WhatIsNotPolynomialInTheIndexIsCarried(string expression)
+            => Assert.IsType<Entity.Summationf>(expression.ToEntity().Simplify());
+
+        /// <summary>
+        /// The product is carried whatever its body, including <c>product(k, k, 1, n)</c>, whose
+        /// closed form <c>factorial(n)</c> would be a wrong answer here: the empty product is
+        /// <c>1</c> at every <c>n &lt; 1</c>, while <c>factorial</c> is undefined at the negative
+        /// integers. Answering it needs the same condition the sum carries, and is not done.
+        /// </summary>
+        [Theory]
+        [InlineData("product(k, k, 1, n)")]
+        [InlineData("product(k ^ 2, k, 1, n)")]
+        public void TheProductIsCarried(string expression)
+            => Assert.IsType<Entity.Productf>(expression.ToEntity().Simplify());
+
+        /// <summary>
+        /// The short concrete ranges keep being written out, which is the cheaper route and the
+        /// only one that answers a summand this cannot read.
+        /// </summary>
+        [Theory]
+        [InlineData("sum(k, k, 1, 3)", "6")]
+        [InlineData("sum(k ^ 2, k, 1, 10)", "385")]
+        [InlineData("sum(2 ^ k, k, 1, 5)", "62")]
+        [InlineData("sum(1 / k, k, 1, 4)", "25/12")]
+        [InlineData("product(k, k, 1, 5)", "120")]
+        public void AShortConcreteRangeIsUnchanged(string expression, string expected)
+            => Assert.Equal(expected.ToEntity().Evaled, expression.ToEntity().Simplify().Evaled);
+
+        /// <summary>
+        /// The index is still bound: a closed form must not leak it, and substituting it from
+        /// outside must still do nothing.
+        /// </summary>
+        [Fact]
+        public void TheIndexDoesNotEscape()
+        {
+            var closed = "sum(k, k, 1, n)".ToEntity().Simplify();
+            Assert.DoesNotContain((Entity.Variable)"k", closed.Vars);
+            Assert.Equal(closed, closed.Substitute("k", 5));
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Core/SummationProductTest.cs
+++ b/Sources/Tests/UnitTests/Core/SummationProductTest.cs
@@ -53,13 +53,39 @@ namespace AngouriMath.Tests.Core
 
         /// <summary>
         /// A symbolic bound has no finite expansion, so the operator is carried rather than
-        /// refused — which is the reason it is a node and not a parser trick.
+        /// refused — which is the reason it is a node and not a parser trick. A summand that is
+        /// a <em>polynomial</em> in the index is the exception, having a closed form; anything
+        /// else is still carried.
         /// </summary>
+        [Theory]
+        [InlineData("sum(2 ^ k, k, 1, n)")]
+        [InlineData("sum(1 / k, k, 1, n)")]
+        [InlineData("sum(sin(k), k, 1, n)")]
+        public void ASymbolicBoundIsCarried(string expression)
+            => Assert.IsType<Entity.Summationf>(expression.ToEntity().Simplify());
+
+        /// <summary>A product is carried whatever its summand; only the sum has a closed form.</summary>
         [Fact]
-        public void ASymbolicBoundIsCarried()
+        public void AProductWithASymbolicBoundIsCarried()
+            => Assert.IsType<Entity.Productf>("product(k, k, 1, n)".ToEntity().Simplify());
+
+        /// <summary>
+        /// A polynomial summand does have a closed form, and it is given rather than carried.
+        /// The value is checked against the expansion at several bounds instead of against a
+        /// printed form, since what matters is that the two agree.
+        /// </summary>
+        [Theory]
+        [InlineData("sum(k, k, 1, n)")]
+        [InlineData("sum(k ^ 2, k, 1, n)")]
+        [InlineData("sum(2 * k + 1, k, 1, n)")]
+        public void APolynomialSummandIsGivenInClosedForm(string expression)
         {
-            var summation = "sum(k, k, 1, n)".ToEntity().Simplify();
-            Assert.IsType<Entity.Summationf>(summation);
+            var closed = expression.ToEntity().Simplify();
+            Assert.IsNotType<Entity.Summationf>(closed);
+            foreach (var at in new[] { 0, 1, 2, 5, 9 })
+                Assert.Equal(
+                    expression.ToEntity().Substitute("n", at).Simplify().Evaled,
+                    closed.Substitute("n", at).Simplify().Evaled);
         }
 
         /// <summary>
@@ -103,18 +129,33 @@ namespace AngouriMath.Tests.Core
         public void ElsewhereItIsStillTheImaginaryUnit(string expression, string expected) =>
             Assert.Equal(expected.ToEntity().Evaled, expression.ToEntity().Simplify().Evaled);
 
-        /// <summary>A declared index with a symbolic bound is still carried, not guessed at.</summary>
-        [Fact]
-        public void ADeclaredImaginaryUnitIndexWithASymbolicBoundIsCarried() =>
-            Assert.IsType<Entity.Summationf>("sum(i, i, 1, n)".ToEntity().Simplify());
-
         /// <summary>
-        /// Too many terms is left unexpanded: a thousand-term sum is a correct expansion and a
-        /// useless expression, and everything downstream then walks it.
+        /// A declared index is an index wherever it appears, closed form included: <c>sum(i, i,
+        /// 1, n)</c> is the same sum as <c>sum(k, k, 1, n)</c> and gets the same answer, rather
+        /// than being read as the imaginary unit summed over itself.
         /// </summary>
         [Fact]
+        public void ADeclaredImaginaryUnitIndexIsSummedAsAnIndex() =>
+            Assert.Equal(
+                "sum(k, k, 1, n)".ToEntity().Simplify(),
+                "sum(i, i, 1, n)".ToEntity().Simplify());
+
+        /// <summary>
+        /// Too many terms is still not written out: a thousand-term sum is a correct expansion
+        /// and a useless expression, and everything downstream then walks it.
+        /// </summary>
+        /// <remarks>
+        /// It is now <em>answered</em> rather than carried, which is not the same thing as being
+        /// written out — the closed form computes the value instead of building the terms, so
+        /// the expression this returns is a number and not a hundred thousand of them. The
+        /// assertion is therefore on the answer; that it is not an expansion follows from there
+        /// being nothing to expand.
+        /// </remarks>
+        [Fact]
         public void AVeryLongRangeIsNotWrittenOut() =>
-            Assert.IsType<Entity.Summationf>("sum(k, k, 1, 100000)".ToEntity().Simplify());
+            Assert.Equal(
+                Entity.Number.Integer.Create(5000050000L),
+                "sum(k, k, 1, 100000)".ToEntity().Simplify().Evaled);
 
         [Theory]
         [InlineData("sum(k, k, 1, n)")]


### PR DESCRIPTION
A summation wrote itself out term by term where the bounds were concrete and there were fewer
than a hundred terms, and was carried otherwise. So a symbolic bound had no answer at all — and
neither did a long concrete range. Both are the same gap.

```
"sum(k, k, 1, n)".Simplify()        was  sum(k, k, 1, n)
                                    is   piecewise((n + n ^ 2) / 2 provided n >= 0, 0)

"sum(k, k, 1, 100000)".Simplify()   was  sum(k, k, 1, 100000)
                                    is   5000050000
```

This is the row #717's survey names as `n**2/2 + n/2`, and three of that survey's nine gaps are
`sum`/`product`.

| input | now |
|---|---|
| `sum(1, k, 1, n)` | `n` |
| `sum(k ^ 2, k, 1, n)` | `(3n² + 2n³ + n)/6` |
| `sum(k ^ 3, k, 1, n)` | `((n + 1)·n)² / 4` — `Simplify` factors it |
| `sum(a*k^2 + b*k + c, k, 1, n)` | coefficients free of the index carried through |
| `sum(k, k, m, n)` | symbolic **lower** bound too, as `S(n) - S(m - 1)` |

## The condition is the entry, not a caveat

`sum(k, k, 1, n)` is **not** `(n + n^2)/2` for every `n`. At `n = -2` the range is empty, and this
library answers an empty range with the operator's identity — `sum(k, k, 5, 1)` is `0`, which has
its own test — while the polynomial there is `1`.

So the identity holds exactly where `to >= from - 1`, and that is what the answer carries, with
the empty-range value as the other branch. Where the bounds are concrete the condition is
decidable and the piecewise collapses, which is why the long range above comes back an integer
rather than a conditional.

**SymPy prints the bare polynomial for the same input and is not making a mistake.** It reads a
reversed range as the *negated* sum over the flipped one, under which the identity needs no
condition. The condition is what this library's different convention costs — and **code expecting
a bare polynomial out of `Simplify` gets a `Piecewise`**, which is in `BREAKING-CHANGES.md`.

## A wrong answer the suite caught

The first version answered `sum(k, k, 1, 5/2)` with `35/8`. The sum is `1 + 2 = 3` — the index
runs over the integers, and the polynomial continued to a non-integer answers a different
question confidently. `SyntaxDocumentedTest`, which holds `Syntax.md` to its word, failed on it
along with `+oo`.

A bound that *evaluates to a number and is not whole* is now refused outright, so an infinite
series is untouched too. Both are pinned by tests, in the feature's own file as well as the
documented-syntax one.

## No Bernoulli numbers

The sum of a degree-`d` polynomial in the index is a polynomial of degree `d + 1` in the bound —
which is the whole of what is needed. A polynomial of that degree is determined by `d + 2` of its
values, and those values are sums of at most `d + 2` whole numbers, computed directly. Lagrange
interpolation recovers the coefficients exactly, in rational arithmetic, with no table to carry
and no identity to get subtly wrong.

Faulhaber's formula reaches the same answer by a shorter route that needs Bernoulli numbers; the
library has none, and `grep` for them returns nothing.

## The product is deliberately untouched

`product(k, k, 1, n)` is still carried, and that is #717's other row. `factorial(n)` would be a
**wrong** answer for it rather than a missing one: the empty product is `1` at every `n < 1`, and
`Factorialf` carries an `IntrinsicCondition` making it undefined at the negative integers.
Answering it needs the same kind of condition the sum now carries, and is its own change. There
is a test asserting it stays carried, with that reason.

## Three tests changed their verdict, and one did not change its subject

- `ASymbolicBoundIsCarried` — still true of everything this cannot read (`2^k`, `1/k`, `sin(k)`),
  which is what it was about; the polynomial case moved to its own test.
- `ADeclaredImaginaryUnitIndexWithASymbolicBoundIsCarried` — its subject is that a declared `i` is
  an index and not the imaginary unit, so it now asserts that `sum(i, i, 1, n)` and
  `sum(k, k, 1, n)` get the *same* answer, which says the same thing more strongly.
- `AVeryLongRangeIsNotWrittenOut` — its subject is that a hundred thousand terms are not built.
  Still true: the closed form computes rather than expands, so it now asserts the value.

## Docs

`Syntax.md` and `MathS.Sum`'s summary say what happens now. `MathS.Sum`'s `<example>` needed no
change — it prints without `.Simplify()`.

**`Comparison.md`'s `declines` cell is deliberately left as it was measured.** That table records
one `sympyparity` run at one commit, and a hand-corrected cell would be a measurement nobody took;
there is a dated note beside it saying the row has moved and will read `answers` when the harness
is next run — and that the two rows either side have *not* moved, with why.

## Verification

Full suite **9459 passed, 0 failed**, 14 skipped. 40 new tests.

Almost every case is checked by **agreeing with the expansion** at several concrete bounds rather
than against a printed form: the closed form and the term-by-term sum are two routes to one
number, and that they meet is the property worth asserting. The exception is the empty-range test,
which is about the condition and would pass vacuously if it only compared the two routes.

Part of #717.
