### PR TITLE
A rule's declared growth is checked against the corpus (#825)

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -195,3 +195,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/IntegralAnswerCacheTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Core/Transformations/RuleGrowthAgreesWithTheCorpusTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -1455,9 +1455,16 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Any<Entity>("x", node => node is Sumf or Minusf),
                 (node, _) => Functions.Patterns.CollectCommonFactors(node) ?? node,
                 Soundness.Sound,
-                description: "k*p + k*q + ... = k*(p + q + ...), over a whole sum rather than two of its terms",
-                // Declared, because the replacement is code and nothing counts it: the whole point of it is to be smaller.
-                growth: RewriteRuleGrowth.Collects));
+                description: "k*p + k*q + ... = k*(p + q + ...), over a whole sum rather than two of its terms"));
+                // Undeclared, and it used to say `Collects` on the grounds that the whole point of
+                // it is to be smaller. Measured against the corpus it never shrinks and sometimes
+                // grows by eight nodes: `-x + x + -1/2` becomes `x * (-1 + 1) + -1/2`, seven nodes
+                // for seven. Collects wants every firing smaller, Rearranges wants every one the
+                // same size, Expands wants every one bigger, and each of those has a
+                // counterexample here -- so Unknown is the only one of the four that is true.
+                // Making it collect for real means declining where it does not shrink, which is a
+                // change to what the rule does rather than to what it says about itself, and the
+                // folding that turns `x * (-1 + 1)` into zero would have to be checked first.
 
         /// <summary>
         /// <see cref="Functions.Patterns.TrigonometricRules"/>, as data.

--- a/Sources/AngouriMath/Docs/Contributing/WritingARule.md
+++ b/Sources/AngouriMath/Docs/Contributing/WritingARule.md
@@ -133,13 +133,25 @@ A pattern replacement gets:
 - **an exact growth**, counted from the two patterns rather than declared.
 
 A code replacement gets neither, and its growth is `Unknown` unless you declare one. That is the
-honest default — **261** rules sit at `Unknown` — but declare it where you can justify it:
+honest default — **262** rules sit at `Unknown` — but declare it where you can justify it:
 
 ```csharp
 // The Chebyshev expansion of sin(n * a) is a sum of n terms where the pattern is one node,
 // for every n this fires on.
 RewriteRuleGrowth.Expands,
 ```
+
+**A declaration is a claim about every expression the rule fires on, and it is checked.**
+`RuleGrowthAgreesWithTheCorpusTest` runs every declaration against the generated corpus and fails on
+a contradiction, so "the whole point of it is to be smaller" is not a reason — that was the stated
+reason for the one declaration this caught, and the rule it was on never shrank over fourteen
+hundred expressions and grew by as much as eight nodes.
+
+Growth is not documentation. `Saturation.RulesUpTo` selects by it, so `Collects` or `Rearranges`
+puts a rule among the ones equality saturation fires and `Unknown` keeps it out. Claiming a rule
+shrinks when it does not tells the saturation a rewrite is safe to run when nobody established
+that. A corpus can only refute — firing without contradiction is evidence, not proof — so where you
+cannot argue the claim from the code, leave it `Unknown`.
 
 Take `(Entity node, Bindings bound)` rather than `(Bindings bound)` where the replacement needs the
 whole matched node. Rebuilding it from the bindings makes a different object with none of the

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
@@ -84,7 +84,7 @@ namespace AngouriMath.Tests.Core.Transformations
                 "how many rules have a pattern on both sides");
             Stated(33, rules.Count(rule => rule.Reversed is not null),
                 "how many two-sided rules have a direction");
