### PR TITLE
The growth census is held by a test, not quoted in a remark

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Saturation.cs
+++ b/Sources/AngouriMath/Core/Transformations/Saturation.cs
@@ -43,13 +43,22 @@ namespace AngouriMath.Core.Transformations
         /// one, and that is a measurement rather than a preference.</b> It reads like the value a
         /// ceiling should refuse — it means the rule's growth was not judged, because its
         /// replacement is code rather than a written pattern, so admitting it accepts a rewrite
-        /// nobody measured. But it is where the rules are: of the sound rules in
-        /// <see cref="MatchedRules"/>, <b>26 collect, 17 rearrange, 9 expand and 270 are
-        /// unjudged</b>. A ceiling that refuses the fourth value refuses 84% of the library, and
-        /// what is left cannot do much — over six expression pairs equal only through a larger
-        /// intermediate form, the <see cref="RewriteRuleGrowth.Rearranges"/> ceiling proved two,
-        /// and <see cref="RewriteRuleGrowth.Expands"/> — all nine expanding rules added — proved
-        /// <i>the same two</i>. The third was proved only with the unjudged rules admitted.
+        /// nobody measured. But it is where the rules are: of the 324 rules in
+        /// <see cref="MatchedRules"/>, <b>97 collect, 45 rearrange, 30 expand and 152 are
+        /// unjudged</b>. A ceiling that refuses the fourth value still refuses 47% of the library,
+        /// and what is left could not do much when this was written — over six expression pairs
+        /// equal only through a larger intermediate form, the
+        /// <see cref="RewriteRuleGrowth.Rearranges"/> ceiling proved two, and
+        /// <see cref="RewriteRuleGrowth.Expands"/> proved <i>the same two</i>. The third was proved
+        /// only with the unjudged rules admitted.
+        /// </para>
+        /// <para>
+        /// <b>Those figures moved and this paragraph did not.</b> It read "26 collect, 17
+        /// rearrange, 9 expand and 270 are unjudged", and 84% — measured before the growth
+        /// declarations went in, which took the unjudged count from 261 to 152. The argument
+        /// survives the correction and the arithmetic in it did not, which is the reason to state
+        /// counts rather than a conclusion drawn from them. <c>RuleAuthoringGuideTest</c> holds all
+        /// four of these now, so the next time they move this remark fails with them.
         /// </para>
         /// <para>
         /// So the dial that matters is not how far a rule may enlarge; it is whether rules nobody

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
@@ -87,6 +87,18 @@ namespace AngouriMath.Tests.Core.Transformations
             Stated(152, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
                 "how many rules sit at Unknown growth");
 
+            // The rest of the census, because `Saturation.RulesUpTo` argues from it in prose and
+            // the figures it quoted had gone stale by a factor of four -- "26 collect, 17
+            // rearrange, 9 expand and 270 unjudged", measured before the growth declarations
+            // went in. The argument survived; the arithmetic did not. A number a remark reasons
+            // from belongs somewhere that fails when it moves.
+            Stated(97, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Collects),
+                "how many rules are declared Collects");
+            Stated(45, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Rearranges),
+                "how many rules are declared Rearranges");
+            Stated(30, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Expands),
+                "how many rules are declared Expands");
+
             // And the two the document names. By their own names rather than by what the prose
             // calls them: the first is `squared-sine-and-cosine-of-one-argument-sum-to-one` and
             // the prose calls it the Pythagorean identity, which is right and is not what to


### PR DESCRIPTION
`Saturation.RulesUpTo` argues in prose from how the rules split across `RewriteRuleGrowth`, and the figures it quoted were stale by a factor of four.

It said **"26 collect, 17 rearrange, 9 expand and 270 are unjudged"**, and **"84% of the library"**. The real split is **97 / 45 / 30 / 152** — those numbers were measured before the growth declarations went in, which took the unjudged count from 261 to 152.

## The argument survives; the arithmetic did not

A ceiling that refuses `Unknown` still refuses **47%** of the rules, so the conclusion — that the dial which matters is whether unjudged rules may fire at all, not how far a rule may enlarge — is unchanged. Only the numbers it reasons from were wrong.

Which is the point: a number a remark argues from belongs somewhere that fails when it moves.

## So it is held now

`RuleAuthoringGuideTest` already pinned the 152. It pins all four, so the next time they move this remark fails with them.

Found by an audit of #746 tier 2, and verified against the test rather than taken from the audit — the three new counts were unpinned until this PR, so I had no way to check them except by pinning them.

## Checks

Full suite 9564 passed, 0 failed, 14 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura