### PR TITLE
A cancelled quotient says its operand is defined, not only non-zero (#1174)

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -117,6 +117,33 @@ read first.
 
 | **Silent** | `"1/x - 1/x".ToEntity().Simplify()`, and every difference of a term from itself where that term can be undefined | `0`, including at `x = 0` where neither side has a value | `0 provided not x = 0` |
 
+| **Silent** | `"(x + 1)!/(x + 1)!".ToEntity().Simplify()`, and every cancelled quotient whose repeated part can be undefined | `1 provided not (1 + x)! = 0` | `1 provided 1 + x in RR and (1 + x >= 0 or not 1 + x in ZZ)` — the same value everywhere, a condition that says why |
+
+### A cancelled quotient says its operand is defined, not only non-zero
+
+`a / a = 1` and `(keep * c) / c = keep` attached `provided c is not zero`. That excludes the zero of
+`c` and not the points where `c` has **no value at all**, and where `c` has none the quotient has none
+either — while the cancelled result does.
+
+```
+"ln(x) / ln(x)".Simplify()   was  1 provided not ln(x) = 0    at x = 0: 1, and the quotient is NaN
+```
+
+Both now conjoin the operand's own `DomainCondition`, the way `k - k = 0` does since
+[#1169](https://github.com/asc-community/AngouriMath/issues/1169).
+[#1174](https://github.com/asc-community/AngouriMath/issues/1174)
+
+**Only one shape's printed answer moves, and its value does not.** `(x + 1)!/(x + 1)!` carries the
+factorial's domain instead of `not (1 + x)! = 0`. Measured at x = -4, -3, -2, -1, 0, 2 and -3/2, the
+old condition and the new one agree with the unsimplified quotient at every point — `NaN` at the
+three gamma poles and `1` elsewhere. The old form was adequate there by accident, since `(1 + x)!` is
+`NaN` at a pole and a comparison against `NaN` is not `True`; the new one states the reason rather
+than relying on it. `x / x`, `sin(x) / sin(x)`, `(x * y) / (x * y)` and every other operand that
+cannot be undefined fold the added clause away and are unchanged.
+
+**`ln(x) / ln(x)` itself still answers `1`**, from a candidate `PolynomialLongDivision` produces
+rather than from either of these rules, and #1174 stays open for it.
+
 ### A term subtracted from itself says what it assumes
 
 `k - k = 0` was declared `Sound`, which means it holds for every value the pattern admits with

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -2720,9 +2720,11 @@ namespace AngouriMath.Core.Transformations.Matching
             new MatchedRule(
                 "a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero",
                 MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("a")),
-                bound => new Providedf(1, !bound["a"].EqualTo(0)),
+                // Two assumptions, not one: that a is not zero, and that a has a value at all.
+                // https://github.com/asc-community/AngouriMath/issues/1174
+                bound => new Providedf(1, !bound["a"].EqualTo(0) & bound["a"].DomainCondition),
                 Soundness.SoundUnderAssumptions,
-                description: "a / a = 1, provided a is not zero"),
+                description: "a / a = 1, provided a is not zero and is defined"),
 
             new MatchedRule(
                 "a-power-whose-exponent-divides-by-a-logarithm-of-its-own-base-changes-base",
@@ -3444,15 +3446,21 @@ namespace AngouriMath.Core.Transformations.Matching
             new MatchedRule(
                 "a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero",
                 MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("a")),
-                bound => Integer.One.Provided(!bound["a"].EqualTo(Integer.Zero)),
+                // Two assumptions, not one: that a is not zero, and that a has a value at all.
+                // https://github.com/asc-community/AngouriMath/issues/1174
+                bound => Integer.One.Provided(
+                    !bound["a"].EqualTo(Integer.Zero) & bound["a"].DomainCondition),
                 Soundness.SoundUnderAssumptions,
-                description: "a / a = 1, provided a is not zero"),
+                description: "a / a = 1, provided a is not zero and is defined"),
             new MatchedRule(
                 "a-shared-factor-cancels-out-of-a-quotient",
                 MatchPattern.Node<Divf>(MatchPattern.Commutative<Mulf>(MatchPattern.Any("keep"), MatchPattern.Any("c")), MatchPattern.Any("c")),
-                bound => bound["keep"].Provided(!bound["c"].EqualTo(Integer.Zero)),
+                // Two assumptions, not one: that c is not zero, and that c has a value at all.
+                // https://github.com/asc-community/AngouriMath/issues/1174
+                bound => bound["keep"].Provided(
+                    !bound["c"].EqualTo(Integer.Zero) & bound["c"].DomainCondition),
                 Soundness.SoundUnderAssumptions,
-                description: "(keep * c) / c = keep, provided c is not zero"),
+                description: "(keep * c) / c = keep, provided c is not zero and is defined"),
             new MatchedRule(
                 "a-shared-factor-cancels-between-two-products",
                 MatchPattern.Node<Divf>(MatchPattern.Commutative<Mulf>(MatchPattern.Any("num"), MatchPattern.Any("c")), MatchPattern.Commutative<Mulf>(MatchPattern.Any("c"), MatchPattern.Any("den"))),

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Common.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Common.cs
@@ -210,12 +210,19 @@ namespace AngouriMath.Functions
             Mulf(Sumf(Variable var1, var any1), Minusf(Variable var1a, var any1a))
                 when (var1, any1) == (var1a, any1a) => new Powf(var1, 2) - new Powf(any1, 2),
 
-            // a / a
-            Divf(var any1, var any1a) when any1 == any1a => Integer.One.Provided(!any1.EqualTo(Integer.Zero)),
+            // a / a. Two assumptions, not one: that a is not zero, and that a has a value at all.
+            // `ln(x) / ln(x)` is undefined at x = 0 and `1` is not, and `not ln(x) = 0` does not
+            // exclude it -- ln(0) is -oo, so the comparison is a definite false and the condition
+            // holds. https://github.com/asc-community/AngouriMath/issues/1174
+            Divf(var any1, var any1a) when any1 == any1a =>
+                Integer.One.Provided(!any1.EqualTo(Integer.Zero) & any1.DomainCondition),
 
-            // (a * c) / c
-            Divf(Mulf(var any1, var any2), var any2a) when any2 == any2a => any1.Provided(!any2.EqualTo(Integer.Zero)),
-            Divf(Mulf(var any2, var any1), var any2a) when any2 == any2a => any1.Provided(!any2.EqualTo(Integer.Zero)),
+            // (a * c) / c. Two assumptions, not one: that c is not zero, and that c has a value
+            // at all. https://github.com/asc-community/AngouriMath/issues/1174
+            Divf(Mulf(var any1, var any2), var any2a) when any2 == any2a =>
+                any1.Provided(!any2.EqualTo(Integer.Zero) & any2.DomainCondition),
+            Divf(Mulf(var any2, var any1), var any2a) when any2 == any2a =>
+                any1.Provided(!any2.EqualTo(Integer.Zero) & any2.DomainCondition),
             Divf(Mulf(var any1, var any2), Mulf(var any2a, var any3)) when any2 == any2a => (any1 / any3).Provided(!any2.EqualTo(Integer.Zero)),
             Divf(Mulf(var any1, var any2), Mulf(var any3, var any2a)) when any2 == any2a => (any1 / any3).Provided(!any2.EqualTo(Integer.Zero)),
             Divf(Mulf(var any2, var any1), Mulf(var any2a, var any3)) when any2 == any2a => (any1 / any3).Provided(!any2.EqualTo(Integer.Zero)),

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Power.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Power.cs
@@ -46,7 +46,10 @@ namespace AngouriMath.Functions
         internal static Entity PowerRules(Entity x) => x switch
         {
             // {} / {} = 1 provided not {} = 0
-            Divf(var any1, var any1a) when any1 == any1a => new Providedf(1, !any1.EqualTo(0)),
+            // Two assumptions, not one: that a is not zero, and that a has a value at all.
+            // https://github.com/asc-community/AngouriMath/issues/1174
+            Divf(var any1, var any1a) when any1 == any1a =>
+                new Providedf(1, !any1.EqualTo(0) & any1.DomainCondition),
 
             // {1}^({2} / log({3}, {1})) = {3}^{2}
             Powf(var any1, Divf(var any2, Logf(var any3, var any1a))) when any1 == any1a => new Powf(any3, any2),

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleEffectsMeasuredTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleEffectsMeasuredTest.cs
@@ -87,8 +87,26 @@ namespace AngouriMath.Tests.Core.Transformations
                     foreach (var right in level2.Where((_, i) => i % 23 == 0))
                         level3.Add(string.Format(shape, left, right));
 
+            // A rule about `a op a` needs a corpus of `a op a`. `a / a = 1` and `k - k = 0` are
+            // the two rules this check exists for, and what makes either wrong is an operand that
+            // is undefined somewhere -- so the operand has to be something that can be. The
+            // corpus had `ln(x)` and never `ln(x) / ln(x)`, which is why removing the blanket
+            // exemption for a Providedf reported nothing until this went in.
+            // https://github.com/asc-community/AngouriMath/issues/1174
+            // The cancellations too, not only `a op a`: `(y * c) / c` is `y` provided c is not
+            // zero, and that condition has the same hole in it as `c / c` did.
+            var repeated = new List<string>();
+            foreach (var shape in Leaves.Concat(Unary.Select(u => string.Format(u, "x"))).Concat(Reached))
+                foreach (var op in new[]
+                {
+                    "({0}) / ({0})", "({0}) - ({0})",
+                    "(y * ({0})) / ({0})", "(({0}) * y) / ({0})",
+                    "(y * ({0})) / (({0}) * z)", "(({0}) * y) / (z * ({0}))",
+                })
+                    repeated.Add(string.Format(op, shape));
+
             var parsed = new List<Entity>();
-            foreach (var source in level1.Concat(level2).Concat(level3).Concat(Reached))
+            foreach (var source in level1.Concat(level2).Concat(level3).Concat(Reached).Concat(repeated))
             {
                 try { parsed.Add(source.ToEntity()); }
                 catch { /* the generator makes some strings the parser declines */ }
@@ -179,7 +197,9 @@ namespace AngouriMath.Tests.Core.Transformations
                 if (rule.Soundness is not Soundness.Sound) continue;
                 foreach (var (before, after) in firings)
                 {
-                    // A rule whose replacement attaches a condition is declaring the change.
+                    // A rule whose replacement attaches a condition is declaring the change, and
+                    // whether the condition is strong enough is asked separately by
+                    // ARuleThatAttachesAConditionAttachesASufficientOne.
                     if (after.Nodes.Any(n => n is Entity.Providedf)) continue;
 
                     // Arithmetic only. Substituting a real into a boolean or a set is a category
@@ -221,6 +241,95 @@ namespace AngouriMath.Tests.Core.Transformations
             Assert.True(gone.Count == 0,
                 $"{gone.Count} entries above no longer offend and should be deleted:\n"
                 + string.Join("\n", gone));
+        }
+
+        /// <summary>
+        /// <b>A condition is a claim, and this is the claim checked.</b> A rule that attaches a
+        /// <c>Provided</c> is asserting that what it excludes is <i>enough</i> — that wherever the
+        /// condition holds, the rewrite is right. Asked of every rule that attaches one, at any
+        /// tier, because attaching a condition is what states an assumption rather than leaving it
+        /// unstated.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Why this is not the check above with an exemption removed.</b> That one is asked
+        /// only of <see cref="Soundness.Sound"/> rules, and the rule this was written for —
+        /// <c>a / a = 1</c> — is <see cref="Soundness.SoundUnderAssumptions"/>, so removing the
+        /// exemption reported nothing. The tier is carrying two meanings: <i>assumes something it
+        /// never states</i>, which nothing can check, and <i>states its assumption as a
+        /// condition</i>, which is exactly this. The two need separate questions.
+        /// </para>
+        /// <para>
+        /// The condition is honoured for free rather than interpreted: a <c>Providedf</c> whose
+        /// condition is false evaluates to <c>NaN</c>, so asking whether the whole replacement has
+        /// a value at a point already accounts for it. What is left over is a replacement that has
+        /// a value where the original had none — the condition admitting a point it should have
+        /// excluded.
+        /// </para>
+        /// </remarks>
+        [Fact]
+        public void ARuleThatAttachesAConditionAttachesASufficientOne()
+        {
+            var insufficient = new List<string>();
+
+            foreach (var (rule, firings) in Firings())
+                foreach (var (before, after) in firings)
+                {
+                    if (!after.Nodes.Any(n => n is Entity.Providedf)) continue;
+                    // Asked of `before` only. A Providedf's condition *is* a Statement, so
+                    // `IsArithmetic(after)` is false for every rule that attaches one -- the guard
+                    // that keeps booleans out of the check above excludes exactly the population
+                    // this one is about. `after` needs no guard: HasValueAt answers false for
+                    // anything that does not evaluate to a finite number, which is the direction
+                    // this skips anyway.
+                    if (IsArithmetic(before) is false) continue;
+
+                    foreach (var point in CheckPoints)
+                    {
+                        var had = HasValueAt(before, point);
+                        var has = HasValueAt(after, point);
+                        if (had is null || has is null) continue;
+                        // Only the direction that invents an answer. A condition that excludes
+                        // more than it needs to loses a rewrite; one that excludes less states
+                        // something untrue.
+                        if (had is true || has is false) continue;
+                        insufficient.Add($"{rule.Name}: {before.Stringize()} -> {after.Stringize()} "
+                                         + $"at {point.Stringize()}: had no value, has one");
+                        break;
+                    }
+                }
+
+            // Named rather than counted. `a / a = 1` attaches `provided a is not zero`, which
+            // excludes the zero of a and not the points where a has no value at all -- so
+            // `ln(x) / ln(x)` answers 1 at x = 0, where `ln(0)` is -oo, `-oo = 0` is a definite
+            // false, and the condition holds. Fixing it should delete the entry rather than leave
+            // a name that means nothing.
+            // https://github.com/asc-community/AngouriMath/issues/1174
+            // Empty, and it has been used. `a / a = 1` attached `provided a is not zero`, which
+            // excludes the zero of a and not the points where a has no value at all -- so
+            // `ln(x) / ln(x)` answered 1 at x = 0, where `ln(0)` is -oo, `-oo = 0` is a definite
+            // false, and the condition held. It attaches `a`'s DomainCondition as well now.
+            //
+            // `a-quotient-of-symbolic-parts-is-grouped-pairwise` was a second entry here and went
+            // with the same change rather than needing one of its own: it computes its answer
+            // through `PairwiseGroupedQuotient`, which puts each grouped factor through the Power
+            // switch, and the `a / a` arm of that switch is one of the three spellings corrected.
+            // https://github.com/asc-community/AngouriMath/issues/1174
+            var known = System.Array.Empty<string>();
+
+            var offending = insufficient.Select(c => c.Split(':')[0]).Distinct().ToList();
+            var unexpected = offending.Except(known).ToList();
+
+            Assert.True(unexpected.Count == 0,
+                $"{unexpected.Count} rules attach a condition that admits a point where the "
+                + "original has no value and the replacement does:\n"
+                + string.Join("\n", insufficient.Where(c => unexpected.Contains(c.Split(':')[0])).Take(20)));
+
+            // The other direction, so a name here cannot outlive what it describes.
+            var gone = known.Except(offending).ToList();
+            Assert.True(gone.Count == 0,
+                $"{gone.Count} entries above now attach a sufficient condition and should be "
+                + "deleted:\n" + string.Join("\n", gone));
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/PatternsTest/SimplifyTest.cs
+++ b/Sources/Tests/UnitTests/PatternsTest/SimplifyTest.cs
@@ -80,7 +80,14 @@ namespace AngouriMath.Tests.PatternsTest
         // discharges itself. Checked at x = 3, 0, -1 and -2: the new form agrees with the
         // original at all four, where `1` disagreed at every pole.
         // https://github.com/asc-community/AngouriMath/issues/1081
-        [Fact] public void FactorialXP1OverFactorialXP1() => AssertSimplify(MathS.Factorial(x + 1) / MathS.Factorial(x + 1), "1 provided not (1 + x)! = 0");
+        // And the condition is now the factorial's own domain rather than `a != 0`, because
+        // `a / a = 1` conjoins the operand's DomainCondition since
+        // https://github.com/asc-community/AngouriMath/issues/1174. The value does not move:
+        // measured at x = -4, -3, -2, -1, 0, 2 and -3/2, the old condition and the new one agree
+        // with the unsimplified quotient at every one -- NaN at the three poles and 1 elsewhere.
+        // The old form was adequate here by accident, since `(1 + x)!` is NaN at a pole and a
+        // comparison against NaN is not True; the new one says so rather than relying on it.
+        [Fact] public void FactorialXP1OverFactorialXP1() => AssertSimplify(MathS.Factorial(x + 1) / MathS.Factorial(x + 1), "1 provided 1 + x in RR and (1 + x >= 0 or not 1 + x in ZZ)");
         [Fact] public void FactorialXP1OverFactorialX() => AssertSimplify(MathS.Factorial(1 + x) / MathS.Factorial(x), 1 + x);
         [Fact] public void FactorialXP1OverFactorialXM2() => AssertSimplify(MathS.Factorial(1 + x) / MathS.Factorial(-2 + x), "x3 - x");
         [Fact] public void FactorialXP1OverFactorialXM1() => AssertSimplify(MathS.Factorial(1 + x) / MathS.Factorial(-1 + x), x * (1 + x));
@@ -92,7 +99,9 @@ namespace AngouriMath.Tests.PatternsTest
         [Fact] public void FactorialXOverFactorialXM3() => AssertSimplifyIdentical(MathS.Factorial(x) / MathS.Factorial(x - 3));
         [Fact] public void FactorialXM1OverFactorialXP1() => AssertSimplify(MathS.Factorial(x - 1) / MathS.Factorial(x + 1), 1 / (x * (x + 1)));
         [Fact] public void FactorialXM1OverFactorialX() => AssertSimplify(MathS.Factorial(-1 + x) / MathS.Factorial(x), 1 / x);
-        [Fact] public void FactorialXM1OverFactorialXM1() => AssertSimplify(MathS.Factorial(x - 1) / MathS.Factorial(x - 1), "1 provided not (-1 + x)! = 0");
+        // The domain condition, as above. `FactorialXOverFactorialX` keeps the older form and is
+        // not a inconsistency to fix here: a bare `x!` reaches this through a different candidate.
+        [Fact] public void FactorialXM1OverFactorialXM1() => AssertSimplify(MathS.Factorial(x - 1) / MathS.Factorial(x - 1), "1 provided x - 1 in RR and (x - 1 >= 0 or not x - 1 in ZZ)");
         [Fact] public void FactorialXM1OverFactorialXM2() => AssertSimplify(MathS.Factorial(-1 + x) / MathS.Factorial(-2 + x), x - 1);
         // Same two factors, now in ascending order: the polynomial factorer offers
         // (x - 1) * (x - 2) and the complexity metric cannot tell the two orders apart.


### PR DESCRIPTION
`a / a = 1` and `(keep * c) / c = keep` attached `provided c is not zero`. That excludes the zero of
`c` and not the points where `c` has **no value at all** — and where `c` has none, the quotient has
none either, while the cancelled result does.

```
"ln(x) / ln(x)".Simplify()   was  1 provided not ln(x) = 0    at x = 0: 1, and the quotient is NaN
```

Both conjoin the operand's own `DomainCondition` now, the way `k - k = 0` does since #1169.
**Part of #1174, which stays open** — see the last section.

## Seven sites for two rules

`a / a` is written four times — twice as data in `MatchedRules` and once each in the `Common` and
`Power` switches — and `(keep * c) / c` three. The `Power` switch spelling is the one that mattered
most and was the least obvious: `PairwiseGroupedQuotient` puts every grouped factor through
`PowerRules`, so `a-quotient-of-symbolic-parts-is-grouped-pairwise` was reported as a second offender
and needed no change of its own once that arm was corrected.

## The check is the durable half

`ARuleThatAttachesAConditionAttachesASufficientOne` asks every rule that attaches a condition whether
the condition is **enough** — at any tier, because attaching one is what states an assumption rather
than leaving it unstated. Its known-list is empty and asserted in both directions.

**It is not the definedness check above it with an exemption removed**, and that was measured rather
than assumed:

- Removing the `Providedf` exemption from `NoSoundRuleChangesWhereItsResultHasAValue` reported
  nothing, because that check asks only `Sound` rules and `a / a = 1` is `SoundUnderAssumptions`. The
  tier carries two meanings — *assumes something it never states*, which nothing can check, and
  *states its assumption as a condition*, which is exactly checkable — and they need separate
  questions.
- The corpus needed `f(x) / f(x)` and `(y * c) / c` shapes. It had `ln(x)` and never `ln(x) / ln(x)`.
- The guard that keeps booleans out of the older check excludes **every** conditioned rule, since a
  `Providedf`'s condition is a `Statement`. Copying it into the new check made it vacuous, and the
  fix is to ask it of the original only.

Adding the `(y * c) / c` shapes is what reported `a-shared-factor-cancels-out-of-a-quotient` — the
second family, which reading had not found.

## One printed answer moves and no value does

`(x + 1)!/(x + 1)!` carries the factorial's domain instead of `not (1 + x)! = 0`. Measured at
x = -4, -3, -2, -1, 0, 2 and -3/2: the old condition and the new one agree with the unsimplified
quotient at **every** point — `NaN` at the three gamma poles and `1` elsewhere. The old form was
adequate there by accident, since `(1 + x)!` is `NaN` at a pole and a comparison against `NaN` is not
`True`; the new one states the reason rather than relying on it.

Every other operand that cannot be undefined folds the added clause away: `x / x`, `sin(x) / sin(x)`,
`(x * y) / (x * y)`, `(2 * x) / x`, `x^2 / x` are all unchanged. Recorded in `BREAKING-CHANGES.md`.

## What is still wrong, and why it is not in this PR

`ln(x) / ln(x)` still answers `1`. Every registered set now yields the sufficient condition:

```
Common / Power / CommonDenominator (+2 variants)  ->  1 provided not ln(x) = 0 and not x = 0
PolynomialLongDivision                            ->  0 + 1 + 0 / ln(x)
```

That last folds to `1 provided not ln(x) = 0` — the condition arriving from `Divf`'s own `0 / n`
inner-simplify rule, not from any cancellation rule — and `Simplify` rates it best. The division
claimed quotient 1 and remainder 0 without carrying that the divisor has to be defined. That is a
different mechanism in a different place, so #1174 stays open for it rather than being closed here.

`ln(x * y) / ln(x * y)`, which that set does not rewrite, is already correct end to end.

## Checks

Full suite 9560 passed, 0 failed, 14 skipped — measured after rebasing onto #1175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
