### PR TITLE
A nested radical comes apart (#717)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -107,9 +107,48 @@ read first.
 | **Silent** | `"arccotan(-1)".ToEntity().Simplify()`, and every negative argument the inverse-trigonometric table knows | `3/4 * pi` — the textbook range, and **not equal to `arccotan(-1)`**, whose value is `-pi/4` | `-1/4 * pi` |
 | | `"e ^ ln(x)".ToEntity().Simplify()`, and every exponential of a natural logarithm | `e ^ ln(x)` — left as written | `x` |
 | | `"a => a + 3".ToEntity()`, and every lambda written with an arrow | `UnhandledParseException` | `lambda(a, a + 3)` |
+| | `"sqrt(5 + 2 * sqrt(6))".ToEntity().Simplify()`, and every nested radical whose discriminant is a rational square | `sqrt(5 + 2 * sqrt(6))` — left as written | `sqrt(3) + sqrt(2)` |
 | | `"sum(k, k, 1, n)".ToEntity().Simplify()`, and every summation whose body is a polynomial in the index | `sum(k, k, 1, n)` — carried | `piecewise((n + n ^ 2) / 2 provided n >= 0, 0)` |
 | | `"sum(k, k, 1, 100000)".ToEntity().Simplify()`, and every concrete range past a hundred terms | `sum(k, k, 1, 100000)` — carried | `5000050000` |
 | | `"product(k, k, 1, n)".ToEntity().Simplify()`, and every product whose body is a monomial in the index | `product(k, k, 1, n)` — carried | `piecewise(n! provided n >= 1, 1)` |
+
+### A nested radical comes apart
+
+`sqrt(5 + 2*sqrt(6))` is a radical under a radical, and it is two plain ones added.
+
+```
+"sqrt(5 + 2 * sqrt(6))".Simplify()   was  sqrt(5 + 2 * sqrt(6))   is  sqrt(3) + sqrt(2)
+"sqrt(7 - 4 * sqrt(3))".Simplify()   was  as written              is  2 - sqrt(3)
+"sqrt(9 + 4 * sqrt(5))".Simplify()   was  as written              is  sqrt(5) + 2
+"sqrt(11 + 6 * sqrt(2))".Simplify()  was  as written              is  3 + sqrt(2)
+"sqrt(6 - 2 * sqrt(5))".Simplify()   was  as written              is  sqrt(5) - 1
+```
+
+Squaring `sqrt(x) + sqrt(y)` gives `x + y + 2*sqrt(x*y)`, so matching that against
+`a + b*sqrt(c)` makes `x` and `y` the roots of `t^2 - a*t + b^2*c/4`. They are rational exactly
+when `a^2 - b^2*c` is the square of a rational, and that is the whole test — decidable in exact
+arithmetic rather than a search. The sign of `b` chooses the sum or the difference, since squaring
+either gives `a + |b|*sqrt(c)`.
+
+**No condition is attached and none is owed.** A non-negative `a` and a non-negative discriminant
+are required before anything is built, and together they make the radicand, `x` and `y` all
+non-negative — so what fires is an identity between real numbers with no branch chosen. A negative
+`a` is refused rather than conditioned.
+
+**A radicand with no rational split is left as written**, `sqrt(1 + sqrt(2))` among them, and so
+is anything that is not `a + b*sqrt(c)`.
+
+**Where the denesting is longer, `Simplify` keeps the nested form.** `sqrt(2 + sqrt(3))` does come
+apart — to `(sqrt(6) + sqrt(2))/2` — and the nested spelling is the shorter of the two, so that is
+what comes back. The rule offers the alternative; the selection is by size, as it is everywhere
+else.
+
+One radicand is a boundary rather than a rule: `sqrt(3 + 2*sqrt(2))` is answered by the rule —
+applying the set gives `sqrt(2) + 1`, the shorter form — and `Simplify` nonetheless returns the
+nested one. There is a test pinning what happens; the cause is not established, and the obvious
+suspect was measured and ruled out.
+
+[#717](https://github.com/asc-community/AngouriMath/issues/717).
 
 ### A polynomial summand is summed in closed form
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -186,3 +186,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 [Tests/UnitTests/Core/ClosedFormProductTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/PatternsTest/DenestRadicalTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -2884,7 +2884,25 @@ namespace AngouriMath.Core.Transformations.Matching
                 Soundness.Sound,
                 when: bound => Functions.Patterns.ReduceRadical(
                     (Integer)bound["radicand"], (Rational)bound["power"]) is not null,
-                description: "sqrt(8) = 2 * sqrt(2), and its like for a positive whole radicand"));
+                description: "sqrt(8) = 2 * sqrt(2), and its like for a positive whole radicand"),
+
+            // The rule above takes a whole power out from under one root; this takes a root out
+            // from under another, which is the nesting rather than the size. Sound rather than
+            // conditional: the helper refuses every radicand it cannot square its answer back
+            // to, so what fires is an identity between two non-negative reals with no branch
+            // chosen -- see the remarks on DenestRadical for why a non-negative `a` and a square
+            // discriminant are the whole of what it needs.
+            new MatchedRule(
+                "a-nested-radical-is-a-sum-of-two-plain-ones",
+                MatchPattern.Node<Powf>(
+                    MatchPattern.Any("radicand"),
+                    MatchPattern.Any<Rational>("power", ratio => ratio.ERational.Equals(
+                        PeterO.Numbers.ERational.Create(
+                            PeterO.Numbers.EInteger.One, PeterO.Numbers.EInteger.FromInt32(2))))),
+                bound => Functions.Patterns.DenestRadical(bound["radicand"])!,
+                Soundness.Sound,
+                when: bound => Functions.Patterns.DenestRadical(bound["radicand"]) is not null,
+                description: "sqrt(5 + 2*sqrt(6)) = sqrt(2) + sqrt(3)"));
 
         /// <summary>
         /// <see cref="Functions.Patterns.CommonRules"/>, as data.

