### PR TITLE
A factor of -1 is a sign, not a factor to take out (#1167)

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -1023,12 +1023,18 @@ namespace AngouriMath.Core.Transformations.Matching
                 // one node for one.
                 growth: RewriteRuleGrowth.Rearranges),
 
-            // (-a * x) * y -> -(a * (x * y)), the negative factor either way round
+            // (-a * x) * y -> -(a * (x * y)), the negative factor either way round.
+            // A factor of -1 is declined here and in the three rules below it: its magnitude is 1,
+            // so "taking the factor out" leaves a literal `1 *` behind that says nothing, and the
+            // numerator rule and the denominator rule then undo each other around it -- `-x / (-y)`
+            // grew by four nodes a pass for ever. -1 is not a factor to take out, it is the sign,
+            // and the two rules above this one already answer it.
+            // https://github.com/asc-community/AngouriMath/issues/1167
             new MatchedRule(
                 "a-negative-factor-in-a-left-product-comes-out",
                 MatchPattern.Node<Mulf>(
                     MatchPattern.Commutative<Mulf>(
-                        MatchPattern.Any<Real>("n", value => value.IsNegative),
+                        MatchPattern.Any<Real>("n", value => value.IsNegative && value != -1),
                         MatchPattern.Any("x")),
                     MatchPattern.Any("y")),
                 bound => -((-(Real)bound["n"]) * (bound["x"] * bound["y"])),
@@ -1040,12 +1046,13 @@ namespace AngouriMath.Core.Transformations.Matching
                 // 63 firings over the corpus.
                 growth: RewriteRuleGrowth.Expands),
 
-            // (-a * x) / y -> -(a * (x / y))
+            // (-a * x) / y -> -(a * (x / y)). Declines -1; see the left-product rule above, and
+            // note that this rule and the denominator one below are the pair that cycled.
             new MatchedRule(
                 "a-negative-factor-in-a-numerator-comes-out",
                 MatchPattern.Node<Divf>(
                     MatchPattern.Commutative<Mulf>(
-                        MatchPattern.Any<Real>("n", value => value.IsNegative),
+                        MatchPattern.Any<Real>("n", value => value.IsNegative && value != -1),
                         MatchPattern.Any("x")),
                     MatchPattern.Any("y")),
                 bound => -((-(Real)bound["n"]) * (bound["x"] / bound["y"])),
@@ -1056,13 +1063,13 @@ namespace AngouriMath.Core.Transformations.Matching
                 // at +2 on all 63 firings over the corpus.
                 growth: RewriteRuleGrowth.Expands),
 
