### PR TITLE
Name the rule that fires, not the one with the right shape (#1171)

### DIFF
--- a/Sources/AngouriMath/Docs/Contributing/InversePairTable.md
+++ b/Sources/AngouriMath/Docs/Contributing/InversePairTable.md
@@ -111,8 +111,16 @@ Power: (-2) ^ 2 * (1/2) ^ 2   ->  ((-2) * 1/2) ^ 2    ->  (-2) ^ 2 * (1/2) ^ 2
 ```
 
 `two-powers-of-one-exponent-share-a-base` collects `a ^ b * c ^ b` into `(a * c) ^ b`;
-`positive-power-of-a-product-distributes` takes it straight back. Nothing derived that. The loop is
-the evidence, and the two rule names fall out of reading which arms fired.
+`a-numeric-factor-comes-out-of-a-power-of-a-product` takes it straight back. Nothing derived that.
+The loop is the evidence.
+
+**The names do not fall out of reading the patterns, and this paragraph said they did.** It named
+`positive-power-of-a-product-distributes` as the second rule — a real rule, with exactly the right
+shape, which is in `CollapseMultipleFractions` and not in `Power`, so `ApplyHere` on `Power` can
+never reach it. The rule that actually fires is narrower than the one the shape suggests: it wants a
+*numeric* factor and a *numeric* exponent, so that `c ^ d` can be evaluated. Asking the set which of
+its own rules fires is one loop and settles it; that is the step this document skipped, in the very
+section arguing that behaviour is a better source than derivation.
 
 What this is and is not:
 

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleConfluenceTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleConfluenceTest.cs
@@ -292,7 +292,11 @@ namespace AngouriMath.Tests.Core.Transformations
                 "Power[a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero,two-powers-of-one-base-divide-by-subtracting-exponents]",
                 "Power[a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero,two-powers-of-one-exponent-share-a-quotient-of-bases]",
                 "Power[two-powers-of-one-base-divide-by-subtracting-exponents,two-powers-of-one-exponent-share-a-quotient-of-bases]",
-                // `e ^ 3 * e ^ 3` -> e ^ 6 against (e ^ 2) ^ 3. The inverse pair of #1171.
+                // `e ^ 3 * e ^ 3` -> e ^ 6 against (e ^ 2) ^ 3. Not the pair #1171 is about, which
+                // this comment used to claim: that one is `two-powers-of-one-exponent-share-a-base`
+                // against `a-numeric-factor-comes-out-of-a-power-of-a-product`, and it is a
+                // non-terminating loop rather than a one-step disagreement. This is an ordinary
+                // arm ordering, and the two share a rule name and nothing else.
                 "Power[two-powers-of-one-base-multiply-by-adding-exponents,two-powers-of-one-exponent-share-a-base]",
             };
 

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleSetsDoNotCycleTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleSetsDoNotCycleTest.cs
@@ -112,14 +112,24 @@ namespace AngouriMath.Tests.Core.Transformations
         /// rather than as a set name, so that the entry says what it is excusing.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Both are <c>Power</c> holding an inverse pair:
         /// <c>two-powers-of-one-exponent-share-a-base</c> collects <c>a ^ b * c ^ b</c> into
-        /// <c>(a * c) ^ b</c> and <c>positive-power-of-a-product-distributes</c> takes it straight
-        /// back. Neither rule is wrong and each is wanted in its own direction; a *set* containing
-        /// both has no normal form to reach, which is
+        /// <c>(a * c) ^ b</c>, and <c>a-numeric-factor-comes-out-of-a-power-of-a-product</c> takes
+        /// it straight back. Neither rule is wrong and each is wanted in its own direction; a
+        /// *set* containing both has no normal form to reach, which is
         /// <a href="https://github.com/asc-community/AngouriMath/issues/1171">#1171</a>.
         /// <see cref="Entity.Simplify()"/> is unaffected — it folds between passes, so <c>1 * x</c>
         /// collapses and the shape the second rule needs stops existing.
+        /// </para>
+        /// <para>
+        /// <b>The second rule was named wrongly here first, and the name is the whole content of
+        /// an entry like this.</b> It said <c>positive-power-of-a-product-distributes</c>, which is
+        /// a real rule with the right shape and is in <c>CollapseMultipleFractions</c>, not in
+        /// <c>Power</c> — so <see cref="MatchedRuleSet.ApplyHere"/> on <c>Power</c> can never reach
+        /// it. Asking the set which of its own rules fires is one loop and settles it; reading two
+        /// rule names off their patterns does not.
+        /// </para>
         /// </remarks>
         private static readonly string[] KnownCycles =
         {


### PR DESCRIPTION
#1171 says the `Power` set cycles between `two-powers-of-one-exponent-share-a-base` and
`positive-power-of-a-product-distributes`. **The second is wrong.**

That rule is real and has exactly the right shape — and it is in `CollapseMultipleFractions`, not in
`Power`, so `ApplyHere` on `Power` can never reach it. Asking the set which of its own rules fires:

```
1 ^ (-2) * x ^ (-2)
    two-powers-of-one-exponent-share-a-base              -> (1 * x) ^ (-2)
(1 * x) ^ (-2)
    a-numeric-factor-comes-out-of-a-power-of-a-product    -> 1 ^ (-2) * x ^ (-2)

Is positive-power-of-a-product-distributes in Power? False
    it is in: CollapseMultipleFractions
```

The rule that actually fires is **narrower than the shape suggests**: it wants a *numeric* factor and
a *numeric* exponent, so that `c ^ d` can be evaluated. That is not a detail — it is most of what
anyone deciding what to do about #1171 needs to know, because it means the two are not general
inverses. They disagree only on the overlap.

## Corrected in the three places that repeated it

- `RuleSetsDoNotCycleTest.KnownCycles` — the remark on the pinned loops
- `Docs/Contributing/InversePairTable.md` — the section on observing a pair rather than deriving it
- `RuleConfluenceTest` — a comment calling an ordinary arm ordering *"the inverse pair of #1171"*. It
  is not. That one is a one-step disagreement between `two-powers-of-one-base-multiply-by-adding-exponents`
  and `two-powers-of-one-exponent-share-a-base`; this is a non-terminating loop. They share one rule
  name and nothing else.

## Why this was worth a commit of its own

The name is the whole content of an entry like that. A pinned loop exists so somebody can go and read
the two rules, and naming a rule that is not in the set sends them to the wrong file.

It also went into a document whose own argument is that **behaviour is a better source than
derivation** — while itself being derived from the patterns rather than measured. The check is one
loop over the set:

```csharp
foreach (var rule in power.Rules)
    if (rule.TryApply(node) is { } r && !r.Equals(node)) …
```

No behaviour changes; comments and one documentation section only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
