### PR TITLE
Seven rules say how much they expand (#825)

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -373,7 +373,13 @@ namespace AngouriMath.Core.Transformations.Matching
                 // than an identity that needs one. Measured at 0 as well as away from it before
                 // the tier was written down.
                 Soundness.Sound,
-                description: "a ^ n = 1 / a ^ (-n), for a negative integer n"));
+                description: "a ^ n = 1 / a ^ (-n), for a negative integer n",
+                // Three nodes become five, for every input: the power stays a power with its
+                // exponent replaced one for one, and the quotient and the numerator 1 the
+                // replacement wraps it in are the two. A different mechanism from the negation
+                // rules that share this figure, and the same arithmetic. Measured at +2 on all
+                // 27 firings over the corpus.
+                growth: RewriteRuleGrowth.Expands));
 
         /// <summary>
         /// <see cref="Functions.Patterns.InvertNegativeMultipliers"/>, as data.
@@ -924,7 +930,11 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any<Real>("r", value => value.IsNegative)),
                 bound => -((-(Real)bound["l"]) + (Entity)(-(Real)bound["r"])),
                 Soundness.Sound,
-                description: "(-a) + (-b) = -(a + b)"),
+                description: "(-a) + (-b) = -(a + b)",
+                // Three nodes become five, for every input: the negation the replacement puts
+                // round the whole sum is two nodes, and each literal is replaced by its
+                // magnitude one for one. Measured at +2 on all 9 firings over the corpus.
+                growth: RewriteRuleGrowth.Expands),
 
             // x + (-a) -> x - a, either way round
             new MatchedRule(
@@ -964,7 +974,11 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any("x")),
                 bound => -(bound["x"] + -(Real)bound["n"]),
                 Soundness.Sound,
-                description: "(-a) - x = -(x + a)"),
+                description: "(-a) - x = -(x + a)",
+                // Three nodes become five, for every input: the difference becomes a sum, one
+                // operator for one, and the negation round the whole of it is the two.
+                // Measured at +2 on all 27 firings over the corpus.
+                growth: RewriteRuleGrowth.Expands),
 
             // (-a) * (-b) -> a * b
             new MatchedRule(
@@ -996,7 +1010,12 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any("y")),
                 bound => -((-(Real)bound["n"]) * (bound["x"] * bound["y"])),
                 Soundness.Sound,
-                description: "(-a * x) * y = -(a * (x * y))"),
+                description: "(-a * x) * y = -(a * (x * y))",
+                // Five nodes become seven, for every input: the two products are regrouped, two
+                // operators for two, the literal is replaced by its magnitude one for one, and
+                // the negation round the whole of it is the difference. Measured at +2 on all
+                // 63 firings over the corpus.
+                growth: RewriteRuleGrowth.Expands),
 
             // (-a * x) / y -> -(a * (x / y))
             new MatchedRule(
@@ -1008,7 +1027,11 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any("y")),
                 bound => -((-(Real)bound["n"]) * (bound["x"] / bound["y"])),
                 Soundness.Sound,
-                description: "(-a * x) / y = -(a * (x / y))"),
+                description: "(-a * x) / y = -(a * (x / y))",
+                // Five nodes become seven, by the same count as its two neighbours: operators
+                // for operators, magnitude for literal, and the negation is the two. Measured
+                // at +2 on all 63 firings over the corpus.
+                growth: RewriteRuleGrowth.Expands),
 
             // y * (-a * x) -> -(a * (x * y))
             new MatchedRule(
@@ -1020,7 +1043,10 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Any("x"))),
                 bound => -((-(Real)bound["n"]) * (bound["x"] * bound["y"])),
                 Soundness.Sound,
-                description: "y * (-a * x) = -(a * (x * y))"),
+                description: "y * (-a * x) = -(a * (x * y))",
+                // Five nodes become seven, the mirror of the left-product rule above and by the
+                // same count. Measured at +2 on all 84 firings over the corpus.
+                growth: RewriteRuleGrowth.Expands),
 
             // y / (-a * x) -> -(y / (a * x)). What is left stays under the line: written the
             // other way, as the numerator rules above are, the quotient came back inverted --