-            // y * (-a * x) -> -(a * (x * y))
+            // y * (-a * x) -> -(a * (x * y)). Declines -1; see the left-product rule above.
             new MatchedRule(
                 "a-negative-factor-in-a-right-product-comes-out",
                 MatchPattern.Node<Mulf>(
                     MatchPattern.Any("y"),
                     MatchPattern.Commutative<Mulf>(
-                        MatchPattern.Any<Real>("n", value => value.IsNegative),
+                        MatchPattern.Any<Real>("n", value => value.IsNegative && value != -1),
                         MatchPattern.Any("x"))),
                 bound => -((-(Real)bound["n"]) * (bound["x"] * bound["y"])),
                 Soundness.Sound,
@@ -1074,12 +1081,14 @@ namespace AngouriMath.Core.Transformations.Matching
             // y / (-a * x) -> -(y / (a * x)). What is left stays under the line: written the
             // other way, as the numerator rules above are, the quotient came back inverted --
             // https://github.com/asc-community/AngouriMath/issues/936 and the note on the switch.
+            // Declines -1; see the left-product rule above, and note that this rule and the
+            // numerator one are the pair that cycled.
             new MatchedRule(
                 "a-negative-factor-in-a-denominator-comes-out",
                 MatchPattern.Node<Divf>(
                     MatchPattern.Any("y"),
                     MatchPattern.Commutative<Mulf>(
-                        MatchPattern.Any<Real>("n", value => value.IsNegative),
+                        MatchPattern.Any<Real>("n", value => value.IsNegative && value != -1),
                         MatchPattern.Any("x"))),
                 bound => -(bound["y"] / ((-(Real)bound["n"]) * bound["x"])),
                 Soundness.Sound,

--- a/Sources/AngouriMath/Docs/Contributing/InversePairTable.md
+++ b/Sources/AngouriMath/Docs/Contributing/InversePairTable.md
@@ -97,6 +97,37 @@ addressability itself for 29 sets.
   that: infrastructure that cannot be exercised by the registry as it stands, which is why the first
   attempt was reverted rather than shipped.
 
+## A pair that cannot be derived can still be observed
+
+Everything above is about deriving the table — from syntax, or from `MatchPattern`. There is a third
+source, and it is neither: **run the sets and watch what comes back**.
+
+`RuleSetsDoNotCycleTest` applies each set to a fixed point over a generated corpus and fails on a term
+the set has already produced. Two of the loops it reports are one inverse pair:
+
+```
+Power: 1 ^ (-2) * x ^ (-2)    ->  (1 * x) ^ (-2)      ->  1 ^ (-2) * x ^ (-2)
+Power: (-2) ^ 2 * (1/2) ^ 2   ->  ((-2) * 1/2) ^ 2    ->  (-2) ^ 2 * (1/2) ^ 2
+```
+
+`two-powers-of-one-exponent-share-a-base` collects `a ^ b * c ^ b` into `(a * c) ^ b`;
+`positive-power-of-a-product-distributes` takes it straight back. Nothing derived that. The loop is
+the evidence, and the two rule names fall out of reading which arms fired.
+
+What this is and is not:
+
+- **It is a lower bound, and a cheap one.** A pair that never fires on the corpus is invisible to it,
+  and a pair split across two sets never meets. It cannot enumerate the table.
+- **It needs no reversibility mechanism at all**, which is the whole of what makes it available
+  today: it is behaviour observed at the top of the pipeline, not a property computed about a rule.
+- **It answers the question equality saturation actually asks.** The consumer in the opening quote
+  needs to know which rewrites undo each other *so that it stops*; a pair that provably makes a set
+  fail to terminate is exactly that, whether or not it is the whole table.
+
+Filed as [#1171](https://github.com/asc-community/AngouriMath/issues/1171), which is a design question
+rather than a bug — both rules are correct and each is wanted in its own direction. `Simplify` is
+unaffected, because it folds between passes and the shape the second rule needs stops existing.
+
 ## What is not decided here
 
 Which of the two real options — generator-level reversibility, or redirecting `Rules` to

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Common.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Common.cs
@@ -44,12 +44,17 @@ namespace AngouriMath.Functions
             Mulf(Real { IsNegative: true } num1, Real { IsNegative: true } num2) => (-num1) * (Entity)(-num2),
             Divf(Real { IsNegative: true } num1, Real { IsNegative: true } num2) => (-num1) / (Entity)(-num2),
 
-            Mulf(Mulf(Real { IsNegative: true } num, var any1), var any2) => -((-num) * (any1 * any2)),
-            Mulf(Mulf(var any1, Real { IsNegative: true } num), var any2) => -((-num) * (any1 * any2)),
-            Divf(Mulf(Real { IsNegative: true } num, var any1), var any2) => -((-num) * (any1 / any2)),
-            Divf(Mulf(var any1, Real { IsNegative: true } num), var any2) => -((-num) * (any1 / any2)),
-            Mulf(var any2, Mulf(Real { IsNegative: true } num, var any1)) => -((-num) * (any1 * any2)),
-            Mulf(var any2, Mulf(var any1, Real { IsNegative: true } num)) => -((-num) * (any1 * any2)),
+            // Each of these eight declines a factor of -1: its magnitude is 1, so taking it out
+            // leaves a literal `1 *` that says nothing, and the numerator arms and the denominator
+            // arms then undo each other around it -- -x / (-y) grew by four nodes a pass for ever.
+            // -1 is not a factor to take out, it is the sign, and the two arms above answer it.
+            // https://github.com/asc-community/AngouriMath/issues/1167
+            Mulf(Mulf(Real { IsNegative: true } num, var any1), var any2) when num != -1 => -((-num) * (any1 * any2)),
+            Mulf(Mulf(var any1, Real { IsNegative: true } num), var any2) when num != -1 => -((-num) * (any1 * any2)),
+            Divf(Mulf(Real { IsNegative: true } num, var any1), var any2) when num != -1 => -((-num) * (any1 / any2)),
+            Divf(Mulf(var any1, Real { IsNegative: true } num), var any2) when num != -1 => -((-num) * (any1 / any2)),
+            Mulf(var any2, Mulf(Real { IsNegative: true } num, var any1)) when num != -1 => -((-num) * (any1 * any2)),
+            Mulf(var any2, Mulf(var any1, Real { IsNegative: true } num)) when num != -1 => -((-num) * (any1 * any2)),
             // A negative factor under the line comes out as a sign in front, and what is left
             // stays under the line: a / (-b * c) is -(a / (b * c)), not -(b * (c / a)). Written
             // the latter way -- as the four rules above it are, where the negative factor is in
@@ -57,8 +62,8 @@ namespace AngouriMath.Functions
             // and Simplify takes whichever candidate is shortest, so the inverted one won
             // wherever it was smaller: 1 / (x * (-1 - 1/x)) simplified to -(1 + x), which is its
             // reciprocal.
-            Divf(var any2, Mulf(Real { IsNegative: true } num, var any1)) => -(any2 / ((-num) * any1)),
-            Divf(var any2, Mulf(var any1, Real { IsNegative: true } num)) => -(any2 / ((-num) * any1)),
+            Divf(var any2, Mulf(Real { IsNegative: true } num, var any1)) when num != -1 => -(any2 / ((-num) * any1)),
+            Divf(var any2, Mulf(var any1, Real { IsNegative: true } num)) when num != -1 => -(any2 / ((-num) * any1)),
 
             _ => x
         };

--- a/Sources/Tests/UnitTests/Core/Transformations/RulePriorityTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RulePriorityTest.cs
@@ -40,7 +40,13 @@ namespace AngouriMath.Tests.Core.Transformations
     [Trait("Area", "Core")]
     public sealed class RulePriorityTest
     {
-        private static readonly string[] Leaves = { "x", "y", "2", "-1", "1/2", "0", "1", "3" };
+        // `-2` earns its place by not being `-1`. Four rules that take a negative factor out of a
+        // product decline a factor of -1, which is the sign rather than a factor to take out
+        // (https://github.com/asc-community/AngouriMath/issues/1167) — so with -1 as the only
+        // negative leaf they matched nothing here and the subsumption claims about them went
+        // unwitnessed. A corpus whose only negative is the one case a rule excludes cannot
+        // exercise the rule.
+        private static readonly string[] Leaves = { "x", "y", "2", "-1", "-2", "1/2", "0", "1", "3" };
 
         private static readonly string[] Unary =
         {
@@ -135,12 +141,26 @@ namespace AngouriMath.Tests.Core.Transformations
         /// by the wider one too.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Over all 322 rules rather than within a set, because the relation is about patterns and
         /// nothing about it stops at a set boundary: <b>961</b> ordered pairs claim subsumption,
-        /// <b>513</b> of them are put to the test by the corpus containing something the narrower
-        /// pattern matches, and none is contradicted across 56,892 nodes. The count of witnessed
-        /// claims is asserted as well — a corpus that stopped reaching these shapes would otherwise
-        /// turn this into a test that passes by asking nothing.
+        /// <b>501</b> of them are put to the test by the corpus containing something the narrower
+        /// pattern matches, and none is contradicted across <b>85,153</b> nodes. All three counts
+        /// are asserted — a corpus that stopped reaching these shapes would otherwise turn this
+        /// into a test that passes by asking nothing, and a witnessed count means nothing without
+        /// what it was measured over.
+        /// </para>
+        /// <para>
+        /// <b>Why 501 and not 513.</b> Adding <c>-2</c> to the leaves moved it, and not the way it
+        /// looks. Measured four ways: on the old leaves the <c>-1</c> guard of
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1167">#1167</a> cost 24
+        /// witnesses (513 to 489), because <c>-1</c> was the only negative leaf and the four
+        /// guarded rules then matched nothing at all. With <c>-2</c> present the guard costs
+        /// <b>nothing</b> — 501 either way — which is what says the leaf restores exactly what the
+        /// guard removed. The remaining 513-to-501 is not coverage at all: <c>level3</c> samples
+        /// every eleventh element of <c>level2</c>, so a longer <c>level2</c> lands the sample on
+        /// different expressions.
+        /// </para>
         /// </remarks>
         [Fact]
         public void SubsumptionIsNeverContradictedByMatching()
@@ -185,7 +205,11 @@ namespace AngouriMath.Tests.Core.Transformations
             }
 
             Assert.Equal(961, claims.Count);
-            Assert.Equal(513, witnessed);
+            Assert.Equal(501, witnessed);
+            // Asserted so the two figures in the remark above cannot go stale in silence: the
+            // whole point of `witnessed` is that it is a coverage number, and it means nothing
+            // without knowing what it was measured over.
+            Assert.Equal(85153, nodes.Count);
         }
 
         /// <summary>
@@ -370,22 +394,21 @@ namespace AngouriMath.Tests.Core.Transformations
                 "Common: a-common-factor-of-two-subtracted-products-comes-out | a-term-subtracted-from-itself-vanishes",
                 "Common: a-factor-shared-by-a-product-and-a-quotient-added-comes-out | a-negated-term-in-a-sum-is-a-subtraction",
                 "Common: a-factor-shared-by-a-quotient-and-a-product-added-comes-out | a-negated-term-in-a-sum-is-a-subtraction",
-                "Common: a-function-times-a-number-puts-the-number-first | a-negated-reciprocal-rational-factor-is-a-negated-division",
+                "Common: a-function-times-a-number-puts-the-number-first | a-reciprocal-rational-factor-is-a-division",
                 "Common: a-product-of-two-quotients-is-one-quotient | a-thing-times-itself-is-its-square",
-                "Common: a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero | a-difference-over-its-own-reverse-is-minus-one",
                 "Common: a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero | a-shared-factor-cancels-between-two-products",
-                "Common: a-quotient-times-a-thing-keeps-the-divisor-outermost | a-negated-reciprocal-rational-factor-is-a-negated-division",
+                "Common: a-quotient-times-a-thing-keeps-the-divisor-outermost | a-reciprocal-rational-factor-is-a-division",
                 "Common: a-quotient-times-a-thing-keeps-the-divisor-outermost | a-thing-times-a-quotient-keeps-the-divisor-outermost",
                 "Common: a-quotient-times-a-thing-keeps-the-divisor-outermost | a-thing-times-itself-is-its-square",
                 "Common: a-term-added-to-itself-doubles | a-negated-term-in-a-sum-is-a-subtraction",
-                "Common: a-thing-times-a-quotient-keeps-the-divisor-outermost | a-negated-reciprocal-rational-factor-is-a-negated-division",
+                "Common: a-thing-times-a-quotient-keeps-the-divisor-outermost | a-reciprocal-rational-factor-is-a-division",
                 "Common: a-thing-times-a-quotient-keeps-the-divisor-outermost | a-thing-times-itself-is-its-square",
                 "Common: a-variable-times-a-number-puts-the-number-first | a-reciprocal-rational-factor-is-a-division",
                 "Common: dividing-by-a-quotient-multiplies-by-its-reciprocal | a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero",
                 "Common: dividing-by-a-quotient-multiplies-by-its-reciprocal | dividing-twice-divides-by-the-product",
                 "Common: dividing-twice-divides-by-the-product | a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero",
-                "Common: two-numbers-around-a-factor-collect | a-negated-reciprocal-rational-factor-is-a-negated-division",
-                "Common: two-numeric-factors-around-a-variable-collect | a-negated-reciprocal-rational-factor-is-a-negated-division",
+                "Common: two-numbers-around-a-factor-collect | a-reciprocal-rational-factor-is-a-division",
+                "Common: two-numeric-factors-around-a-variable-collect | a-reciprocal-rational-factor-is-a-division",
                 "Common: two-numeric-multiples-of-one-variable-add | a-common-factor-of-two-added-products-comes-out",
                 "Common: two-numeric-multiples-of-one-variable-add | a-negated-term-in-a-sum-is-a-subtraction",
                 "Common: two-numeric-multiples-of-one-variable-add | a-term-added-to-itself-doubles",
@@ -394,8 +417,12 @@ namespace AngouriMath.Tests.Core.Transformations
                 "Factorization: a-factor-shared-by-two-added-products-comes-out | a-term-added-to-itself-doubles",
                 "Factorization: a-factor-shared-by-two-subtracted-products-comes-out | a-term-subtracted-from-itself-vanishes",
                 "Factorization: a-term-added-to-itself-doubles | a-common-factor-is-collected-out-of-a-whole-sum",
-                "NumericNeat: a-negative-factor-in-a-left-product-comes-out | a-negative-factor-in-a-right-product-comes-out",
-                "NumericNeat: a-negative-factor-in-a-numerator-comes-out | a-negative-factor-in-a-denominator-comes-out",
+                // NumericNeat had two entries here and has none. They were
+                // `a-negative-factor-in-a-left-product-comes-out | ...-right-...` and
+                // `a-negative-factor-in-a-numerator-comes-out | ...-denominator-...`, and the
+                // second of those is the pair that undid each other for ever on `-x / (-y)`. All
+                // four decline a factor of -1 now, so they no longer fire on one node together.
+                // https://github.com/asc-community/AngouriMath/issues/1167
                 "Power: a-numeric-factor-comes-out-of-a-power-of-a-product | a-reciprocal-power-is-a-quotient",
                 "Power: a-power-of-a-power-multiplies-the-exponents | a-reciprocal-power-is-a-quotient",
                 "Power: a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero | two-powers-of-one-base-divide-by-subtracting-exponents",

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleSetTerminationTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleSetTerminationTest.cs
@@ -46,14 +46,24 @@ namespace AngouriMath.Tests.Core.Transformations
         /// needs to be actionable.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// <c>Power</c> splits a power of a product — <c>(2 * x) ^ 2</c> to <c>2 ^ 2 * x ^ 2</c> —
         /// and something has to fold <c>2 ^ 2</c> before the result stops being a power of a
-        /// product. <c>NumericNeat</c> rewrites <c>--x</c> through a product of ones that only
-        /// collapses when the normalisation multiplies them out. Both are the same shape: a rule
-        /// whose right-hand side is a fixed point only after arithmetic that the set itself does
-        /// not do.
+        /// product: a rule whose right-hand side is a fixed point only after arithmetic that the
+        /// set itself does not do.
+        /// </para>
+        /// <para>
+        /// <c>NumericNeat</c> was here for the same reason and is not any more. It rewrote
+        /// <c>--x</c> through a product of ones that collapsed only when the normalisation
+        /// multiplied them out, because four rules took a factor of <c>-1</c> out of a product and
+        /// left its magnitude behind as a literal <c>1 *</c>. They decline <c>-1</c> now — it is
+        /// the sign rather than a factor to take out — so the ones are never made and the set
+        /// settles on its own. That is
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1167">#1167</a>, and this
+        /// list is one of the two places that recorded it.
+        /// </para>
         /// </remarks>
-        private static readonly HashSet<string> SettleOnlyComposed = new() { "Power", "NumericNeat" };
+        private static readonly HashSet<string> SettleOnlyComposed = new() { "Power" };
 
         private static readonly string[] Leaves = { "x", "y", "2", "-1", "1/2", "1", "0" };
 

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleSetsDoNotCycleTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleSetsDoNotCycleTest.cs
@@ -64,9 +64,38 @@ namespace AngouriMath.Tests.Core.Transformations
             "2 * x + 3 * x", "x + x", "x - x", "x * x", "a * c + a / b",
         };
 
+        private static readonly string[] Leaves =
+            { "x", "y", "2", "-1", "-2", "1/2", "-1/2", "1", "0" };
+
+        private static readonly string[] Unary =
+            { "-({0})", "1 / ({0})", "({0}) ^ 2", "({0}) ^ (-2)", "sqrt({0})", "sin({0})", "abs({0})" };
+
+        private static readonly string[] Binary =
+            { "({0}) + ({1})", "({0}) - ({1})", "({0}) * ({1})", "({0}) / ({1})", "({0}) ^ ({1})" };
+
+        /// <summary>
+        /// The seeds above, and the generated arithmetic the growth check uses on top of them.
+        /// The seeds alone are shapes somebody thought of; the grammar reaches the arrangements
+        /// nobody would write down, which is where <c>-x / (-y)</c> came from in the first place.
+        /// </summary>
         private static IEnumerable<Entity> Corpus()
         {
-            foreach (var source in Seeds)
+            var generated = new List<string>(Leaves);
+            var level2 = new List<string>();
+            foreach (var shape in Unary)
+                foreach (var inner in generated)
+                    level2.Add(string.Format(shape, inner));
+            foreach (var shape in Binary)
+                foreach (var left in generated)
+                    foreach (var right in generated)
+                        level2.Add(string.Format(shape, left, right));
+            var level3 = new List<string>();
+            foreach (var shape in Binary)
+                foreach (var left in level2.Where((_, i) => i % 17 == 0))
+                    foreach (var right in level2.Where((_, i) => i % 23 == 0))
+                        level3.Add(string.Format(shape, left, right));
+
+            foreach (var source in Seeds.Concat(generated).Concat(level2).Concat(level3))
             {
                 Entity parsed;
                 try { parsed = source.ToEntity(); }
@@ -77,6 +106,26 @@ namespace AngouriMath.Tests.Core.Transformations
 
         /// <summary>How many rewrites to allow before calling it divergence rather than a cycle.</summary>
         private const int Steps = 64;
+
+        /// <summary>
+        /// The cycles that are known, filed and deliberately still here. Written as the whole loop
+        /// rather than as a set name, so that the entry says what it is excusing.
+        /// </summary>
+        /// <remarks>
+        /// Both are <c>Power</c> holding an inverse pair:
+        /// <c>two-powers-of-one-exponent-share-a-base</c> collects <c>a ^ b * c ^ b</c> into
+        /// <c>(a * c) ^ b</c> and <c>positive-power-of-a-product-distributes</c> takes it straight
+        /// back. Neither rule is wrong and each is wanted in its own direction; a *set* containing
+        /// both has no normal form to reach, which is
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1171">#1171</a>.
+        /// <see cref="Entity.Simplify()"/> is unaffected — it folds between passes, so <c>1 * x</c>
+        /// collapses and the shape the second rule needs stops existing.
+        /// </remarks>
+        private static readonly string[] KnownCycles =
+        {
+            "Power: 1 ^ (-2) * x ^ (-2)  ->  (1 * x) ^ (-2)  ->  1 ^ (-2) * x ^ (-2)",
+            "Power: (-2) ^ 2 * (1/2) ^ 2  ->  ((-2) * 1/2) ^ 2  ->  (-2) ^ 2 * (1/2) ^ 2",
+        };
 
         [Fact]
         public void NoRuleSetRewritesBackToATermItHasAlreadyProduced()
@@ -107,9 +156,18 @@ namespace AngouriMath.Tests.Core.Transformations
                     }
                 }
 
-            Assert.True(cycles.Count == 0,
-                $"{cycles.Count} rule sets rewrite back to a term they have already produced:\n"
-                + string.Join("\n", cycles.Distinct()));
+            var found = cycles.Distinct().ToList();
+            var unexpectedCycles = found.Except(KnownCycles).ToList();
+            Assert.True(unexpectedCycles.Count == 0,
+                $"{unexpectedCycles.Count} rule sets rewrite back to a term they have already "
+                + "produced:\n" + string.Join("\n", unexpectedCycles));
+
+            // And each known one is still there, so that fixing #1171 deletes the entry rather
+            // than leaving a loop written out here that no longer happens.
+            var goneCycles = KnownCycles.Except(found).ToList();
+            Assert.True(goneCycles.Count == 0,
+                $"{goneCycles.Count} entries above no longer cycle and should be deleted:\n"
+                + string.Join("\n", goneCycles));
         }
 
         /// <summary>