-            Stated(261, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
+            Stated(262, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
                 "how many rules sit at Unknown growth");
 
             // And the two the document names. By their own names rather than by what the prose

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleGrowthAgreesWithTheCorpusTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleGrowthAgreesWithTheCorpusTest.cs
@@ -1,0 +1,158 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Core.Transformations;
+using AngouriMath.Core.Transformations.Matching;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// A rule's <see cref="RewriteRuleGrowth"/> is a claim about every expression it fires on:
+    /// <c>Collects</c> says the replacement is smaller, <c>Rearranges</c> that it is the same
+    /// size, <c>Expands</c> that it is larger. Here that claim is run against a generated corpus
+    /// instead of being taken on trust.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// It is worth checking because growth is <b>load-bearing</b> and not documentation:
+    /// <c>Saturation.RulesUpTo</c> selects by it, so a rule declaring <c>Collects</c> or
+    /// <c>Rearranges</c> is one equality saturation fires and a rule left at <c>Unknown</c> is
+    /// one it does not. A declaration that is wrong in the shrinking direction tells the
+    /// saturation a rewrite is safe to run when it is not.
+    /// </para>
+    /// <para>
+    /// A corpus can only refute, never confirm: firing on fourteen hundred expressions without
+    /// contradicting a claim is evidence for it and not proof of it, since the claim is about
+    /// every expression there is. So this fails on a contradiction and says nothing about a rule
+    /// it could not make fire.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class RuleGrowthAgreesWithTheCorpusTest
+    {
+        private static readonly string[] Leaves =
+            { "x", "y", "2", "-1", "-2", "1/2", "-1/2", "1", "0" };
+
+        private static readonly string[] Unary =
+            { "-({0})", "1 / ({0})", "({0}) ^ 2", "({0}) ^ (-2)", "sqrt({0})", "sin({0})", "abs({0})" };
+
+        private static readonly string[] Binary =
+            { "({0}) + ({1})", "({0}) - ({1})", "({0}) * ({1})", "({0}) / ({1})", "({0}) ^ ({1})" };
+
+        /// <summary>
+        /// The same shape as the corpus <c>MatchedRulesAgreeWithTheSwitchTest</c> builds, and for
+        /// the same reason: generated inputs reach arrangements nobody would think to write down.
+        /// </summary>
+        private static List<Entity> Corpus()
+        {
+            var level1 = new List<string>(Leaves);
+            var level2 = new List<string>();
+            foreach (var shape in Unary)
+                foreach (var inner in level1)
+                    level2.Add(string.Format(shape, inner));
+            foreach (var shape in Binary)
+                foreach (var left in level1)
+                    foreach (var right in level1)
+                        level2.Add(string.Format(shape, left, right));
+            var level3 = new List<string>();
+            foreach (var shape in Binary)
+                foreach (var left in level2.Where((_, i) => i % 17 == 0))
+                    foreach (var right in level2.Where((_, i) => i % 23 == 0))
+                        level3.Add(string.Format(shape, left, right));
+
+            var parsed = new List<Entity>();
+            foreach (var source in level1.Concat(level2).Concat(level3))
+            {
+                try { parsed.Add(source.ToEntity()); }
+                catch { /* the generator makes some strings the parser declines */ }
+            }
+            return parsed;
+        }
+
+        private static int Size(Entity entity) => entity.Nodes.Count();
+
+        /// <summary>
+        /// Every firing of every rule over the corpus, as (rule, how the size moved). A rule that
+        /// hands back what it was given has not fired and is not counted — the factorial sets
+        /// have arms that match a shape and then decline.
+        /// </summary>
+        private static Dictionary<MatchedRule, List<(Entity Before, Entity After)>> Firings()
+        {
+            var corpus = Corpus();
+            var firings = new Dictionary<MatchedRule, List<(Entity, Entity)>>();
+            foreach (var set in MatchedRules.All)
+                foreach (var rule in set.Rules)
+                {
+                    var seen = new List<(Entity, Entity)>();
+                    foreach (var expr in corpus)
+                    {
+                        Entity? after;
+                        try { after = rule.TryApply(expr); }
+                        catch { continue; /* a rule declining loudly is not this test's subject */ }
+                        if (after is not null && after != expr)
+                            seen.Add((expr, after));
+                    }
+                    firings[rule] = seen;
+                }
+            return firings;
+        }
+
+        [Fact]
+        public void NoDeclaredGrowthIsContradictedByTheCorpus()
+        {
+            var wrong = new List<string>();
+            foreach (var (rule, firings) in Firings())
+            {
+                if (rule.Growth is RewriteRuleGrowth.Unknown || firings.Count == 0)
+                    continue;
+                foreach (var (before, after) in firings)
+                {
+                    var delta = Size(after) - Size(before);
+                    var contradicts = rule.Growth switch
+                    {
+                        RewriteRuleGrowth.Collects => delta >= 0,
+                        RewriteRuleGrowth.Rearranges => delta != 0,
+                        RewriteRuleGrowth.Expands => delta <= 0,
+                        _ => false
+                    };
+                    if (contradicts)
+                    {
+                        wrong.Add($"{rule.Name} declares {rule.Growth} but {before} -> {after} "
+                                  + $"moves {Size(before)} nodes to {Size(after)}");
+                        break;
+                    }
+                }
+            }
+
+            Assert.True(wrong.Count == 0,
+                $"{wrong.Count} rules contradicted by the corpus:\n" + string.Join("\n", wrong));
+        }
+
+        /// <summary>
+        /// The corpus has to actually exercise the declarations, or the test above passes by
+        /// never running. Named as a count that moves rather than as "most of them".
+        /// </summary>
+        [Fact]
+        public void TheCorpusExercisesTheDeclarationsItChecks()
+        {
+            var fired = Firings().Where(pair => pair.Value.Count > 0).ToList();
+            var declared = fired.Count(pair => pair.Key.Growth is not RewriteRuleGrowth.Unknown);
+
+            // Named as counts that move rather than as "most of them". 84 rules reach the corpus,
+            // 18 of them carrying a declaration -- so the check above is exercised, and the other
+            // 66 are the measured evidence for declaring more of them.
+            Assert.True(fired.Count >= 80, $"only {fired.Count} rules fired at all");
+            Assert.True(declared >= 15, $"only {declared} rules with a declared growth fired");
+        }
+    }
+}


