### PR TITLE
A term subtracted from itself says what it assumes (#1169)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -115,6 +115,33 @@ read first.
 | | `"x^2/(x^2 + 2)^2".Integrate("x")`, and every polynomial numerator over one | `integral(x ^ 2 / (x ^ 2 + 2) ^ 2, x)` — left unevaluated, after 93 s | the antiderivative, in 0.57 s |
 | | `"1/(x^2 - 1)^2".Integrate("x")`, and every repeated quadratic whose roots are real | `C - ln(x + -1) / 4 + ln(1 + 2 * x + x ^ 2) / 8 + -1/2 * x / (x ^ 2 + -1)` | `C - ln(1 + (-2) / (x + 1)) / 4 + -1/2 * x / (x ^ 2 + -1)` — the same value, one logarithm rather than two |
 
+| **Silent** | `"1/x - 1/x".ToEntity().Simplify()`, and every difference of a term from itself where that term can be undefined | `0`, including at `x = 0` where neither side has a value | `0 provided not x = 0` |
+
+### A term subtracted from itself says what it assumes
+
+`k - k = 0` was declared `Sound`, which means it holds for every value the pattern admits with
+nothing assumed. It assumed one: that `k` has a value.
+
+```
+"1/x - 1/x".Simplify()          was  0                    is  0 provided not x = 0
+"ln(x) - ln(x)".Simplify()      was  0                    is  0 provided not x = 0
+"x^(-2) - x^(-2)".Simplify()    was  0                    is  0 provided not x = 0
+```
+
+At `x = 0` the left side is undefined and `0` is not, so the rewrite invented an answer. Its sibling
+for the same shape, `a / a = 1`, has always attached `provided a is not zero`; this one attached
+nothing ([#1169](https://github.com/asc-community/AngouriMath/issues/1169)).
+
+**Nothing else moves.** The condition is the operand's own `DomainCondition`, which is trivially
+true for anything that cannot be undefined and folds away — `x - x`, `sin(x) - sin(x)`,
+`(x + 1) - (x + 1)`, `x * y - x * y` and `sqrt(x) - sqrt(x)` all still answer a bare `0`, and
+`x - x + y` still answers `y`. Only the three shapes above gain a condition, and each of them is one
+that was wrong.
+
+Found by `RuleEffectsMeasuredTest.NoSoundRuleChangesWhereItsResultHasAValue`, which substitutes a
+real for every free variable — **zero among them** — and compares whether both sides still evaluate
+to something finite.
+
 ### A repeated quadratic denominator is integrated
 
 `1/(x^2 + 1)^2` had no antiderivative, while `1/(x^2 - 1)^2` and `1/(x^2 + 2x + 1)^2` both did — a

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -1490,7 +1490,7 @@ namespace AngouriMath.Core.Transformations.Matching
             new MatchedRule(
                 "a-term-subtracted-from-itself-vanishes",
                 MatchPattern.Node<Minusf>(MatchPattern.Any("k"), MatchPattern.Any("k")),
-                bound => Integer.Create(0),
+                bound => Integer.Create(0).Provided(bound["k"].DomainCondition),
                 Soundness.Sound,
                 description: "k - k = 0",
                 // Declared, because the replacement is code and nothing counts it: three nodes become one.
@@ -3371,7 +3371,7 @@ namespace AngouriMath.Core.Transformations.Matching
             new MatchedRule(
                 "a-term-subtracted-from-itself-vanishes",
                 MatchPattern.Node<Minusf>(MatchPattern.Any("a"), MatchPattern.Any("a")),
-                bound => Integer.Zero,
+                bound => Integer.Zero.Provided(bound["a"].DomainCondition),
                 Soundness.Sound,
                 description: "k - k = 0",
                 // Everything the pattern matched goes and one node arrives, and the operand was

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Common.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Common.cs
@@ -169,7 +169,7 @@ namespace AngouriMath.Functions
             Minusf(var any1, Mulf(var any2, var any1a)) when any1 == any1a => any1 * (1 - any2),
             Minusf(Mulf(var any1, var any2), var any1a) when any1 == any1a => any1 * (any2 - 1),
             Minusf(Mulf(var any2, var any1), var any1a) when any1 == any1a => any1 * (any2 - 1),
-            Minusf(var any1, var any1a) when any1 == any1a => 0,
+            Minusf(var any1, var any1a) when any1 == any1a => Integer.Create(0).Provided(any1.DomainCondition),
 
             // {1} / {2} + {1} * {3} = {1} * (1 / {2} + {3})
             Sumf(Divf(var any1, var any2), Mulf(var any1a, var any3)) when any1 == any1a => any1 * (1 / any2 + any3),

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.ExpandFactorize.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.ExpandFactorize.cs
@@ -57,7 +57,7 @@ namespace AngouriMath.Functions
             Minusf(var any1, Mulf(var any2, var any1a)) when any1 == any1a => any1 * (1 - any2),
             Minusf(Mulf(var any1, var any2), var any1a) when any1 == any1a => any1 * (any2 - 1),
             Minusf(Mulf(var any2, var any1), var any1a) when any1 == any1a => any1 * (any2 - 1),
-            Minusf(var any1, var any1a) when any1 == any1a => 0,
+            Minusf(var any1, var any1a) when any1 == any1a => Integer.Create(0).Provided(any1.DomainCondition),
 
             // a ^ b * c ^ b = (a * c) ^ b
             //

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleEffectsMeasuredTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleEffectsMeasuredTest.cs
@@ -201,12 +201,12 @@ namespace AngouriMath.Tests.Core.Transformations
                 }
             }
 
-            // Named rather than counted. `k - k = 0` is declared Sound and assumes k has a value:
-            // at x = 0, `x^(-2) - x^(-2)` is undefined and `0` is not. Its sibling for the same
-            // shape, `a / a = 1`, attaches `provided a is not zero` and this one attaches nothing.
-            // Fixing it should delete the entry rather than leave a name that means nothing.
+            // Empty, and it has been used. `k - k = 0` was declared Sound and assumed k has a
+            // value: at x = 0, `x^(-2) - x^(-2)` is undefined and `0` is not. It attaches the
+            // operand's own DomainCondition now, the way its sibling `a / a = 1` always has, and
+            // the entry that named it here is gone rather than left behind meaning nothing.
             // https://github.com/asc-community/AngouriMath/issues/1169
-            var known = new[] { "a-term-subtracted-from-itself-vanishes" };
+            var known = System.Array.Empty<string>();
 
             var offending = changed.Select(c => c.Split(':')[0]).Distinct().ToList();
             var unexpected = offending.Except(known).ToList();
@@ -216,7 +216,11 @@ namespace AngouriMath.Tests.Core.Transformations
                 + "value without attaching a condition:\n"
                 + string.Join("\n", changed.Where(c => unexpected.Contains(c.Split(':')[0])).Take(20)));
 
-            Assert.Equal(known, offending.Intersect(known).ToArray());
+            // The other direction, so a name here cannot outlive what it describes.
+            var gone = known.Except(offending).ToList();
+            Assert.True(gone.Count == 0,
+                $"{gone.Count} entries above no longer offend and should be deleted:\n"
+                + string.Join("\n", gone));
         }
 
         /// <summary>


### PR DESCRIPTION
`k - k = 0` was declared `Sound`, which means it holds for every value the pattern admits with
nothing assumed. It assumed one: that `k` has a value.

```
"1/x - 1/x".Simplify()          was  0     is  0 provided not x = 0
"ln(x) - ln(x)".Simplify()      was  0     is  0 provided not x = 0
"x^(-2) - x^(-2)".Simplify()    was  0     is  0 provided not x = 0
```

At `x = 0` the left side is undefined and `0` is not, so the rewrite invented an answer. Its sibling
for the same shape, `a / a = 1`, has always attached `provided a is not zero`; this one attached
nothing. Closes #1169.

## Why a condition rather than a re-tiering

The other available move was to drop the rule from `Sound` to `SoundUnderAssumptions`. That makes the
*label* true without making the *answer* true — `Simplify` would still hand back a bare `0`, and a
derivation would still report a step that invented a value. The condition is what the boolean rules
already do where they need it.

## Nothing else moves, and that was measured before choosing

The condition is the operand's own `DomainCondition`, which is trivially true for anything that
cannot be undefined and folds away:

```
x - x                 ->  0        (x + 1) - (x + 1)   ->  0
sin(x) - sin(x)       ->  0        x * y - x * y       ->  0
sqrt(x) - sqrt(x)     ->  0        x - x + y           ->  y
```

Only the three shapes at the top gain a condition, and each of those is a case that was wrong.

## Both spellings, and there were three of them

Twenty-seven of the thirty sets no longer run their `switch`, but the agreement tests still hold the
two forms to each other — so correcting the data form alone failed three tests. The same arm lives in
`Patterns.Common.cs` **and** in `Patterns.ExpandFactorize.cs`, because the rule appears in two sets.

## The check that found it now has nothing pinned

`RuleEffectsMeasuredTest.NoSoundRuleChangesWhereItsResultHasAValue` (#1170) carried this rule as its
one known exception, with a note saying a fix should delete the entry rather than leave a name that
means nothing. This deletes it, and the test asserts in that direction too — so the deletion is
required, not optional.

Two things had to be true before that check could bite, and neither was at first: the sample points
have to include **zero**, and "has a value" has to mean `Entity.Number { IsFinite: true }` rather
than `is Number`, because `NaN` **is** a `Number` and testing for one calls the undefined case
defined. It was validated by removing the `Provided` from `a / a = 1` and confirming the check then
fails.

## Checks

Full suite 9558 passed, 0 failed, 14 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