@@ -127,19 +185,15 @@ namespace AngouriMath.Tests.Core.Transformations
         [Fact]
         public void EveryRegisteredSetSettlesOnTheSeeds()
         {
-            // Named rather than counted, so that finding another one is a change to this list.
-            // NumericNeat grows `-x / (-y)` by four nodes a pass for ever: the rules that bring a
-            // negative factor out of a numerator and out of a denominator each leave the
-            // magnitude of -1 behind as a literal `1 *` factor instead of folding it, and then
-            // undo each other around it --
-            //   -1 * x / (-y)
-            //   -1 * 1 * x / (1 * y) * 1 * (-1)
-            //   -1 * 1 * 1 * x / (1 * y) * 1 * 1 * (-1)
-            // `Simplify` is not affected and answers `x / y`, because the pipeline is bounded and
-            // picks by size rather than running this set alone to a fixed point. It is a set with
-            // no fixed point on an ordinary input all the same.
-            // https://github.com/asc-community/AngouriMath/issues/1167
-            var known = new[] { "NumericNeat: -x / (-y)" };
+            // The two shapes of #1171, which are the whole-tree face of the pair in
+            // <see cref="KnownCycles"/>. Nothing else is excused: NumericNeat grew `-x / (-y)` by
+            // four nodes a pass for ever until #1167, and its entry here is gone rather than left
+            // behind meaning nothing.
+            var known = new[]
+            {
+                "Power: 1 ^ (-2) * x ^ (-2)",
+                "Power: (-2) ^ 2 * (1/2) ^ 2",
+            };
 
             var unsettled = new List<string>();
 
@@ -161,9 +215,12 @@ namespace AngouriMath.Tests.Core.Transformations
                 $"{unexpected.Count} set-and-expression pairs newly fail to reach a fixed point "
                 + $"in {Steps} passes:\n" + string.Join("\n", unexpected.Take(20)));
 
