### PR TITLE
A rule set that never settles over a whole tree is caught too (#825)

### DIFF
--- a/Sources/Tests/UnitTests/Core/Transformations/RuleSetsDoNotCycleTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleSetsDoNotCycleTest.cs
@@ -113,6 +113,60 @@ namespace AngouriMath.Tests.Core.Transformations
         }
 
         /// <summary>
+        /// The same question over a whole tree rather than at the root, which is the half the
+        /// loop above cannot answer: a full pass can move its rewrite to a different node each
+        /// time and never repeat a term while still never settling.
+        /// </summary>
+        /// <remarks>
+        /// <c>UntilStable</c> reports hitting its bound as <b>no answer</b> rather than as the
+        /// last value reached, and its remarks say why — "an unbounded rewrite loop is the failure
+        /// mode this layer is supposed to make visible, and handing back a value from the middle
+        /// of one would hide exactly the case worth seeing". This is a caller taking it up on
+        /// that.
+        /// </remarks>
+        [Fact]
+        public void EveryRegisteredSetSettlesOnTheSeeds()
+        {
+            // Named rather than counted, so that finding another one is a change to this list.
+            // NumericNeat grows `-x / (-y)` by four nodes a pass for ever: the rules that bring a
+            // negative factor out of a numerator and out of a denominator each leave the
+            // magnitude of -1 behind as a literal `1 *` factor instead of folding it, and then
+            // undo each other around it --
+            //   -1 * x / (-y)
+            //   -1 * 1 * x / (1 * y) * 1 * (-1)
+            //   -1 * 1 * 1 * x / (1 * y) * 1 * 1 * (-1)
+            // `Simplify` is not affected and answers `x / y`, because the pipeline is bounded and
+            // picks by size rather than running this set alone to a fixed point. It is a set with
+            // no fixed point on an ordinary input all the same.
+            // https://github.com/asc-community/AngouriMath/issues/1167
+            var known = new[] { "NumericNeat: -x / (-y)" };
+
+            var unsettled = new List<string>();
+
+            foreach (var set in RewriteRules.All)
+            {
+                var rewriting = Transformation.Rewriting(set).UntilStable(Steps);
+                foreach (var start in Corpus())
+                {
+                    TransformationResult result;
+                    try { result = rewriting.Apply(start); }
+                    catch { continue; /* a rule declining loudly is not this test's subject */ }
+                    if (!result.Succeeded)
+                        unsettled.Add($"{set.Name}: {start.Stringize()}");
+                }
+            }
+
+            var unexpected = unsettled.Distinct().Except(known).ToList();
+            Assert.True(unexpected.Count == 0,
+                $"{unexpected.Count} set-and-expression pairs newly fail to reach a fixed point "
+                + $"in {Steps} passes:\n" + string.Join("\n", unexpected.Take(20)));
+
+            // And the known one is still known: fixing it should delete it from the list rather
+            // than leave a name here that no longer means anything.
+            Assert.Equal(known, unsettled.Distinct().Intersect(known).ToArray());
+        }
+
+        /// <summary>
         /// The loop above has to actually rewrite something, or it passes by never firing. Named
         /// as a count that moves rather than as "it works".
         /// </summary>


### PR DESCRIPTION
The cycle check merged in #1165 rewrites at the **root**, which is what makes its "a term came back"
criterion mean something — and it is also what it cannot see past. A full pass can move its rewrite
to a different node each time and never repeat a term while still never settling.

`UntilStable` already answers that question, and says so in its own remarks:

> Hitting the bound is reported as **no answer** rather than as the last value reached. An unbounded
> rewrite loop is the failure mode this layer is supposed to make visible, and handing back a value
> from the middle of one would hide exactly the case worth seeing.

This is a caller taking it up on that, over every registered set and the same seeds.

## It finds one, and it is not a cycle

**`NumericNeat` has no fixed point on `-x / (-y)`.** It grows by four nodes a pass, indefinitely:

```
  0    7  -x / (-y)
  1    9  -1 * x / (-y)
  2   15  -1 * 1 * x / (1 * y) * 1 * (-1)
  3   19  -1 * 1 * 1 * x / (1 * y) * 1 * 1 * (-1)
  ...
```

No term ever repeats, so the root check was right to pass — this needed the whole-tree form.

`a-negative-factor-in-a-numerator-comes-out` and its denominator twin each take a negative factor out
and write the **magnitude** back in its place. When the factor is `-1` the magnitude is `1`, and it
goes back as a literal `1 *` rather than folding away; the two rules then undo each other around the
factors that accumulate.

**That is #1056 one file over.** #1056 was fixed by having the collecting rule decline `c = -1`, with
a comment giving the reason — *"that is not a numeric factor to collect but the sign, which the
language spells as a product."* The same reasoning applies here.

## Latent, not live — checked rather than assumed

**`Simplify` is unaffected**: `"-x / (-y)".Simplify()` answers `x / y` in 68 ms, because the pipeline
is bounded and selects by size rather than running this set alone to a fixed point. Nothing a user
does today reaches it.

It still matters. A caller may reasonably use `Transformation.Rewriting(set).UntilStable(n)` — that
is what the layer is for — and equality saturation runs sets against a budget, which a set with no
fixed point spends.

## Not fixed here

Declining at a magnitude of `1` is the obvious move and matches #1056's precedent, but it narrows two
rules that are otherwise doing useful work. [#1167](https://github.com/asc-community/AngouriMath/issues/1167)
records what a fix would need to establish first: which expressions currently reach a better form
*through* the `1 *` step, and whether `Simplify`'s answer moves for any of them.

**Pinned as the one known pair rather than counted**, so a new one fails the test — and so does this
one disappearing. A fix should delete the entry rather than leave a name behind that no longer means
anything.

## Verification

Full suite **9555 passed, 0 failed**, 14 skipped.

Part of #825.
