### PR TITLE
The e-graph folds a rational on insertion, and the safe ceiling is measured on the corpus

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -76,6 +76,7 @@ read first.
 | **Silent** | what `RewriteRuleGrowth.Collects` promises | fewer nodes for every input | never more, and fewer for some — every rule that was `Collects` still is |
 | | `Transformation.CanonicalizationOverGraph(budget).ApplyOrKeep("(2 / x) ^ 3 * x")`, and its like with a power of the denominator | `(2 * 1 / x) ^ 3 * x` — left as written | `8 * x ^ (-2)`; `(2 / x) ^ 3 * x ^ 2` is `8 * 1 / x` |
 | **Silent** | `RewriteRules.Power.Rules[i].Growth` for nine rules, and `Factorization`'s for four | `Unknown` | `Collects` |
+| | `Transformation.CanonicalizationOverGraph(budget).ApplyOrKeep("(x ^ 2) ^ 3 - x ^ 6")`, and every input whose repeated term only appears once a number inside it folds | `-x ^ 6 + x ^ 6` — the rule pass after the graph folded the power, too late for the graph to see the two terms as one | `0` |
 
 ### A cancelled quotient says its operand is defined, not only non-zero
 
@@ -925,6 +926,29 @@ denominator, whose exponents fold as the replacement is built.
 | `RewriteRules.Power.Rules` by growth — collects / rearranges / expands / unknown | 13 / 6 / 1 / 13 | 22 / 6 / 1 / 4 |
 | `RewriteRules.Factorization.Rules` by growth | 4 / 0 / 2 / 5 | 8 / 0 / 2 / 1 |
 | `RewriteRules.All` by growth | 111 / 46 / 31 / 136 | 124 / 46 / 31 / 123 |
+
+### The e-graph folds a rational on insertion
+
+`EGraph.Add` folds an arithmetic operator over two rational leaves into that number's class, as
+it already folded a neutral element: `1 + 1` and `2` are one e-class from the moment either is
+inserted, `3 / 3` is `1`'s, `2 ^ 10` is `1024`'s. Only where the value is itself a rational —
+`1 / 0` and `2 ^ (1/2)` stay as written — only for a whole exponent no larger than 4096 in
+magnitude, and never for a node carrying a codomain of its own. Found by running the safe ceiling
+over 3,630 generated shapes: 54 did not saturate within 20,000 steps and every one was
+constant-only arithmetic, because with nothing folding a number the rearranging rules respell it
+for ever. With the fold, 7 do not — a rational coefficient beside a variable, which stalls at a
+bounded graph with the right extraction rather than running away — and the run takes 24 seconds
+where it did not finish in 590.
+
+**Almost nothing public moves**, because `Transformation.CanonicalizationOverGraph` runs the rule
+pass on either side of the graph and that pass already folds constants: `sqrt(2) * sqrt(3)`,
+`x + 3 / 3`, `2 ^ 1000` and `1 / 0` answer exactly as before. What moves is an input the graph
+could only settle by seeing a folded number *while saturating*.
+
+| | Was | Is |
+|---|---|---|
+| `Transformation.CanonicalizationOverGraph(budget).ApplyOrKeep("(x ^ 2) ^ 3 - x ^ 6")` | `-x ^ 6 + x ^ 6` | `0` |
+| the same on `sqrt(2) * sqrt(3)`, `x + 3 / 3`, `2 - 0 + 0 * 2`, `(x + 1) * (x - 1)`, `2 ^ 1000`, `1 / 0`, `2 ^ (1/2)` | `sqrt(6)`, `1 + x`, `2`, `-1 + x ^ 2`, the 302-digit integer, `NaN`, `sqrt(2)` | the same |
 
 ## 2.4.0 — since 2.3.0
 

--- a/Sources/AngouriMath/Core/Transformations/EGraph.cs
+++ b/Sources/AngouriMath/Core/Transformations/EGraph.cs
@@ -6,10 +6,12 @@
 //
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using AngouriMath.Core.Transformations.Matching;
 using AngouriMath.Extensions;
