### PR TITLE
Seventeen more rules say how they change the size of what they match (#825)

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -1594,14 +1594,20 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Arctanf>(MatchPattern.Node<Powf>(MatchPattern.Exact(Integer.Create(3)), MatchPattern.Exact(Rational.Create(1, 2)))),
                 bound => MathS.pi / 3,
                 Soundness.Sound,
-                description: "arctan(sqrt(3)) = pi/3"),
+                description: "arctan(sqrt(3)) = pi/3",
+                // The pattern binds nothing, so both sides are a fixed size and the delta is a
+                // number rather than an expression in the operands.
+                growth: RewriteRuleGrowth.Collects),
 
             new MatchedRule(
                 "the-arctangent-of-one-over-root-three",
                 MatchPattern.Node<Arctanf>(MatchPattern.Node<Divf>(MatchPattern.Exact(Integer.Create(1)), MatchPattern.Node<Powf>(MatchPattern.Exact(Integer.Create(3)), MatchPattern.Exact(Rational.Create(1, 2))))),
                 bound => MathS.pi / 6,
                 Soundness.Sound,
-                description: "arctan(1 / sqrt(3)) = pi/6"),
+                description: "arctan(1 / sqrt(3)) = pi/6",
+                // The pattern binds nothing, so both sides are a fixed size and the delta is a
+                // number rather than an expression in the operands.
+                growth: RewriteRuleGrowth.Collects),
 
             // The cosecant's own condition has to be carried: 2cos(u) is a number where
             // sin(u) is zero and sin(2u) csc(u) is not.
@@ -1967,7 +1973,10 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any<Set.FiniteSet>("s", finite => finite.Count == 1)),
                 bound => bound["x"].EqualTo(((Set.FiniteSet)bound["s"]).First()),
                 Soundness.Sound,
-                description: "x in {a} = (x = a)"),
+                description: "x in {a} = (x = a)",
+                // The singleton set goes and the membership becomes an equality, one node for one,
+                // so exactly -1. `EqualTo` is a bare `Equalsf` and does not chain.
+                growth: RewriteRuleGrowth.Collects),
 
             // x in (a; b) is written out as the inequalities it stands for
             new MatchedRule(
@@ -1992,7 +2001,10 @@ namespace AngouriMath.Core.Transformations.Matching
                     "s", finite => finite == Functions.Patterns.FullBooleanSet),
                 bound => Set.SpecialSet.Create(Domain.Boolean),
                 Soundness.Sound,
-                description: "{ True, False } = the boolean domain"),
+                description: "{ True, False } = the boolean domain",
+                // The pattern binds nothing, so both sides are a fixed size and the delta is a
+                // number rather than an expression in the operands.
+                growth: RewriteRuleGrowth.Collects),
 
             // (-oo; +oo) is the domain it is an interval of, where that domain names a set.
             // The Any case is refused in the condition rather than left to the replacement:
@@ -2008,7 +2020,10 @@ namespace AngouriMath.Core.Transformations.Matching
                                      && interval.Codomain is not Domain.Any),
                 bound => Set.SpecialSet.Create(((Set.Interval)bound["i"]).Codomain),
                 Soundness.Sound,
-                description: "(-oo; +oo) = the domain it is an interval of"));
+                description: "(-oo; +oo) = the domain it is an interval of",
+                // The interval and its two bounds become the one node of a special set, and the
+                // bounds are matched exactly rather than bound, so the delta is a number.
+                growth: RewriteRuleGrowth.Collects));
 
         /// <summary>
         /// <see cref="Functions.Patterns.SortRules"/>, as data — one set per sort level.
@@ -3205,7 +3220,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Mulf>(MatchPattern.Node<Mulf>(MatchPattern.Any<Number>("c"), MatchPattern.Any<Function>("f")), MatchPattern.Node<Mulf>(MatchPattern.Any<Number>("d"), MatchPattern.Any<Function>("g"))),
                 bound => bound["f"] * bound["g"] * ((Number)bound["c"] * (Number)bound["d"]),
                 Soundness.SoundUnderAssumptions,