-            // And the known one is still known: fixing it should delete it from the list rather
+            // And each known one is still known: fixing it should delete it from the list rather
             // than leave a name here that no longer means anything.
-            Assert.Equal(known, unsettled.Distinct().Intersect(known).ToArray());
+            var gone = known.Except(unsettled).ToList();
+            Assert.True(gone.Count == 0,
+                $"{gone.Count} entries above now settle and should be deleted:\n"
+                + string.Join("\n", gone));
         }
 
         /// <summary>


### PR DESCRIPTION
Two things, on one branch because the second is what found the first.

## A factor of -1 is a sign, not a factor to take out

Four rules bring a negative factor out of a numerator or a denominator. Given a magnitude of 1 they
took it out anyway, leaving the 1 behind as a literal `1 *` factor that says nothing — and the
numerator rule and the denominator rule then undid each other around it. `NumericNeat` applied to
`-x / (-y)` grows by four nodes a pass and never reaches a fixed point.

They now decline a factor of `-1`, which is not a factor to take out but the sign the rewrite is
about; the two rules directly above them, `(-a) * (-b) = a * b` and `(-a) / (-b) = a / b`, already
answer that case. Closes #1167.

Both spellings changed together — the four `MatchedRule`s and the eight `switch` arms in
`Patterns.Common.cs` that carry the same rules with their commutative variants. Twenty-seven of the
thirty sets no longer run their switch, but the agreement tests still hold the two forms to each
other.