+using static AngouriMath.Entity.Number;
 
 namespace AngouriMath.Core.Transformations
 {
@@ -155,6 +157,13 @@ namespace AngouriMath.Core.Transformations
             // afterwards does not reach back and fold.
             if (NeutralClass(canonical) is { } folded)
                 return folded;
+            // And an arithmetic operator over two rational leaves denotes exactly the rational it
+            // evaluates to, so it is that number's class rather than a fresh e-node. Found by
+            // running the safe ceiling over the growth corpus: every one of the 54 inputs that did
+            // not saturate was constant-only arithmetic -- `2 - 0 + 0 * 2`, `1/2 * 2 * sin(y)` --
+            // because the rearranging rules respell a number for ever when nothing folds it.
+            if (ConstantClass(canonical) is { } evaluated)
+                return evaluated;
             var id = NewClass();
             hashcons[canonical] = id;
             classes[id].Add(canonical);
@@ -254,6 +263,61 @@ namespace AngouriMath.Core.Transformations
                     return Find(node.Children[1]);
             }
             return null;
+        }
+
+        /// <summary>
+        /// The operators a rational fold is asked of: the arithmetic ones. A function of a
+        /// rational is rarely a rational, and a factorial evaluated on insertion would be paying
+        /// for an answer nobody asked for.
+        /// </summary>
+        [ConstantField]
+        private static readonly HashSet<string> FoldableOps = new()
+        {
+            nameof(Entity.Sumf), nameof(Entity.Minusf), nameof(Entity.Mulf), nameof(Entity.Divf),
+            nameof(Entity.Powf),
+        };
+
+        /// <summary>
+        /// A power is folded only for a whole exponent no larger than this in magnitude, so that
+        /// inserting <c>2 ^ 100000000</c> does not compute it.
+        /// </summary>
+        private const int LargestFoldedExponent = 4096;
+
+        [ConcurrentField]
+        private static readonly ConcurrentDictionary<string, Rational?> rationalLeaves = new();
+
+        private static Rational? RationalLeaf(string op)
+            => rationalLeaves.GetOrAdd(op, printed => TryParseLeaf(printed) as Rational);
+
+        /// <summary>The rational the class <paramref name="id"/> holds as a plain leaf, if any.</summary>
+        private Rational? RationalOf(int id)
+        {
+            if (!classes.TryGetValue(Find(id), out var set)) return null;
+            foreach (var node in set)
+                if (node.Children.Length == 0 && node.Codomain is null && RationalLeaf(node.Op) is { } value)
+                    return value;
+            return null;
+        }
+
+        /// <summary>
+        /// If <paramref name="node"/> is an arithmetic operator over two rational leaves whose
+        /// value is itself a rational, the class of that rational -- <see langword="null"/>
+        /// otherwise, which includes a quotient by zero, an irrational root and any node carrying
+        /// a codomain of its own.
+        /// </summary>
+        private int? ConstantClass(ENode node)
+        {
+            if (node.Codomain is not null || node.Children.Length != 2 || !FoldableOps.Contains(node.Op))
+                return null;
+            if (RationalOf(node.Children[0]) is not { } left || RationalOf(node.Children[1]) is not { } right)
+                return null;
+            if (node.Op == nameof(Entity.Powf)
+                && (right is not Integer exponent || exponent.EInteger.Abs() > LargestFoldedExponent))
+                return null;
+            Entity? value;
+            try { value = MatchPattern.ConstructNode(OperatorType(node.Op), new Entity[] { left, right })?.Evaled; }
+            catch { return null; }
+            return value is Rational folded ? Add(Key(folded), Array.Empty<int>(), null) : null;
         }
 
         /// <summary>Every e-class currently in the graph.</summary>

--- a/Sources/AngouriMath/Docs/Contributing/InversePairTable.md
+++ b/Sources/AngouriMath/Docs/Contributing/InversePairTable.md
@@ -142,10 +142,15 @@ What this is and is not:
   #746 tier 2 called "a scheduling policy for `Expands`/`Unknown` rules": on this input the
   runaway is not a tier, it is one pair.
 
