### PR TITLE
A saturation check compared two things that have no value (#1162)

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -1260,15 +1260,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 bound => bound["k"] & (bound["p"] | bound["q"]),
                 Soundness.Sound,
                 when: bound => Functions.Patterns.IsLogic(bound["k"], bound["p"], bound["q"]),
-                description: "((k and p) or (k and q)) = (k and (p or q))"),
-                // Undeclared, though the count is plain: the shared operand is matched twice and
-                // written once, so the delta is -(1 + |k|). Declaring it puts the rule among the
-                // ones equality saturation fires, and there it takes
-                // `a and b or a and not b` to `a and (b or not b)` -- which is the identity for
-                // booleans and not for what `IsLogic` lets through, since a free variable passes
-                // that guard and may be substituted with a number.
-                // `EqualitySaturationNeverChangesTheValueItClaimsToPreserve` catches it at 0.37.
-                // The growth is not what is wrong here, so it is not the thing to write down.
+                description: "((k and p) or (k and q)) = (k and (p or q))",
+                // The shared operand is matched twice and written once, and the three connectives
+                // stay three, so the delta is -(1 + |k|).
+                growth: RewriteRuleGrowth.Collects),
 
             new MatchedRule(
                 "a-conjunction-of-disjunctions-sharing-an-operand-distributes",
@@ -1278,8 +1273,9 @@ namespace AngouriMath.Core.Transformations.Matching
                 bound => bound["k"] | (bound["p"] & bound["q"]),
                 Soundness.Sound,
                 when: bound => Functions.Patterns.IsLogic(bound["k"], bound["p"], bound["q"]),
-                description: "((k or p) and (k or q)) = (k or (p and q))"),
-                // Undeclared for the same reason as its dual above, and by the same count.
+                description: "((k or p) and (k or q)) = (k or (p and q))",
+                // The same count as its dual above: -(1 + |k|).
+                growth: RewriteRuleGrowth.Collects),
 
             // Absorption, and the absorption that leaves something behind. Four arms each in the
             // switch, and the negated form four more.

--- a/Sources/AngouriMath/Docs/Contributing/WritingARule.md
+++ b/Sources/AngouriMath/Docs/Contributing/WritingARule.md
@@ -133,7 +133,7 @@ A pattern replacement gets:
 - **an exact growth**, counted from the two patterns rather than declared.
 
 A code replacement gets neither, and its growth is `Unknown` unless you declare one. That is the
-honest default — **154** rules sit at `Unknown` — but declare it where you can justify it:
+honest default — **152** rules sit at `Unknown` — but declare it where you can justify it:
 
 ```csharp
 // The Chebyshev expansion of sin(n * a) is a sum of n terms where the pattern is one node,

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
@@ -84,7 +84,7 @@ namespace AngouriMath.Tests.Core.Transformations
                 "how many rules have a pattern on both sides");
             Stated(33, rules.Count(rule => rule.Reversed is not null),
                 "how many two-sided rules have a direction");
-            Stated(154, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
+            Stated(152, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
                 "how many rules sit at Unknown growth");
 
             // And the two the document names. By their own names rather than by what the prose

--- a/Sources/Tests/UnitTests/Core/Transformations/TransformationTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/TransformationTest.cs
@@ -842,6 +842,23 @@ namespace AngouriMath.Tests.Core.Transformations
                 Entity beforeEvaled, afterEvaled;
                 try { beforeEvaled = before.Evaled; afterEvaled = after.Evaled; }
                 catch { continue; } // a boolean/set-valued corpus entry: not this test's claim
+
+                // The `catch` above was meant to skip those entries and does not: substituting a
+                // real into `a and b` throws nothing, it hands back `0.37 and 0.37` unevaluated,
+                // and two *different* unevaluated forms of a thing with no truth value then
+                // compare unequal. That is not a value changing. `(a and b) or (a and not b)`
+                // distributing to `a and (b or not b)` failed here for that reason alone.
+                //
+                // Skipped only when *neither* side has a value. One side evaluating and the other
+                // not is a rewrite that lost one, which is exactly what this test is for.
+                var beforeHasValue = beforeEvaled is Entity.Number;
+                var afterHasValue = afterEvaled is Entity.Number;
+                if (!beforeHasValue && !afterHasValue) continue;
+                Assert.True(beforeHasValue && afterHasValue,
+                    $"{source} at {point.Stringize()}: {beforeEvaled.Stringize()} and "
+                        + $"{afterEvaled.Stringize()} -- one of them has a value and the other "
+                        + $"does not, via {output.Stringize()}");
+
                 Assert.True(beforeEvaled.EqualsImprecisely(afterEvaled),
                     $"{source} at {point.Stringize()}: {beforeEvaled.Stringize()} became "
                         + $"{afterEvaled.Stringize()} via {output.Stringize()}");


### PR DESCRIPTION
**#1162 says a rule marked `Sound` changes the value. It does not, and this retracts that.**

I filed it while declaring growths, blamed `IsLogic` for admitting a free variable, and stated the
mechanism before measuring the values it makes a claim about. Measuring them:

```
(0.37 and 0.37) or (0.37 and not 0.37)   ->   37/100 and 37/100 or 37/100 and not 37/100
0.37 and (0.37 or not 0.37)              ->   37/100 and (37/100 or not 37/100)
```

A boolean operation on a non-boolean **does not evaluate to `NaN` — it does not evaluate at all.**
Both sides are stuck. Neither has a truth value. Nothing changed.
`(a and b) or (a and not b) = a and (b or not b)` is a boolean identity and was right all along.

## The defect is in the check

`EqualitySaturationNeverChangesTheValueItClaimsToPreserve` substitutes a real for every free
variable, calls `.Evaled` on both sides inside a `try`, and has

```csharp
catch { continue; } // a boolean/set-valued corpus entry: not this test's claim
```

**That skip never fires.** `.Evaled` on `0.37 and 0.37` throws nothing; it returns the node
unevaluated. So `EqualsImprecisely` compares two *different* unevaluated forms of a thing with no
value and reports a disagreement. The test's own comment names the entries it means to exclude, and
its mechanism for excluding them has never worked — `"a and b or a and not b"` is in its corpus
precisely so the boolean rules are exercised.

## The fix is strictly stronger than what it replaces

Skipped only when **neither** side has a value. **One side evaluating and the other not now fails
loudly** — that is a rewrite which lost a value, exactly what this test exists to catch, and today it
would have been compared structurally and might well have passed.

## What it unblocks

Both boolean distributions can now say their growth. The count was never in doubt — the shared
operand is matched twice and written once, so `-(1 + |k|)` — only whether declaring it was safe,
since a declaration is what puts a rule into the set equality saturation fires. **152 rules sit at
`Unknown`, down from 154.**

## Verification

Full suite **9554 passed, 0 failed**, 14 skipped.

Closes #1162. Part of #825.