-                description: "(c * f) * (d * g) = f * g * (c * d), for numeric c and d"),
+                description: "(c * f) * (d * g) = f * g * (c * d), for numeric c and d",
+                // The two numbers are folded into one as the replacement is built, so five nodes
+                // around the two functions become three: exactly -2.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "two-functions-in-a-sum-come-together",
                 MatchPattern.Commutative<Sumf>(MatchPattern.Node<Sumf>(MatchPattern.Any<Function>("f"), MatchPattern.Any("a")), MatchPattern.Any<Function>("g")),

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -1587,7 +1587,11 @@ namespace AngouriMath.Core.Transformations.Matching
                     / (1 - (Real)bound["a"] * (Real)bound["b"])).InnerSimplified),
                 Soundness.SoundUnderAssumptions,
                 when: bound => ((Real)bound["a"] * (Real)bound["b"]).Evaled is Real product && product < 1,
-                description: "arctan(a) + arctan(b) = arctan((a + b) / (1 - a*b)), while a*b < 1"),
+                description: "arctan(a) + arctan(b) = arctan((a + b) / (1 - a*b)), while a*b < 1",
+                // Both operands are matched as Real and so are leaves, and the tangent formula is
+                // folded to a single one by the InnerSimplified on it, so five nodes become two:
+                // exactly -3, for every pair the `when` admits.
+                growth: RewriteRuleGrowth.Collects),
 
             new MatchedRule(
                 "the-arctangent-of-root-three",
@@ -2724,7 +2728,11 @@ namespace AngouriMath.Core.Transformations.Matching
                         MatchPattern.Node<Logf>(MatchPattern.Any("c"), MatchPattern.Any("a")))),
                 bound => new Powf(bound["c"], bound["n"]),
                 Soundness.SoundUnderAssumptions,
-                description: "a ^ (n / log(c, a)) = c ^ n"),
+                description: "a ^ (n / log(c, a)) = c ^ n",
+                // The base is matched twice -- once as the base and once inside the logarithm -- and
+                // written not at all, and the quotient and the logarithm go with it: the delta is
+                // -(3 + 2|a|), at most -5.
+                growth: RewriteRuleGrowth.Collects),
 
             // Both orientations are written out in the `switch`, so one commutative rule fires
             // exactly where the pair did.
@@ -2827,7 +2835,10 @@ namespace AngouriMath.Core.Transformations.Matching
                             MatchPattern.Any("n")))),
                 bound => new Powf(bound["a"] / new Powf(bound["b"], bound["c"]), bound["n"]),
                 Soundness.SoundUnderAssumptions,
-                description: "a ^ n / b ^ (c * n) = (a / b ^ c) ^ n, for a positive whole c"),
+                description: "a ^ n / b ^ (c * n) = (a / b ^ c) ^ n, for a positive whole c",
+                // The exponent is matched twice and written once, and one power node goes: the delta
+                // is -(1 + |n|), at most -2 and further the larger the exponent is.
+                growth: RewriteRuleGrowth.Collects),
 
             new MatchedRule(
                 "a-quotient-of-powers-whose-exponents-differ-by-a-whole-factor-takes-it-into-the-dividend",
@@ -2840,7 +2851,10 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("n"))),
                 bound => new Powf(new Powf(bound["a"], bound["c"]) / bound["b"], bound["n"]),
                 Soundness.SoundUnderAssumptions,
-                description: "a ^ (c * n) / b ^ n = (a ^ c / b) ^ n, for a positive whole c"),
+                description: "a ^ (c * n) / b ^ n = (a ^ c / b) ^ n, for a positive whole c",
+                // The exponent is matched twice and written once, and one power node goes with it:
+                // the delta is -(1 + |n|), the mirror of the rule that takes it into the divisor.
+                growth: RewriteRuleGrowth.Collects),
 
             new MatchedRule(
                 "a-thing-over-a-power-of-itself-is-one-power",
@@ -2997,7 +3011,10 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("n"))),
                 bound => bound["a"] / new Powf(bound["b"], bound["n"] + bound["m"]),
                 Soundness.SoundUnderAssumptions,
