### PR TITLE
Collects means never larger, and Common declares sixteen more growths

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -70,6 +70,10 @@ read first.
 | **Silent** | `"1/x - 1/x".ToEntity().Simplify()`, and every difference of a term from itself where that term can be undefined | `0`, including at `x = 0` where neither side has a value | `0 provided not x = 0` |
 | **Silent** | `"(x + 1)!/(x + 1)!".ToEntity().Simplify()`, and every cancelled quotient whose repeated part can be undefined | `1 provided not (1 + x)! = 0` | `1 provided 1 + x in RR and (1 + x >= 0 or not 1 + x in ZZ)` — the same value everywhere, a condition that says why |
 | | `"ln(x)/ln(x)".ToEntity().Simplify()`, and every quotient divided out by a divisor that can be undefined | `1 provided not ln(x) = 0` — which is `1` at `x = 0`, where the quotient has no value | `1 provided not ln(x) = 0 and not x = 0` |
+| | `Transformation.CanonicalizationOverGraph(budget).ApplyOrKeep("(x + y) * (x - y)")`, and every input one of `Common`'s sixteen newly declared rules collects | `(-y + x) * (x + y)` — not the tree `x ^ 2 - y ^ 2` reaches | `-y ^ 2 + x ^ 2` — one tree for both |
+| | the same on `x + x`, and `x + x * y` | `x + x`, `x * y + x` — left as written | `2 * x`, `(1 + y) * x` |
+| **Silent** | `RewriteRules.Common.Rules[i].Growth`, for sixteen rules | `Unknown` | `Collects` for fourteen, `Rearranges` and `Expands` for the reciprocal-factor pair |
+| **Silent** | what `RewriteRuleGrowth.Collects` promises | fewer nodes for every input | never more, and fewer for some — every rule that was `Collects` still is |
 
 ### A cancelled quotient says its operand is defined, not only non-zero
 
@@ -864,6 +868,37 @@ the middle of a rewrite. It is a bound where there was none, not a tight one.
 `SolveSystem`. What stopped each is reported separately, which is the thing
 [#896](https://github.com/asc-community/AngouriMath/issues/896) said a caller could not previously
 find out.
+
+### `Collects` promises never larger, and `Common` declares sixteen growths
+
+`RewriteRuleGrowth.Collects` used to mean the replacement is written with fewer nodes than the
+pattern for every input. It now means **never more, and fewer for some** — `Rearranges` is still
+the same size for every input and `Expands` still larger for every input. Every rule that was
+`Collects` still is, and every count written beside one ("exactly −2", "at most −4") still holds; the
+promise is weaker only where nothing relied on the strong one. The reason is the commonest
+collecting shape in the library: a hole matched twice and written once beside one new node,
+`a + a = 2 * a`, `a * a = a ^ 2`, `a + a * b = a * (1 + b)`, which is `1 − |a|` — exactly as large
+at a leaf and smaller everywhere else. Under the strict reading it could not be declared at all,
+and thirteen of `Common`'s rules sat at `Unknown` for it.
+
+Sixteen of `Common`'s rules declare a growth now, so `RewriteRules.Common.Rules[i].Growth` changes
+for them, and `Saturation.RulesUpTo(Rearranges)` — the ceiling `Transformation.CanonicalizationOverGraph`
+runs at by default — admits fifteen more rules, 157 of 324 where it was 142. What that changes on
+ordinary input is what those rules do: a repeated term collects over the graph where it used to be
+left as written, and the difference of squares reaches the tree its expansion reaches.
+`Entity.Canonicalize()` runs `Transformation.Canonicalization`, the rule pass rather than the graph,
+and answers exactly as before on every input below.
+
+| | Was | Is |
+|---|---|---|
+| `Transformation.CanonicalizationOverGraph(budget).ApplyOrKeep("(x + y) * (x - y)")` | `(-y + x) * (x + y)` — not the tree `x ^ 2 - y ^ 2` reaches, `-y ^ 2 + x ^ 2` | `-y ^ 2 + x ^ 2` — one tree for both |
+| the same on `(x + 1) * (x - 1)` | `(1 + x) * (-1 + x)` | `-1 + x ^ 2` |
+| the same on `x + x` | `x + x` — left as written | `2 * x` |
+| the same on `x + x * y` | `x * y + x` — reordered, not collected | `(1 + y) * x` |
+| `RewriteRules.Common.Rules[i].Growth`, for sixteen rules | `Unknown` | `Collects` for fourteen; `Rearranges` for `a-reciprocal-rational-factor-is-a-division`, `Expands` for its negated twin |
+| `RewriteRules.Common.Rules` by growth — collects / rearranges / expands / unknown | 21 / 14 / 5 / 22 | 35 / 15 / 6 / 6 |
+| `RewriteRules.All` by growth | 97 / 45 / 30 / 152 | 111 / 46 / 31 / 136 |
+| what `RewriteRuleGrowth.Collects` promises | fewer nodes for every input | never more, and fewer for some |
 
 ## 2.4.0 — since 2.3.0
 

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -2739,6 +2739,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 // https://github.com/asc-community/AngouriMath/issues/1174
                 bound => new Providedf(1, !bound["a"].EqualTo(0) & bound["a"].DomainCondition),
                 Soundness.SoundUnderAssumptions,
+                // Left Unknown: the condition attached carries a copy of a and a's own domain
+                // condition, whose size nothing here bounds.
                 description: "a / a = 1, provided a is not zero and is defined"),
 
             new MatchedRule(
@@ -3375,13 +3377,19 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Commutative<Sumf>(MatchPattern.Any("a"), MatchPattern.Commutative<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
                 bound => bound["a"] * (1 + bound["b"]),
                 Soundness.SoundUnderAssumptions,
-                description: "k + k * q = k * (1 + q)"),
+                description: "k + k * q = k * (1 + q)",
+                // The shared term is matched twice and written once, and the 1 is one node more:
+                // the delta is 1 - |k|, nothing at a leaf and a shrink beyond it.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-term-added-to-itself-doubles",
                 MatchPattern.Node<Sumf>(MatchPattern.Any("a"), MatchPattern.Any("a")),
                 bound => 2 * bound["a"],
                 Soundness.Sound,
-                description: "k + k = 2 * k"),
+                description: "k + k = 2 * k",
+                // The term is matched twice and written once, and the 2 is one node more: the
+                // delta is 1 - |k|, nothing at a leaf and a shrink beyond it.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-common-factor-of-two-subtracted-products-comes-out",
                 MatchPattern.Node<Minusf>(MatchPattern.Commutative<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("b")), MatchPattern.Commutative<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("c"))),
