### PR TITLE
A third level built with binary shapes finds 39 more arm orderings

### DIFF
--- a/Sources/Tests/UnitTests/Core/Transformations/RuleConfluenceTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleConfluenceTest.cs
@@ -53,7 +53,10 @@ namespace AngouriMath.Tests.Core.Transformations
     [Trait("Area", "Core")]
     public sealed class RuleConfluenceTest
     {
-        private static readonly string[] Leaves = { "x", "y", "2", "-1", "1/2", "0", "1", "3" };
+        // `-2` is here because `-1` is not enough of a negative: the four rules that take a
+        // negative factor out of a product decline a factor of -1 since #1167, so a corpus whose
+        // only negative is -1 cannot make them fire at all.
+        private static readonly string[] Leaves = { "x", "y", "2", "-1", "-2", "1/2", "0", "1", "3" };
 
         private static readonly string[] Unary =
         {
@@ -89,7 +92,13 @@ namespace AngouriMath.Tests.Core.Transformations
         {
             var level1 = new List<string>(Leaves);
             var level2 = Grow(level1, binary: true);
-            var level3 = Grow(level2.Where((_, i) => i % 11 == 0).ToList(), binary: false);
+            // `binary: true`, and that is the point of this line. A unary-only third level never
+            // builds a quotient of quotients or a product of quotients, which are exactly the
+            // shapes where two arms of one set both fire on one node — `RulePriorityTest`'s own
+            // remark measured the cost of the omission on its corpus, where growing the third
+            // level with binary shapes took the conflicts it could see from 3 to 45. This test is
+            // the one that remark names.
+            var level3 = Grow(level2.Where((_, i) => i % 11 == 0).ToList(), binary: true);
             var parsed = new List<Entity>();
             foreach (var source in level1.Concat(level2).Concat(level3))
             {
@@ -194,15 +203,92 @@ namespace AngouriMath.Tests.Core.Transformations
         {
             var conflicts = ConflictingPairs(out var examples);
 
+            // Forty-two, and it was three. The three were all this corpus could reach while its
+            // third level was unary: a quotient of quotients and a product of quotients are the
+            // shapes where two arms of one set both fire, and nothing built them. Each entry is
+            // an ordered pair `[first,second]` where `first` wins because it is written first,
+            // and the example beside it is a node they disagree on.
             var recorded = new[]
             {
-                // x * 1/2 -> 1/2 * x (the sort) rather than x / 2 (the quotient). Both settle to
-                // x / 2 once InnerSimplified has run.
+                // Four ways to collapse nested fractions, on `x / (1/2) * x / (1/2)` and
+                // `1 / 1 / (x / (1/2))`. Every arm is right; they differ in how far they go in
+                // one pass, and the normalisation settles them.
+                "CollapseMultipleFractions[product-of-two-quotients,product-with-a-quotient-on-the-left]",
+                "CollapseMultipleFractions[product-of-two-quotients,product-with-a-quotient-on-the-right]",
+                "CollapseMultipleFractions[product-with-a-quotient-on-the-right,product-with-a-quotient-on-the-left]",
+                "CollapseMultipleFractions[quotient-of-two-quotients,quotient-whose-denominator-is-a-quotient]",
+                "CollapseMultipleFractions[quotient-of-two-quotients,quotient-whose-numerator-is-a-quotient]",
+                "CollapseMultipleFractions[quotient-whose-numerator-is-a-quotient,quotient-whose-denominator-is-a-quotient]",
+
+                // `-x + -x`, which four arms all claim: collect the factor, read the negation as
+                // a subtraction, double the term, or add the numeric multiples. -> -(x + x),
+                // -x - x, 2 * -x, (-2) * x.
+                "Common[a-common-factor-of-two-added-products-comes-out,a-negated-term-in-a-sum-is-a-subtraction]",
+                "Common[a-common-factor-of-two-added-products-comes-out,a-term-added-to-itself-doubles]",
+                "Common[a-term-added-to-itself-doubles,a-negated-term-in-a-sum-is-a-subtraction]",
+                "Common[two-numeric-multiples-of-one-variable-add,a-common-factor-of-two-added-products-comes-out]",
+                "Common[two-numeric-multiples-of-one-variable-add,a-negated-term-in-a-sum-is-a-subtraction]",
+                "Common[two-numeric-multiples-of-one-variable-add,a-term-added-to-itself-doubles]",
+                // and `-x - -x`, the same disagreement subtracted: -(x - x) against 0.
+                "Common[a-common-factor-of-two-subtracted-products-comes-out,a-term-subtracted-from-itself-vanishes]",
+                "Common[two-numeric-multiples-of-one-variable-subtract,a-common-factor-of-two-subtracted-products-comes-out]",
+
+                // A negation in a sum beside a shared factor: `-x + x / (1/2)` -> x either way.
+                "Common[a-factor-shared-by-a-product-and-a-quotient-added-comes-out,a-negated-term-in-a-sum-is-a-subtraction]",
+                "Common[a-factor-shared-by-a-quotient-and-a-product-added-comes-out,a-negated-term-in-a-sum-is-a-subtraction]",
+
+                // The sort against the quotient: a number moved to the front rather than put
+                // under the line. `x * 1/2` -> 1/2 * x rather than x / 2, and both settle to
+                // x / 2 once InnerSimplified has run. Four spellings of one disagreement.
+                "Common[a-function-times-a-number-puts-the-number-first,a-reciprocal-rational-factor-is-a-division]",
+                "Common[a-quotient-times-a-thing-keeps-the-divisor-outermost,a-reciprocal-rational-factor-is-a-division]",
+                "Common[a-thing-times-a-quotient-keeps-the-divisor-outermost,a-reciprocal-rational-factor-is-a-division]",
                 "Common[a-variable-times-a-number-puts-the-number-first,a-reciprocal-rational-factor-is-a-division]",
+                "Common[two-numbers-around-a-factor-collect,a-reciprocal-rational-factor-is-a-division]",
+                "Common[two-numeric-factors-around-a-variable-collect,a-reciprocal-rational-factor-is-a-division]",
+
+                // `x / (1/2) * x / (1/2)`: collapse the two quotients, keep a divisor outermost,
+                // or see a thing times itself. -> x ^ 2 / (1/4), x * x / (1/2) / (1/2),
+                // (x / (1/2)) ^ 2.
+                "Common[a-product-of-two-quotients-is-one-quotient,a-quotient-times-a-thing-keeps-the-divisor-outermost]",
+                "Common[a-product-of-two-quotients-is-one-quotient,a-thing-times-a-quotient-keeps-the-divisor-outermost]",
+                "Common[a-product-of-two-quotients-is-one-quotient,a-thing-times-itself-is-its-square]",
+                "Common[a-quotient-times-a-thing-keeps-the-divisor-outermost,a-thing-times-a-quotient-keeps-the-divisor-outermost]",
+                "Common[a-quotient-times-a-thing-keeps-the-divisor-outermost,a-thing-times-itself-is-its-square]",
+                "Common[a-thing-times-a-quotient-keeps-the-divisor-outermost,a-thing-times-itself-is-its-square]",
+
+                // `-x / (-x)`: the same 1, with the condition written about -x or about x.
+                "Common[a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero,a-shared-factor-cancels-between-two-products]",
+                // `x / (1/2) / (x / (1/2))` and `1 / 1 / (x / (1/2))`: cancel the whole quotient
+                // at once, or take one division apart first.
+                "Common[dividing-by-a-quotient-multiplies-by-its-reciprocal,a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero]",
+                "Common[dividing-by-a-quotient-multiplies-by-its-reciprocal,dividing-twice-divides-by-the-product]",
+                "Common[dividing-twice-divides-by-the-product,a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero]",
+
+                // `(-1) / x * 1 / 1` -> (-1) / x against -1 / x, which print apart and are one
+                // expression.
+                "DivisionPreparing[reciprocal-factor-becomes-a-quotient,numeric-numerator-out-of-a-product]",
+
+                // Factorization repeats Common's `-x + -x` and `-x - -x` disagreement, and adds
+                // `x + 0 + x + 0` -> 2 * x against x * 2.
+                "Factorization[a-factor-shared-by-two-added-products-comes-out,a-term-added-to-itself-doubles]",
+                "Factorization[a-factor-shared-by-two-subtracted-products-comes-out,a-term-subtracted-from-itself-vanishes]",
+                "Factorization[a-term-added-to-itself-doubles,a-common-factor-is-collected-out-of-a-whole-sum]",
+
                 // (-x) ^ (-1) -> -1 / x rather than 1 / (-x).
                 "Power[a-numeric-factor-comes-out-of-a-power-of-a-product,a-reciprocal-power-is-a-quotient]",
                 // (e ^ y) ^ (-1) -> e ^ (y * (-1)) rather than 1 / e ^ y.
                 "Power[a-power-of-a-power-multiplies-the-exponents,a-reciprocal-power-is-a-quotient]",
+                // `x ^ (-1) / x ^ (-1)`: cancel the quotient, subtract the exponents, or share
+                // the exponent over a quotient of bases. The three answers carry three different
+                // conditions, which is what
+                // <a href="https://github.com/asc-community/AngouriMath/issues/1174">#1174</a> is
+                // about -- `1 provided not 1 / x = 0` excludes nothing at x = 0.
+                "Power[a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero,two-powers-of-one-base-divide-by-subtracting-exponents]",
+                "Power[a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero,two-powers-of-one-exponent-share-a-quotient-of-bases]",
+                "Power[two-powers-of-one-base-divide-by-subtracting-exponents,two-powers-of-one-exponent-share-a-quotient-of-bases]",
+                // `e ^ 3 * e ^ 3` -> e ^ 6 against (e ^ 2) ^ 3. The inverse pair of #1171.
+                "Power[two-powers-of-one-base-multiply-by-adding-exponents,two-powers-of-one-exponent-share-a-base]",
             };
 
             Assert.Equal(

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleConfluenceTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleConfluenceTest.cs
@@ -39,13 +39,18 @@ namespace AngouriMath.Tests.Core.Transformations
     /// nothing either way, and are not recorded as agreeing.
     /// </para>
     /// <para>
-    /// <b>And a shallower sample than it reads as.</b> The third level below is grown with unary
-    /// shapes only, so this corpus never builds a quotient of quotients or a product of quotients —
-    /// which is where a special rule and the general rule that would swallow it meet.
-    /// <c>RulePriorityTest</c> asks the same question of the same rules written as data, over a
-    /// corpus grown with binary shapes at every level, and finds <b>45</b> conflicts where this
-    /// finds three. It also names them as the rules they are between rather than as the indices
-    /// below, which is what the note on
+    /// <b>It used to be a shallower sample than it read as.</b> The third level was grown with
+    /// unary shapes only, so this corpus never built a quotient of quotients or a product of
+    /// quotients — which is where a special rule and the general rule that would swallow it meet.
+    /// This paragraph said so, and said that <c>RulePriorityTest</c> finds <b>45</b> conflicts over
+    /// a corpus grown with binary shapes at every level where this finds three. Growing this one
+    /// the same way takes it from three to <b>42</b>. The sentence was right and sat here being
+    /// right for as long as it took somebody to act on it.
+    /// </para>
+    /// <para>
+    /// Still a sample. What is fixed is that it is no longer a sample of only the shapes one
+    /// unary can build. <c>RulePriorityTest</c> also names its conflicts as the rules they are
+    /// between rather than as the indices below, which is what the note on
     /// <see cref="AConflictIsReportableAsThePatternsItIsBetween"/> asks for; a data rule has a name
     /// and a <c>switch</c> arm does not.
     /// </para>

--- a/Sources/Tests/UnitTests/Core/Transformations/RulePriorityTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RulePriorityTest.cs
@@ -79,12 +79,13 @@ namespace AngouriMath.Tests.Core.Transformations
         /// which is the difference that matters here.
         /// </summary>
         /// <remarks>
-        /// <see cref="RuleConfluenceTest"/> grows its third level with unary shapes only, so it
-        /// never builds a quotient of quotients or a product of quotients — and those are exactly
-        /// the shapes where a specific rule and the general rule that would swallow it both fire.
-        /// On that corpus <b>none</b> of the subsumption-ordered pairs below overlaps at all.
-        /// Growing the third level with binary shapes too finds six of them, and takes the
-        /// conflicts this sees from 3 to 45.
+        /// A third level grown with unary shapes only never builds a quotient of quotients or a
+        /// product of quotients — and those are exactly the shapes where a specific rule and the
+        /// general rule that would swallow it both fire. On such a corpus <b>none</b> of the
+        /// subsumption-ordered pairs below overlaps at all. Growing the third level with binary
+        /// shapes too finds six of them, and takes the conflicts this sees from 3 to 45.
+        /// <see cref="RuleConfluenceTest"/> was the standing example of the omission and is not
+        /// any more: grown the same way, its recorded arm orderings went from 3 to 42.
         /// </remarks>
         private static List<Entity> Expressions()
         {

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleSetTerminationTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleSetTerminationTest.cs
@@ -65,7 +65,10 @@ namespace AngouriMath.Tests.Core.Transformations
         /// </remarks>
         private static readonly HashSet<string> SettleOnlyComposed = new() { "Power" };
 
-        private static readonly string[] Leaves = { "x", "y", "2", "-1", "1/2", "1", "0" };
+        // `-2` is here because `-1` is not enough of a negative: the four rules that take a
+        // negative factor out of a product decline a factor of -1 since #1167, so a corpus whose
+        // only negative is -1 cannot make them fire at all.
+        private static readonly string[] Leaves = { "x", "y", "2", "-1", "-2", "1/2", "1", "0" };
 
         private static readonly string[] Unary =
         {
@@ -104,6 +107,16 @@ namespace AngouriMath.Tests.Core.Transformations
                 foreach (var inner in level2)
                     level3.Add(string.Format(shape, inner));
 
+            // And binary at the third level too, sampled, because a unary-only third level never
+            // builds a quotient of quotients or a product of quotients -- the shapes where two
+            // rules of one set both fire on one node. `RulePriorityTest` measured what that
+            // costs on its own corpus: growing the third level with binary shapes took the
+            // conflicts it can see from 3 to 45. This corpus had the same blind spot.
+            foreach (var shape in Binary)
+                foreach (var left in level2.Where((_, i) => i % 17 == 0))
+                    foreach (var right in level2.Where((_, i) => i % 23 == 0))
+                        level3.Add(string.Format(shape, left, right));
+
             var parsed = new List<Entity>();
             foreach (var source in level1.Concat(level2).Concat(level3))
             {
@@ -112,6 +125,16 @@ namespace AngouriMath.Tests.Core.Transformations
             }
             return parsed;
         }
+
+        /// <summary>
+        /// The corpus is the whole strength of the two checks below, and neither of them fails
+        /// when it shrinks — a smaller corpus makes them pass sooner, which is the failure mode a
+        /// coverage number exists to stop. <b>4344</b> inputs, of which <b>1760</b> are the binary
+        /// third level (5 shapes over 22 sampled left operands and 16 sampled right ones).
+        /// </summary>
+        [Fact]
+        public void TheCorpusIsTheSizeTheseChecksWereMeasuredOn() =>
+            Assert.Equal(4344, Inputs.Count);
 
         private static bool Terminates(RewriteRuleSet set, Entity from, bool normalise, out Entity stuck)
         {


### PR DESCRIPTION
`RuleConfluenceTest` grew its third level with **unary shapes only**, so it never built a quotient of
quotients or a product of quotients — and those are exactly the shapes where two arms of one set both
fire on one node. Its recorded list of load-bearing arm orderings read as **three**. It is **forty-two**.

The omission was already measured and written down, in `RulePriorityTest`'s own remark:

> `RuleConfluenceTest` grows its third level with unary shapes only, so it never builds a quotient of
> quotients or a product of quotients — and those are exactly the shapes where a specific rule and the
> general rule that would swallow it both fire. On that corpus **none** of the subsumption-ordered
> pairs below overlaps at all. Growing the third level with binary shapes too finds six of them, and
> takes the conflicts this sees from 3 to 45.

That remark names this test as the one with the blind spot. This is that sentence acted on.

## What the forty-two are

Not rules being wrong. An arm ordering is load-bearing when two **correct** arms answer one node
differently and the order they are written in decides which answer a reader gets. Most of the
forty-two are one disagreement written several ways:

- four arms all claim `-x + -x` — `-(x + x)`, `-x - x`, `2 * -x`, `(-2) * x`
- six spellings of the sort against the quotient — `x * 1/2` → `1/2 * x` rather than `x / 2`
- six ways to collapse `x / (1/2) * x / (1/2)`
- six ways to collapse nested fractions in `CollapseMultipleFractions`

Each is recorded with an example beside it rather than as a count.

## One of them is not benign

`x ^ (-1) / x ^ (-1)` reaches three arms that answer it with three different **conditions**, and
`1 provided not 1 / x = 0` excludes nothing at `x = 0`.

Chasing that found **#1174**, filed rather than fixed here: `a / a = 1` attaches `provided a is not
zero`, which excludes the zero of `a` and not the points where `a` has no value.

```
"ln(x) / ln(x)".Simplify()  ->  1 provided not ln(x) = 0     at x = 0: was NaN, is 1
```

Measured, not inferred — including *why* only some operands slip through: `ln(0)` is `-oo` rather than
`NaN`, so `-oo = 0` is a definite `false` and the condition holds. Where the operand goes to `NaN`
instead (`tan(x) / tan(x)` at `pi/2`) the comparison is poisoned and the answer stays undefined. It is
the same defect #1169 was in the sibling rule, and #1174 also names why the check that found #1169
could not find this one.

## `RuleSetTerminationTest`, and a negative result worth having

It had the same unary-only third level and gets the same treatment. It finds **no new
non-terminating set** — a result rather than a non-event, because the corpus is now asserted: 4344
inputs, 1760 of them the binary third level. Nothing failed when that corpus shrank before, since a
smaller corpus makes these checks pass sooner, which is the failure mode a coverage number exists to
stop.

## `-2` is a leaf in both now

`-1` was the only negative in either corpus, and since #1167 the four rules that take a negative
factor out of a product decline a factor of `-1`. A corpus whose only negative is the one case a rule
excludes cannot make that rule fire at all.

## Checks

Full suite 9559 passed, 0 failed, 14 skipped.

Part of #825.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
