### PR TITLE
The growth corpus reaches 194 rules instead of 84 (#825)

### DIFF
--- a/Sources/Tests/UnitTests/Core/Transformations/RuleGrowthAgreesWithTheCorpusTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleGrowthAgreesWithTheCorpusTest.cs
@@ -124,6 +124,17 @@ namespace AngouriMath.Tests.Core.Transformations
             // Logarithms in and of reciprocals.
             "log(1/2, x)", "log(2, 1/x)", "log(1/2, 1/x)", "log(1/x, y)", "log(x, 1/y)",
 
+            // A comparison standing where a number would. The rules about comparisons bind their
+            // operands with `Any`, so one of them can be a comparison itself -- and building the
+            // replacement with `<` or `>` then *chains*, where the same rule written with
+            // `EqualTo` would not: `(x > y) < 0` is `x > y and y < 0`, seven nodes rather than
+            // three. Without these a rule whose replacement chains looks like a clean shrink at
+            // every point the corpus reaches and is not one.
+            "(x > y) < 0", "(x > y) > 0", "(x > y) <= 0", "(x > y) >= 0",
+            "(x > y) / (-2) > 0", "(x > y) / (-2) < 0", "(x < y) / (-2) >= 0",
+            "(-2) * (x > y) > 0", "(x > y) * (-2) < 0", "0 > (x > y)", "0 < (x < y)",
+            "2 > (x > y)", "(x > y) = 0",
+
             // A factorial beside a zero, and the differences and products that contain their own
             // operand a second time.
             "x! = 0", "(x - y) / (y - x)", "x - (x - y)", "(x - y) - x",

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleGrowthAgreesWithTheCorpusTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleGrowthAgreesWithTheCorpusTest.cs
@@ -53,6 +53,57 @@ namespace AngouriMath.Tests.Core.Transformations
         /// The same shape as the corpus <c>MatchedRulesAgreeWithTheSwitchTest</c> builds, and for
         /// the same reason: generated inputs reach arrangements nobody would think to write down.
         /// </summary>
+        /// <summary>
+        /// Shapes the arithmetic grammar above does not build. Without them the corpus reaches
+        /// the sets about quotients and powers and none of the six about trigonometry, booleans,
+        /// sets, comparisons or factorials — so those rules' declarations would be checked by a
+        /// test that never ran them.
+        /// </summary>
+        private static readonly string[] Reached =
+        {
+            // trigonometric, and the arguments the multiple-angle and collapse rules want
+            "sin(x)", "cos(x)", "tan(x)", "cotan(x)", "sec(x)", "cosec(x)",
+            "sin(2 * x)", "cos(2 * x)", "sin(x + y)", "cos(x + y)", "sin(3 * x)", "cos(3 * x)",
+            "sin(x) * cos(x)", "cos(x) * sin(x)", "sin(x) ^ 2 + cos(x) ^ 2", "cos(x) ^ 2 + sin(x) ^ 2",
+            "sin(x) / cos(x)", "cos(x) / sin(x)", "1 / sin(x)", "1 / cos(x)", "1 / tan(x)",
+            "tan(x) * cotan(x)", "sin(x) ^ 2", "cos(x) ^ 2", "sin(x) ^ 2 - cos(x) ^ 2",
+            "arcsin(x)", "arccos(x)", "arctan(x)", "arccotan(x)",
+            "arcsin(x) + arccos(x)", "arctan(x) + arccotan(x)", "sin(arcsin(x))", "cos(arccos(x))",
+
+            // logarithms and exponentials
+            "ln(x)", "log(2, x)", "ln(x * y)", "ln(x ^ 2)", "e ^ ln(x)", "ln(e ^ x)",
+            "log(x, x)", "2 ^ x * 2 ^ y", "e ^ x * e ^ y",
+
+            // factorials, both sets
+            "x!", "(x + 1)!", "(x + 1)! / x!", "x! / (x + 1)!", "x! * (x + 1)", "(x + 1) * x!",
+            "(x + 2)! / x!",
+
+            // boolean
+            "a and b", "a or b", "not a", "not (not a)", "a implies b", "a xor b",
+            "a and not a", "a or not a", "a and a", "a or a", "a and (a or b)", "a or (a and b)",
+            "not (a and b)", "not (a or b)", "a and (b or c)", "(a and b) or (a and c)",
+            "true and a", "false or a", "true or a", "false and a",
+
+            // comparisons and the equality set
+            "x > y", "x < y", "x >= y", "x <= y", "x = y", "(x < y) or (x = y)", "(x > y) or (x = y)",
+            "not (x > y)", "not (x = y)",
+
+            // sets
+            "x in [1; 2]", "[1; 2] \\/ [3; 4]", "[1; 2] /\\ [3; 4]", "[1; 2] \\ [3; 4]",
+            "A \\/ A", "A /\\ A", "A \\/ {}", "A /\\ {}", "{ t : t > 0 }",
+
+            // powers and roots the arithmetic grammar reaches only shallowly
+            "sqrt(x) * sqrt(x)", "sqrt(x ^ 2)", "(x ^ 2) ^ 3", "x ^ 2 * x ^ 3", "x ^ 3 / x ^ 2",
+            "x ^ 2 * y ^ 2", "(x / y) ^ 2", "x ^ (1/2) * x ^ (1/2)", "(-x) ^ 2",
+            "1 / x ^ (-2)", "x ^ 0", "0 ^ x",
+
+            // polynomial shapes for the division, gcd and factorisation sets
+            "(x ^ 2 - 1) / (x - 1)", "(x ^ 2 + 2 * x + 1) / (x + 1)", "x ^ 2 - 1",
+            "x ^ 2 + 2 * x + 1", "x ^ 3 - 1", "x ^ 2 - y ^ 2", "x ^ 4 - y ^ 4",
+            "x ^ 2 + 2 * x * y + y ^ 2", "(x + y) ^ 2", "(x + y) * (x - y)",
+            "1 / (1 + sqrt(2))", "1 / (sqrt(3) - 1)", "2 / (1 + sqrt(x))",
+        };
+
         private static List<Entity> Corpus()
         {
             var level1 = new List<string>(Leaves);
@@ -71,7 +122,7 @@ namespace AngouriMath.Tests.Core.Transformations
                         level3.Add(string.Format(shape, left, right));
 
             var parsed = new List<Entity>();
-            foreach (var source in level1.Concat(level2).Concat(level3))
+            foreach (var source in level1.Concat(level2).Concat(level3).Concat(Reached))
             {
                 try { parsed.Add(source.ToEntity()); }
                 catch { /* the generator makes some strings the parser declines */ }
@@ -88,7 +139,9 @@ namespace AngouriMath.Tests.Core.Transformations
         /// </summary>
         private static Dictionary<MatchedRule, List<(Entity Before, Entity After)>> Firings()
         {
-            var corpus = Corpus();
+            // Every node, not only the root: a rule matches where its shape sits, and asking
+            // only about whole corpus expressions leaves most rules never firing at all.
+            var corpus = Corpus().SelectMany(expr => expr.Nodes).Distinct().ToList();
             var firings = new Dictionary<MatchedRule, List<(Entity, Entity)>>();
             foreach (var set in MatchedRules.All)
                 foreach (var rule in set.Rules)
@@ -148,11 +201,13 @@ namespace AngouriMath.Tests.Core.Transformations
             var fired = Firings().Where(pair => pair.Value.Count > 0).ToList();
             var declared = fired.Count(pair => pair.Key.Growth is not RewriteRuleGrowth.Unknown);
 
-            // Named as counts that move rather than as "most of them". 84 rules reach the corpus,
-            // 18 of them carrying a declaration -- so the check above is exercised, and the other
-            // 66 are the measured evidence for declaring more of them.
-            Assert.True(fired.Count >= 80, $"only {fired.Count} rules fired at all");
-            Assert.True(declared >= 15, $"only {declared} rules with a declared growth fired");
+            // Named as counts that move rather than as "most of them". 139 of the 324 rules reach
+            // the corpus and 51 of those carry a declaration, so the check above is exercised
+            // rather than passing by never running; the other 88 are the measured evidence for
+            // declaring more of them. It was 84 and 18 before the shapes in `Reached` were added
+            // and before rules were tried at every node rather than only at the root.
+            Assert.True(fired.Count >= 135, $"only {fired.Count} rules fired at all");
+            Assert.True(declared >= 48, $"only {declared} rules with a declared growth fired");
         }
     }
 }

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleGrowthAgreesWithTheCorpusTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleGrowthAgreesWithTheCorpusTest.cs
@@ -50,14 +50,10 @@ namespace AngouriMath.Tests.Core.Transformations
             { "({0}) + ({1})", "({0}) - ({1})", "({0}) * ({1})", "({0}) / ({1})", "({0}) ^ ({1})" };
 
         /// <summary>
-        /// The same shape as the corpus <c>MatchedRulesAgreeWithTheSwitchTest</c> builds, and for
-        /// the same reason: generated inputs reach arrangements nobody would think to write down.
-        /// </summary>
-        /// <summary>
-        /// Shapes the arithmetic grammar above does not build. Without them the corpus reaches
-        /// the sets about quotients and powers and none of the six about trigonometry, booleans,
-        /// sets, comparisons or factorials — so those rules' declarations would be checked by a
-        /// test that never ran them.
+        /// Shapes the arithmetic grammar does not build. Without them the corpus reaches the sets
+        /// about quotients and powers and none of the six about trigonometry, booleans, sets,
+        /// comparisons or factorials — so those rules' declarations would be checked by a test
+        /// that never ran them.
         /// </summary>
         private static readonly string[] Reached =
         {
@@ -102,6 +98,37 @@ namespace AngouriMath.Tests.Core.Transformations
             "x ^ 2 + 2 * x + 1", "x ^ 3 - 1", "x ^ 2 - y ^ 2", "x ^ 4 - y ^ 4",
             "x ^ 2 + 2 * x * y + y ^ 2", "(x + y) ^ 2", "(x + y) * (x - y)",
             "1 / (1 + sqrt(2))", "1 / (sqrt(3) - 1)", "2 / (1 + sqrt(x))",
+
+            // Comparisons. The largest block of rules the arithmetic grammar cannot reach at all:
+            // they key on zero or a number being on the left, on both sides being the same thing,
+            // and on a negative factor or divisor standing beside a zero.
+            "0 > x", "0 < x", "0 >= x", "0 <= x", "0 = x",
+            "2 > x", "2 < x", "2 >= x", "2 <= x", "2 = x",
+            "x > x", "x < x", "x >= x", "x <= x",
+            "x / (-2) > 0", "x / (-2) < 0", "x / (-2) >= 0", "x / (-2) <= 0", "x / (-2) = 0",
+            "(-2) * x > 0", "(-2) * x < 0", "(-2) * x >= 0", "(-2) * x <= 0", "(-2) * x = 0",
+            "x * (-2) > 0", "x * (-2) < 0", "x * (-2) >= 0", "x * (-2) <= 0", "x * (-2) = 0",
+            "(x > y) and (y > z)", "(x < y) and (y < z)",
+            "not (x >= y)", "not (x <= y)", "not (x < y)", "y > x", "y >= x",
+
+            // Boolean, both directions of De Morgan and the absorptions with a negation.
+            "not a and not b", "not a or not b", "a and not b", "a or not b",
+            "not a or b", "not a and b", "a and (b and c)", "a or (b or c)",
+            "(a and b) and c", "(a or b) or c", "(a or b) and (a or c)", "(a and b) or c",
+
+            // The trigonometric reciprocal pairs and the inverses the shapes above miss.
+            "cosec(x) * sin(x)", "sin(x) * cosec(x)", "sec(x) * cos(x)", "cos(x) * sec(x)",
+            "cotan(arccotan(x))", "tan(arctan(x))", "arcsin(sin(x))", "arctan(tan(x))",
+            "sin(2 * x) * cosec(x)", "cos(2 * x) * sec(x)", "cotan(x) * tan(x)",
+
+            // Logarithms in and of reciprocals.
+            "log(1/2, x)", "log(2, 1/x)", "log(1/2, 1/x)", "log(1/x, y)", "log(x, 1/y)",
+
+            // A factorial beside a zero, and the differences and products that contain their own
+            // operand a second time.
+            "x! = 0", "(x - y) / (y - x)", "x - (x - y)", "(x - y) - x",
+            "x * y - x", "x - x * y", "x * x", "x * x * y", "x * (x * y)",
+            "sin(x) * 2", "2 * sin(x)",
         };
 
         private static List<Entity> Corpus()
@@ -201,13 +228,13 @@ namespace AngouriMath.Tests.Core.Transformations
             var fired = Firings().Where(pair => pair.Value.Count > 0).ToList();
             var declared = fired.Count(pair => pair.Key.Growth is not RewriteRuleGrowth.Unknown);
 
-            // Named as counts that move rather than as "most of them". 139 of the 324 rules reach
-            // the corpus and 51 of those carry a declaration, so the check above is exercised
-            // rather than passing by never running; the other 88 are the measured evidence for
+            // Named as counts that move rather than as "most of them". 194 of the 324 rules reach
+            // the corpus and 59 of those carry a declaration, so the check above is exercised
+            // rather than passing by never running; the rest are the measured evidence for
             // declaring more of them. It was 84 and 18 before the shapes in `Reached` were added
             // and before rules were tried at every node rather than only at the root.
-            Assert.True(fired.Count >= 135, $"only {fired.Count} rules fired at all");
-            Assert.True(declared >= 48, $"only {declared} rules with a declared growth fired");
+            Assert.True(fired.Count >= 190, $"only {fired.Count} rules fired at all");
+            Assert.True(declared >= 56, $"only {declared} rules with a declared growth fired");
         }
     }
 }