@@ -3396,13 +3404,19 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Minusf>(MatchPattern.Any("a"), MatchPattern.Commutative<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
                 bound => bound["a"] * (1 - bound["b"]),
                 Soundness.SoundUnderAssumptions,
-                description: "a - a * b = a * (1 - b)"),
+                description: "a - a * b = a * (1 - b)",
+                // The shared term is matched twice and written once, and the 1 is one node more:
+                // the delta is 1 - |a|, nothing at a leaf and a shrink beyond it.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-term-taken-from-a-product-of-itself-comes-out",
                 MatchPattern.Node<Minusf>(MatchPattern.Commutative<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("b")), MatchPattern.Any("a")),
                 bound => bound["a"] * (bound["b"] - 1),
                 Soundness.SoundUnderAssumptions,
-                description: "a * b - a = a * (b - 1)"),
+                description: "a * b - a = a * (b - 1)",
+                // The shared term is matched twice and written once, and the 1 is one node more:
+                // the delta is 1 - |a|, nothing at a leaf and a shrink beyond it.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-term-subtracted-from-itself-vanishes",
                 MatchPattern.Node<Minusf>(MatchPattern.Any("a"), MatchPattern.Any("a")),
@@ -3417,25 +3431,37 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Sumf>(MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("b")), MatchPattern.Commutative<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("c"))),
                 bound => bound["a"] * (1 / bound["b"] + bound["c"]),
                 Soundness.SoundUnderAssumptions,
-                description: "a / b + a * c = a * (1 / b + c)"),
+                description: "a / b + a * c = a * (1 / b + c)",
+                // The shared factor is matched twice and written once, and the 1 over b is one
+                // node more than the quotient it replaces: the delta is 1 - |a|.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-factor-shared-by-a-product-and-a-quotient-added-comes-out",
                 MatchPattern.Node<Sumf>(MatchPattern.Commutative<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("c")), MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
                 bound => bound["a"] * (bound["c"] + 1 / bound["b"]),
                 Soundness.SoundUnderAssumptions,
-                description: "a * c + a / b = a * (c + 1 / b)"),
+                description: "a * c + a / b = a * (c + 1 / b)",
+                // The shared factor is matched twice and written once, and the 1 over b is one
+                // node more than the quotient it replaces: the delta is 1 - |a|.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-term-added-to-a-quotient-of-itself-comes-out",
                 MatchPattern.Commutative<Sumf>(MatchPattern.Any<Entity>("a", one => one is not Integer(1)), MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
                 bound => bound["a"] * (1 + 1 / bound["b"]),
                 Soundness.SoundUnderAssumptions,
+                // Left Unknown: the 1 and the 1 over b are three nodes more against the one copy
+                // of a that goes, so the delta is 3 - |a| -- larger at a leaf, smaller only from
+                // four nodes up.
                 description: "a + a / b = a * (1 + 1 / b)"),
             new MatchedRule(
                 "a-thing-times-itself-is-its-square",
                 MatchPattern.Node<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("a")),
                 bound => new Powf(bound["a"], 2),
                 Soundness.Sound,