-                description: "a / b ^ n / b ^ m = a / b ^ (n + m)"),
+                description: "a / b ^ n / b ^ m = a / b ^ (n + m)",
+                // The base is matched twice and written once, and one quotient and one power go:
+                // the delta is -(2 + |b|), at most -3.
+                growth: RewriteRuleGrowth.Collects),
 
             new MatchedRule(
                 "a-variable-times-a-power-puts-the-power-first",
@@ -3229,7 +3246,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Commutative<Mulf>(MatchPattern.Node<Mulf>(MatchPattern.Any<Number>("c"), MatchPattern.Any<Function>("f")), MatchPattern.Any<Number>("d")),
                 bound => (Number)bound["c"] * (Number)bound["d"] * bound["f"],
                 Soundness.SoundUnderAssumptions,
-                description: "(c * f) * d = (c * d) * f, for numeric c and d"),
+                description: "(c * f) * d = (c * d) * f, for numeric c and d",
+                // The two numbers are folded into one as the replacement is built, so four nodes
+                // around the function become two: exactly -2.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "two-numeric-multiples-of-functions-collect-their-numbers",
                 MatchPattern.Node<Mulf>(MatchPattern.Node<Mulf>(MatchPattern.Any<Number>("c"), MatchPattern.Any<Function>("f")), MatchPattern.Node<Mulf>(MatchPattern.Any<Number>("d"), MatchPattern.Any<Function>("g"))),

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -1635,7 +1635,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 bound => bound["a"],
                 Soundness.SoundUnderAssumptions,
                 when: bound => Functions.Patterns.WithinHalfPi(bound["a"], closed: true),
-                description: "arcsin(sin(a)) = a, for a in [-pi/2; pi/2]"),
+                description: "arcsin(sin(a)) = a, for a in [-pi/2; pi/2]",
+                // The function and its inverse both go and the angle is handed back untouched, so
+                // two nodes disappear whatever the angle is: exactly -2.
+                growth: RewriteRuleGrowth.Collects),
 
             new MatchedRule(
                 "arccosine-of-a-cosine-inside-its-own-interval",
@@ -1643,7 +1646,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 bound => bound["a"],
                 Soundness.SoundUnderAssumptions,
                 when: bound => Functions.Patterns.WithinZeroAndPi(bound["a"], closed: true),
-                description: "arccos(cos(a)) = a, for a in [0; pi]"),
+                description: "arccos(cos(a)) = a, for a in [0; pi]",
+                // The function and its inverse both go and the angle is handed back untouched, so
+                // two nodes disappear whatever the angle is: exactly -2.
+                growth: RewriteRuleGrowth.Collects),
 
             new MatchedRule(
                 "arctangent-of-a-tangent-inside-its-own-interval",
@@ -1651,7 +1657,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 bound => bound["a"],
                 Soundness.SoundUnderAssumptions,
                 when: bound => Functions.Patterns.WithinHalfPi(bound["a"], closed: false),
-                description: "arctan(tan(a)) = a, for a in (-pi/2; pi/2)"),
+                description: "arctan(tan(a)) = a, for a in (-pi/2; pi/2)",
+                // The function and its inverse both go and the angle is handed back untouched, so
+                // two nodes disappear whatever the angle is: exactly -2.
+                growth: RewriteRuleGrowth.Collects),
 
             new MatchedRule(
                 "arccotangent-of-a-cotangent-inside-its-own-range",
@@ -1659,7 +1668,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 bound => bound["a"],
                 Soundness.SoundUnderAssumptions,
                 when: bound => Functions.Patterns.WithinArccotanRange(bound["a"]),
-                description: "arccotan(cotan(a)) = a, for a in arccotan's own range"),
+                description: "arccotan(cotan(a)) = a, for a in arccotan's own range",
+                // The function and its inverse both go and the angle is handed back untouched, so
+                // two nodes disappear whatever the angle is: exactly -2.
+                growth: RewriteRuleGrowth.Collects),
 
             new MatchedRule(
                 "a-sine-of-an-arcsine",
@@ -3150,7 +3162,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Mulf>(MatchPattern.Node<Mulf>(MatchPattern.Any<Number>("c"), MatchPattern.Any<Function>("f")), MatchPattern.Any<Function>("g")),
                 bound => bound["f"] * bound["g"] * bound["c"],
                 Soundness.SoundUnderAssumptions,
-                description: "(c * f) * g = c * (f * g), for a numeric c"),
+                description: "(c * f) * g = c * (f * g), for a numeric c",
+                // The numeric factor moves to the outside of the product and the two functions come
+                // together, which is two products either way round: the same size for every input.
+                growth: RewriteRuleGrowth.Rearranges),
             new MatchedRule(
                 "a-product-of-two-quotients-is-one-quotient",
                 MatchPattern.Node<Mulf>(MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("b")), MatchPattern.Node<Divf>(MatchPattern.Any("c"), MatchPattern.Any("d"))),

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -3211,7 +3211,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Commutative<Sumf>(MatchPattern.Node<Sumf>(MatchPattern.Any<Function>("f"), MatchPattern.Any("a")), MatchPattern.Any<Function>("g")),
                 bound => bound["f"] + bound["g"] + bound["a"],
                 Soundness.SoundUnderAssumptions,
