### PR TITLE
Eight more rules say how they change the size of what they match (#825)

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -1907,7 +1907,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 bound => ((Set)bound["a"]).Intersect((Set)bound["b"])
                     .Unite(((Set)bound["a"]).Intersect((Set)bound["c"])),
                 Soundness.Sound,
-                description: "A /\\ (B \\/ C) = (A /\\ B) \\/ (A /\\ C)"),
+                description: "A /\\ (B \\/ C) = (A /\\ B) \\/ (A /\\ C)",
+                // The set that is distributed over the union is matched once and written twice, so
+                // the delta is +(1 + |A|): at least +2, and further the larger that set is.
+                growth: RewriteRuleGrowth.Expands),
 
             new MatchedRule(
                 "an-intersection-distributes-over-a-union-on-its-left",
@@ -1918,7 +1921,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 bound => ((Set)bound["b"]).Intersect((Set)bound["a"])
                     .Unite(((Set)bound["c"]).Intersect((Set)bound["a"])),
                 Soundness.Sound,
-                description: "(B \\/ C) /\\ A = (B /\\ A) \\/ (C /\\ A)"),
+                description: "(B \\/ C) /\\ A = (B /\\ A) \\/ (C /\\ A)",
+                // The set that is distributed over the union is matched once and written twice,
+                // so the delta is +(1 + |A|): at least +2, the mirror of the rule above.
+                growth: RewriteRuleGrowth.Expands),
 
             // A \/ A = A
             new MatchedRule(
@@ -1934,7 +1940,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Set.SetMinusf>(MatchPattern.Any("a"), MatchPattern.Any("a")),
                 bound => Set.Empty,
                 Soundness.Sound,
-                description: "A \\ A = {}"),
+                description: "A \\ A = {}",
+                // Everything the pattern matches goes and one node arrives, so the delta is -2|A|:
+                // at most -2, and further the larger the set is.
+                growth: RewriteRuleGrowth.Collects),
 
             // { x : x in S } = S. The repeated "v" is what the switch wrote as `when v1 == v1a`.
             new MatchedRule(
@@ -2874,7 +2883,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 bound => new Powf(bound["c"], bound["d"]) * new Powf(bound["a"], bound["d"]),
                 Soundness.SoundUnderAssumptions,
                 when: bound => bound["d"] is Integer || bound["c"] is Real { IsPositive: true },
-                description: "(c * a) ^ d = c ^ d * a ^ d, for numeric c and d"),
+                description: "(c * a) ^ d = c ^ d * a ^ d, for numeric c and d",
+                // Both c and d are Numbers, which are leaves, so the pattern is four nodes around
+                // the remaining hole and the replacement is six: exactly +2, for every input.
+                growth: RewriteRuleGrowth.Expands),
 
             new MatchedRule(
                 "a-reciprocal-power-is-a-quotient",
@@ -2959,7 +2971,10 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Powf>(MatchPattern.Any("a"), MatchPattern.Any("n"))),
                 bound => new Powf(bound["a"], bound["n"]) * bound["v"],
                 Soundness.Sound,
-                description: "v * a ^ n = a ^ n * v, for a variable v"),
+                description: "v * a ^ n = a ^ n * v, for a variable v",
+                // The two operands of the product are written the other way round and nothing else
+                // moves, so the two sides are the same size whatever they are filled with.
+                growth: RewriteRuleGrowth.Rearranges),
 
             // https://github.com/asc-community/AngouriMath/issues/902
             new MatchedRule(
@@ -3404,7 +3419,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Minusf>(MatchPattern.Any("a"), MatchPattern.Commutative<Sumf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
                 bound => -bound["b"],
                 Soundness.Sound,
-                description: "a - (a + b) = -b"),
+                description: "a - (a + b) = -b",
+                // The repeated operand goes twice over and a negation of two nodes arrives in place
+                // of the difference and the sum, so the delta is -2|a|: at most -2.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-term-added-to-a-difference-that-takes-it-away",
                 MatchPattern.Commutative<Sumf>(MatchPattern.Any("a"), MatchPattern.Node<Minusf>(MatchPattern.Any("b"), MatchPattern.Any("a"))),

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -506,7 +506,12 @@ namespace AngouriMath.Core.Transformations.Matching
                 // p the integers below p^k sharing a factor with it are exactly the multiples of
                 // p, of which there are p^(k-1).
                 Soundness.Sound,
-                description: "phi(p ^ k) = p ^ (k - 1) * (p - 1), for a prime p"));
+                description: "phi(p ^ k) = p ^ (k - 1) * (p - 1), for a prime p",
+                // Each of the two holes is used once on both sides, and (p - 1) folds to a single
+                // integer as the replacement is built -- the cast noted above is what makes it
+                // fold. So what the replacement adds is the product and the decremented exponent,
+                // three nodes, for every input.
+                growth: RewriteRuleGrowth.Expands));
 
         /// <summary>
         /// <see cref="Functions.Patterns.CollapseTrigonometricFunctions"/>, as data.