-                description: "a * a = a ^ 2"),
+                description: "a * a = a ^ 2",
+                // The factor is matched twice and written once, and the exponent is one node
+                // more: the delta is 1 - |a|, nothing at a leaf and a shrink beyond it.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "two-numeric-factors-around-a-variable-collect",
                 MatchPattern.Commutative<Mulf>(MatchPattern.Node<Mulf>(MatchPattern.Any<Number>("c"), MatchPattern.Any<Variable>("v")), MatchPattern.Any<Number>("d")),
@@ -3459,7 +3485,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Commutative<Mulf>(MatchPattern.Any("a"), MatchPattern.Commutative<Mulf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
                 bound => new Powf(bound["a"], 2) * bound["b"],
                 Soundness.Sound,
-                description: "a * (a * b) = a ^ 2 * b"),
+                description: "a * (a * b) = a ^ 2 * b",
+                // The factor is matched twice and written once, and the exponent is one node
+                // more: the delta is 1 - |a|, nothing at a leaf and a shrink beyond it.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-negated-term-in-a-sum-is-a-subtraction",
                 MatchPattern.Commutative<Sumf>(MatchPattern.Node<Mulf>(MatchPattern.Exact(Integer.Create(-1)), MatchPattern.Any("neg")), MatchPattern.Any("rest")),
@@ -3475,7 +3504,11 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Commutative<Mulf>(MatchPattern.Node<Minusf>(MatchPattern.Any<Variable>("v"), MatchPattern.Any("a")), MatchPattern.Node<Sumf>(MatchPattern.Any<Variable>("v"), MatchPattern.Any("a"))),
                 bound => new Powf(bound["v"], 2) - new Powf(bound["a"], 2),
                 Soundness.Sound,
-                description: "(a - b) * (a + b) = a ^ 2 - b ^ 2"),
+                description: "(a - b) * (a + b) = a ^ 2 - b ^ 2",
+                // The variable is a leaf either way; the other operand is matched twice and
+                // written once, and the two exponents are two nodes more against the operator
+                // that goes: the delta is 1 - |b|, nothing at a leaf and a shrink beyond it.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-quotient-of-a-thing-by-itself-is-one-unless-it-is-zero",
                 MatchPattern.Node<Divf>(MatchPattern.Any("a"), MatchPattern.Any("a")),
@@ -3484,6 +3517,8 @@ namespace AngouriMath.Core.Transformations.Matching
                 bound => Integer.One.Provided(
                     !bound["a"].EqualTo(Integer.Zero) & bound["a"].DomainCondition),
                 Soundness.SoundUnderAssumptions,