### PR DESCRIPTION
A declaration is only checked if the corpus makes the rule fire. The arithmetic grammar reached **84
of the 324**, and six whole sets — trigonometry, booleans, sets, comparisons and both factorial ones
— were never exercised at all. A declaration on any of their rules was being checked by a test that
never ran it.

| | before | after |
|---|---|---|
| rules that fire | 84 | **194** |
| declared rules actually checked | 18 | **59** |
| rules the corpus cannot reach | 240 | **130** |

## Three changes

**A rule is tried at every node**, not only at the root. A rule matches where its shape sits, and
asking only about whole corpus expressions left most of them never firing.

**Shapes the generated grammar does not build**, supplied on top of it the way
`MatchedRulesAgreeWithTheSwitchTest` already supplies its own: the trigonometric identities and the
arguments the multiple-angle rules want, logarithms, factorials both ways round, the boolean laws,
set operations, and the polynomial shapes the division, gcd and factorisation sets match.

**The comparison set, which was the largest block still out of reach.** Its rules key on zero or a
number being on the *left* of the operator, on both sides being the same thing, and on a negative
factor or divisor standing beside a zero — none of which an arithmetic grammar produces, because it
builds comparisons only in the form a person would write:

```
0 > x        x >= x        x / (-2) > 0        (-2) * x <= 0
```

over all five comparison operators. With those, De Morgan in both directions rather than one, the
trigonometric reciprocal pairs (`cosec(x) * sin(x)`, `cotan(arccotan(x))` — shapes rules exist for
and nothing built), logarithms in and of reciprocal bases, and the differences and products that
contain their own operand a second time.

Both counts are asserted, so the check cannot quietly stop being exercised.

## Nothing it newly reaches contradicts a declaration

Worth stating rather than assuming: this coverage is exactly where an untested claim would have been
hiding, and the one false declaration this test found when it was written (#1158) was found the same
way — by making a rule fire that nothing had made fire before. All 59 declarations that now run
survive it.

## No growth changes here

This alters nothing that runs. The undeclared rules it newly exercises are the measured evidence for
declaring them, which is #1161 and its successors — `Saturation.RulesUpTo` builds its set as the
rules up to `Rearranges`, so those declarations do change which rules equality saturation fires.

## Verification

Full suite **9552 passed, 0 failed**, 14 skipped.

Part of #825.