--- a/Sources/AngouriMath/Docs/Contributing/WritingARule.md
+++ b/Sources/AngouriMath/Docs/Contributing/WritingARule.md
@@ -18,7 +18,7 @@ effect". This is how to supply those seven things.
 ## Where a rule goes
 
 `Core/Transformations/Matching/MatchedRules.cs`, as a value in a `MatchedRuleSet`. **33** sets and
-**323** rules live there today.
+**324** rules live there today.
 
 The `switch` statements in `Functions/Simplification/Patterns` are the older form. Twenty-seven of
 the thirty registered sets no longer run theirs, and **none of those twenty-seven describes it any
@@ -62,7 +62,7 @@ in a name and putting the identity in brackets after it:
 2. Tangent is sine over cosine (tan(a) = sin(a) / cos(a)), so tan(x) becomes sin(x) / cos(x).
 ```
 
-So the name has to be a clause that survives being read that way. **All 294 distinct rule names are,
+So the name has to be a clause that survives being read that way. **All 295 distinct rule names are,
 and `StepAsASentenceTest` holds them to it** — a name with a capital, a bracket or an underscore
 fails that test rather than degrading the prose quietly.
 
@@ -89,7 +89,7 @@ debugged for an afternoon.
 | `Left.ToString()` | `Divf(var a, Divf(var b, var c))` — how the matcher spells it |
 
 Write the identity with `=`, not `->`: it is an equality, and the arrow belongs to the direction the
-rule happens to be applied in. **293** rules carry one today; a new rule should.
+rule happens to be applied in. **294** rules carry one today; a new rule should.
 
 ## The pattern language
 
@@ -121,7 +121,7 @@ matches and silently builds nothing. `BuildableNodeTypesTest` is the list.
 
 ## Replacement: a pattern, or code
 
-**35** of the 323 rules have a pattern on both sides. The rest build their answer in code, and both
+**35** of the 324 rules have a pattern on both sides. The rest build their answer in code, and both
 are legitimate — but the choice costs two things, so make it deliberately.
 
 A pattern replacement gets:
@@ -133,7 +133,7 @@ A pattern replacement gets:
 - **an exact growth**, counted from the two patterns rather than declared.
 
 A code replacement gets neither, and its growth is `Unknown` unless you declare one. That is the
-honest default — **260** rules sit at `Unknown` — but declare it where you can justify it:
+honest default — **261** rules sit at `Unknown` — but declare it where you can justify it:
 
 ```csharp
 // The Chebyshev expansion of sin(n * a) is a sum of n terms where the pattern is one node,
@@ -154,7 +154,7 @@ limit, against nothing for handing the node over.
 | `SoundUnderAssumptions` | holds given something the rule does not check |
 | `Heuristic` | usually right |
 
-**181** of the 323 rules are `Sound` and **142** are conditional. Every one of the thirty registered
+**182** of the 324 rules are `Sound` and **142** are conditional. Every one of the thirty registered
 *sets* declares `SoundUnderAssumptions`, because a set's tier is the **minimum** over its rules — so
 the set grain says nothing and the rule grain says everything. A derivation reports the rule's tier
 (`RewriteStep.Soundness`), which is why getting it right matters beyond the label.

--- a/Sources/AngouriMath/Docs/Usage/Comparison.md
+++ b/Sources/AngouriMath/Docs/Usage/Comparison.md
@@ -248,19 +248,28 @@ Long answers are truncated in the table below at 64 characters, with `…`.
 | holonomic | holonomic functions | `expr_to_holonomic exists: True` | `<no member at all matching "Holonomic">` | absent |
 | codegen | compile to a callable | `9` | `9` | answers |
 
-### Two rows have moved since the run
+### Four rows have moved since the run
 
