### PR TITLE
Each of the Power inverse pair declines the other's shape (#1171)

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -2810,9 +2810,22 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Node<Powf>(MatchPattern.Any("b"), MatchPattern.Any("n"))),
                 bound => new Powf(bound["a"] * bound["b"], bound["n"]),
                 Soundness.SoundUnderAssumptions,
-                when: bound => bound["n"] is Integer
-                               || (bound["a"].Evaled is Real { IsPositive: true }
-                                   && bound["b"].Evaled is Real { IsPositive: true }),
+                when: bound => (bound["n"] is Integer
+                                || (bound["a"].Evaled is Real { IsPositive: true }
+                                    && bound["b"].Evaled is Real { IsPositive: true }))
+                               // And declines the one shape its neighbour undoes.
+                               // `a-numeric-factor-comes-out-of-a-power-of-a-product` takes a
+                               // numeric factor back out of `(c * a) ^ d` when d is numeric too,
+                               // so `1 ^ (-2) * x ^ (-2)` collected and expanded for ever. The
+                               // narrower rule is the one with the opinion worth keeping there:
+                               // it exists so `c ^ d` can be evaluated, which is why it wants
+                               // both numeric. Where *both* bases are numeric there is nothing to
+                               // take out afterwards and this one still fires, so `2 ^ 2 * 3 ^ 2`
+                               // still collects and `3 ^ (-1/2) * 2 ^ (-1/2)` is still
+                               // `sqrt(6) / 6` rather than `sqrt(3) * sqrt(2) / 6`.
+                               // https://github.com/asc-community/AngouriMath/issues/1171
+                               && !(bound["n"] is Number
+                                    && bound["a"] is Number != bound["b"] is Number),
                 description: "a ^ n * b ^ n = (a * b) ^ n",
                 // The exponent is matched twice and written once, so the delta is -(1 + |n|) --
                 // -2 for an exponent of one node and more for a larger one. The same identity
@@ -2944,8 +2957,13 @@ namespace AngouriMath.Core.Transformations.Matching
                     MatchPattern.Any<Number>("d")),
                 bound => new Powf(bound["c"], bound["d"]) * new Powf(bound["a"], bound["d"]),
                 Soundness.SoundUnderAssumptions,
-                when: bound => bound["d"] is Integer || bound["c"] is Real { IsPositive: true },
-                description: "(c * a) ^ d = c ^ d * a ^ d, for numeric c and d",
+                // And declines when the other factor is numeric as well, because then there is
+                // nothing to take the factor out *of*: `two-powers-of-one-exponent-share-a-base`
+                // collects those back together, and the two looped. `(2 * 3) ^ 2` folds to 36 on
+                // its own. https://github.com/asc-community/AngouriMath/issues/1171
+                when: bound => (bound["d"] is Integer || bound["c"] is Real { IsPositive: true })
+                               && bound["a"] is not Number,
+                description: "(c * a) ^ d = c ^ d * a ^ d, for a numeric c and d and a symbolic a",
                 // Both c and d are Numbers, which are leaves, so the pattern is four nodes around
                 // the remaining hole and the replacement is six: exactly +2, for every input.
                 growth: RewriteRuleGrowth.Expands),

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Power.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Power.cs
@@ -90,11 +90,18 @@ namespace AngouriMath.Functions
             //                         is i * i = -1 while the second is sqrt(1) = 1
             //
             // https://github.com/asc-community/AngouriMath/issues/801
+            // And declines the one shape the numeric-factor arm below undoes: that one takes a
+            // numeric factor back out of `(c * a) ^ d` when d is numeric too, so
+            // `1 ^ (-2) * x ^ (-2)` collected and expanded for ever. Where *both* bases are
+            // numeric there is nothing to take out afterwards and this still fires, so
+            // `2 ^ 2 * 3 ^ 2` collects and `3 ^ (-1/2) * 2 ^ (-1/2)` is still `sqrt(6) / 6`.
+            // https://github.com/asc-community/AngouriMath/issues/1171
             Mulf(Powf(var any1, var any3), Powf(var any2, var any3a))
                 when any3 == any3a
                      && (any3 is Integer
                          || (any1.Evaled is Real { IsPositive: true }
                              && any2.Evaled is Real { IsPositive: true }))
+                     && !(any3 is Number && any1 is Number != any2 is Number)
                 => new Powf(any1 * any2, any3),
             // Same condition, same reason -- sqrt(2) / sqrt(-3) is -0.8165i where
             // (2 / -3)^(1/2) is +0.8165i. https://github.com/asc-community/AngouriMath/issues/802
@@ -163,8 +170,13 @@ namespace AngouriMath.Functions
             // while the second is -0.7937 -- the negation, not the value. A positive constant
             // is safe whatever the sign of x, which is why the rule is narrowed rather than
             // removed. https://github.com/asc-community/AngouriMath/issues/752