@@ -2835,7 +2840,10 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Logf>(MatchPattern.Any<Number>("c"), MatchPattern.Any("a"))),
                 bound => bound["a"],
                 Soundness.SoundUnderAssumptions,
-                description: "a ^ log(a, b) = b"),
+                description: "a ^ log(a, b) = b",
+                // The base is a Number and so a leaf, and the power and the logarithm both go, so
+                // four nodes around the remaining hole disappear: exactly -4, for every input.
+                growth: RewriteRuleGrowth.Collects),
 
             // The same identity through `e`, which the rule above cannot reach: `ln(b)` is stored
             // as log(e, b) and `e` is a Constant, not a Number, so `Any<Number>` never binds it

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -3173,7 +3173,10 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any<Number>("d")),
                 bound => (Number)bound["c"] / (Number)bound["d"] * bound["a"],
                 Soundness.SoundUnderAssumptions,
-                description: "(c * a) / d = (c / d) * a, for numeric c and d other than -1"),
+                description: "(c * a) / d = (c / d) * a, for numeric c and d other than -1",
+                // The two numbers are folded into one as the replacement is built, and every hole
+                // the pattern binds is a leaf or is used once, so two nodes go: exactly -2.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "dividing-twice-divides-by-the-product",
                 MatchPattern.Node<Divf>(MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("b")), MatchPattern.Any("c")),
@@ -3339,13 +3342,19 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Commutative<Mulf>(MatchPattern.Node<Mulf>(MatchPattern.Any<Number>("c"), MatchPattern.Any<Variable>("v")), MatchPattern.Any<Number>("d")),
                 bound => (Number)bound["c"] * (Number)bound["d"] * bound["v"],
                 Soundness.Sound,
-                description: "(c * v) * d = (c * d) * v, for numeric c and d"),
+                description: "(c * v) * d = (c * d) * v, for numeric c and d",
+                // The two numbers are folded into one as the replacement is built, and every hole
+                // the pattern binds is a leaf or is used once, so two nodes go: exactly -2.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "two-numeric-terms-around-a-variable-collect",
                 MatchPattern.Commutative<Sumf>(MatchPattern.Node<Sumf>(MatchPattern.Any<Variable>("v"), MatchPattern.Any<Number>("c")), MatchPattern.Any<Number>("d")),
                 bound => bound["v"] + ((Number)bound["c"] + (Number)bound["d"]),
                 Soundness.Sound,