## The corpus that had to find it

`RuleSetsDoNotCycleTest` ran on hand-written seeds — shapes somebody thought of — and `-x / (-y)` was
in that list only because #1056 had already put it there. A check that confirms the last bug is not
the same as one that finds the next.

It now also generates the arithmetic grammar the growth check uses: nine leaves, seven unary and five
binary shapes, composed two and three deep and sampled at the third level.

**It found the next one on its first run.** #1171: `Power` contains an inverse pair —
`two-powers-of-one-exponent-share-a-base` collects `a ^ b * c ^ b` into `(a * c) ^ b` and
`positive-power-of-a-product-distributes` takes it straight back — so applying the set to a fixed
point alternates for ever:

```
Power: 1 ^ (-2) * x ^ (-2)    ->  (1 * x) ^ (-2)      ->  1 ^ (-2) * x ^ (-2)
Power: (-2) ^ 2 * (1/2) ^ 2   ->  ((-2) * 1/2) ^ 2    ->  (-2) ^ 2 * (1/2) ^ 2
```

**Not fixed here, deliberately.** Neither rule is wrong and each is wanted in its own direction; a
*set* holding both has no normal form to reach, and which of the three possible answers is right is a
decision about normal forms rather than a bug fix. Both loops are pinned by name with the issue.