+            // And declines when the other factor is numeric as well, because then there is nothing
+            // to take the factor out *of*: the shared-exponent arm above collects those back
+            // together, and the two looped. `(2 * 3) ^ 2` folds to 36 on its own.
+            // https://github.com/asc-community/AngouriMath/issues/1171
             Powf(Mulf(Number const1, var any1), Number const2)
-                when const2 is Integer || const1 is Real { IsPositive: true } =>
+                when (const2 is Integer || const1 is Real { IsPositive: true })
+                     && any1 is not Number =>
                 new Powf(const1, const2) * new Powf(any1, const2),
 
             // {1} ^ (-1) = 1 / {1}

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleSetTerminationTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleSetTerminationTest.cs
@@ -47,23 +47,32 @@ namespace AngouriMath.Tests.Core.Transformations
         /// </summary>
         /// <remarks>
         /// <para>
-        /// <c>Power</c> splits a power of a product — <c>(2 * x) ^ 2</c> to <c>2 ^ 2 * x ^ 2</c> —
-        /// and something has to fold <c>2 ^ 2</c> before the result stops being a power of a
-        /// product: a rule whose right-hand side is a fixed point only after arithmetic that the
-        /// set itself does not do.
+        /// <b>Empty, and both entries it held have been used.</b> Every registered set reaches a
+        /// fixed point on its own now; none of them needs the normalisation between passes to
+        /// stop. That is worth stating, because it is the property
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> tier 2 asks
+        /// for and it was not true of this registry until recently.
         /// </para>
         /// <para>
-        /// <c>NumericNeat</c> was here for the same reason and is not any more. It rewrote
-        /// <c>--x</c> through a product of ones that collapsed only when the normalisation
-        /// multiplied them out, because four rules took a factor of <c>-1</c> out of a product and
-        /// left its magnitude behind as a literal <c>1 *</c>. They decline <c>-1</c> now — it is
-        /// the sign rather than a factor to take out — so the ones are never made and the set
-        /// settles on its own. That is
-        /// <a href="https://github.com/asc-community/AngouriMath/issues/1167">#1167</a>, and this
-        /// list is one of the two places that recorded it.
+        /// <c>NumericNeat</c> rewrote <c>--x</c> through a product of ones that collapsed only
+        /// when the normalisation multiplied them out, because four rules took a factor of
+        /// <c>-1</c> out of a product and left its magnitude behind as a literal <c>1 *</c>. They
+        /// decline <c>-1</c> now, it being the sign rather than a factor to take out:
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1167">#1167</a>.
+        /// </para>
+        /// <para>
+        /// <c>Power</c> split a power of a product — <c>(2 * x) ^ 2</c> to <c>2 ^ 2 * x ^ 2</c> —
+        /// and something had to fold <c>2 ^ 2</c> before the result stopped being a power of a
+        /// product. Its collector and its numeric-factor rule were an inverse pair that undid each
+        /// other, and each declines the other's shape now:
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1171">#1171</a>.
+        /// </para>
+        /// <para>
+        /// Named rather than counted, and asserted in both directions, so a set that starts
+        /// needing the normalisation fails here rather than being absorbed into a number.
         /// </para>
         /// </remarks>
-        private static readonly HashSet<string> SettleOnlyComposed = new() { "Power" };
+        private static readonly HashSet<string> SettleOnlyComposed = new();
 
         // `-2` is here because `-1` is not enough of a negative: the four rules that take a
         // negative factor out of a product decline a factor of -1 since #1167, so a corpus whose

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleSetsDoNotCycleTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleSetsDoNotCycleTest.cs
@@ -113,29 +113,25 @@ namespace AngouriMath.Tests.Core.Transformations
         /// </summary>
         /// <remarks>
         /// <para>
-        /// Both are <c>Power</c> holding an inverse pair:
-        /// <c>two-powers-of-one-exponent-share-a-base</c> collects <c>a ^ b * c ^ b</c> into
-        /// <c>(a * c) ^ b</c>, and <c>a-numeric-factor-comes-out-of-a-power-of-a-product</c> takes
-        /// it straight back. Neither rule is wrong and each is wanted in its own direction; a
-        /// *set* containing both has no normal form to reach, which is
+        /// <b>Empty, and it has been used.</b> Two loops were pinned here, both <c>Power</c>
+        /// alternating between <c>two-powers-of-one-exponent-share-a-base</c>, which collects
+        /// <c>a ^ n * b ^ n</c> into <c>(a * b) ^ n</c>, and
+        /// <c>a-numeric-factor-comes-out-of-a-power-of-a-product</c>, which takes a numeric factor
+        /// straight back out. Each declines the other's shape now and the entries are gone rather
+        /// than left behind meaning nothing —
         /// <a href="https://github.com/asc-community/AngouriMath/issues/1171">#1171</a>.
-        /// <see cref="Entity.Simplify()"/> is unaffected — it folds between passes, so <c>1 * x</c>
-        /// collapses and the shape the second rule needs stops existing.
         /// </para>
         /// <para>
         /// <b>The second rule was named wrongly here first, and the name is the whole content of
         /// an entry like this.</b> It said <c>positive-power-of-a-product-distributes</c>, which is
         /// a real rule with the right shape and is in <c>CollapseMultipleFractions</c>, not in