+                // Left Unknown: the condition attached carries a copy of a and a's own domain
+                // condition, whose size nothing here bounds.
                 description: "a / a = 1, provided a is not zero and is defined"),
             new MatchedRule(
                 "a-shared-factor-cancels-out-of-a-quotient",
@@ -3493,24 +3528,32 @@ namespace AngouriMath.Core.Transformations.Matching
                 bound => bound["keep"].Provided(
                     !bound["c"].EqualTo(Integer.Zero) & bound["c"].DomainCondition),
                 Soundness.SoundUnderAssumptions,
+                // Left Unknown: the condition attached carries a copy of c and c's own domain
+                // condition, whose size nothing here bounds.
                 description: "(keep * c) / c = keep, provided c is not zero and is defined"),
             new MatchedRule(
                 "a-shared-factor-cancels-between-two-products",
                 MatchPattern.Node<Divf>(MatchPattern.Commutative<Mulf>(MatchPattern.Any("num"), MatchPattern.Any("c")), MatchPattern.Commutative<Mulf>(MatchPattern.Any("c"), MatchPattern.Any("den"))),
                 bound => (bound["num"] / bound["den"]).Provided(!bound["c"].EqualTo(Integer.Zero)),
                 Soundness.SoundUnderAssumptions,
+                // Left Unknown: the condition attached carries a copy of c, so the delta is
+                // 2 - |c| -- larger at a leaf, smaller from three nodes up.
                 description: "(num * c) / (c * den) = num / den, provided c is not zero"),
             new MatchedRule(
                 "a-difference-over-its-own-reverse-is-minus-one",
                 MatchPattern.Node<Divf>(MatchPattern.Node<Minusf>(MatchPattern.Any("a"), MatchPattern.Any("b")), MatchPattern.Node<Minusf>(MatchPattern.Any("b"), MatchPattern.Any("a"))),
                 (node, bound) => new Providedf(-1, !node.DirectChildren[1].EqualTo(0)),
                 Soundness.SoundUnderAssumptions,
+                // Left Unknown: the condition attached carries a copy of the divisor, so the
+                // delta is 3 - |a| - |b| -- larger at two leaves, smaller from four nodes up.
                 description: "(a - b) / (b - a) = -1, provided a is not b"),
             new MatchedRule(
                 "a-sum-over-its-own-reverse-is-one",
                 MatchPattern.Node<Divf>(MatchPattern.Node<Sumf>(MatchPattern.Any("a"), MatchPattern.Any("b")), MatchPattern.Node<Sumf>(MatchPattern.Any("b"), MatchPattern.Any("a"))),
                 (node, bound) => new Providedf(1, !node.DirectChildren[1].EqualTo(0)),
                 Soundness.SoundUnderAssumptions,
+                // Left Unknown: the condition attached carries a copy of the divisor, so the
+                // delta is 3 - |a| - |b| -- larger at two leaves, smaller from four nodes up.
                 description: "(a + b) / (b + a) = 1, provided the sum is not zero"),
             new MatchedRule(
                 "a-number-over-a-numeric-multiple-splits",
@@ -3535,7 +3578,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Commutative<Sumf>(MatchPattern.Any("a"), MatchPattern.Commutative<Sumf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
                 bound => 2 * bound["a"] + bound["b"],
                 Soundness.Sound,
-                description: "a + (a + b) = 2 * a + b"),
+                description: "a + (a + b) = 2 * a + b",
+                // The term is matched twice and written once, and the 2 is one node more: the
+                // delta is 1 - |a|, nothing at a leaf and a shrink beyond it.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-term-taken-back-out-of-a-sum-it-is-in",
                 MatchPattern.Node<Minusf>(MatchPattern.Commutative<Sumf>(MatchPattern.Any("a"), MatchPattern.Any("b")), MatchPattern.Any("a")),
@@ -3568,13 +3614,19 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Commutative<Sumf>(MatchPattern.Any("a"), MatchPattern.Node<Minusf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
                 bound => 2 * bound["a"] - bound["b"],
                 Soundness.Sound,
-                description: "a + (a - b) = 2 * a - b"),
+                description: "a + (a - b) = 2 * a - b",
+                // The term is matched twice and written once, and the 2 is one node more: the
+                // delta is 1 - |a|, nothing at a leaf and a shrink beyond it.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-difference-that-takes-a-term-away-subtracted-from-it",
                 MatchPattern.Node<Minusf>(MatchPattern.Any("a"), MatchPattern.Node<Minusf>(MatchPattern.Any("b"), MatchPattern.Any("a"))),
                 bound => 2 * bound["a"] - bound["b"],
                 Soundness.Sound,
-                description: "a - (b - a) = 2 * a - b"),
+                description: "a - (b - a) = 2 * a - b",
+                // The term is matched twice and written once, and the 2 is one node more: the
+                // delta is 1 - |a|, nothing at a leaf and a shrink beyond it.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-difference-that-starts-from-a-term-subtracted-from-it",
                 MatchPattern.Node<Minusf>(MatchPattern.Any("a"), MatchPattern.Node<Minusf>(MatchPattern.Any("a"), MatchPattern.Any("b"))),
@@ -3589,7 +3641,10 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Minusf>(MatchPattern.Node<Minusf>(MatchPattern.Any("b"), MatchPattern.Any("a")), MatchPattern.Any("a")),
                 bound => bound["b"] - 2 * bound["a"],
                 Soundness.Sound,
-                description: "(b - a) - a = b - 2 * a"),
+                description: "(b - a) - a = b - 2 * a",
+                // The term is matched twice and written once, and the 2 is one node more: the
+                // delta is 1 - |a|, nothing at a leaf and a shrink beyond it.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-term-taken-from-a-difference-that-starts-from-it",
                 MatchPattern.Node<Minusf>(MatchPattern.Node<Minusf>(MatchPattern.Any("a"), MatchPattern.Any("b")), MatchPattern.Any("a")),
@@ -3621,7 +3676,11 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Node<Divf>(MatchPattern.Node<Mulf>(MatchPattern.Node<Signumf>(MatchPattern.Any("a")), MatchPattern.Node<Mulf>(MatchPattern.Any("b"), MatchPattern.Any("a"))), MatchPattern.Node<Absf>(MatchPattern.Any("a"))),
                 bound => bound["b"].Provided(!bound["a"].EqualTo(Integer.Zero)),
                 Soundness.SoundUnderAssumptions,
-                description: "(sgn(a) * (b * a)) / abs(a) = b, provided a is not zero"),
+                description: "(sgn(a) * (b * a)) / abs(a) = b, provided a is not zero",
+                // Three copies of a go and one comes back inside the condition; the sign, the
+                // absolute value, the quotient and two products go against the three nodes the
+                // condition and its attachment add: the delta is -1 - 2|a|, at most -3.
+                growth: RewriteRuleGrowth.Collects),
             new MatchedRule(
                 "a-sign-times-an-absolute-value-of-one-thing-is-that-thing",
                 MatchPattern.Commutative<Mulf>(MatchPattern.Node<Signumf>(MatchPattern.Any("a")), MatchPattern.Node<Absf>(MatchPattern.Any("a"))),
@@ -3636,13 +3695,19 @@ namespace AngouriMath.Core.Transformations.Matching
                 MatchPattern.Commutative<Mulf>(MatchPattern.Any<Entity>("r", one => Functions.Patterns.IsWholeReciprocal(one, 1)), MatchPattern.Any("a")),
                 bound => bound["a"] / Functions.Patterns.DenominatorOf(bound["r"]),
                 Soundness.Sound,
-                description: "a * (1 / c) = a / c, for a rational c"),
+                description: "a * (1 / c) = a / c, for a rational c",
+                // The reciprocal is a single rational leaf, and its denominator is a single leaf
+                // under a quotient in place of the product: one node for one, whatever a is.
+                growth: RewriteRuleGrowth.Rearranges),
             new MatchedRule(
                 "a-negated-reciprocal-rational-factor-is-a-negated-division",
                 MatchPattern.Commutative<Mulf>(MatchPattern.Any<Entity>("r", one => Functions.Patterns.IsWholeReciprocal(one, -1)), MatchPattern.Any("a")),
                 bound => -(bound["a"] / Functions.Patterns.DenominatorOf(bound["r"])),
                 Soundness.Sound,
-                description: "a * (-1 / c) = -(a / c), for a rational c"),
+                description: "a * (-1 / c) = -(a / c), for a rational c",
+                // As above, and the negation put round the quotient is two nodes more, whatever
+                // a is.
+                growth: RewriteRuleGrowth.Expands),
             // Parity, over the whole complex plane. The poles of the odd ones sit symmetrically
             // about zero -- tan(-z) is undefined exactly where tan(z) is -- so the domain neither
             // widens nor narrows and no condition is owed.