`Simplify` is unaffected, and that was measured rather than assumed: `1 ^ (-2) * x ^ (-2)` answers
`1 / x ^ 2` and `(-2) ^ 2 * (1/2) ^ 2` answers `1`. The pipeline folds between passes, so `1 * x`
collapses and the shape the second rule needs stops existing. What makes the cycle visible is
applying the set **alone**, which is what the transformation layer lets a caller do.

## Both known-lists assert in the other direction

A pinned loop that stops happening fails the test, so a fix deletes the entry rather than leaving a
loop written out that no longer occurs. `NumericNeat`'s entry is gone by exactly that route — the
#1167 fix made the test demand its deletion.

## Three recorded verdicts moved, each because the fix worked

- **`RuleSetTerminationTest`** listed `NumericNeat` among the sets that settle only once the
  normalisation runs between passes — and its remark named the reason exactly: *"rewrites `--x`
  through a product of ones that only collapses when the normalisation multiplies them out"*. That
  product of ones is the `1 *` this fix stops making. It settles alone now and has left the list.
- **`RulePriorityTest`** recorded two conflicts left to declaration order in `NumericNeat`, one of
  them the numerator-and-denominator pair itself. Both are gone.
- **That test's corpus had `-1` as its only negative leaf**, which is the one case these rules now
  exclude — so they matched nothing at all and the subsumption claims about them went unwitnessed.
  `-2` is a leaf now.

Measured four ways rather than assumed, because the count moved in a way that looks like lost
coverage and mostly is not:

| corpus | guard | witnessed |
|---|---|---|
| old leaves | off | 513 |
| old leaves | **on** | **489** |
| `-2` added | off | 501 |
| `-2` added | **on** | **501** |

With `-2` present the guard costs **nothing** — that is what says the leaf restores exactly what the
guard removed. The residual 513→501 is not coverage at all: `level3` samples every eleventh element
of `level2`, so a longer `level2` lands the sample on different expressions.

The corpus size is asserted alongside the witnessed count now. A coverage number means nothing
without what it was measured over, and both figures were prose in a remark that nothing held to
them.

## A note added to `InversePairTable.md`

That document is about why the inverse-pair table cannot be *derived*, from syntax or from
`MatchPattern`. There is a third source it did not consider: **run the sets and watch what comes
back**. It is a lower bound rather than an enumeration — a pair that never fires is invisible to it,
and a pair split across two sets never meets — but it needs no reversibility mechanism at all, and it
answers the question equality saturation actually asks, which is which rewrites undo each other *so
that it stops*.

## Checks

Full suite 9558 passed, 0 failed, 14 skipped — measured after rebasing onto #1170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
