### PR TITLE
The perfect-square collapse asks the rewrite graph before it asks Simplify

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Saturation.cs
+++ b/Sources/AngouriMath/Core/Transformations/Saturation.cs
@@ -84,6 +84,17 @@ namespace AngouriMath.Core.Transformations
                 .ToList();
 
         /// <summary>
+        /// <see cref="RulesUpTo"/> at <see cref="RewriteRuleGrowth.Rearranges"/> — the rules that
+        /// never enlarge — built once, lazily: a caller inside the simplifier must not rebuild
+        /// the list per call, and the registry must not be read at this type's initialisation.
+        /// </summary>
+        internal static IReadOnlyList<MatchedRule> SafeRules => safeRules.Value;
+
+        [ConstantField]
+        private static readonly Lazy<IReadOnlyList<MatchedRule>> safeRules
+            = new(() => RulesUpTo(RewriteRuleGrowth.Rearranges));
+
+        /// <summary>
         /// Merges into <paramref name="graph"/> every equality <paramref name="rules"/> reach from
         /// what it already holds, until a pass changes nothing or <paramref name="ledger"/> stops
         /// it. Answers whether it reached that fixed point rather than the ceiling.

--- a/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
+++ b/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
@@ -607,7 +607,7 @@ namespace AngouriMath.Core.Transformations
             /// </summary>
             [ConstantField]
             private static readonly IReadOnlyList<Matching.MatchedRule> SafeRules
-                = Saturation.RulesUpTo(RewriteRuleGrowth.Rearranges);
+                = Saturation.SafeRules;
 
             /// <summary>
             /// <see cref="SafeRules"/>.Count, for <see cref="Transformation.EqualitySaturationSafeRuleCount"/>

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.ExpandFactorize.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.ExpandFactorize.cs
@@ -5,6 +5,9 @@
 // Website: https://am.angouri.org.
 //
 
+using System;
+using AngouriMath.Core.Budgets;
+using AngouriMath.Core.Transformations;
 using PeterO.Numbers;
 using static AngouriMath.Entity;
 
@@ -161,16 +164,43 @@ namespace AngouriMath.Functions
                 var crossTerm = 2 * p * q;
                 if (DiffersNumerically(crossTerm, w) && DiffersNumerically(crossTerm, -w))
                     continue;
-                var product = crossTerm.Simplify();
-                var candidate =
-                    (product - w).Simplify() == 0 ? new Powf((p + q).Simplify(), 2) :
-                    (product + w).Simplify() == 0 ? new Powf((p - q).Simplify(), 2) :
-                    null;
+                // The rewrite graph first, at the ceiling of rules that never enlarge: it proves
+                // 2 * sqrt(2) * sqrt(3) and 2 * sqrt(6) equal in a millisecond where the symbolic
+                // test below runs Simplify three times over radicals. A false from it is "not
+                // proved", never "unequal", so the symbolic test still runs where the graph does
+                // not reach, and the numeric check at the end disposes of both the same way.
+                // The graph's first production caller -- #746 tier 2's item 5, measured here.
+                var sign = Saturation.ProvesEqual(crossTerm, w, Saturation.SafeRules, PerfectSquareProofBudget) ? 1
+                         : Saturation.ProvesEqual(crossTerm, -w, Saturation.SafeRules, PerfectSquareProofBudget) ? -1
+                         : 0;
+                if (sign == 0)
+                {
+                    var product = crossTerm.Simplify();
+                    sign = (product - w).Simplify() == 0 ? 1
+                         : (product + w).Simplify() == 0 ? -1
+                         : 0;
+                }
+                var candidate = sign switch
+                {
+                    1 => new Powf((p + q).Simplify(), 2),
+                    -1 => new Powf((p - q).Simplify(), 2),
+                    _ => null,
+                };
                 if (candidate is { } square && AgreesNumerically(expr, square))
                     return square;
             }
             return null;
         }
+
+        /// <summary>
+        /// What the rewrite graph may spend proving a cross term equal to its candidate: two
+        /// thousand steps and fifty milliseconds. On the corpus the safe ceiling saturates a
+        /// term of this size in under a millisecond and a few dozen e-nodes, so this is a lid
+        /// against the stall family rather than a working allowance.
+        /// https://github.com/asc-community/AngouriMath/issues/1200
+        /// </summary>
+        [ConstantField] private static readonly WorkBudget PerfectSquareProofBudget
+            = new() { Steps = 2_000, Time = TimeSpan.FromMilliseconds(50) };
 
         /// <summary>Sample points, negative first: a branch-cut error shows nowhere else.</summary>
         [ConstantField] private static readonly EDecimal[] PerfectSquareSamplePoints =