--- a/Sources/AngouriMath/Core/Transformations/RewriteRule.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRule.cs
@@ -31,7 +31,17 @@ namespace AngouriMath.Core.Transformations
     /// </remarks>
     public enum RewriteRuleGrowth
     {
-        /// <summary>The replacement is written with fewer operators and operands than the pattern.</summary>
+        /// <summary>
+        /// The replacement is never written with more operators and operands than the pattern,
+        /// and with fewer for some of what the pattern matches.
+        /// </summary>
+        /// <remarks>
+        /// "Never more" is the half the growth ceiling relies on; "fewer for some" is what
+        /// separates this from <see cref="Rearranges"/>. The commonest collecting shape — a hole
+        /// matched twice and written once beside one new node, <c>a + a = 2 * a</c> — is exactly
+        /// as large at a leaf and smaller everywhere else, and a strict "always fewer" would have
+        /// left it unjudged.
+        /// </remarks>
         Collects,
 
         /// <summary>The two are written with the same number, so the rule moves things about.</summary>

--- a/Sources/AngouriMath/Core/Transformations/Saturation.cs
+++ b/Sources/AngouriMath/Core/Transformations/Saturation.cs
@@ -44,8 +44,8 @@ namespace AngouriMath.Core.Transformations
         /// ceiling should refuse — it means the rule's growth was not judged, because its
         /// replacement is code rather than a written pattern, so admitting it accepts a rewrite
         /// nobody measured. But it is where the rules are: of the 324 rules in
-        /// <see cref="MatchedRules"/>, <b>97 collect, 45 rearrange, 30 expand and 152 are
-        /// unjudged</b>. A ceiling that refuses the fourth value still refuses 47% of the library,
+        /// <see cref="MatchedRules"/>, <b>111 collect, 46 rearrange, 31 expand and 136 are
+        /// unjudged</b>. A ceiling that refuses the fourth value still refuses 42% of the library,
         /// and what is left could not do much when this was written — over six expression pairs
         /// equal only through a larger intermediate form, the
         /// <see cref="RewriteRuleGrowth.Rearranges"/> ceiling proved two, and

--- a/Sources/AngouriMath/Docs/Contributing/WritingARule.md
+++ b/Sources/AngouriMath/Docs/Contributing/WritingARule.md
@@ -135,7 +135,7 @@ A pattern replacement gets:
 - **an exact growth**, counted from the two patterns rather than declared.
 
 A code replacement gets neither, and its growth is `Unknown` unless you declare one. That is the
-honest default — **152** rules sit at `Unknown` — but declare it where you can justify it:
+honest default — **136** rules sit at `Unknown` — but declare it where you can justify it:
 
 ```csharp
 // The Chebyshev expansion of sin(n * a) is a sum of n terms where the pattern is one node,
@@ -157,7 +157,12 @@ cannot argue the claim from the code, leave it `Unknown`.
 
 **Count the pattern against the replacement in terms of the holes**, and the answer is usually one
 of a few shapes. A hole matched twice and written once gives `-(1 + |a|)`, which is a `Collects`
-stronger than the corpus will show you, since the corpus fills its holes with single nodes. A
+stronger than the corpus will show you, since the corpus fills its holes with single nodes. The same
+hole beside one new node — `a + a = 2 * a`, `a * a = a ^ 2`, `a + a * b = a * (1 + b)` — gives
+`1 - |a|`: exactly as large at a leaf and smaller everywhere else, and that is `Collects` too.
+**`Collects` promises never larger, and smaller for some input**; `Rearranges` promises the same
+size for every input. "Never larger" is the half the growth ceiling relies on, and the corpus checks
+`Collects` by looking for a firing that grew, not for one that failed to shrink. A
 replacement holding no hole at all — a constant, or `pi/2` — collects by the whole of the pattern.
 Operators mapping one for one with every hole used once is `Rearranges`. A pattern that binds
 nothing — `arctan(sqrt(3)) = pi/3`, `{ True, False }` — has a fixed size on both sides, so its delta
@@ -165,22 +170,28 @@ is a number and there is nothing to argue. And two numbers combined with `Number
 into one node** as the replacement is built, which is worth two on its own: `(c * v) * d` collects
 where the same rule written without the cast would only rearrange.
 
-**Four shapes look declarable and are not.** Each of these measured a clean, constant delta over the
+**Two shapes look declarable and are not.** Each of these measured a clean, constant delta over the
 corpus, and each is false:
 
 | | |
 |---|---|
 | the replacement is built with `<`, `>` and their kin | they **chain**: `(x > y) < 0` is `x > y and y < 0`, so a three-node replacement becomes seven. `EqualTo` does not chain, which is why the `equals` rules are declared and their comparison twins are not |
-| the replacement attaches a `Provided` built from the operands | its size grows with them while the pattern's shrinks away, so the delta changes sign: `2 - |c|` for the shared-factor cancellation, `4 - |a| - |b|` for `(a - b) / (b - a)` |
-| a hole can be filled by two spellings of one thing | `IsWholeReciprocal` takes the literal `1/3`, which is one node, and a written `1 / c`, which is three — so the delta is 0 in one and −2 in the other |
-| a hole is repeated and the replacement squares it | `a * (a * b) = a^2 * b` is `1 - |a|`: zero for a leaf and negative for anything bigger |
+| the replacement attaches a `Provided` built from the operands | its size grows with them while the pattern's shrinks away, so the delta changes sign: `2 - |c|` for the shared-factor cancellation, `3 - |a| - |b|` for `(a - b) / (b - a)`, and `3 - |a|` for `a + a / b = a * (1 + 1 / b)`, which is *larger* at a leaf though the corpus never fired it |
+
+Two more used to be listed here and are not. The repeated hole that pays a literal to be gathered —
+`a * (a * b) = a ^ 2 * b`, `k + k = 2 * k` and their relatives, every one `1 - |a|` — was
+undeclarable only while `Collects` was read as "always fewer"; it is the commonest collecting shape
+there is, and `Collects` promises never larger. `Common`'s thirteen are declared, with the count in
+each one's comment; the relatives in `Power` and `Factorization` — `a ^ n * a`, `a / b / b` and
+theirs — are the next to declare, each on its own count. And the reciprocal-factor rules were said
+to admit two spellings of one thing; `IsWholeReciprocal` is `entity is Rational(...)`, so it admits
+the literal only, and the pair is exactly `Rearranges` and exactly `Expands`.
 
 **Every rule still at `Unknown` has been looked at, and each falls into one of the shapes above.**
 Most of them compute their answer through a helper, so there is nothing to count; the rest either
-build a comparison, attach a `Provided` sized by their own operands, or are the repeated hole that
-pays a literal to be gathered — `a ^ n * a`, `a / b / b`, `a * a`, `k + k` and their two dozen
-relatives, every one of them `1 - |a|`. So `Unknown` here is a finding rather than a gap, and a new
-`Unknown` should be one too.
+build a comparison or attach a `Provided` sized by their own operands. So `Unknown` here is a
+finding rather than a gap, and a new `Unknown` should be one too — written beside the rule, as
+`Common`'s six are.
 
 **The comparison set is settled, and settled as `Unknown`.** Its sixty-odd rules were gone through
 one at a time and all but seven fall into the shapes above: most build their replacement with `<` or

--- a/Sources/Tests/UnitTests/Core/Transformations/CanonicalExtractionTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/CanonicalExtractionTest.cs
@@ -261,17 +261,20 @@ namespace AngouriMath.Tests.Core.Transformations
         }
 
         /// <summary>
-        /// Widening the ceiling brings the difference of squares together — the narrow ceiling
-        /// leaves the product and the expansion as two forms, and the widest one canonicalises
-        /// both to the same tree.
+        /// The difference of squares used to need the widest ceiling: the narrow one left the
+        /// product and the expansion as two forms. It does not since
+        /// <c>a-difference-times-a-sum-of-one-pair-is-a-difference-of-squares</c> was declared
+        /// <c>Collects</c> on its count — <c>1 - |b|</c>, never larger — which is what admits it
+        /// to the narrow ceiling. Both ceilings canonicalise the two to one tree now, and this
+        /// used to assert the narrow one could not.
         /// </summary>
         [Fact]