-                description: "(f + a) + g = f + g + a, for functions f and g"),
+                description: "(f + a) + g = f + g + a, for functions f and g",
+                // The three operands are regrouped and nothing else moves: two sums stay two sums
+                // and each hole is used once on both sides.
+                growth: RewriteRuleGrowth.Rearranges),
             new MatchedRule(
                 "a-variable-times-a-number-puts-the-number-first",
                 MatchPattern.Node<Mulf>(MatchPattern.Any<Variable>("v"), MatchPattern.Any<Number>("c")),
@@ -3312,7 +3315,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Minusf>(MatchPattern.Any("a"), MatchPattern.Any("a")),
                 bound => Integer.Zero,
                 Soundness.Sound,
-                description: "k - k = 0"),
+                description: "k - k = 0",
+                // Everything the pattern matched goes and one node arrives, and the operand was
+                // matched twice: the delta is -2|k|, at most -2 and further the larger it is.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-factor-shared-by-a-quotient-and-a-product-added-comes-out",
                 MatchPattern.Node<Sumf>(MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("b")), MatchPattern.Commutative<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("c"))),
@@ -3412,7 +3418,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Divf>(MatchPattern.Any<Number>("c"), MatchPattern.Commutative<Mulf>(MatchPattern.Any<Number>("d"), MatchPattern.Any("a"))),
                 bound => (Number)bound["c"] / (Number)bound["d"] / bound["a"],
                 Soundness.SoundUnderAssumptions,
-                description: "c / (d * a) = (c / d) / a, for numeric c and d"),
+                description: "c / (d * a) = (c / d) / a, for numeric c and d",
+                // The two numbers are folded into one as the replacement is built, so four nodes
+                // around the remaining hole become two: exactly -2.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "two-numbers-around-a-factor-collect",
                 MatchPattern.Node<Mulf>(MatchPattern.Any<Number>("c"), MatchPattern.Node<Mulf>(MatchPattern.Any<Number>("d"), MatchPattern.Any("a"))),
@@ -3519,7 +3528,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Commutative<Mulf>(MatchPattern.Node<Signumf>(MatchPattern.Any("a")), MatchPattern.Node<Absf>(MatchPattern.Any("a"))),
                 bound => bound["a"],
                 Soundness.SoundUnderAssumptions,
-                description: "sgn(a) * abs(a) = a"),
+                description: "sgn(a) * abs(a) = a",
+                // Three nodes around two copies of the operand become the one copy that is left, so
+                // the delta is -(3 + |a|): at most -4.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-reciprocal-rational-factor-is-a-division",
                 MatchPattern.Commutative<Mulf>(MatchPattern.Any<Entity>("r", one => Functions.Patterns.IsWholeReciprocal(one, 1)), MatchPattern.Any("a")),