-                description: "(v + c) + d = v + (c + d), for numeric c and d"),
+                description: "(v + c) + d = v + (c + d), for numeric c and d",
+                // The two numbers are folded into one as the replacement is built, and every hole
+                // the pattern binds is a leaf or is used once, so two nodes go: exactly -2.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-factor-repeated-across-a-product-squares",
                 MatchPattern.Commutative<Mulf>(MatchPattern.Any("a"), MatchPattern.Commutative<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
@@ -3409,7 +3418,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Mulf>(MatchPattern.Any<Number>("c"), MatchPattern.Node<Mulf>(MatchPattern.Any<Number>("d"), MatchPattern.Any("a"))),
                 bound => (Number)bound["c"] * (Number)bound["d"] * bound["a"],
                 Soundness.Sound,
-                description: "c * (d * a) = (c * d) * a, for numeric c and d"),
+                description: "c * (d * a) = (c * d) * a, for numeric c and d",
+                // The two numbers are folded into one as the replacement is built, and every hole
+                // the pattern binds is a leaf or is used once, so two nodes go: exactly -2.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-term-repeated-across-a-sum-doubles",
                 MatchPattern.Commutative<Sumf>(MatchPattern.Any("a"), MatchPattern.Commutative<Sumf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
@@ -3421,7 +3433,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Minusf>(MatchPattern.Commutative<Sumf>(MatchPattern.Any("a"), MatchPattern.Any("b")), MatchPattern.Any("a")),
                 bound => bound["b"],
                 Soundness.Sound,
-                description: "(a + b) - a = b"),
+                description: "(a + b) - a = b",
+                // All of the pattern but one hole disappears, and the repeated operand goes twice
+                // over: the delta is -(2 + 2|a|), at most -4.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-sum-containing-a-term-taken-from-that-term-leaves-the-rest-negated",
                 MatchPattern.Node<Minusf>(MatchPattern.Any("a"), MatchPattern.Commutative<Sumf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
@@ -3436,7 +3451,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Commutative<Sumf>(MatchPattern.Any("a"), MatchPattern.Node<Minusf>(MatchPattern.Any("b"), MatchPattern.Any("a"))),
                 bound => bound["b"],
                 Soundness.Sound,
-                description: "a + (b - a) = b"),
+                description: "a + (b - a) = b",
+                // All of the pattern but one hole disappears, and the repeated operand goes twice
+                // over: the delta is -(2 + 2|a|), at most -4.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-term-added-to-a-difference-that-starts-from-it",
                 MatchPattern.Commutative<Sumf>(MatchPattern.Any("a"), MatchPattern.Node<Minusf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
@@ -3586,7 +3604,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Signumf>(MatchPattern.Node<Mulf>(MatchPattern.Any<Real>("neg", real => real.IsNegative), MatchPattern.Any("rest"))),
                 bound => -new Signumf((-(Real)bound["neg"]) * bound["rest"]),
                 Soundness.Sound,
-                description: "sgn(-a) = -sgn(a)"));
+                description: "sgn(-a) = -sgn(a)",
+                // The negative literal inside is replaced by its magnitude, one node for one, and
+                // the negation the replacement puts round the whole of it is two nodes more.
+                growth: RewriteRuleGrowth.Expands));
 
         /// <summary>
         /// Every <see cref="MatchedRuleSet"/> this class declares — the parameterless ones as

--- a/Sources/AngouriMath/Docs/Contributing/WritingARule.md
+++ b/Sources/AngouriMath/Docs/Contributing/WritingARule.md
@@ -133,7 +133,7 @@ A pattern replacement gets:
 - **an exact growth**, counted from the two patterns rather than declared.
 
 A code replacement gets neither, and its growth is `Unknown` unless you declare one. That is the
-honest default — **182** rules sit at `Unknown` — but declare it where you can justify it:
+honest default — **175** rules sit at `Unknown` — but declare it where you can justify it:
 
 ```csharp
 // The Chebyshev expansion of sin(n * a) is a sum of n terms where the pattern is one node,

--- a/Sources/AngouriMath/Docs/Contributing/WritingARule.md
+++ b/Sources/AngouriMath/Docs/Contributing/WritingARule.md
@@ -133,7 +133,7 @@ A pattern replacement gets:
 - **an exact growth**, counted from the two patterns rather than declared.
 
 A code replacement gets neither, and its growth is `Unknown` unless you declare one. That is the
-honest default — **184** rules sit at `Unknown` — but declare it where you can justify it:
+honest default — **182** rules sit at `Unknown` — but declare it where you can justify it:
 
 ```csharp
 // The Chebyshev expansion of sin(n * a) is a sum of n terms where the pattern is one node,

--- a/Sources/AngouriMath/Docs/Contributing/WritingARule.md
+++ b/Sources/AngouriMath/Docs/Contributing/WritingARule.md
@@ -169,6 +169,14 @@ corpus, and each is false:
 | a hole can be filled by two spellings of one thing | `IsWholeReciprocal` takes the literal `1/3`, which is one node, and a written `1 / c`, which is three — so the delta is 0 in one and −2 in the other |
 | a hole is repeated and the replacement squares it | `a * (a * b) = a^2 * b` is `1 - |a|`: zero for a leaf and negative for anything bigger |
 