-**concrete / symbolic summation** and **concrete / symbolic product** were both measured as
-`declines` at `6b93b401` and are answered now: `sum(k, k, 1, n)` is `(n + n^2)/2` and
-`product(k, k, 1, n)` is `factorial(n)`, each carrying a condition on the range being non-empty
-that this library's empty-range convention requires and SymPy's reversed-range convention does
-not. The rows are left as they were measured rather than edited, because the table is a record of
-one run at one commit and a hand-corrected cell would be a measurement nobody took; they will
-read `answers` when `sympyparity` is next run.
+Each was measured as `declines` at `6b93b401` and is answered now:
 
-The row between them has **not** moved. *Infinite series* is still declined —
-`sum(1 / k ^ 2, k, 1, +oo)` needs the zeta function, which the row four below records as absent,
-and an infinite bound is refused outright by both closed forms.
+| row | this library, re-measured |
+|---|---|
+| polys / factor over the rationals | `x ^ 4 - 1` is `(x + 1) * (x - 1) * (x ^ 2 + 1)` |
+| simplify / radical denesting | `sqrt(5 + 2 * sqrt(6))` is `sqrt(3) + sqrt(2)` |
+| concrete / symbolic summation | `sum(k, k, 1, n)` is `(n + n^2)/2` |
+| concrete / symbolic product | `product(k, k, 1, n)` is `factorial(n)` |
+
+The last two each carry a condition on the range being non-empty, which this library's
+empty-range convention requires and SymPy's reversed-range convention does not.
+
+**The cells are left as they were measured rather than edited.** The table is a record of one run
+at one commit, and a hand-corrected cell would be a measurement nobody took; they will read
+`answers` when `sympyparity` is next run.
+
+Two neighbours have **not** moved, and both for the same reason — a special function this library
+does not have. *Infinite series* needs `zeta`, which the row four below records as absent, and an
+infinite bound is refused outright by both closed forms; *combine logarithms* is declined here and
+by SymPy alike, so it was never a parity gap.
 
 ### Implemented, but not reachable from outside
 

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Power.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Power.cs
@@ -252,6 +252,13 @@ namespace AngouriMath.Functions
             Powf(Integer { IsPositive: true } radicand, Rational and not Integer and var power)
                 when ReduceRadical(radicand, power) is { } reduced => reduced,
 
+            // sqrt(5 + 2*sqrt(6)) = sqrt(2) + sqrt(3). The rule above takes a whole power out
+            // from under one root; this one takes a root out from under another, which is the
+            // nesting rather than the size.
+            Powf(var radicand, Rational half)
+                when half.ERational.Equals(ERational.Create(EInteger.One, EInteger.FromInt32(2)))
+                    && DenestRadical(radicand) is { } denested => denested,
+
             _ => x
         };
 
@@ -452,6 +459,162 @@ namespace AngouriMath.Functions
             // n^(p/q) = (a^q * b)^(p/q) = a^p * b^(p/q)
             return new Powf(Integer.Create(outside), Integer.Create(power.ERational.Numerator))
                  * new Powf(Integer.Create(inside), power);