--- a/Sources/Tests/UnitTests/Core/Transformations/PerfectSquareProofTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/PerfectSquareProofTest.cs
@@ -42,7 +42,13 @@ namespace AngouriMath.Tests.Core.Transformations
     [Trait("Area", "Core")]
     public sealed class PerfectSquareProofTest
     {
-        private static readonly WorkBudget Budget = new() { Steps = 2_000, Time = TimeSpan.FromMilliseconds(50) };
+        /// <summary>
+        /// The production caller's step ceiling with a wall that cannot fire: the first CI run
+        /// of this test spent the caller's fifty milliseconds on a cold JIT three seconds into
+        /// the process and reported the surd product unproved. Steps are what bound a proof;
+        /// a wall in a test measures the runner.
+        /// </summary>
+        private static readonly WorkBudget Budget = new() { Steps = 2_000, Time = TimeSpan.FromSeconds(30) };
 
         [Theory]
         [InlineData("2 * sqrt(2) * sqrt(3)", "2 * sqrt(6)")]

--- a/Sources/Tests/UnitTests/Core/Transformations/PerfectSquareProofTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/PerfectSquareProofTest.cs
@@ -1,0 +1,80 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Core.Budgets;
+using AngouriMath.Core.Transformations;
+using AngouriMath.Extensions;
+using AngouriMath.Functions;
+using Xunit;
+
+namespace AngouriMath.Tests.Core.Transformations
+{
+    /// <summary>
+    /// The rewrite graph's first production caller: the perfect-square collapse asks
+    /// <see cref="Saturation.ProvesEqual"/> whether a cross term equals its candidate before it
+    /// asks <c>Simplify</c>. These are the two facts that make that safe and worth doing.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Measured, per stage, on the inputs the rule fires on.</b> Where the graph proves, it is
+    /// faster than the symbolic test it replaces — 0.55 ms against 1.7–5.1 ms for
+    /// <c>2 * sqrt(2) * sqrt(3)</c> against <c>2 * sqrt(6)</c>, and nothing at all where the
+    /// two terms are already one tree. Where it does not prove it spends 0.24 ms and the
+    /// symbolic test runs as before. And at the level of a whole <c>Simplify</c> the change is
+    /// inside the noise, because the collapse's cost is elsewhere: 3–163 ms per call, in the
+    /// candidate's own <c>Simplify</c> and the numeric checks. So this is a production caller
+    /// that meets the standing condition — it runs only after the numeric pre-filter, bounded —
+    /// and not a speed-up to advertise.
+    /// </para>
+    /// <para>
+    /// <b>The graph refuses the identity the site's remarks call false.</b>
+    /// <c>sqrt(x) * sqrt(y) = sqrt(x * y)</c> fails on the branch cuts, and the one rule that
+    /// could assert it is guarded to whole exponents and positive real bases. A proof engine that
+    /// proved it would make the numeric disposer the only thing between this rule and a wrong
+    /// answer; asserted here so that a loosened guard fails before it reaches the rule.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class PerfectSquareProofTest
+    {
+        private static readonly WorkBudget Budget = new() { Steps = 2_000, Time = TimeSpan.FromMilliseconds(50) };
+
+        [Theory]
+        [InlineData("2 * sqrt(2) * sqrt(3)", "2 * sqrt(6)")]
+        [InlineData("2 * sqrt(2) * sqrt(3)", "2 * (sqrt(2) * sqrt(3))")]
+        public void TheSafeCeilingProvesTheCrossTerm(string cross, string candidate)
+            => Assert.True(Saturation.ProvesEqual(cross.ToEntity(), candidate.ToEntity(), Saturation.SafeRules, Budget));
+
+        /// <summary>
+        /// And what it does not prove, which is why the symbolic test is a fallback rather than a
+        /// memory: no rule at the safe ceiling commutes a product of two symbolic roots, so the
+        /// same cross term regrouped is two trees the graph never joins. The constant case above
+        /// joins only because the fold takes both to <c>2 * sqrt(6)</c>.
+        /// </summary>
+        [Fact]
+        public void TheSafeCeilingDoesNotRegroupASymbolicProduct()
+            => Assert.False(Saturation.ProvesEqual("2 * sqrt(a) * sqrt(b)".ToEntity(), "2 * (sqrt(a) * sqrt(b))".ToEntity(), Saturation.SafeRules, Budget));
+
+        [Theory]
+        [InlineData("2 * sqrt(x) * sqrt(y)", "2 * sqrt(x * y)")]
+        [InlineData("sqrt(x) * sqrt(y)", "sqrt(x * y)")]
+        public void TheSafeCeilingDoesNotProveTheBranchCutIdentity(string left, string right)
+            => Assert.False(Saturation.ProvesEqual(left.ToEntity(), right.ToEntity(), Saturation.SafeRules, Budget));
+
+        [Theory]
+        [InlineData("2 + 2 * sqrt(2) * sqrt(3) + 3", "(sqrt(3) + sqrt(2)) ^ 2")]
+        [InlineData("2 + 2 * sqrt(6) + 3", "(sqrt(3) + sqrt(2)) ^ 2")]
+        [InlineData("a + 2 * sqrt(a) * sqrt(b) + b", "(sqrt(a) + sqrt(b)) ^ 2")]
+        public void TheCollapseStillAnswersWhatItAnswered(string sum, string square)
+            => Assert.Equal(square.ToEntity(), Patterns.CollapseToPerfectSquare(sum.ToEntity()));
+
+        [Fact]
+        public void TheCollapseStillDeclinesTheBranchCutShape()
+            => Assert.Null(Patterns.CollapseToPerfectSquare("x + 2 * sqrt(x * y) + y".ToEntity()));
+    }
+}


### PR DESCRIPTION
#746 tier 2's last open item is a production caller for the rewrite graph, with the standing
performance condition measured. #1198 measured the graph on the corpus and found it cheap and never
ahead of `Simplify` on extraction — so the caller worth having is one that needs the graph's
*proof*, not its form. The library has exactly one place that decides an equality by subtracting
and simplifying: the perfect-square collapse, whose remark calls that test "the whole cost of this
rule".

## What changes

After the numeric pre-filter passes, the collapse asks `Saturation.ProvesEqual(crossTerm, w)`
first, at the safe ceiling, under 2,000 steps / 50 ms, and falls through to the three `Simplify`
calls only where the graph does not prove. A `false` from the graph is "not proved", never
"unequal", so nothing the site reached before is lost, and the numeric disposer at the end treats
both routes the same. `Saturation.SafeRules` is the rule list built once, lazily; the catalogue's
private copy reads it.

## Measured, per stage

| cross term vs candidate | graph | symbolic test it replaces | whole collapse | whole `Simplify` |
|---|---|---|---|---|
| `2·√2·√3` vs `2·√6` | **proved, 0.55 ms** | 1.67 ms | 3.1 ms | 1.3 ms |
| `2·√a·√b` vs itself | proved, 0 ms | 3.29 ms | 163 ms | 48 ms |
| `2·√x·√y` vs `2·√(xy)` | not proved, 0.24 ms — **correctly**: the branch-cut identity | 2.85 ms | 19 ms | 37 ms |
| `2·√1·√(x/2)` vs `√(2x)` | not proved, 0.24 ms | 5.14 ms | 50 ms | 59 ms |

So: where the graph proves it is 3–6× faster than what it replaces; where it doesn't it costs
0.24 ms; and **at the level of a whole `Simplify` the change is inside the noise** (before/after
medians over 15 runs: 52.4 → 50.5 ms, 60.4 → 60.2, 46.9 → 46.3), because the collapse's cost is
in the candidate's own `Simplify` and the numeric checks, not in the equality test. This is a
caller that meets the condition — it runs only after the numeric pre-filter, bounded — and not a
speed-up to advertise. What made the proved case reachable at all is #1198's constant fold
(`2·3 → 6` inside the graph).

`PerfectSquareProofTest` pins the two facts the caller rests on — the graph proves the surd
product; it **refuses** `√x·√y = √(xy)`, so a loosened guard fails there before it reaches the rule
— and that the collapse answers exactly what it answered.

Part of #746. With this, tier 2's list from the session stands at: items 1–4 done, item 5 has its
first caller; what remains is the e-matcher over the 35 two-sided rules (`EMatching.md`), which
changes speed rather than reach.

## Checks

Full suite 9610 passed, 0 failed, 14 skipped — 9 of them new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