-        public void TheWidestCeilingBringsTheDifferenceOfSquaresTogether()
+        public void TheNarrowCeilingBringsTheDifferenceOfSquaresTogether()
         {
             var product = "(x + y) * (x - y)".ToEntity();
             var squares = "x ^ 2 - y ^ 2".ToEntity();
 
-            Assert.NotEqual(Narrow.ApplyOrKeep(product), Narrow.ApplyOrKeep(squares));
+            Assert.Equal(Narrow.ApplyOrKeep(product), Narrow.ApplyOrKeep(squares));
             Assert.Equal(Wide.ApplyOrKeep(product), Wide.ApplyOrKeep(squares));
         }
 

--- a/Sources/Tests/UnitTests/Core/Transformations/ProvidedInAnEClassTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/ProvidedInAnEClassTest.cs
@@ -84,15 +84,17 @@ namespace AngouriMath.Tests.Core.Transformations
         }
 
         /// <summary>
-        /// <b>The safe ceiling is nearly inert on ordinary input.</b> Four of these five come back
-        /// exactly as they went in; only the Pythagorean identity moves. That is not a defect in
+        /// <b>The safe ceiling is nearly inert on ordinary input.</b> Three of these five come back
+        /// exactly as they went in; the Pythagorean identity moves, and the difference of squares
+        /// has since its rule was declared <c>Collects</c> — to <c>x ^ 2 - 1 ^ 2</c>, since no
+        /// safe rule folds a numeric power. That is not a defect in
         /// the expressions — it is what the graph can do today with the rules it is allowed to
         /// use, and it is the measurement
         /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> tier 2 needs
         /// before the graph is wired into anything.
         /// </summary>
         /// <remarks>
-        /// <c>SafeRules</c> is <c>RulesUpTo(Rearranges)</c>, 142 of 324 rules. The 152 sitting at
+        /// <c>SafeRules</c> is <c>RulesUpTo(Rearranges)</c>, 157 of 324 rules. The 136 sitting at
         /// <c>Unknown</c> are excluded by design, since their growth was never judged — so the
         /// ceiling that is safe to run finds little, and the ceiling that finds things admits
         /// rewrites nobody measured. That trade is the open part of tier 2, and this pins where it
@@ -116,8 +118,8 @@ namespace AngouriMath.Tests.Core.Transformations
                     moved.Add($"{source} -> {extracted.Stringize()}");
             }
 
-            Assert.True(still.Count == 4 && moved.Count == 1,
-                $"the safe ceiling moved {moved.Count} of 5 and left {still.Count}; it was 1 and 4.\n"
+            Assert.True(still.Count == 3 && moved.Count == 2,
+                $"the safe ceiling moved {moved.Count} of 5 and left {still.Count}; it was 2 and 3.\n"
                 + "moved:\n" + string.Join("\n", moved)
                 + "\nunchanged:\n" + string.Join("\n", still));
         }

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
@@ -89,7 +89,7 @@ namespace AngouriMath.Tests.Core.Transformations
                 "how many rules have a pattern on both sides");
             Stated(33, rules.Count(rule => rule.Reversed is not null),
                 "how many two-sided rules have a direction");
-            Stated(152, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
+            Stated(136, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Unknown),
                 "how many rules sit at Unknown growth");
 
             // The rest of the census, because `Saturation.RulesUpTo` argues from it in prose and
@@ -97,11 +97,11 @@ namespace AngouriMath.Tests.Core.Transformations
             // rearrange, 9 expand and 270 unjudged", measured before the growth declarations
             // went in. The argument survived; the arithmetic did not. A number a remark reasons
             // from belongs somewhere that fails when it moves.
-            Stated(97, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Collects),
+            Stated(111, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Collects),
                 "how many rules are declared Collects");
-            Stated(45, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Rearranges),
+            Stated(46, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Rearranges),
                 "how many rules are declared Rearranges");
-            Stated(30, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Expands),
+            Stated(31, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Expands),
                 "how many rules are declared Expands");
 
             // And the two the document names. By their own names rather than by what the prose

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleGrowthAgreesWithTheCorpusTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleGrowthAgreesWithTheCorpusTest.cs
@@ -140,6 +140,11 @@ namespace AngouriMath.Tests.Core.Transformations
             "x! = 0", "(x - y) / (y - x)", "x - (x - y)", "(x - y) - x",
             "x * y - x", "x - x * y", "x * x", "x * x * y", "x * (x * y)",
             "sin(x) * 2", "2 * sin(x)",