+        }
+
+        /// <summary>
+        /// The exact square root of a non-negative rational, or <see langword="null"/> where it
+        /// has none. <c>4/9</c> gives <c>2/3</c>; <c>2</c> gives nothing.
+        /// </summary>
+        /// <remarks>
+        /// A rational in lowest terms is a square exactly when its numerator and denominator both
+        /// are, since a square's prime factorisation has even exponents throughout and the two
+        /// share no prime. Asked of each separately, which is why there is no gcd here.
+        /// </remarks>
+        private static ERational? ExactSquareRoot(ERational value)
+        {
+            if (value.IsNegative || !value.IsFinite)
+                return null;
+            var numerator = value.Numerator.Sqrt();
+            if (!numerator.Multiply(numerator).Equals(value.Numerator))
+                return null;
+            var denominator = value.Denominator.Sqrt();
+            if (!denominator.Multiply(denominator).Equals(value.Denominator))
+                return null;
+            return ERational.Create(numerator, denominator);
+        }
+
+        /// <summary>
+        /// <c>sqrt(a + b*sqrt(c))</c> written without the nesting, as <c>sqrt(x) +- sqrt(y)</c>,
+        /// or <see langword="null"/> where it has no such form.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Squaring <c>sqrt(x) + sqrt(y)</c> gives <c>x + y + 2*sqrt(x*y)</c>, so matching it
+        /// against <c>a + b*sqrt(c)</c> asks for <c>x + y = a</c> and <c>4*x*y = b^2*c</c> —
+        /// which makes <c>x</c> and <c>y</c> the two roots of <c>t^2 - a*t + b^2*c/4</c>, namely
+        /// <c>(a +- sqrt(a^2 - b^2*c))/2</c>. They are rational exactly when
+        /// <c>d = a^2 - b^2*c</c> is the square of one, and that is the whole test: a decidable
+        /// question in exact arithmetic rather than a search.
+        /// </para>
+        /// <para>
+        /// <b>The sign of <c>b</c> chooses between the two forms.</b> Squaring gives
+        /// <c>a + |b|*sqrt(c)</c> whichever way, since <c>2*sqrt(x*y)</c> is not negative — so a
+        /// negative <c>b</c> is the difference <c>sqrt(x) - sqrt(y)</c>, which needs
+        /// <c>x >= y</c> and gets it, <c>sqrt(d)</c> being non-negative.
+        /// </para>
+        /// <para>
+        /// <b>Every condition reduces to two.</b> The identity needs <c>x</c> and <c>y</c>
+        /// non-negative and the radicand itself non-negative; given <c>a >= 0</c> and
+        /// <c>d >= 0</c>, all of them follow — <c>sqrt(d) &lt;= a</c> makes <c>y</c>
+        /// non-negative, and <c>a - |b|*sqrt(c) >= 0</c> is <c>d >= 0</c> restated. So the rule
+        /// asks for a non-negative <c>a</c> and a <c>d</c> that is a rational square, and needs
+        /// nothing else.
+        /// </para>
+        /// <para>
+        /// Returns null rather than the input where it does not apply, so the rule does not fire
+        /// and the rewriting terminates — the same contract as
+        /// <see cref="ReduceRadical(Integer, Rational)"/> above.
+        /// </para>
+        /// </remarks>
+        internal static Entity? DenestRadical(Entity radicand)
+        {
+            // a + b*sqrt(c), read off the sum's terms: exactly one rational, exactly one
+            // rational multiple of a root. Anything else is not this shape.
+            ERational? rational = null;
+            ERational? coefficient = null;
+            ERational? under = null;
+            foreach (var term in Sumf.LinearChildren(radicand))
+            {
+                if (term.Evaled is Rational whole)
+                {
+                    if (rational is not null)
+                        return null;
+                    rational = whole.ERational;
+                    continue;
+                }
+                if (coefficient is not null || !TryReadRootTerm(term, out var scale, out var inside))
+                    return null;
+                coefficient = scale;
+                under = inside;
+            }
+
+            if (rational is not { } a || coefficient is not { } b || under is not { } c)
+                return null;
+            if (a.IsNegative)
+                return null;
+
+            var discriminant = a.Multiply(a).Subtract(b.Multiply(b).Multiply(c));
+            if (ExactSquareRoot(discriminant) is not { } root)
+                return null;
+
+            var two = ERational.FromInt32(2);
+            var x = a.Add(root).Divide(two);
+            var y = a.Subtract(root).Divide(two);
+
+            // Nothing was nested to begin with if the inner root is a square, and this would
+            // then compete with `ReduceRadical` over the same expression rather than answering
+            // a question it left.
+            if (ExactSquareRoot(c) is not null)
+                return null;
+
+            Entity first = MathS.Sqrt(Rational.Create(x)).InnerSimplified;
+            Entity second = MathS.Sqrt(Rational.Create(y)).InnerSimplified;
+            return b.IsNegative ? first - second : first + second;
+        }
+
+        /// <summary>
+        /// A term of the form <c>k * sqrt(m)</c> with both rational, as its two parts.
+        /// <c>sqrt(6)</c> is read with a <c>k</c> of one.
+        /// </summary>
+        /// <remarks>
+        /// <b>Any half-integer exponent counts, not only one half.</b> The rules that run
+        /// alongside this one gather <c>2 * sqrt(2)</c> into <c>2 ^ (3/2)</c>, so by the time a
+        /// radicand reaches here its root has usually been folded into its coefficient — and a
+        /// reader that insists on a written <c>sqrt</c> sees <c>3 + 2 ^ (3/2)</c> and declines a
+        /// radicand it can perfectly well denest. <c>m ^ (p/2)</c> for odd <c>p</c> is
+        /// <c>m ^ ((p - 1) / 2) * sqrt(m)</c>, which is the same two parts; an even <c>p</c> is
+        /// not a root at all and is read as an ordinary rational factor by the case below.
+        /// </remarks>
+        private static bool TryReadRootTerm(Entity term, out ERational scale, out ERational inside)
+        {
+            scale = ERational.One;
+            inside = ERational.Zero;
+            var seenRoot = false;
+            foreach (var factor in Mulf.LinearChildren(term))
+                switch (factor)
+                {
+                    case Powf(var under, Rational exponent)
+                        when exponent.ERational.Denominator.Equals(EInteger.FromInt32(2))
+                            && under.Evaled is Rational { ERational.Sign: > 0 } radicand:
+                        if (seenRoot)
+                            return false;
+                        seenRoot = true;
+                        inside = radicand.ERational;
+                        // p/2 with p odd, the denominator being two in lowest terms. The whole
+                        // part comes out as a factor and the half stays under the root.
+                        var half = exponent.ERational.Numerator
+                            .Subtract(EInteger.One).Divide(EInteger.FromInt32(2));
+                        scale = scale.Multiply(Pow(radicand.ERational, half));
+                        break;
+                    case var other when other.Evaled is Rational multiplier:
+                        scale = scale.Multiply(multiplier.ERational);
+                        break;
+                    default:
+                        return false;
+                }
+            return seenRoot;
+        }
+
+        /// <summary>A rational raised to a whole power, negative exponents included.</summary>
+        private static ERational Pow(ERational value, EInteger exponent)
+        {
+            if (exponent.IsZero)
+                return ERational.One;
+            var magnitude = exponent.Abs().ToInt32Checked();
+            var result = ERational.One;
+            for (var i = 0; i < magnitude; i++)
+                result = result.Multiply(value);
+            return exponent.Sign < 0 ? ERational.One.Divide(result) : result;
         }
     }
 }

