### PR TITLE
A monomial body is multiplied in closed form (#717)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -109,6 +109,7 @@ read first.
 | | `"a => a + 3".ToEntity()`, and every lambda written with an arrow | `UnhandledParseException` | `lambda(a, a + 3)` |
 | | `"sum(k, k, 1, n)".ToEntity().Simplify()`, and every summation whose body is a polynomial in the index | `sum(k, k, 1, n)` — carried | `piecewise((n + n ^ 2) / 2 provided n >= 0, 0)` |
 | | `"sum(k, k, 1, 100000)".ToEntity().Simplify()`, and every concrete range past a hundred terms | `sum(k, k, 1, 100000)` — carried | `5000050000` |
+| | `"product(k, k, 1, n)".ToEntity().Simplify()`, and every product whose body is a monomial in the index | `product(k, k, 1, n)` — carried | `piecewise(n! provided n >= 1, 1)` |
 
 ### A polynomial summand is summed in closed form
 
@@ -147,11 +148,48 @@ answers a different question. `+oo` is refused the same way, so an infinite seri
 **A product is unchanged, whatever its body.** `product(k, k, 1, n)` is still carried, and
 `factorial(n)` would be a wrong answer for it rather than a missing one: the empty product is `1`
 at every `n < 1`, and `factorial` is undefined at the negative integers. Answering it needs the
-same kind of condition the sum now carries, and is not done here.
+same kind of condition the sum now carries, and is not done here. *It is done in the entry below,
+which gives it that condition.*
 
 No Bernoulli numbers are involved. The sum of a degree-`d` polynomial is a polynomial of degree
 `d + 1`, so `d + 2` of its values determine it, and those values are short sums computed directly;
 interpolating them recovers the coefficients exactly in rational arithmetic.
+
+[#717](https://github.com/asc-community/AngouriMath/issues/717).
+
+### A monomial body is multiplied in closed form
+
+The same for `product`, with the narrower reach a product has: a sum of two terms is the sum of
+their sums, and a product of two terms is not the product of their products in any way that
+helps. What separates is the body that **is** one term.
+
+```
+"product(k, k, 1, n)".Simplify()      was  product(k, k, 1, n)
+                                      is   piecewise(n! provided n >= 1, 1)
+
+"product(2, k, 1, 500)".Simplify()    was  product(2, k, 1, 500)
+                                      is   3273390607896141870013189696827599152216642046043064789483291368096133796404674554883270092325904157150886684127560071009217256545885393053328527589376
+```
+
+`product(k^2, k, 1, n)` is `(n!)^2`, `product(2 * k, k, 1, n)` is `n! * 2^n`, and a constant body
+needs no factorial at all — `product(c, k, m, n)` is `c^(n - m + 1)`, symbolic lower bound and
+all.
+
+**The condition is `to >= from`, where the sum's is `to >= from - 1`,** and the one point between
+them is the whole reason. At the empty range the closed form is `c^0`, which is `1` for every `c`
+except zero and undefined there, while the empty product is `1` for every `c` including zero.
+Giving that point to the identity branch keeps a value from becoming an undefinedness, and costs
+nothing, since both branches say `1` there.
+
+**A lower bound that is not a concrete integer of at least one is declined** where the index is in
+the body, rather than conditioned. `product(k, k, a, b)` is `b!/(a-1)!` only for `a >= 1`; below
+that the range runs through zero so the product is `0`, while `(a-1)!` is undefined. That cannot
+share a branch with the empty-range case, because `a < 1` does not make the range empty — a
+piecewise reading "identity otherwise" would be wrong there. So `product(k, k, 0, n)` and
+`product(k, k, m, n)` stay as written.
+
+**What is not one term is carried**, `product(k + 1, k, 1, n)` included. As for the sum, a bound
+that is a number and not a whole one is carried too.
 
 [#717](https://github.com/asc-community/AngouriMath/issues/717).
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -181,3 +181,8 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 [Tests/UnitTests/Core/ClosedFormSummationTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[AngouriMath/Functions/Algebra/Polynomials/MonomialProduct.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+[Tests/UnitTests/Core/ClosedFormProductTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Convenience/MathS.cs
+++ b/Sources/AngouriMath/Convenience/MathS.cs
@@ -6999,14 +6999,27 @@ namespace AngouriMath
         /// <summary>
         /// A product of <paramref name="expr"/> as <paramref name="var"/> runs from
         /// <paramref name="from"/> to <paramref name="to"/> inclusive. Mirrors
-        /// <see cref="Sum(Entity, Entity, Entity, Entity)"/> exactly, with an empty range
-        /// multiplying to <c>1</c>.
+        /// <see cref="Sum(Entity, Entity, Entity, Entity)"/>, with an empty range multiplying to
+        /// <c>1</c>.
         /// </summary>
         /// <param name="expr">The factor. It may mention <paramref name="var"/>.</param>
         /// <param name="var">The index, which this binds.</param>
         /// <param name="from">The first value of the index.</param>
         /// <param name="to">The last value of the index, inclusive.</param>
-        /// <returns>The product written out where it can be, and an unevaluated node otherwise.</returns>
+        /// <returns>
+        /// The product written out where the bounds are concrete integers and there are not too
+        /// many terms; a closed form where the factor is a <b>monomial</b> in the index — a
+        /// narrower class than the sum's, a product having no linearity to take a sum of terms
+        /// apart with; and an unevaluated node otherwise.
+        /// </returns>
+        /// <remarks>
+        /// The closed form's condition is <c>to &gt;= from</c> rather than the sum's
+        /// <c>to &gt;= from - 1</c>: at the empty range itself it would be <c>c ^ 0</c>, which is
+        /// undefined at <c>c = 0</c> where the empty product is <c>1</c>. Where the index is in
+        /// the factor the lower bound must be a concrete integer of at least one, since the
+        /// answer is a ratio of factorials and <c>factorial</c> has no value at the negative
+        /// integers.
+        /// </remarks>
         /// <example>
         /// <code>
         /// using System;

--- a/Sources/AngouriMath/Docs/Usage/Comparison.md
+++ b/Sources/AngouriMath/Docs/Usage/Comparison.md
@@ -248,20 +248,19 @@ Long answers are truncated in the table below at 64 characters, with `…`.
 | holonomic | holonomic functions | `expr_to_holonomic exists: True` | `<no member at all matching "Holonomic">` | absent |
 | codegen | compile to a callable | `9` | `9` | answers |
 
-### One row has moved since the run
+### Two rows have moved since the run
 
-**concrete / symbolic summation** was measured as `declines` at `6b93b401` and is answered now:
-`sum(k, k, 1, n)` is `(n + n^2)/2`, carrying the condition `n >= 0` that this library's
-empty-range convention requires and SymPy's reversed-range convention does not. The row is left
-as it was measured rather than edited, because the table is a record of one run at one commit and
-a hand-corrected cell would be a measurement nobody took; it will read `answers` when
-`sympyparity` is next run.
+**concrete / symbolic summation** and **concrete / symbolic product** were both measured as
+`declines` at `6b93b401` and are answered now: `sum(k, k, 1, n)` is `(n + n^2)/2` and
+`product(k, k, 1, n)` is `factorial(n)`, each carrying a condition on the range being non-empty
+that this library's empty-range convention requires and SymPy's reversed-range convention does
+not. The rows are left as they were measured rather than edited, because the table is a record of
+one run at one commit and a hand-corrected cell would be a measurement nobody took; they will
+read `answers` when `sympyparity` is next run.
 
-The two rows either side of it have **not** moved. *Infinite series* is still declined —
-`sum(1 / k ^ 2, k, 1, +oo)` needs the zeta function, which the row four below records as absent.
-*Symbolic product* is still declined, and deliberately: `factorial(n)` is undefined at the
-negative integers where the empty product is `1`, so answering it needs a condition of the same
-kind the sum now carries.
+The row between them has **not** moved. *Infinite series* is still declined —
+`sum(1 / k ^ 2, k, 1, +oo)` needs the zeta function, which the row four below records as absent,
+and an infinite bound is refused outright by both closed forms.
 
 ### Implemented, but not reachable from outside
 

--- a/Sources/AngouriMath/Docs/Usage/Syntax.md
+++ b/Sources/AngouriMath/Docs/Usage/Syntax.md
@@ -255,8 +255,16 @@ rather than a hundred thousand terms. The answer carries the condition it needs 
 — because below that the range is empty and the polynomial is not zero; where the bounds are
 concrete that condition is decidable and the answer is a number. A bound that is a number and not
 a whole one still stays as written, since the index runs over the integers and
-`sum(k, k, 1, 5/2)` is `1 + 2` rather than the polynomial at `5/2`. A `product` stays as written
-whatever its body.
+`sum(k, k, 1, 5/2)` is `1 + 2` rather than the polynomial at `5/2`.
+
+A `product` gets the same treatment over the narrower class its shape allows: a **monomial** in
+the index, since a product has no linearity to take a sum of terms apart with. So
+`product(k, k, 1, n)` is `factorial(n)`, `product(k ^ 2, k, 1, n)` is `factorial(n) ^ 2`, and
+`product(c, k, m, n)` is `c ^ (n - m + 1)`. Its condition is `to >= from` rather than
+`to >= from - 1`, because at the empty range itself the closed form would be `c ^ 0` — undefined
+at `c = 0`, where the empty product is `1`. Where the index appears in the body the lower bound
+must be a concrete integer of at least one, `factorial` having no value at the negative integers;
+`product(k, k, 0, n)` therefore stays as written.
 
 **The declared name means the name, and only inside the operator that declares it.** Two names
 show this, because both mean something else in this language:

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/MonomialProduct.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/MonomialProduct.cs
@@ -1,0 +1,108 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using PeterO.Numbers;
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// A product whose body is a monomial in the index, written in closed form:
+    /// <c>product(k, k, 1, n)</c> is <c>factorial(n)</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The sibling of <see cref="PolynomialSummation"/> and a narrower thing than it, because a
+    /// product has no linearity to take apart: a sum of two terms is the sum of their sums, and a
+    /// product of two terms is not the product of their products in any way that helps. What is
+    /// left is the body that <em>is</em> a single term — <c>c * k^p</c> — over which the product
+    /// separates into a power of the constant and a power of the factorial.
+    /// </para>
+    /// <para>
+    /// <b>The condition is the same one, for the same reason.</b> An empty range multiplies to
+    /// <c>1</c>, so <c>product(k, k, 1, n)</c> is <c>1</c> at every <c>n &lt; 1</c>, while
+    /// <c>factorial(n)</c> is not — it is undefined at the negative integers, being the gamma
+    /// function's poles. Answering the one with the other unconditionally would turn a value into
+    /// an undefinedness, which is the failure the contract's O4 is about. The identity holds
+    /// where <c>to >= from - 1</c>, and that is what is attached.
+    /// </para>
+    /// <para>
+    /// <b>A positive lower bound where the index is in the body</b>, and that one cannot go in the
+    /// condition. <c>product(k, k, a, b)</c> is <c>b! / (a-1)!</c> only where <c>a >= 1</c>; below
+    /// that the range runs through zero and the product is <c>0</c>, while <c>(a-1)!</c> is
+    /// undefined. But <c>a &lt; 1</c> does not mean the range is empty, so it cannot share a
+    /// branch with the empty-range case — a piecewise saying "identity otherwise" would be wrong
+    /// there. So it is decided before anything is built, and a lower bound that is not a concrete
+    /// integer of at least one is declined instead. A constant body has no such restriction,
+    /// there being no factorial in its answer.
+    /// </para>
+    /// </remarks>
+    internal static class MonomialProduct
+    {
+        /// <summary>
+        /// The largest power of the index this will take. The answer carries the factorial to
+        /// that power, so the ceiling is about how big an expression is worth returning.
+        /// </summary>
+        private const int MaxPower = 16;
+
+        /// <summary>
+        /// <c>product(expression, index, from, to)</c> written in closed form, or
+        /// <see langword="null"/> where the body is not a monomial in the index, or the bounds
+        /// are not ones the identity speaks about.
+        /// </summary>
+        internal static Entity? ClosedForm(Entity expression, Entity var, Entity from, Entity to)
+        {
+            if (var is not Variable index)
+                return null;
+            if (!PolynomialSummation.IsWholeOrSymbolic(from) || !PolynomialSummation.IsWholeOrSymbolic(to))
+                return null;
+            if (!TreeAnalyzer.TryGetPolynomial(expression, index, out var monomials))
+                return null;
+
+            // One term, or this is not a monomial and the product does not separate.
+            if (monomials.Count != 1)
+                return null;
+            var only = System.Linq.Enumerable.Single(monomials);
+            if (only.Key.Sign < 0 || !only.Key.CanFitInInt32())
+                return null;
+            var power = only.Key.ToInt32Checked();
+            if (power > MaxPower)
+                return null;
+            var coefficient = only.Value;
+            if (coefficient.ContainsNode(index))
+                return null;
+
+            // How many times the body is multiplied: to - from + 1, which the condition below
+            // guarantees is not negative.
+            var count = (to - from + 1).InnerSimplified;
+            Entity closed = MathS.Pow(coefficient, count);
+
+            if (power > 0)
+            {
+                // b! / (a-1)! needs a - 1 to be a whole number that factorial is defined at,
+                // which is decided here rather than asked in the condition -- see the remarks.
+                if (from.Evaled is not Integer lower || lower.EInteger.Sign < 1)
+                    return null;
+                var factorials = (MathS.Factorial(to) / MathS.Factorial(from - 1)).InnerSimplified;
+                closed *= power == 1 ? factorials : MathS.Pow(factorials, Integer.Create(power));
+            }
+
+            // `to >= from` and not `to >= from - 1`, which is where the sum's condition sits.
+            // The two agree everywhere but the empty range itself, and there the closed form is
+            // c^0 -- which is 1 for every c except 0, where it is undefined, while the empty
+            // product is 1 for every c including 0. Handing the empty range to the identity
+            // branch instead keeps a value from becoming an undefinedness, and costs nothing:
+            // both branches say 1 there.
+            return MathS.Piecewise(new[]
+            {
+                new Providedf(closed.InnerSimplified, new GreaterOrEqualf(to, from)),
+                new Providedf(Integer.Create(1), Entity.Boolean.True),
+            }).InnerSimplified;
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialSummation.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/PolynomialSummation.cs
@@ -121,7 +121,7 @@ namespace AngouriMath.Functions
         /// anything symbolic to go through — the symbolic case being the one the closed form
         /// exists for.
         /// </remarks>
-        private static bool IsWholeOrSymbolic(Entity bound)
+        internal static bool IsWholeOrSymbolic(Entity bound)
             => bound.Evaled is Integer || bound.Evaled is not Number;
 
         /// <summary>

--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
@@ -226,8 +226,15 @@ namespace AngouriMath
             private protected override Entity IntrinsicCondition => Boolean.True;
 
             /// <inheritdoc/>
+            /// <remarks>
+            /// The expansion first and the closed form after, as for the sum — and the closed
+            /// form is narrower here, a product having no linearity to take a general polynomial
+            /// apart with. A monomial body is what separates.
+            /// </remarks>
             protected override Entity InnerSimplify(bool isExact) =>
-                Summationf.Expanded(this, Expression, Var, From, To, static (a, b) => a * b, 1, isExact) ?? this;
+                Summationf.Expanded(this, Expression, Var, From, To, static (a, b) => a * b, 1, isExact)
+                ?? Functions.MonomialProduct.ClosedForm(Expression, Var, From, To)
+                ?? this;
         }
 
         public partial record Limitf

--- a/Sources/Tests/UnitTests/Core/ClosedFormProductTest.cs
+++ b/Sources/Tests/UnitTests/Core/ClosedFormProductTest.cs
@@ -1,0 +1,154 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Core
+{
+    /// <summary>
+    /// A product whose body is a monomial in the index, answered in closed form:
+    /// <c>product(k, k, 1, n)</c> is <c>factorial(n)</c>.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/717">#717</a>
+    /// </summary>
+    /// <remarks>
+    /// Narrower than the sum's closed form, and not by omission: a sum of two terms is the sum of
+    /// their sums, and a product of two terms is not the product of their products in any way
+    /// that helps. What separates is the body that <em>is</em> one term.
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class ClosedFormProductTest
+    {
+        /// <summary>
+        /// The closed form agrees with writing the product out, at bounds either side of the
+        /// empty-range boundary — which is where the two could disagree and did.
+        /// </summary>
+        private static void AgreesWithTheExpansion(string expression, params int[] bounds)
+        {
+            var closed = expression.ToEntity().Simplify();
+            Assert.IsNotType<Entity.Productf>(closed);
+            foreach (var at in bounds)
+                Assert.Equal(
+                    expression.ToEntity().Substitute("n", at).Simplify().Evaled,
+                    closed.Substitute("n", at).Simplify().Evaled);
+        }
+
+        /// <summary>The factorial, which is the row the survey names.</summary>
+        [Theory]
+        [InlineData("product(k, k, 1, n)")]
+        [InlineData("product(k ^ 2, k, 1, n)")]
+        [InlineData("product(k ^ 3, k, 1, n)")]
+        public void ThePowerOfAFactorial(string expression)
+            => AgreesWithTheExpansion(expression, -2, -1, 0, 1, 2, 3, 5, 8);
+
+        /// <summary>A constant factor comes out as a power of itself, one per term.</summary>
+        [Theory]
+        [InlineData("product(2, k, 1, n)")]
+        [InlineData("product(c, k, 1, n)")]
+        [InlineData("product(2 * k, k, 1, n)")]
+        [InlineData("product(c * k, k, 1, n)")]
+        [InlineData("product(c * k ^ 2, k, 1, n)")]
+        public void AConstantFactor(string expression)
+            => AgreesWithTheExpansion(expression, -2, -1, 0, 1, 2, 3, 5);
+
+        /// <summary>
+        /// <b>The empty range is where the boundary had to move.</b> The sum's condition is
+        /// <c>to >= from - 1</c>; the product's is <c>to >= from</c>, because at the empty range
+        /// itself the closed form is <c>c^0</c> — which is <c>1</c> for every <c>c</c> but zero,
+        /// and undefined there, while the empty product is <c>1</c> for every <c>c</c> including
+        /// zero. Handing that one point to the identity branch keeps a value from becoming an
+        /// undefinedness.
+        /// </summary>
+        [Fact]
+        public void TheEmptyProductIsOneEvenWhereTheBodyIsZero()
+        {
+            var closed = "product(c, k, 1, n)".ToEntity().Simplify();
+            var atTheBoundary = closed.Substitute("n", 0).Substitute("c", 0).Simplify();
+            Assert.Equal(Entity.Number.Integer.Create(1), atTheBoundary.Evaled);
+            Assert.False(atTheBoundary.Evaled.IsNaN);
+        }
+
+        /// <summary>A symbolic lower bound, where the body has no index to need a factorial.</summary>
+        [Fact]
+        public void ASymbolicLowerBoundWithAConstantBody()
+        {
+            var closed = "product(c, k, m, n)".ToEntity().Simplify();
+            Assert.IsNotType<Entity.Productf>(closed);
+            foreach (var (from, to) in new[] { (1, 4), (2, 5), (3, 3), (4, 3), (-1, 2) })
+                Assert.Equal(
+                    "product(c, k, m, n)".ToEntity().Substitute("m", from).Substitute("n", to)
+                        .Substitute("c", 3).Simplify().Evaled,
+                    closed.Substitute("m", from).Substitute("n", to).Substitute("c", 3).Simplify().Evaled);
+        }
+
+        /// <summary>
+        /// A concrete range too long to write out is answered rather than carried, the same as
+        /// for the sum.
+        /// </summary>
+        [Fact]
+        public void ARangeTooLongToWriteOutIsStillAnswered()
+            => Assert.Equal(
+                MathS.Pow(2, 500).Evaled,
+                "product(2, k, 1, 500)".ToEntity().Simplify().Evaled);
+
+        /// <summary>
+        /// <b>A lower bound that is not a concrete positive integer is declined where the index
+        /// is in the body</b>, and that cannot be a condition instead. <c>b!/(a-1)!</c> holds
+        /// only for <c>a >= 1</c>; below it the range runs through zero and the product is
+        /// <c>0</c> while <c>(a-1)!</c> is undefined — and <c>a &lt; 1</c> does not mean the
+        /// range is empty, so it cannot share a branch with the empty-range case.
+        /// </summary>
+        [Theory]
+        [InlineData("product(k, k, 0, n)")]
+        [InlineData("product(k, k, -3, n)")]
+        [InlineData("product(k, k, m, n)")]
+        public void ALowerBoundThatIsNotAConcretePositiveIntegerIsDeclined(string expression)
+            => Assert.IsType<Entity.Productf>(expression.ToEntity().Simplify());
+
+        /// <summary>
+        /// What is not a monomial in the index is carried. A product has no linearity, so a sum
+        /// of terms in the body is not something this takes apart.
+        /// </summary>
+        [Theory]
+        [InlineData("product(k + 1, k, 1, n)")]
+        [InlineData("product(k ^ 2 + k, k, 1, n)")]
+        [InlineData("product(2 ^ k, k, 1, n)")]
+        [InlineData("product(sin(k), k, 1, n)")]
+        [InlineData("product(1 / k, k, 1, n)")]
+        public void WhatIsNotAMonomialIsCarried(string expression)
+            => Assert.IsType<Entity.Productf>(expression.ToEntity().Simplify());
+
+        /// <summary>
+        /// A bound that is a number and not a whole one is carried, as for the sum: the index
+        /// runs over the integers.
+        /// </summary>
+        [Theory]
+        [InlineData("product(k, k, 1, 5/2)")]
+        [InlineData("product(k, k, 1, +oo)")]
+        public void ABoundThatIsNotAWholeNumberIsCarried(string expression)
+            => Assert.IsType<Entity.Productf>(expression.ToEntity().Simplify());
+
+        /// <summary>The short concrete ranges are written out as they were.</summary>
+        [Theory]
+        [InlineData("product(k, k, 1, 5)", "120")]
+        [InlineData("product(k, k, 3, 6)", "360")]
+        [InlineData("product(k ^ 2, k, 1, 4)", "576")]
+        [InlineData("product(k, k, 5, 1)", "1")]
+        [InlineData("product(2 ^ k, k, 1, 4)", "1024")]
+        public void AShortConcreteRangeIsUnchanged(string expression, string expected)
+            => Assert.Equal(expected.ToEntity().Evaled, expression.ToEntity().Simplify().Evaled);
+
+        /// <summary>The index stays bound.</summary>
+        [Fact]
+        public void TheIndexDoesNotEscape()
+        {
+            var closed = "product(k, k, 1, n)".ToEntity().Simplify();
+            Assert.DoesNotContain((Entity.Variable)"k", closed.Vars);
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Core/ClosedFormSummationTest.cs
+++ b/Sources/Tests/UnitTests/Core/ClosedFormSummationTest.cs
@@ -153,14 +153,18 @@ namespace AngouriMath.Tests.Core
             => Assert.IsType<Entity.Summationf>(expression.ToEntity().Simplify());
 
         /// <summary>
-        /// The product is carried whatever its body, including <c>product(k, k, 1, n)</c>, whose
-        /// closed form <c>factorial(n)</c> would be a wrong answer here: the empty product is
-        /// <c>1</c> at every <c>n &lt; 1</c>, while <c>factorial</c> is undefined at the negative
-        /// integers. Answering it needs the same condition the sum carries, and is not done.
+        /// A product whose body this cannot read is carried. The ones it can are
+        /// <see cref="ClosedFormProductTest"/>'s subject — a product has no linearity, so where
+        /// the sum takes any polynomial apart the product needs a single term.
         /// </summary>
+        /// <remarks>
+        /// <c>product(k, k, 1, n)</c> was on this list, for wanting a condition of the same kind
+        /// the sum carries: the empty product is <c>1</c> at every <c>n &lt; 1</c>, while
+        /// <c>factorial</c> is undefined at the negative integers. It has that condition now.
+        /// </remarks>
         [Theory]
-        [InlineData("product(k, k, 1, n)")]
-        [InlineData("product(k ^ 2, k, 1, n)")]
+        [InlineData("product(k + 1, k, 1, n)")]
+        [InlineData("product(2 ^ k, k, 1, n)")]
         public void TheProductIsCarried(string expression)
             => Assert.IsType<Entity.Productf>(expression.ToEntity().Simplify());
 

--- a/Sources/Tests/UnitTests/Core/SummationProductTest.cs
+++ b/Sources/Tests/UnitTests/Core/SummationProductTest.cs
@@ -64,10 +64,15 @@ namespace AngouriMath.Tests.Core
         public void ASymbolicBoundIsCarried(string expression)
             => Assert.IsType<Entity.Summationf>(expression.ToEntity().Simplify());
 
-        /// <summary>A product is carried whatever its summand; only the sum has a closed form.</summary>
-        [Fact]
-        public void AProductWithASymbolicBoundIsCarried()
-            => Assert.IsType<Entity.Productf>("product(k, k, 1, n)".ToEntity().Simplify());
+        /// <summary>
+        /// A product is carried unless its body is a single term. Where the sum takes any
+        /// polynomial apart by linearity, a product has none to take it apart with.
+        /// </summary>
+        [Theory]
+        [InlineData("product(k + 1, k, 1, n)")]
+        [InlineData("product(2 ^ k, k, 1, n)")]
+        public void AProductWithASymbolicBoundIsCarried(string expression)
+            => Assert.IsType<Entity.Productf>(expression.ToEntity().Simplify());
 
         /// <summary>
         /// A polynomial summand does have a closed form, and it is given rather than carried.


### PR DESCRIPTION
The same for `product` as #1152 did for `sum`, over the narrower class a product's shape allows.

```
"product(k, k, 1, n)".Simplify()      was  product(k, k, 1, n)
                                      is   piecewise(n! provided n >= 1, 1)

"product(2, k, 1, 500)".Simplify()    was  product(2, k, 1, 500)
                                      is   2^500, written out in full
```

| input | now |
|---|---|
| `product(k ^ 2, k, 1, n)` | `(n!)^2` |
| `product(k ^ 3, k, 1, n)` | `(n!)^3` |
| `product(2 * k, k, 1, n)` | `n! * 2^n` |
| `product(c, k, m, n)` | `c^(n - m + 1)` — symbolic lower bound, no factorial needed |

This closes the last of the three `sum`/`product` rows in #717's survey.

## Narrower than the sum, and not by omission

A sum of two terms is the sum of their sums; a product of two terms is not the product of their
products in any way that helps. There is no linearity to take a general polynomial apart with, so
what separates is the body that **is** one term — `c * k^p`, over which the product becomes a
power of the constant times a power of the factorial.

`product(k + 1, k, 1, n)` is therefore still carried, and there is a test saying so.

## The condition moved by one, and that is the interesting part

The sum's condition is `to >= from - 1`. The product's is `to >= from`, and the single point
between them is the reason.

At the empty range itself the closed form is `c^0` — which is `1` for every `c` **except zero**,
where it is undefined, while the empty product is `1` for every `c` **including** zero. Handing
that one point to the identity branch keeps a value from becoming an undefinedness, which is what
the contract's O4 asks. It costs nothing: both branches say `1` there.

I found this by comparing the closed form against the expansion at bounds either side of the
boundary — it is not visible from the formula, and it is why the tests are written as agreement
with the expansion rather than against a printed form.

## A lower bound that cannot be a condition

`product(k, k, a, b)` is `b!/(a-1)!` only where `a >= 1`. Below that the range runs through zero,
so the product is `0`, while `(a-1)!` is undefined at the negative integers.

That **cannot** go into the piecewise condition, because `a < 1` does not mean the range is empty
— a branch reading "identity otherwise" would answer `1` where the product is `0`. So it is
decided before anything is built: a lower bound that is not a concrete integer of at least one is
declined outright where the index is in the body. `product(k, k, 0, n)` and `product(k, k, m, n)`
stay as written, with tests carrying that reason.

A constant body has no such restriction, there being no factorial in its answer — hence
`product(c, k, m, n)` working with `m` symbolic.

## Records that changed their verdict

Three tests asserted the product is carried, **two of them added by #1152 an hour earlier**, with
the reason it could not yet be answered. They now assert what is still carried — a body that is
not one term.

Corrected the same way: `Syntax.md`, `MathS.Product`'s `<returns>`, and #1152's own
`BREAKING-CHANGES.md` entry, which said answering the product "is not done here".

`Comparison.md`'s `declines` cell is again **left as it was measured**. That table records one
`sympyparity` run at one commit, and a hand-corrected cell would be a measurement nobody took; its
note now names two moved rows rather than one, and says the row between them — infinite series —
has not moved, an infinite bound being refused outright by both closed forms.

## Verification

Full suite **9487 passed, 0 failed**, 14 skipped. 27 new tests.

Every closed form is checked by agreeing with the expansion at bounds on both sides of the
empty-range boundary. The exception is the `c = 0` test, which is about the boundary itself and
would pass vacuously if it only compared the two routes.

Part of #717.