--- a/Sources/AngouriMath/Docs/Contributing/WritingARule.md
+++ b/Sources/AngouriMath/Docs/Contributing/WritingARule.md
@@ -133,7 +133,7 @@ A pattern replacement gets:
 - **an exact growth**, counted from the two patterns rather than declared.
 
 A code replacement gets neither, and its growth is `Unknown` unless you declare one. That is the
-honest default — **160** rules sit at `Unknown` — but declare it where you can justify it:
+honest default — **154** rules sit at `Unknown` — but declare it where you can justify it:
 
 ```csharp
 // The Chebyshev expansion of sin(n * a) is a sum of n terms where the pattern is one node,

--- a/Sources/AngouriMath/Docs/Contributing/WritingARule.md
+++ b/Sources/AngouriMath/Docs/Contributing/WritingARule.md
@@ -173,6 +173,13 @@ corpus, and each is false:
 | a hole can be filled by two spellings of one thing | `IsWholeReciprocal` takes the literal `1/3`, which is one node, and a written `1 / c`, which is three — so the delta is 0 in one and −2 in the other |
 | a hole is repeated and the replacement squares it | `a * (a * b) = a^2 * b` is `1 - |a|`: zero for a leaf and negative for anything bigger |
 
+**Every rule still at `Unknown` has been looked at, and each falls into one of the shapes above.**
+Most of them compute their answer through a helper, so there is nothing to count; the rest either
+build a comparison, attach a `Provided` sized by their own operands, or are the repeated hole that
+pays a literal to be gathered — `a ^ n * a`, `a / b / b`, `a * a`, `k + k` and their two dozen
+relatives, every one of them `1 - |a|`. So `Unknown` here is a finding rather than a gap, and a new
+`Unknown` should be one too.
+
 **The comparison set is settled, and settled as `Unknown`.** Its sixty-odd rules were gone through
 one at a time and all but seven fall into the shapes above: most build their replacement with `<` or
 `>` and so chain; the rest either attach a `Provided` sized by their own operands — the chain

--- a/Sources/AngouriMath/Docs/Contributing/WritingARule.md
+++ b/Sources/AngouriMath/Docs/Contributing/WritingARule.md
@@ -133,7 +133,7 @@ A pattern replacement gets:
 - **an exact growth**, counted from the two patterns rather than declared.
 
 A code replacement gets neither, and its growth is `Unknown` unless you declare one. That is the
-honest default — **171** rules sit at `Unknown` — but declare it where you can justify it:
+honest default — **165** rules sit at `Unknown` — but declare it where you can justify it:
 
 ```csharp
 // The Chebyshev expansion of sin(n * a) is a sum of n terms where the pattern is one node,
@@ -157,7 +157,11 @@ cannot argue the claim from the code, leave it `Unknown`.
 of a few shapes. A hole matched twice and written once gives `-(1 + |a|)`, which is a `Collects`
 stronger than the corpus will show you, since the corpus fills its holes with single nodes. A
 replacement holding no hole at all — a constant, or `pi/2` — collects by the whole of the pattern.
-Operators mapping one for one with every hole used once is `Rearranges`.
+Operators mapping one for one with every hole used once is `Rearranges`. A pattern that binds
+nothing — `arctan(sqrt(3)) = pi/3`, `{ True, False }` — has a fixed size on both sides, so its delta
+is a number and there is nothing to argue. And two numbers combined with `Number` arithmetic **fold
+into one node** as the replacement is built, which is worth two on its own: `(c * v) * d` collects
+where the same rule written without the cast would only rearrange.
 
 **Four shapes look declarable and are not.** Each of these measured a clean, constant delta over the
 corpus, and each is false:

--- a/Sources/AngouriMath/Docs/Contributing/WritingARule.md
+++ b/Sources/AngouriMath/Docs/Contributing/WritingARule.md
@@ -133,7 +133,7 @@ A pattern replacement gets:
 - **an exact growth**, counted from the two patterns rather than declared.
 
 A code replacement gets neither, and its growth is `Unknown` unless you declare one. That is the