-        /// <c>Power</c> — so <see cref="MatchedRuleSet.ApplyHere"/> on <c>Power</c> can never reach
-        /// it. Asking the set which of its own rules fires is one loop and settles it; reading two
-        /// rule names off their patterns does not.
+        /// <c>Power</c> — so <see cref="MatchedRuleSet.ApplyHere"/> on <c>Power</c> could never
+        /// reach it. Asking the set which of its own rules fires is one loop and settles it;
+        /// reading two rule names off their patterns does not, and the wrong name made the fix
+        /// look like a choice between normal forms rather than a guard.
         /// </para>
         /// </remarks>
-        private static readonly string[] KnownCycles =
-        {
-            "Power: 1 ^ (-2) * x ^ (-2)  ->  (1 * x) ^ (-2)  ->  1 ^ (-2) * x ^ (-2)",
-            "Power: (-2) ^ 2 * (1/2) ^ 2  ->  ((-2) * 1/2) ^ 2  ->  (-2) ^ 2 * (1/2) ^ 2",
-        };
+        private static readonly string[] KnownCycles = System.Array.Empty<string>();
 
         [Fact]
         public void NoRuleSetRewritesBackToATermItHasAlreadyProduced()
@@ -195,15 +191,10 @@ namespace AngouriMath.Tests.Core.Transformations
         [Fact]
         public void EveryRegisteredSetSettlesOnTheSeeds()
         {
-            // The two shapes of #1171, which are the whole-tree face of the pair in
-            // <see cref="KnownCycles"/>. Nothing else is excused: NumericNeat grew `-x / (-y)` by
-            // four nodes a pass for ever until #1167, and its entry here is gone rather than left
-            // behind meaning nothing.
-            var known = new[]
-            {
-                "Power: 1 ^ (-2) * x ^ (-2)",
-                "Power: (-2) ^ 2 * (1/2) ^ 2",
-            };
+            // Empty, and both entries it held have been used. The two shapes of #1171 were the
+            // whole-tree face of the pair in <see cref="KnownCycles"/> and went with it; NumericNeat
+            // grew `-x / (-y)` by four nodes a pass for ever until #1167 and went before that.
+            var known = System.Array.Empty<string>();
 
             var unsettled = new List<string>();
 


### PR DESCRIPTION
`two-powers-of-one-exponent-share-a-base` collects `a ^ n * b ^ n` into `(a * b) ^ n`;
`a-numeric-factor-comes-out-of-a-power-of-a-product` takes a numeric factor straight back out of it.
Applying `Power` to a fixed point alternated between them for ever on `1 ^ (-2) * x ^ (-2)`.

**Closes #1171.**

## Why this is a guard and not a choice between normal forms

That framing was mine, and it came from naming the wrong rule (corrected in #1179). These are not two
general inverses. The expander is the **narrower** rule — numeric factor *and* numeric exponent,
written that way so `c ^ d` can be evaluated, which is what makes `4 ^ (1/2) * x ^ (1/2)` into
`2 * sqrt(x)`. So they disagree only on the overlap, and one guard each keeps both directions:

- the **collector** declines when exactly one base is a `Number` and the exponent is a `Number` —
  the shape the expander undoes;
- the **expander** declines when the other factor is a `Number` too, because then there is nothing to
  take the factor out *of*, and `(2 * 3) ^ 2` folds to `36` on its own.

**Both clauses are needed.** A single symmetric guard — the collector declining whenever *either*
base is numeric — costs an answer: `3 ^ (-1/2) * 2 ^ (-1/2)` becomes `sqrt(3) * sqrt(2) / 6` instead
of `sqrt(6) / 6`.

`ByPriority` cannot express this, incidentally: subsumption compares patterns at one node (`Mulf`
against `Powf`), and what collides is the specific rule's *output* with the general rule's pattern.

## No answer moves, and that was measured

8,310 generated inputs simplified on a build of `master` and on this branch, output diffed:
**zero differences.**

Worth stating because two of them look like regressions and are not — `(2 * x) ^ 2` and `(3 * x) ^ 3`
come back unexpanded here, and they come back unexpanded on `master` too. I checked precisely because
they looked wrong.

## Three recorded lists empty out

- `RuleSetsDoNotCycleTest.KnownCycles` — both entries
- the settling check's known list — the whole-tree face of the same two
- **`RuleSetTerminationTest.SettleOnlyComposed`** — held `Power`, now holds nothing

The third is the one worth noticing. **Every registered set reaches a fixed point on its own; none
needs the normalisation between passes to stop.** That is the property #746 tier 2 asks for —
"termination checked by tooling rather than asserted by authors" — and it was not true of this
registry a week ago. All three lists assert in both directions, so a set that starts needing the
normalisation fails rather than being absorbed into a number.

Both spellings changed together, `MatchedRules` and `Patterns.Power.cs`.

## Checks

Full suite 9560 passed, 0 failed, 14 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