--- a/Sources/Tests/UnitTests/Core/Transformations/AddressableRulesTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/AddressableRulesTest.cs
@@ -299,7 +299,7 @@ namespace AngouriMath.Tests.Core.Transformations
             // are thirty-three; NumericNeat's sixteen are eleven, six of them being three rules
             // written once per side a negative factor can sit on; and the two factorial sets are
             // eight arms each written as three. Every other repointed set is one arm for one rule.
-            Assert.Equal(314, withRules.Sum(set => set.Rules.Count));
+            Assert.Equal(315, withRules.Sum(set => set.Rules.Count));
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
@@ -212,6 +212,7 @@ namespace AngouriMath.Tests.Core.Transformations
                     "a-negative-integer-power-becomes-a-reciprocal: ReplacementIsCode",
                     "a-negative-minuend-comes-out-in-front: ReplacementIsCode",
                     "a-negative-subtracted-is-added: ReplacementIsCode",
+                    "a-nested-radical-is-a-sum-of-two-plain-ones: ReplacementIsCode",
                     "a-number-over-a-numeric-multiple-splits: ReplacementIsCode",
                     "a-number-plus-a-function-puts-the-function-first: ReplacementIsCode",
                     "a-number-plus-a-variable-puts-the-variable-first: ReplacementIsCode",

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
@@ -43,7 +43,7 @@ namespace AngouriMath.Tests.Core.Transformations
         public void WhereARuleGoes()
         {
             Stated(33, MatchedRules.All.Count, "the number of rule sets written as data");
-            Stated(323, MatchedRules.All.Sum(set => set.Rules.Count), "the number of rules written as data");
+            Stated(324, MatchedRules.All.Sum(set => set.Rules.Count), "the number of rules written as data");
             Stated(30, RewriteRules.All.Count, "the number of registered sets");
             Stated(27, RewriteRules.All.Count(set =>
                     MatchedRules.All.Any(data => data.Name == set.Name)
@@ -59,7 +59,7 @@ namespace AngouriMath.Tests.Core.Transformations
         {
             var names = MatchedRules.All.SelectMany(set => set.Rules)
                 .Select(rule => rule.Name).Distinct(StringComparer.Ordinal).ToList();
-            Stated(294, names.Count, "the number of distinct rule names");
+            Stated(295, names.Count, "the number of distinct rule names");
 
             var words = names.Select(name => name.Split('-').Length).ToList();
             Stated(4, words.Min(), "the shortest rule name in words");
@@ -68,7 +68,7 @@ namespace AngouriMath.Tests.Core.Transformations
 
         [Fact]
         public void TheIdentityIsNotTheName()
-            => Stated(293,
+            => Stated(294,
                 MatchedRules.All.SelectMany(set => set.Rules).Count(rule => rule.Description is not null),
                 "how many rules carry an identity");
 
@@ -84,7 +84,7 @@ namespace AngouriMath.Tests.Core.Transformations
                 "how many rules have a pattern on both sides");
             Stated(33, rules.Count(rule => rule.Reversed is not null),
                 "how many two-sided rules have a direction");
-            Stated(260, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
+            Stated(261, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
                 "how many rules sit at Unknown growth");
 
             // And the two the document names. By their own names rather than by what the prose
@@ -113,7 +113,7 @@ namespace AngouriMath.Tests.Core.Transformations
         public void SoundnessIsPerRule()
         {
             var rules = MatchedRules.All.SelectMany(set => set.Rules).ToList();
-            Stated(181, rules.Count(rule => rule.Soundness is Soundness.Sound),
+            Stated(182, rules.Count(rule => rule.Soundness is Soundness.Sound),
                 "how many rules are Sound");
             Stated(142, rules.Count(rule => rule.Soundness is Soundness.SoundUnderAssumptions),
                 "how many rules are SoundUnderAssumptions");

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleMetadataTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleMetadataTest.cs
@@ -85,8 +85,8 @@ namespace AngouriMath.Tests.Core.Transformations
         public void SoundnessIsFinerPerRuleThanPerSet()
         {
             var rules = MatchedRules.All.SelectMany(set => set.Rules).ToList();
-            Assert.Equal(323, rules.Count);
-            Assert.Equal(181, rules.Count(rule => rule.Soundness is Soundness.Sound));
+            Assert.Equal(324, rules.Count);
+            Assert.Equal(182, rules.Count(rule => rule.Soundness is Soundness.Sound));
             Assert.Equal(142, rules.Count(rule => rule.Soundness is Soundness.SoundUnderAssumptions));
 
             // And every set still reports the weakest of them, which is what makes the set grain
@@ -168,7 +168,7 @@ namespace AngouriMath.Tests.Core.Transformations
             var repointed = RewriteRules.All
                 .Where(set => set.Rules.Count > 0 && set.Rules.All(rule => rule.Soundness is not null))
                 .ToList();
-            Assert.Equal(293, repointed.Sum(set => set.Rules.Count));
+            Assert.Equal(294, repointed.Sum(set => set.Rules.Count));
             Assert.All(repointed, set => Assert.All(set.Rules, rule => Assert.NotNull(rule.Description)));
         }
 

--- a/Sources/Tests/UnitTests/Core/Transformations/StepAsASentenceTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/StepAsASentenceTest.cs
@@ -59,7 +59,7 @@ namespace AngouriMath.Tests.Core.Transformations
         {
             var names = MatchedRules.All.SelectMany(set => set.Rules).Select(rule => rule.Name)
                 .Distinct(StringComparer.Ordinal).ToList();
-            Assert.Equal(294, names.Count);
+            Assert.Equal(295, names.Count);
             Assert.All(names, name => Assert.True(Explanation.IsProse(name),
                 $"'{name}' is a rule name that does not read as a phrase in English"));
 

--- a/Sources/Tests/UnitTests/PatternsTest/DenestRadicalTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/DenestRadicalTest.cs
@@ -1,0 +1,165 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.PatternsTest
+{
+    /// <summary>
+    /// <c>sqrt(5 + 2*sqrt(6))</c> is <c>sqrt(2) + sqrt(3)</c>: a radical under a radical, written
+    /// without the nesting.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/717">#717</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Squaring <c>sqrt(x) + sqrt(y)</c> gives <c>x + y + 2*sqrt(x*y)</c>, so matching that
+    /// against <c>a + b*sqrt(c)</c> makes <c>x</c> and <c>y</c> the roots of
+    /// <c>t^2 - a*t + b^2*c/4</c>. They are rational exactly when <c>a^2 - b^2*c</c> is the
+    /// square of a rational, which is the whole test — decidable in exact arithmetic, not a
+    /// search.
+    /// </para>
+    /// <para>
+    /// The claim under test is <b>the answer squared is the radicand</b>, checked exactly rather
+    /// than at sample points, since that is the identity itself and not a consequence of it.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Patterns")]
+    public sealed class DenestRadicalTest
+    {
+        /// <summary>Squares the answer and compares it with what was under the root.</summary>
+        private static void DenestsTo(string nested, string expected)
+        {
+            var got = nested.ToEntity().Simplify();
+            Assert.Equal(expected.ToEntity().Simplify(), got);
+
+            var radicand = ((Entity.Powf)nested.ToEntity()).Base;
+            Assert.Equal(Entity.Number.Integer.Create(0), (got * got - radicand).Simplify());
+        }
+
+        /// <summary>The textbook ones, and the shape the issue names.</summary>
+        [Theory]
+        [InlineData("sqrt(5 + 2 * sqrt(6))", "sqrt(3) + sqrt(2)")]
+        [InlineData("sqrt(7 - 4 * sqrt(3))", "2 - sqrt(3)")]
+        [InlineData("sqrt(9 + 4 * sqrt(5))", "sqrt(5) + 2")]
+        [InlineData("sqrt(11 + 6 * sqrt(2))", "3 + sqrt(2)")]
+        [InlineData("sqrt(6 - 2 * sqrt(5))", "sqrt(5) - 1")]
+        public void ANestedRadicalComesApart(string nested, string expected)
+            => DenestsTo(nested, expected);
+
+        /// <summary>
+        /// The sign of the inner coefficient chooses between the sum and the difference, since
+        /// squaring either gives <c>a + |b|*sqrt(c)</c>.
+        /// </summary>
+        [Theory]
+        [InlineData("sqrt(7 - 4 * sqrt(3))", 0.2679491924311227)]
+        [InlineData("sqrt(6 - 2 * sqrt(5))", 1.2360679774997896)]
+        [InlineData("sqrt(5 + 2 * sqrt(6))", 3.1462643699419726)]
+        public void TheAnswerHasTheValueTheRadicalHad(string nested, double value)
+            => Assert.Equal(value, (double)nested.ToEntity().Simplify().EvalNumerical().RealPart, 12);
+
+        /// <summary>
+        /// <b>Where the discriminant is not a square there is nothing to find</b>, and the radical
+        /// stays as written rather than acquiring a worse form.
+        /// </summary>
+        [Theory]
+        [InlineData("sqrt(1 + sqrt(2))")]
+        [InlineData("sqrt(3 + sqrt(5))")]
+        [InlineData("sqrt(1 + 2 * sqrt(7))")]
+        public void ARadicandWithNoRationalSplitIsLeftAlone(string nested)
+            => Assert.Equal(nested.ToEntity(), nested.ToEntity().Simplify());
+
+        /// <summary>
+        /// A negative <c>a</c> is refused: the radicand is then negative wherever the identity
+        /// would apply, and the two sides sit on different sides of the branch cut.
+        /// </summary>
+        [Fact]
+        public void ANegativeOuterTermIsRefused()
+            => Assert.Null(AngouriMath.Functions.Patterns.DenestRadical("-5 + 2 * sqrt(6)".ToEntity()));
+
+        /// <summary>
+        /// What the helper declines outright, so that the rule cannot fire on it: a radicand that
+        /// is not <c>a + b*sqrt(c)</c> at all.
+        /// </summary>
+        [Theory]
+        [InlineData("6")]
+        [InlineData("x + sqrt(2)")]
+        [InlineData("5 + 2 * sqrt(6) + sqrt(7)")]
+        [InlineData("5 + 2 * sqrt(4)")]
+        public void WhatIsNotANestedRadicalIsDeclined(string radicand)
+            => Assert.Null(AngouriMath.Functions.Patterns.DenestRadical(radicand.ToEntity()));
+
+        /// <summary>
+        /// <b>The inner root is read however the other rules have left it.</b> They gather
+        /// <c>2 * sqrt(2)</c> into <c>2 ^ (3/2)</c>, so a reader that insisted on a written
+        /// <c>sqrt</c> would decline a radicand it can denest — the two spellings must agree.
+        /// </summary>
+        [Fact]
+        public void AGatheredRootIsStillARoot()
+            => Assert.Equal(
+                AngouriMath.Functions.Patterns.DenestRadical("3 + 2 * sqrt(2)".ToEntity()),
+                AngouriMath.Functions.Patterns.DenestRadical("3 + 2^(3/2)".ToEntity()));
+
+        /// <summary>
+        /// The neighbouring radical rules keep working: one takes a whole power out from under a
+        /// root, this one takes a root out from under another, and they do not fight.
+        /// </summary>
+        [Theory]
+        [InlineData("sqrt(4)", "2")]
+        [InlineData("sqrt(8)", "2 * sqrt(2)")]
+        [InlineData("sqrt(2)", "sqrt(2)")]
+        [InlineData("sqrt(x)", "sqrt(x)")]
+        public void TheNeighbouringRadicalRulesAreUnchanged(string input, string expected)
+            => Assert.Equal(expected.ToEntity().Simplify(), input.ToEntity().Simplify());
+
+        /// <summary>
+        /// <b>A denesting that is not shorter is not taken</b>, which is `Simplify` choosing by
+        /// size rather than this rule declining. <c>sqrt(2 + sqrt(3))</c> does denest — to
+        /// <c>(sqrt(6) + sqrt(2))/2</c> — and the nested form is the smaller of the two, so that
+        /// is what comes back.
+        /// </summary>
+        [Fact]
+        public void ADenestingThatIsLongerIsNotChosen()
+        {
+            Assert.NotNull(AngouriMath.Functions.Patterns.DenestRadical("2 + sqrt(3)".ToEntity()));
+            Assert.Equal("sqrt(2 + sqrt(3))".ToEntity(), "sqrt(2 + sqrt(3))".ToEntity().Simplify());
+        }
+
+        /// <summary>
+        /// A boundary recorded rather than explained. The rule fires on this radicand — applying
+        /// the set directly gives <c>sqrt(2) + 1</c>, which is the shorter form by the metric
+        /// that ranks candidates — yet <c>Simplify</c> does not offer it among its alternatives
+        /// and returns the nested form.
+        /// </summary>
+        /// <remarks>
+        /// It is not the perfect-square collapse re-nesting the radicand: measured,
+        /// <c>CollapseToPerfectSquare</c> answers null for <c>3 + 2*sqrt(2)</c>, so that
+        /// hypothesis is out rather than unexamined. The cause is somewhere in how the pipeline
+        /// reaches this shape, and is not established — which is why this is a test of what
+        /// happens and not a claim about why.
+        /// </remarks>
+        [Fact]
+        public void OneRadicandTheRuleAnswersButSimplifyDoesNotTake()
+        {
+            Assert.Equal("sqrt(2) + 1".ToEntity(), AngouriMath.Functions.Patterns.PowerRules("sqrt(3 + 2 * sqrt(2))".ToEntity()));
+            Assert.Equal("sqrt(3 + 2 * sqrt(2))".ToEntity(), "sqrt(3 + 2 * sqrt(2))".ToEntity().Simplify());
+        }
+
+        /// <summary>Both spellings of the rule answer alike, which the agreement test also asks.</summary>
+        [Theory]
+        [InlineData("sqrt(5 + 2 * sqrt(6))")]
+        [InlineData("sqrt(3 + 2 * sqrt(2))")]
+        [InlineData("sqrt(2 + sqrt(3))")]
+        [InlineData("sqrt(1 + sqrt(2))")]
+        [InlineData("sqrt(8)")]
+        public void TheSwitchAndTheDataAgree(string input)
+            => Assert.Equal(
+                AngouriMath.Functions.Patterns.PowerRules(input.ToEntity()),
+                AngouriMath.Core.Transformations.Matching.MatchedRules.Power.ApplyHere(input.ToEntity()));
+    }
+}


### PR DESCRIPTION
`sqrt(5 + 2*sqrt(6))` is a radical under a radical, and it is two plain ones added.

```
"sqrt(5 + 2 * sqrt(6))".Simplify()   was  sqrt(5 + 2 * sqrt(6))   is  sqrt(3) + sqrt(2)
"sqrt(7 - 4 * sqrt(3))".Simplify()   was  as written              is  2 - sqrt(3)
"sqrt(9 + 4 * sqrt(5))".Simplify()   was  as written              is  sqrt(5) + 2
"sqrt(11 + 6 * sqrt(2))".Simplify()  was  as written              is  3 + sqrt(2)
"sqrt(6 - 2 * sqrt(5))".Simplify()   was  as written              is  sqrt(5) - 1
```

This is #717's `sqrtdenest` row, and `Docs/Usage/Comparison.md`'s `simplify / radical denesting`
row, which records the first of those verbatim.

## The test is decidable, not a search

Squaring `sqrt(x) + sqrt(y)` gives `x + y + 2*sqrt(x*y)`, so matching that against `a + b*sqrt(c)`
asks for `x + y = a` and `4*x*y = b^2*c` — which makes `x` and `y` the roots of
`t^2 - a*t + b^2*c/4`, namely `(a +- sqrt(a^2 - b^2*c))/2`. They are rational **exactly when**
`a^2 - b^2*c` is the square of a rational, and that is the whole condition.

The sign of `b` chooses between the sum and the difference, since squaring either gives
`a + |b|*sqrt(c)`.

## Sound, not conditional

A non-negative `a` and a non-negative discriminant are required before anything is built, and
together they give everything else: `sqrt(d) <= a` makes `y` non-negative, and
`a - |b|*sqrt(c) >= 0` is `d >= 0` restated, so the radicand is non-negative too. What fires is an
identity between real numbers with no branch chosen — hence `Soundness.Sound`. A negative `a` is
**refused** rather than conditioned.

## Two things the neighbours forced

**The inner root is read however the other rules have left it.** They gather `2 * sqrt(2)` into
`2 ^ (3/2)`, so a reader insisting on a written `sqrt` sees `3 + 2 ^ (3/2)` and declines a radicand
it can perfectly well denest. Any half-integer exponent counts, `m ^ (p/2)` being
`m ^ ((p-1)/2) * sqrt(m)`. There is a test asserting the two spellings give the same answer.

**Both forms of the rule are added.** `MatchedRulesAgreeWithTheSwitchTest` holds the data rule and
its `switch` twin to each other over a generated corpus that includes `sqrt` over sums, so a data
rule without its mirror fails as soon as the corpus produces a denestable radicand. Written next to
`ReduceRadical` — which takes a whole power out from under one root where this takes a root out
from under another — and to the same contract: one helper answers both the `when` and the
replacement, and null means decline.

## What it does not do

**Where the denesting is longer, `Simplify` keeps the nested form.** `sqrt(2 + sqrt(3))` does come
apart — to `(sqrt(6) + sqrt(2))/2` — and the nested spelling is shorter, so that is what comes
back. The rule offers the alternative; selection is by size, as everywhere else. Asserted, so that
the behaviour is recorded rather than looking like a gap.

**One radicand is a boundary I could not explain, and it is pinned as one.**
`sqrt(3 + 2*sqrt(2))` is answered by the rule — applying the set gives `sqrt(2) + 1`, which is the
shorter form by the metric that ranks candidates — and `Simplify` returns the nested one anyway.

My hypothesis was that the perfect-square collapse re-nests the radicand. **Measured, and it is
not:** `CollapseToPerfectSquare` answers null for `3 + 2*sqrt(2)`. So that is ruled out rather than
unexamined, and I have not published a cause I did not establish. The test asserts both halves of
what happens and says so.

## The census

One rule moves eleven recorded numbers. `WritingARule.md` and the four test files that hold the
document to it — `RuleAuthoringGuideTest`, `RuleMetadataTest`, `StepAsASentenceTest`,
`AddressableRulesTest` — plus `ReversibleRuleTest`'s classification list, which is a list rather
than a count precisely so that a rule changing shape cannot pass unnoticed.

`Comparison.md`'s `radical denesting` cell is **left as it was measured**, with its note now naming
four moved rows rather than two: `factor over the rationals` had already gone stale before today.
That table records one `sympyparity` run at one commit, and a hand-corrected cell would be a
measurement nobody took.

## Verification

Full suite **9515 passed, 0 failed**, 14 skipped. 28 new tests.

Every denesting is checked by **squaring the answer and comparing it with the radicand exactly** —
residual `0`, not agreement at sample points — since that is the identity itself rather than a
consequence of it. Values are checked numerically as well.

Part of #717.