-honest default — **175** rules sit at `Unknown` — but declare it where you can justify it:
+honest default — **171** rules sit at `Unknown` — but declare it where you can justify it:
 
 ```csharp
 // The Chebyshev expansion of sin(n * a) is a sum of n terms where the pattern is one node,

--- a/Sources/AngouriMath/Docs/Contributing/WritingARule.md
+++ b/Sources/AngouriMath/Docs/Contributing/WritingARule.md
@@ -133,7 +133,7 @@ A pattern replacement gets:
 - **an exact growth**, counted from the two patterns rather than declared.
 
 A code replacement gets neither, and its growth is `Unknown` unless you declare one. That is the
-honest default — **165** rules sit at `Unknown` — but declare it where you can justify it:
+honest default — **160** rules sit at `Unknown` — but declare it where you can justify it:
 
 ```csharp
 // The Chebyshev expansion of sin(n * a) is a sum of n terms where the pattern is one node,

--- a/Sources/Tests/UnitTests/Core/Transformations/CanonicalExtractionTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/CanonicalExtractionTest.cs
@@ -417,24 +417,37 @@ namespace AngouriMath.Tests.Core.Transformations
 
         /// <summary>
         /// Where the rules actually are, asserted rather than described — the fact that decides
-        /// what the growth ceiling is worth. The great majority are unjudged, because their
-        /// replacement is code rather than a written pattern, so a ceiling below the widest
-        /// leaves most of the library out.
+        /// what the growth ceiling is worth.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This used to say that the great majority are unjudged and to guard the share at under
+        /// a quarter: 69 of 324 when it was written. The declarations of
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/825">#825</a> took it past
+        /// half — 164 of 324 — so the old premise is spent rather than merely out of date, and
+        /// the test is renamed instead of having its number loosened again.
+        /// </para>
+        /// <para>
+        /// What is worth guarding now is that the ceiling is still doing something. It is the
+        /// <c>Rearranges</c> one that the transformation catalogue actually uses, and if it ever
+        /// admits nearly everything then <see cref="Saturation.RulesUpTo"/> has stopped being a
+        /// dial and the caller who asks for the narrow set is paying for a distinction that is no
+        /// longer there.
+        /// </para>
+        /// </remarks>
         [Fact]
-        public void MostSoundRulesHaveNoJudgedGrowth()
+        public void TheGrowthCeilingStillLeavesASubstantialPartOut()
         {
+            var used = Saturation.RulesUpTo(RewriteRuleGrowth.Rearranges).Count;
             var judged = Saturation.RulesUpTo(RewriteRuleGrowth.Expands).Count;
             var all = Saturation.RulesUpTo(RewriteRuleGrowth.Unknown).Count;
 
-            // It was under a quarter and is now about a quarter: 69 of 324 when this was first
-            // measured, 85 as the declarations of #825 land. The share is meant to rise, so the
-            // guard is that it has not become the majority -- at which point the ceiling would
-            // be excluding little and this test's premise would be gone rather than merely
-            // out of date.
-            Assert.True(all > 2 * judged,
-                $"{judged} of {all} sound rules have a judged growth, which is more than half "
-                + "-- the ceiling now excludes so little that it is worth asking what it is for");
+            Assert.True(all > judged,
+                $"every one of the {all} sound rules now has a judged growth, so the ceiling "
+                + "excludes nothing at all and is no longer a dial");
+            Assert.True(all - used > all / 4,
+                $"the ceiling the catalogue uses admits {used} of {all} sound rules, leaving "
+                + $"{all - used} out -- less than a quarter, so it has stopped being a dial");
         }
 
         #endregion

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
@@ -84,7 +84,7 @@ namespace AngouriMath.Tests.Core.Transformations
                 "how many rules have a pattern on both sides");
             Stated(33, rules.Count(rule => rule.Reversed is not null),
                 "how many two-sided rules have a direction");