@@ -1034,7 +1060,11 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Any("x"))),
                 bound => -(bound["y"] / ((-(Real)bound["n"]) * bound["x"])),
                 Soundness.Sound,
-                description: "y / (-a * x) = -(y / (a * x))"));
+                description: "y / (-a * x) = -(y / (a * x))",
+                // Five nodes become seven, for every input: the quotient and the product stay
+                // as they are, the literal is replaced by its magnitude, and the negation round
+                // the whole of it is the two. Measured at +2 on all 84 firings over the corpus.
+                growth: RewriteRuleGrowth.Expands));
 
         /// <summary>
         /// <see cref="Functions.Patterns.BooleanRules"/>, as data.

--- a/Sources/AngouriMath/Docs/Contributing/WritingARule.md
+++ b/Sources/AngouriMath/Docs/Contributing/WritingARule.md
@@ -133,7 +133,7 @@ A pattern replacement gets:
 - **an exact growth**, counted from the two patterns rather than declared.
 
 A code replacement gets neither, and its growth is `Unknown` unless you declare one. That is the
-honest default — **262** rules sit at `Unknown` — but declare it where you can justify it:
+honest default — **255** rules sit at `Unknown` — but declare it where you can justify it:
 
 ```csharp
 // The Chebyshev expansion of sin(n * a) is a sum of n terms where the pattern is one node,

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
@@ -84,7 +84,7 @@ namespace AngouriMath.Tests.Core.Transformations
                 "how many rules have a pattern on both sides");
             Stated(33, rules.Count(rule => rule.Reversed is not null),
                 "how many two-sided rules have a direction");
-            Stated(262, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
+            Stated(255, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
                 "how many rules sit at Unknown growth");
 
             // And the two the document names. By their own names rather than by what the prose


### PR DESCRIPTION
Growth is `Unknown` for a code replacement unless it is declared, and 262 rules sat there. Seven can
say what they do. **255 now do not.**

## Argued from the code, measured against the corpus

Two mechanisms, the same arithmetic.

**Six negation rules** — `(-a) + (-b)`, `(-a) - x`, and the four that bring a negative factor out of
a product, a numerator or a denominator. The operators map one for one, the literal is replaced by
its magnitude, and the negation the replacement puts round the whole of it is two nodes:

```
y / (-a * x)   ->   -(y / (a * x))          five nodes to seven, for every input
```

**One power rule** — `a ^ n = 1 / a ^ (-n)`. The power stays a power with its exponent replaced one
for one; the quotient and its numerator `1` are the two.

Each was also run against the generated corpus by `RuleGrowthAgreesWithTheCorpusTest`, between 9 and
84 firings apiece, none contradicting. That is corroboration and not the argument — the corpus can
only refute.

## Why `Expands` is the right first batch

Not only because it is what they do. `Saturation.RulesUpTo` builds its set as *the rules up to
`Rearranges`*, so:

- declaring `Collects` or `Rearranges` **adds a rule to what equality saturation fires**;
- declaring `Expands` **changes nothing about what runs**.

These seven record something that was already true without moving anything. The `Collects` and
`Rearranges` candidates in the measurement are real too, but each of those is a behavioural change
and wants the saturation measured before and after — a separate PR, not a line in this one.

## The eighth, left alone

`a-negated-reciprocal-rational-factor-is-a-negated-division` measures **+2 on all 18 of its
firings**, which is exactly the evidence the other seven have. It stays `Unknown`.

Working through its pattern I count five nodes to five, so the measurement and my reading of the
code disagree, and I cannot argue the claim. `WritingARule.md` says that where you cannot argue it
from the code you leave it `Unknown` — and that sentence was written in the previous PR, by me, so
it applies here first.

Declaring it on corpus agreement alone would be the same mistake #1158 caught: a growth asserted
from what it looked like rather than from what it does.

## Verification

Full suite **9552 passed, 0 failed**, 14 skipped. The census moves 262 → 255 in
`WritingARule.md` and `RuleAuthoringGuideTest`.

Part of #825.