+
+            // The collecting shapes that are exactly as large at a leaf -- a term beside a product,
+            // a sum or a difference of itself -- and the sign-times-absolute-value cancellation.
+            "x + x * y", "x + (x + y)", "x + (x - y)", "x - (y - x)", "(y - x) - x",
+            "sgn(x) * (y * x) / abs(x)",
         };
 
         private static List<Entity> Corpus()
@@ -211,7 +216,10 @@ namespace AngouriMath.Tests.Core.Transformations
                     var delta = Size(after) - Size(before);
                     var contradicts = rule.Growth switch
                     {
-                        RewriteRuleGrowth.Collects => delta >= 0,
+                        // Collects promises never larger and smaller for some input, so the same
+                        // size is not a contradiction: the corpus fills holes with leaves, where
+                        // `a + a = 2 * a` is exactly as large as it was.
+                        RewriteRuleGrowth.Collects => delta > 0,
                         RewriteRuleGrowth.Rearranges => delta != 0,
                         RewriteRuleGrowth.Expands => delta <= 0,
                         _ => false


### PR DESCRIPTION
#746 tier 2's next item is a declared growth for the rules still at `Unknown` — #1194 showed the
growth ceiling protects only an inverse pair whose directions are declared, so every `Unknown` is
a pair it cannot see. This is the first set, `Common`, and the contract change it needed.

## What the census found

A probe over the corpus split the 152 `Unknown` rules into 55 never fired, 28 mixed, 27/21/21
looking like `Rearranges`/`Collects`/`Expands` — and a corpus can only refute, so `Common`'s 22
were then read in hole sizes. **Thirteen are one shape**: a hole matched twice and written once
beside one new node — `a + a = 2a`, `a·a = a²`, `a + a·b = a(1 + b)`, `(v − a)(v + a) = v² − a²`
and their relatives. Every one is `1 − |a|`: exactly as large at a leaf, smaller everywhere else.

That is the commonest collecting shape there is, and the contract could not say it: `Collects` was
"always fewer", `Rearranges` "always the same", so the family sat at `Unknown` as a finding and
`WritingARule.md` listed it among the shapes that *look declarable and are not*.

## The decision

**`Collects` now promises never larger, and smaller for some input.** `Rearranges` is the same size
for every input; `Expands` larger for every input. Nothing consumed the strict reading: `RulesUpTo(Rearranges)` wants "never grows", the selector-cost test asks for a majority, and the only
check that read `Collects` strictly was the corpus test's own. The 97 existing declarations
("exactly −2", "at most −4") stay true; the corpus contradicts `Collects` only on a firing that
grew. The enum doc, the guide and the test say it in the same words.

## What `Common` declares

| rules | growth | count |
|---|---|---|
| the thirteen above | `Collects` | `1 − |a|`, in each rule's comment |
| `a-sign-times-a-thing-over-its-own-absolute-value-cancels` | `Collects` | `−1 − 2|a|` |
| `a-reciprocal-rational-factor-is-a-division` | `Rearranges` | exactly 0 — `IsWholeReciprocal` is `entity is Rational(...)`, literal only; the guide said it also took a written `1 / c`, and was wrong |
| `a-negated-reciprocal-rational-factor-is-a-negated-division` | `Expands` | exactly +2 |

Six stay `Unknown` and say why beside the rule: five attach a condition sized by their own
operands, and `a + a / b = a(1 + 1/b)` is `3 − |a|` — **two nodes larger at a leaf**, a shape the
corpus had never fired. Six shapes join the corpus so every newly declared rule fires on it.

## Pins that moved

Re-recorded, not loosened:

- the safe ceiling moves **2 of 5** ordinary inputs, not 1: `(x + 1)(x − 1) → x² − 1²`, and stops
  there because no safe rule folds a numeric power;
- the narrow ceiling brings the difference of squares together — a test asserted only the widest
  could, renamed to what it shows now.

Census: **111 collect, 46 rearrange, 31 expand, 136 unjudged**; the safe ceiling admits 157 of
324.

## Changed answers

Measured on a build of master (`72676b0c`) and of this branch, and recorded in
`BREAKING-CHANGES.md`. `Transformation.CanonicalizationOverGraph(budget)` — public, safe ceiling by
default — now collects what the sixteen rules collect: `(x + y) * (x - y)` was `(-y + x) * (x + y)`
and is `-y ^ 2 + x ^ 2`, the tree `x ^ 2 - y ^ 2` reaches; `x + x` was left as written and is
`2 * x`; `x + x * y` is `(1 + y) * x`. `Entity.Canonicalize()` runs the rule pass, not the graph,
and is unchanged on every input probed. Next: the relatives in `Power` and `Factorization` (`aⁿ·a`, `a/b/b`), each on its own count.

Part of #746.

## Checks

Full suite 9579 passed, 0 failed, 14 skipped — one of the 9579 a throwaway census probe, not committed. The Transformations area (822) was run twice more on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