-            Stated(160, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
+            Stated(154, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
                 "how many rules sit at Unknown growth");
 
             // And the two the document names. By their own names rather than by what the prose

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
@@ -84,7 +84,7 @@ namespace AngouriMath.Tests.Core.Transformations
                 "how many rules have a pattern on both sides");
             Stated(33, rules.Count(rule => rule.Reversed is not null),
                 "how many two-sided rules have a direction");
-            Stated(171, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
+            Stated(165, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
                 "how many rules sit at Unknown growth");
 
             // And the two the document names. By their own names rather than by what the prose

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
@@ -84,7 +84,7 @@ namespace AngouriMath.Tests.Core.Transformations
                 "how many rules have a pattern on both sides");
             Stated(33, rules.Count(rule => rule.Reversed is not null),
                 "how many two-sided rules have a direction");
-            Stated(175, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
+            Stated(171, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
                 "how many rules sit at Unknown growth");
 
             // And the two the document names. By their own names rather than by what the prose

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
@@ -84,7 +84,7 @@ namespace AngouriMath.Tests.Core.Transformations
                 "how many rules have a pattern on both sides");
             Stated(33, rules.Count(rule => rule.Reversed is not null),
                 "how many two-sided rules have a direction");
-            Stated(165, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
+            Stated(160, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
                 "how many rules sit at Unknown growth");
 
             // And the two the document names. By their own names rather than by what the prose


### PR DESCRIPTION
Seventeen more, continuing #1163. **175 rules were at `Unknown` on master; 165 are.**

## Two shapes that make the counting easier, both new here

**A pattern that binds nothing has a fixed size on both sides**, so its delta is a number and there
is nothing to argue: `arctan(sqrt(3)) = pi/3` is four nodes to three, `arctan(1/sqrt(3)) = pi/6` is
six to three, `{ True, False }` becomes the single node of the boolean domain, and the unbounded
interval likewise — its bounds are matched exactly rather than bound.

**Two numbers combined with `Number` arithmetic fold into one node** as the replacement is built,
which is worth two on its own. `(c * v) * d`, `(v + c) + d`, `c * (d * a)`, `(c * a) / d`,
`c / (d * a)` and `(c * f) * (d * g)` all **collect** for that reason — and the same rules written
without the cast would only *rearrange*. That difference is invisible unless you look for it, and it
is not new: the comment on `eulers-totient-of-a-prime-power` records the agreement test catching
exactly this distinction between `(p - 1)`, which folds, and `(k - 1)`, which does not.

Both shapes are now in `WritingARule.md`.

## The rest

| | |
|---|---|
| `k - k = 0` | everything matched goes for one node, operand matched twice — `-2\|k\|` |
| `sgn(a) * abs(a) = a` | three nodes around two copies keep one — `-(3 + \|a\|)` |
| `(a + b) - a = b`, `a + (b - a) = b` | `-(2 + 2\|a\|)` |
| `x in {a} = (x = a)` | singleton goes, membership becomes an equality — exactly **−1** |
| `(f + a) + g = f + g + a` | three operands regrouped, nothing added or dropped |
| `sgn(-a) = -sgn(a)` | the signum that belongs with the other odd functions — exactly **+2** |

## Nine read and left alone

The family that gathers a repeated operand into a doubling — `k + k = 2k`, `a + (a + b)`,
`a + (a - b)`, `a - (b - a)`, `(b - a) - a` — is **all `1 - |a|`**: one node shorter where the operand
is a leaf, longer where it is anything else. The corpus measures `k + k` between −2 and 0, which is
the signature of a rule with no growth to declare rather than one nobody has looked at.

`k - k = 0` sits directly beside `k + k = 2k` in the same set. One is a clean `-2|k|`; the other has
no answer. They look like twins.

The two rules that cancel a shared factor out of a quotient attach a `Provided` sized by that factor,
and `(False implies b)` and `(a xor a)` do the same with a domain condition.

## Verification

**320 targeted tests** — the growth check, the census, the canonical extraction and every
transformation test, including `EqualitySaturationNeverChangesTheValueItClaimsToPreserve`, which is
what a declaration into `SafeRules` has to answer to. CI runs the full suite here.

Part of #825.