+**The comparison set is settled, and settled as `Unknown`.** Its sixty-odd rules were gone through
+one at a time and all but seven fall into the shapes above: most build their replacement with `<` or
+`>` and so chain; the rest either attach a `Provided` sized by their own operands — the chain
+implications, the two rules about comparisons that exclude each other — or compute the answer through
+a helper, as the two that push a negation through a chain do. The seven that *are* declared are the
+`EqualTo` ones, for the reason in the table. Nobody need re-derive that; if you are looking for
+declarable rules, look elsewhere.
+
 **And a declaration can expose a rule whose soundness was wrong.** Writing a growth down moves the
 rule into the set equality saturation runs, which may be the first time it has ever run. That is how
 [#1162](https://github.com/asc-community/AngouriMath/issues/1162) was found: the boolean

--- a/Sources/AngouriMath/Docs/Contributing/WritingARule.md
+++ b/Sources/AngouriMath/Docs/Contributing/WritingARule.md
@@ -133,7 +133,7 @@ A pattern replacement gets:
 - **an exact growth**, counted from the two patterns rather than declared.
 
 A code replacement gets neither, and its growth is `Unknown` unless you declare one. That is the
-honest default — **190** rules sit at `Unknown` — but declare it where you can justify it:
+honest default — **184** rules sit at `Unknown` — but declare it where you can justify it:
 
 ```csharp
 // The Chebyshev expansion of sin(n * a) is a sum of n terms where the pattern is one node,

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
@@ -84,7 +84,7 @@ namespace AngouriMath.Tests.Core.Transformations
                 "how many rules have a pattern on both sides");
             Stated(33, rules.Count(rule => rule.Reversed is not null),
                 "how many two-sided rules have a direction");
-            Stated(182, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
+            Stated(175, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
                 "how many rules sit at Unknown growth");
 
             // And the two the document names. By their own names rather than by what the prose

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
@@ -84,7 +84,7 @@ namespace AngouriMath.Tests.Core.Transformations
                 "how many rules have a pattern on both sides");
             Stated(33, rules.Count(rule => rule.Reversed is not null),
                 "how many two-sided rules have a direction");
-            Stated(190, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
+            Stated(184, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
                 "how many rules sit at Unknown growth");
 
             // And the two the document names. By their own names rather than by what the prose

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
@@ -84,7 +84,7 @@ namespace AngouriMath.Tests.Core.Transformations
                 "how many rules have a pattern on both sides");
             Stated(33, rules.Count(rule => rule.Reversed is not null),
                 "how many two-sided rules have a direction");
-            Stated(184, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
+            Stated(182, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
                 "how many rules sit at Unknown growth");
 
             // And the two the document names. By their own names rather than by what the prose


### PR DESCRIPTION
Eight more, continuing #1161. **190 rules were at `Unknown` on master; 182 are.**

Each is argued by counting the pattern against the replacement in terms of the holes, and each is
checked against the corpus.

| | |
|---|---|
| `A \ A = {}` | everything matched collapses to one node — `-2\|A\|` |
| `a - (a + b) = -b` | the repeated operand goes twice over — `-2\|a\|` |
| `c ^ log(c, a) = a` | base is a `Number` and so a leaf; power and logarithm both go — exactly **−4** |
| `A /\ (B \/ C) = ...` and its mirror | the distributed set is matched once and **written twice** — `+(1 + \|A\|)` |
| `(c * a) ^ d = c ^ d * a ^ d` | `c` and `d` are `Number`s and so leaves — exactly **+2** |
| `phi(p ^ k) = p ^ (k - 1) * (p - 1)` | `(p - 1)` folds to one integer as it is built — exactly **+3** |
| `v * a ^ n = a ^ n * v` | the same two operands the other way round — **0** |

## Eight more read and left alone

All of shapes now documented in `WritingARule.md`, and each measures a clean constant delta over
the corpus:

- **`1 - |a|`, changing sign with the operand** — `a - a*b`, `a*b - a`, and `(a-b)*(a+b) = a² - b²`
  at `2 - |a| - |b|`. Zero or positive where the repeated operand is a leaf, negative where it is
  larger.
- **A `Provided` sized by its own operand** — both spellings of `a / a = 1`, `log(a, a) = 1`, and the
  two rules saying a reciprocal or a factorial is never zero.
- **A replacement computed by a helper** — `a whole power comes out from under a radical` goes
  through `ReduceRadical`, which has no size countable from the pattern.

The identity through `e` needs nothing: it carries a pattern on both sides, so its growth is derived
rather than declared.

## Verification

Targeted rather than the full suite, which CI runs here: **320 tests** across the growth check, the
census, the canonical extraction and every transformation test — including
`EqualitySaturationNeverChangesTheValueItClaimsToPreserve`, which is what a declaration into
`SafeRules` has to answer to, and what found #1162.

Part of #825.