### PR DESCRIPTION
`RewriteRuleGrowth` is a claim about **every** expression a rule fires on: `Collects` says the
replacement is smaller, `Rearranges` the same size, `Expands` larger. For the 35 rules with a
pattern on both sides it is counted from the two patterns. For the rest it is declared by hand, and
nothing checked it.

Running those declarations against the generated corpus finds one that is wrong.

## The one it caught

`a-common-factor-is-collected-out-of-a-whole-sum` declared `Collects`, and the reason was in the
code:

```csharp
// Declared, because the replacement is code and nothing counts it: the whole point of it is to be smaller.
growth: RewriteRuleGrowth.Collects));
```

Over fourteen hundred expressions it fires **42 times, never shrinks, and grows by as much as eight
nodes**:

```
-x + x + -1/2   ->   x * (-1 + 1) + -1/2         seven nodes for seven
```

Which of the four is true, checked rather than chosen: `Collects` wants every firing smaller and a
delta of 0 refutes it; `Rearranges` wants every one the same size and +8 refutes it; `Expands` wants
every one bigger and 0 refutes it. **`Unknown` is the only one left**, and that is what it now says,
with the counterexample recorded next to it.

## Why this is not documentation

`Saturation.RulesUpTo` selects by growth. A rule saying `Collects` or `Rearranges` is one equality
saturation fires; one left at `Unknown` is one it does not. So that rule has been in `SafeRules` on
a claim nobody tested, and a declaration wrong in the shrinking direction tells the saturation a
rewrite is safe to run when nobody established it.

That also means the 262 undeclared rules are not a documentation backlog. Each declaration is a
behavioural change, which is why this PR adds the check and **no new declarations**.

## What is deliberately not done

**The rule is not made to collect for real.** Declining where it does not shrink would make
`Collects` true, but that changes what the rule *does* rather than what it says about itself — and
`x * (-1 + 1)` folding to zero looks like how `-x + x` reaches `0`, so it would have to be
established that the step is not load-bearing first. Separate change, separate measurement.

## What the corpus can and cannot say

**It can only refute.** Firing on fourteen hundred expressions without contradicting a claim is
evidence for it, not proof, since the claim is about every expression there is. So the test fails on
a contradiction and says nothing about a rule it could not make fire — and the doc now says the same
to anyone declaring one.

84 rules reach the corpus, 18 of them carrying a declaration, and the test asserts both counts so
that it cannot pass by never running.

## The other 66

They are the measured evidence for declaring more, and — the useful part — the measurement separates
the ones that can be declared from the ones that cannot:

| observed | rule |
|---|---|
| `+2` on all 84 firings | `a-negative-factor-in-a-denominator-comes-out` |
| `-2` on all firings | `two-powers-of-one-base-multiply-by-adding-exponents` |
| `0` on all 84 firings | `a-thing-times-a-quotient-keeps-the-divisor-outermost` |
| **`-2` to `0`** | `a-term-added-to-itself-doubles` — honestly `Unknown` |
| **`0` to `+4`** | `a-sum-chain-is-sorted-and-grouped` — honestly `Unknown` |

A declaration still has to be arguable from the code; the corpus is what stops one being a guess,
and what refutes it when it is.

Part of #825.