-  And the pair is bounded. The two `Common` coefficient rules are confluent on plain arithmetic —
-  `2 * x * y`, `(1/2) * x` and `2 * (x * y) / 3` saturate in a handful of nodes at the widest
-  ceiling, with the trigonometric sets present and with all of them removed — so making them
-  confluent is not a branch. The runaway is the sine family (`sin(2x)`, `sin(x) cos(x)`, `sin(3x)`,
+  And the pair is bounded. The two `Common` coefficient rules settle on `2 * x * y`, `(1/2) * x`
+  and `2 * (x * y) / 3` in a handful of nodes at the widest ceiling, with the trigonometric sets
+  present and with all of them removed — so making them confluent was not what the runaway
+  needed. They are not confluent in general: over the growth corpus at the safe ceiling,
+  `2 * x * 1/2` and six relatives never report a fixed point, because the spellings of a
+  coefficient beside a variable — `1/2 * x`, `x / 2`, `x * 2 ^ (-1)` — keep being exchanged.
+  That is a stall and not a runaway (a bounded graph and the right extraction, pinned by
+  `ConstantFoldTest`); and the 54 constant-only inputs that *did* run away before the graph
+  folded a number on insertion were the same rules with nothing to stop them. The runaway is the sine family (`sin(2x)`, `sin(x) cos(x)`, `sin(3x)`,
   `sin(2x) cos(2x)`; not `cos(2x)`), and it does not exist without the trigonometric sets.
   **The growth ceiling already withholds one direction of it.** `ExpandMultipleAngle`'s rules are
   declared `Expands`, so `Saturation.SafeRules` — `RulesUpTo(Rearranges)` — fires only the

--- a/Sources/Tests/UnitTests/Core/Transformations/ConstantFoldTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/ConstantFoldTest.cs
@@ -1,0 +1,198 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AngouriMath.Core;
+using AngouriMath.Core.Budgets;
+using AngouriMath.Core.Transformations;
+using AngouriMath.Extensions;
+using AngouriMath.Tests.Corpus;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// The e-graph folds an arithmetic operator over two rational leaves into that number's class
+    /// on insertion, beside the neutral-element fold — and what the safe ceiling does on the
+    /// library's own corpus once it does.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Found by running the safe ceiling over something larger than sixteen expressions</b>,
+    /// which is what <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a>
+    /// tier 2 asked for before the graph is wired into anything. Over the growth corpus's 3,630
+    /// generated shapes, 54 did not saturate within 20,000 steps — and every one of the 54 was
+    /// constant-only arithmetic: <c>2 - 0 + 0 * 2</c>, <c>1/2 * 2 * sin(y)</c>,
+    /// <c>2 + -2 + (-2) / (-1)</c>. With nothing folding a number, the rearranging rules respell
+    /// it for ever — <c>2 * 1/2</c>, <c>2 / 2</c>, <c>1/2 * 2</c> are three e-nodes — and on
+    /// pure constants the safe ceiling did not terminate. Folding them on insertion takes the 54
+    /// to 7, and the run from more than ten minutes to 24 seconds.
+    /// </para>
+    /// <para>
+    /// <b>What is left is a stall, not a runaway.</b> The seven are a rational coefficient
+    /// beside a variable — <c>2 * x * 1/2</c>, <c>x / x * -x</c>, <c>x ^ 2 / x</c> — whose
+    /// spellings <c>1/2 * x</c>, <c>x / 2</c>, <c>x * 2 ^ (-1)</c> the <c>Rearranges</c> rules
+    /// keep exchanging. Given fifteen times the budget they still report no fixed point, but
+    /// the graph barely grows (135–583 e-nodes after thirty seconds) and every one extracts
+    /// the right answer. So the claim in <c>RunawayBreadthTest</c> that the coefficient rules
+    /// are confluent on plain arithmetic is true of the three inputs it pins and not of the
+    /// family; the honest statement is that they are bounded and correct, and not confluent.
+    /// </para>
+    /// <para>
+    /// <b>On the corpus the ceiling is cheap and finds a little more.</b> Every one of the 40
+    /// problems saturates, none above 65 e-nodes; before the fold it moved 6 of the 15
+    /// <c>Simplify</c> problems and matched <c>Simplify</c>'s answer on 3; now 7 and 5 —
+    /// <c>sqrt(2) * sqrt(3)</c> reaches <c>sqrt(6)</c> and <c>(x ^ 2) ^ 3 - x ^ 6</c> reaches
+    /// <c>0</c>. The eight it still leaves need what the safe set has none of: an expanding rule
+    /// (<c>sin(-x)</c> to <c>-sin(x)</c> is declared <c>Expands</c>) or a rule that attaches a
+    /// condition (every <c>Unknown</c> of the cancelling family).
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class ConstantFoldTest
+    {
+        private static readonly WorkBudget Quick = new() { Steps = 3_000, Time = TimeSpan.FromSeconds(1) };
+        private static readonly WorkBudget Corpus = new() { Steps = 20_000, Time = TimeSpan.FromSeconds(2) };
+
+        private static (bool Saturated, int Nodes, Entity? Extracted) Saturate(string source, WorkBudget budget)
+        {
+            var graph = new EGraph();
+            var root = graph.AddEntity(source.ToEntity());
+            var ledger = BudgetLedger.For(nameof(ConstantFoldTest), budget);
+            var saturated = Saturation.Run(graph, Saturation.RulesUpTo(RewriteRuleGrowth.Rearranges), ledger, n => n.Complexity);
+            return (saturated, graph.NodeCount, graph.Extract(root, n => n.Complexity));
+        }
+
+        [Theory]
+        [InlineData("1 + 1", "2")]
+        [InlineData("3 / 3", "1")]
+        [InlineData("2 * 3", "6")]
+        [InlineData("2 ^ 10", "1024")]
+        [InlineData("1/2 + 1/2", "1")]
+        [InlineData("2 ^ (-1)", "1/2")]
+        [InlineData("-1 * 2", "-2")]
+        [InlineData("x + (1 + 1)", "x + 2")]
+        public void AnArithmeticNodeOverRationalLeavesIsItsValueOnInsertion(string source, string value)
+        {
+            var graph = new EGraph();
+            var added = graph.AddEntity(source.ToEntity());
+            var expected = graph.AddEntity(value.ToEntity());
+            Assert.Equal(graph.Find(expected), graph.Find(added));
+        }
+
+        [Theory]
+        [InlineData("1 / 0")]
+        [InlineData("2 ^ (1/2)")]
+        [InlineData("2 ^ 100000")]
+        [InlineData("2 ^ (-100000)")]
+        [InlineData("0 ^ (-1)")]
+        public void WhatIsNotARationalOrNotCheapStaysAsWritten(string source)
+        {
+            var graph = new EGraph();
+            var root = graph.AddEntity(source.ToEntity());
+            Assert.Equal(3, graph.NodeCount);
+            Assert.Equal(source.ToEntity(), graph.Extract(root, n => n.Complexity));
+        }
+
+        /// <summary>
+        /// A node carrying a codomain of its own is not the number: folding <c>domain(1 + 1, ZZ)</c>
+        /// into <c>2</c>'s class would be the conflation <c>ENodeIdentityTest</c> exists to prevent.
+        /// </summary>
+        [Fact]
+        public void ACodomainBearingNodeDoesNotFold()
+        {
+            var graph = new EGraph();
+            var annotated = graph.AddEntity("domain(1 + 1, ZZ)".ToEntity());
+            var two = graph.AddEntity("2".ToEntity());
+            Assert.NotEqual(graph.Find(two), graph.Find(annotated));
+        }
+
+        [Theory]
+        [InlineData("2 - 0 + 0 * 2")]
+        [InlineData("2 + -2 + (-2) / (-1)")]
+        [InlineData("1/2 * 2 * sin(y)")]
+        [InlineData("1/2 * 2 * (x + -1/2)")]
+        [InlineData("(2 - 0) * (-2) / (-1)")]
+        [InlineData("-1/2 + 2 + (-2) / (-1)")]
+        public void ConstantOnlyArithmeticSaturatesAtTheSafeCeiling(string source)
+        {
+            var (saturated, nodes, extracted) = Saturate(source, Quick);
+            Assert.True(saturated, $"{source} runs away again at the safe ceiling: {nodes} e-nodes and no fixed point");
+            Assert.NotNull(extracted);
+            var expected = source.ToEntity().Simplify();
+            Assert.True((extracted! - expected).Simplify().Evaled == 0 || extracted == expected,
+                $"{source} extracts {extracted}, which is not {expected}");
+        }
+
+        /// <summary>
+        /// Pinned in both directions: an entry that starts saturating is to be deleted, and one
+        /// whose graph grows past a thousand e-nodes has stopped being a stall.
+        /// </summary>
+        [Fact]
+        public void ACoefficientBesideAVariableStallsRatherThanRunsAway()
+        {
+            var stalls = new[] { "2 * x * 1/2", "x * 1/2 * 2", "x ^ 2 / x", "x / x * -x" };
+            var answers = new[] { "x", "x", "x", "-x" };
+            var report = new List<string>();
+            for (var i = 0; i < stalls.Length; i++)
+            {
+                var (saturated, nodes, extracted) = Saturate(stalls[i], Quick);
+                if (saturated) report.Add($"{stalls[i]} saturates now, at {nodes} e-nodes; delete it from the list");
+                else if (nodes > 1_000) report.Add($"{stalls[i]} is a runaway now: {nodes} e-nodes");
+                else if (extracted is null || extracted != answers[i].ToEntity())
+                    report.Add($"{stalls[i]} extracts {extracted?.Stringize() ?? "(null)"} rather than {answers[i]}");
+            }
+            Assert.True(report.Count == 0, string.Join("\n", report));
+        }
+
+        /// <summary>
+        /// What the safe ceiling does on the corpus gate's forty problems: saturates on every one,
+        /// stays small, and on the <c>Simplify</c> problems moves seven and matches
+        /// <c>Simplify</c>'s own answer on five. Each figure is asserted exactly, so that a
+        /// declaration that widens or narrows the ceiling shows up here as the count it changed.
+        /// </summary>
+        [Fact]
+        public void TheSafeCeilingOnTheCorpus()
+        {
+            var unsaturated = new List<string>();
+            var largest = 0;
+            var moved = new List<string>();
+            var matched = new List<string>();
+            foreach (var problem in AngouriMath.Tests.Corpus.Corpus.All)
+            {
+                var input = problem.Input.ToEntity();
+                var (saturated, nodes, extracted) = Saturate(problem.Input, Corpus);
+                if (!saturated) unsaturated.Add($"{problem.Name}: {nodes}");
+                largest = Math.Max(largest, nodes);
+                if (problem.Op != Op.Simplify || extracted is null) continue;
+                if (extracted != input)
+                {
+                    moved.Add(problem.Name);
+                    if (extracted == input.Simplify()) matched.Add(problem.Name);
+                }
+            }
+
+            Assert.True(unsaturated.Count == 0, "no fixed point on: " + string.Join(", ", unsaturated));
+            Assert.True(largest <= 65, $"the largest corpus graph is {largest} e-nodes; it was 65");
+            Assert.True(moved.Count == 7, $"the safe ceiling moves {moved.Count} of the Simplify problems; it was 7: {string.Join(", ", moved)}");
+            Assert.True(matched.Count == 5, $"it matches Simplify on {matched.Count}; it was 5: {string.Join(", ", matched)}");
+        }
+
+        /// <summary>
+        /// The one the pinned five-input measurement used to leave at <c>x ^ 2 - 1 ^ 2</c>, "since
+        /// no safe rule folds a numeric power": the fold is not a rule, and it happens on insertion.
+        /// </summary>
+        [Fact]
+        public void TheDifferenceOfSquaresFoldsItsPower()
+        {
+            var (_, _, extracted) = Saturate("(x + 1) * (x - 1)", Quick);
+            Assert.Equal("x ^ 2 - 1".ToEntity(), extracted);
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Core/Transformations/ProvidedInAnEClassTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/ProvidedInAnEClassTest.cs
@@ -86,8 +86,8 @@ namespace AngouriMath.Tests.Core.Transformations
         /// <summary>
         /// <b>The safe ceiling is nearly inert on ordinary input.</b> Three of these five come back
         /// exactly as they went in; the Pythagorean identity moves, and the difference of squares
-        /// has since its rule was declared <c>Collects</c> — to <c>x ^ 2 - 1 ^ 2</c>, since no
-        /// safe rule folds a numeric power. That is not a defect in
+        /// has since its rule was declared <c>Collects</c> — to <c>x ^ 2 - 1</c>, the numeric
+        /// power folded on insertion (<c>ConstantFoldTest</c>). That is not a defect in
         /// the expressions — it is what the graph can do today with the rules it is allowed to
         /// use, and it is the measurement
         /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> tier 2 needs

--- a/Sources/Tests/UnitTests/Core/Transformations/RunawayBreadthTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RunawayBreadthTest.cs
@@ -31,7 +31,9 @@ namespace AngouriMath.Tests.Core.Transformations
     /// <c>2 * (x * y) / 3</c> — the widest ceiling saturates in a handful of nodes, with every
     /// trigonometric set present and with all of them removed. The coefficient rules were
     /// load-bearing in the runaway only because they supplied the respellings the trigonometric
-    /// pair fed on.
+    /// pair fed on. (Measured on these three inputs; the family is not confluent in general —
+    /// <c>2 * x * 1/2</c> never reports a fixed point — but it stalls at a bounded graph with the
+    /// right extraction rather than running away, which <c>ConstantFoldTest</c> pins.)
     /// </para>
     /// <para>
     /// <b>The runaway is a family, and it is bounded to the trigonometric sets.</b> Every sine


### PR DESCRIPTION
#746 tier 2's next item after declaring growth (#1195–#1197) was to evaluate saturation on what
`Simplify` actually sees rather than on sixteen expressions. This is that measurement, the one
mechanism it named, and the pins.

## On the corpus: cheap, and it finds little

Over the corpus gate's forty problems and the two benchmark inputs, at the safe ceiling:

| | |
|---|---|
| saturate | 42 of 42 |
| largest graph | 65 e-nodes — the 473-node `SimplifyHard` input, in 12 ms; everything else ≤ 1 ms |
| `Simplify` problems moved | 6 of 15, matching `Simplify`'s answer on 3 |
| solve / integrate / limit inputs moved | 0 |

The nine it leaves need one of two things the safe set has none of: **a number folded**
(`3/3`, `2·3`, `x^(2·3)`, `ln(e²)`), which is no rule at all; or a rule the ceiling withholds —
`sin(−x) → −sin x` is `Expands`, so `sin(−x) + sin x → 0` is unreachable, and every cancelling
rule is `Unknown` for its condition.

## On 3,630 generated shapes: 54 did not terminate, all constant-only

`2 - 0 + 0 * 2`, `1/2 * 2 * sin(y)`, `2 + -2 + (-2) / (-1)` — with nothing folding a number, the
`Rearranges` rules respell it for ever (`2 · ½`, `2 / 2`, `½ · 2` are three e-nodes), so on pure
constants the safe ceiling did not terminate; two inputs overshot a 2 s wall by 15× and 35×.

## The mechanism

`EGraph.Add` folds an arithmetic operator over two rational leaves into that number's class,
beside the neutral-element fold it already had — only where the value is itself a rational (`1/0`
and `2^(1/2)` stay as written), only for a whole exponent of modest size (`2^100000` is not
computed), and never for a node carrying a codomain of its own (the conflation #1191's
`ENodeIdentityTest` exists to prevent). 

| | before | after |
|---|---|---|
| generated shapes with no fixed point | 54 of 3,630 | **7** |
| the volume run | did not finish in 590 s | 24 s |
| `Simplify` problems moved / matched | 6 / 3 | **7 / 5** — `√2·√3 → √6`, `(x²)³ − x⁶ → 0` |
| largest corpus graph | 65 | 65 |

## What is left is a stall, pinned as one

The seven are a rational coefficient beside a variable — `2 * x * 1/2`, `x / x * -x`,
`x ^ 2 / x` — whose spellings `½·x`, `x/2`, `x·2⁻¹` the `Rearranges` rules keep exchanging.
Fifteen times the budget still finds no fixed point, but the graph barely grows (135–583 e-nodes
after 30 s) and every one extracts the right answer. **That corrects one sentence of #1194**: the
coefficient rules settle on the three inputs it pinned and are *not* confluent as a family; the
breadth test, `InversePairTable.md` and the new test say so.

`ConstantFoldTest` holds all of it: what folds and what does not, the codomain refusal, that the
constant-only inputs saturate, that the stall family stalls (both directions: an entry that starts
saturating is to be deleted, one that grows past a thousand nodes has stopped being a stall), and
the corpus figures exactly.

One fact to know rather than hide: `ln(2^1000) / ln(2^(-1000))` now extracts `ln(<302 digits>) / …`,
because `2^1000` is within the exponent guard and the cost model counts nodes, not digits. It is
correct; it is not tidy; and it is the cost model's business, which is item 5's.

## Changed answers

Measured on a build of master (`d9b8b374`) and of this branch, recorded in `BREAKING-CHANGES.md`.
**Almost nothing public moves**: `Transformation.CanonicalizationOverGraph` runs the rule pass on
either side of the graph, and that pass already folds constants, so `sqrt(2) * sqrt(3)`,
`x + 3 / 3`, `2 ^ 1000` and `1 / 0` answer exactly as before — the `√6` and `0` in the tables
above are the *bare graph*, which is what saturation sees. The one public change on the inputs
probed is `(x ^ 2) ^ 3 - x ^ 6`: `-x ^ 6 + x ^ 6` becomes `0`, because the graph now sees the two
terms as one while saturating rather than after. `Entity.Canonicalize()` is unchanged.

Part of #746.

## Checks

Full suite 9601 passed, 0 failed, 14 skipped — 23 of them new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
