### PR TITLE
Extraction is a fixed point from the leaves up, and a budget is honoured to the millisecond

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/EGraph.cs
+++ b/Sources/AngouriMath/Core/Transformations/EGraph.cs
@@ -98,14 +98,6 @@ namespace AngouriMath.Core.Transformations
     /// </remarks>
     internal sealed class EGraph
     {
-        /// <summary>
-        /// How deep <see cref="Extract(int, Func{Entity, double})"/> will chain through child
-        /// classes before declining to build. A crash guard rather than a quality knob: textbook
-        /// input nests nowhere near this far, so the cap is only reached where the alternative is
-        /// an uncatchable stack overflow.
-        /// </summary>
-        private const int MaxExtractionDepth = 256;
-
         private readonly List<int> parent = new();
         private readonly Dictionary<ENode, int> hashcons = new();
         private readonly Dictionary<int, HashSet<ENode>> classes = new();
@@ -336,6 +328,7 @@ namespace AngouriMath.Core.Transformations
             left = Find(left);
             right = Find(right);
             if (left == right) return false;
+            extractMemo = null;
             parent[right] = left;
             foreach (var node in classes[right]) classes[left].Add(node);
             classes.Remove(right);
@@ -408,7 +401,25 @@ namespace AngouriMath.Core.Transformations
         /// type <see cref="MatchPattern.ConstructNode"/> does not build.
         /// </summary>
         internal Entity? Extract(int id, Func<Entity, double> cost)
-            => Extract(id, new Cheapest(cost), new Dictionary<int, Entity>(), new HashSet<int>());
+        {
+            // One extraction of the whole graph, kept for as long as the graph does not change
+            // and the cost is the same delegate. Only a union can change what an existing class
+            // extracts as -- a new class never alters an old one -- so Union is where it is
+            // dropped. Before this, every witness an e-match attempt wanted was a fresh walk,
+            // once per bound name per binding and once per predicated hole per candidate class,
+            // and one such walk of a 253-node graph took 1.9 s: the walk was top-down with a
+            // cycle guard, and a graph full of union-made cycles defeats a memo that fills only
+            // on completion. https://github.com/asc-community/AngouriMath/issues/1199
+            if (!ReferenceEquals(cost, memoCost) || extractMemo is null)
+            {
+                memoCost = cost;
+                extractMemo = ExtractAll(new Cheapest(cost));
+            }
+            return extractMemo.TryGetValue(Find(id), out var best) ? best : null;
+        }
+
+        private Dictionary<int, Entity>? extractMemo;
+        private Func<Entity, double>? memoCost;
 
         /// <summary>
         /// The least entity the e-class <paramref name="id"/> can be built as under
@@ -421,7 +432,7 @@ namespace AngouriMath.Core.Transformations
         /// well-defined expression where "the least member" is. See <see cref="EntityOrder"/>.
         /// </remarks>
         internal Entity? ExtractLeast(int id, IComparer<Entity> order)
-            => Extract(id, new Least(order), new Dictionary<int, Entity>(), new HashSet<int>());
+            => ExtractAll(new Least(order)).TryGetValue(Find(id), out var least) ? least : null;
 
         /// <summary>
         /// How <c>Extract</c> chooses between the members of one e-class. A
@@ -488,46 +499,61 @@ namespace AngouriMath.Core.Transformations
             public readonly Entity? Best => best;
         }
 
-        private Entity? Extract<TSelection>(int id, TSelection seed,
-            Dictionary<int, Entity> memo, HashSet<int> visiting)
+        /// <summary>
+        /// The best member of every class under <paramref name="seed"/>, from the leaves up: a
+        /// round recomputes each class from its children's current best, and the rounds stop
+        /// when one changes nothing. No recursion, so no depth to guard and no stack to exhaust;
+        /// a member that reaches back into its own class through a union is built from that
+        /// class's current best and offered like any other, and loses to it under any selection
+        /// that does not prefer the larger of two writings of one thing. Rounds are bounded by
+        /// the longest chain of classes, and capped at the class count for a selection that is
+        /// not monotone in its children.
+        /// </summary>
+        private Dictionary<int, Entity> ExtractAll<TSelection>(TSelection seed)
             where TSelection : struct, ISelection
         {
-            id = Find(id);
-            if (memo.TryGetValue(id, out var done)) return done;
-            // visiting is the chain currently being expanded, so its size is this call's depth.
-            // The cycle guard below bounds that chain only by the number of distinct classes,
-            // which unions grow past the input expression's own syntactic depth -- and a
-            // StackOverflowException cannot be caught, so exhausting the stack takes the process
-            // down rather than failing one call. Declining to build is the answer the cycle case
-            // already gives, and the same shape as Gruntz's own MaxDepth.
-            if (visiting.Count >= MaxExtractionDepth) return null;
-            if (!visiting.Add(id)) return null;              // a cycle; the other node will do
-            var selection = seed;
-            selection.Begin();
-            // Ordered, not as the set enumerates: where the selection ties, the answer is
-            // whichever candidate was reached first, and set order is neither specified nor
-            // stable across processes.
-            foreach (var node in NodesOf(id).OrderBy(node => node))
+            var best = new Dictionary<int, Entity>();
+            var leaves = new Dictionary<string, Entity?>();
+            // Ordered, not as the dictionary enumerates: where the selection ties, the answer is
+            // whichever candidate was reached first, and dictionary and set order are neither
+            // specified nor stable across processes.
+            var ids = classes.Keys.OrderBy(id => id).ToList();
+            for (var round = 0; round <= ids.Count; round++)
             {
-                var parts = new Entity[node.Children.Length];
-                var ok = true;
-                for (var i = 0; i < parts.Length && ok; i++)
+                var changed = false;
+                foreach (var id in ids)
                 {
-                    var part = Extract(node.Children[i], seed, memo, visiting);
-                    if (part is null) ok = false;
-                    else parts[i] = part;
+                    var selection = seed;
+                    selection.Begin();
+                    foreach (var node in classes[id].OrderBy(node => node))
+                    {
+                        var parts = new Entity[node.Children.Length];
+                        var ok = true;
+                        for (var i = 0; i < parts.Length && ok; i++)
+                            if (best.TryGetValue(Find(node.Children[i]), out var part)) parts[i] = part;
+                            else ok = false;
+                        if (!ok) continue;
+                        Entity? built;
+                        if (parts.Length == 0)
+                        {
+                            if (!leaves.TryGetValue(node.Op, out built))
+                                leaves[node.Op] = built = TryParseLeaf(node.Op);
+                        }
+                        else built = MatchPattern.ConstructNode(OperatorType(node.Op), parts);
+                        if (built is null) continue;
+                        if (node.Codomain is { } domain) built = built.WithCodomain(domain);
+                        selection.Offer(built);
+                    }
+                    var chosen = selection.Best;
+                    if (chosen is null) continue;
+                    if (!best.TryGetValue(id, out var incumbent) || !chosen.Equals(incumbent))
+                    {
+                        best[id] = chosen;
+                        changed = true;
+                    }
                 }
-                if (!ok) continue;
-                Entity? built = parts.Length == 0
-                    ? TryParseLeaf(node.Op)
-                    : MatchPattern.ConstructNode(OperatorType(node.Op), parts);
-                if (built is null) continue;
-                if (node.Codomain is { } domain) built = built.WithCodomain(domain);
-                selection.Offer(built);
+                if (!changed) break;
             }
-            visiting.Remove(id);
-            var best = selection.Best;
-            if (best is not null) memo[id] = best;
             return best;
         }
 

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
@@ -264,14 +264,31 @@ namespace AngouriMath.Core.Transformations.Matching
         /// </summary>
         internal bool TryEMatchApply(
             EGraph graph, int classId, Func<Entity, double> cost, out int resultClassId)
+            => TryEMatchApply(graph, classId, cost, null, out resultClassId);
+
+        /// <summary>
+        /// <see cref="TryEMatchApply(EGraph, int, Func{Entity, double}, out int)"/>, charging
+        /// <paramref name="spend"/> once for every binding tried after the first. A binding tried
+        /// is a match attempt: the caller charged the first, and an attempt over a class with a
+        /// thousand members is a thousand of them and not one -- which is what let a two-second
+        /// budget run for sixty-nine. A <see langword="false"/> from <paramref name="spend"/>
+        /// ends the attempt as not matched; the caller's ledger says why.
+        /// https://github.com/asc-community/AngouriMath/issues/1199
+        /// </summary>
+        internal bool TryEMatchApply(
+            EGraph graph, int classId, Func<Entity, double> cost, Func<bool>? spend, out int resultClassId)
         {
             if (!Left.CanEMatch)
                 throw new InvalidOperationException(
                     $"'{Name}' cannot e-match; check {nameof(Left)}.{nameof(MatchPattern.CanEMatch)} first.");
 
             resultClassId = 0;
+            var first = true;
             foreach (var ebindings in Left.EMatch(graph, classId, EBindings.Empty, cost))
             {
+                if (!first && spend is not null && !spend()) return false;
+                first = false;
+
                 Bindings? entityBindings = null;
                 bool TryEntityBindings(out Bindings result)
                 {

--- a/Sources/AngouriMath/Core/Transformations/Saturation.cs
+++ b/Sources/AngouriMath/Core/Transformations/Saturation.cs
@@ -120,6 +120,10 @@ namespace AngouriMath.Core.Transformations
                 return ledger.Spend(delta);
             }
 
+            // Handed to the e-matcher so that a binding tried is a step, not only the attempt --
+            // allocated once here rather than per attempt.
+            Func<bool> spend = () => ledger.Spend();
+
             var saturated = false;
             while (!saturated && !ledger.Exhausted)
             {
@@ -189,7 +193,7 @@ namespace AngouriMath.Core.Transformations
                             // wrote, and a predicate that throws on a shape it did not expect must
                             // decline the candidate, not escape Apply.
                             bool matched;
-                            try { matched = rule.TryEMatchApply(graph, id, witnessCost, out other); }
+                            try { matched = rule.TryEMatchApply(graph, id, witnessCost, spend, out other); }
                             catch { continue; }
                             if (!matched) continue;
                         }

--- a/Sources/Tests/UnitTests/Core/Transformations/ConstantFoldTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/ConstantFoldTest.cs
@@ -35,14 +35,18 @@ namespace AngouriMath.Tests.Core.Transformations
     /// to 7, and the run from more than ten minutes to 24 seconds.
     /// </para>
     /// <para>
-    /// <b>What is left is a stall, not a runaway.</b> The seven are a rational coefficient
-    /// beside a variable — <c>2 * x * 1/2</c>, <c>x / x * -x</c>, <c>x ^ 2 / x</c> — whose
-    /// spellings <c>1/2 * x</c>, <c>x / 2</c>, <c>x * 2 ^ (-1)</c> the <c>Rearranges</c> rules
-    /// keep exchanging. Given fifteen times the budget they still report no fixed point, but
-    /// the graph barely grows (135–583 e-nodes after thirty seconds) and every one extracts
-    /// the right answer. So the claim in <c>RunawayBreadthTest</c> that the coefficient rules
-    /// are confluent on plain arithmetic is true of the three inputs it pins and not of the
-    /// family; the honest statement is that they are bounded and correct, and not confluent.
+    /// <b>What is left is bounded by the budget and by nothing else.</b> The seven are a
+    /// rational coefficient beside a variable — <c>2 * x * 1/2</c>, <c>x / x * -x</c>,
+    /// <c>x ^ 2 / x</c> — whose spellings <c>1/2 * x</c>, <c>x / 2</c>, <c>x * 2 ^ (-1)</c> the
+    /// <c>Rearranges</c> rules keep exchanging. Measured once extraction stopped being the
+    /// cost (<a href="https://github.com/asc-community/AngouriMath/issues/1199">#1199</a>):
+    /// <c>x ^ 2 / x</c>, <c>x / x * -x</c> and <c>x / x * x * 1/2</c> are genuine runaways,
+    /// ten to twelve thousand e-nodes in thirty seconds; <c>2 * x * 1/2</c> and its relatives
+    /// plateau at some 560 e-nodes and stop only when 200,000 steps run out. An earlier
+    /// version of this remark called them stalls at 135–583 e-nodes, which was the slow
+    /// extraction and not the graph. Every one extracts the right answer regardless, and the
+    /// claim in <c>RunawayBreadthTest</c> that the coefficient rules are confluent on plain
+    /// arithmetic is true of the three inputs it pins and not of the family.
     /// </para>
     /// <para>
     /// <b>On the corpus the ceiling is cheap and finds a little more.</b> Every one of the 40
@@ -131,11 +135,12 @@ namespace AngouriMath.Tests.Core.Transformations
         }
 
         /// <summary>
-        /// Pinned in both directions: an entry that starts saturating is to be deleted, and one
-        /// whose graph grows past a thousand e-nodes has stopped being a stall.
+        /// Pinned in both directions under a three-thousand-step budget: an entry that starts
+        /// saturating is to be deleted, and one whose graph passes a thousand e-nodes within
+        /// those steps has changed character. The extraction must be right either way.
         /// </summary>
         [Fact]
-        public void ACoefficientBesideAVariableStallsRatherThanRunsAway()
+        public void ACoefficientBesideAVariableIsBoundedByTheBudgetAndExtractsRight()
         {
             var stalls = new[] { "2 * x * 1/2", "x * 1/2 * 2", "x ^ 2 / x", "x / x * -x" };
             var answers = new[] { "x", "x", "x", "-x" };

--- a/Sources/Tests/UnitTests/Core/Transformations/EGraphTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/EGraphTest.cs
@@ -282,15 +282,14 @@ namespace AngouriMath.Tests.Core.Transformations
         }
 
         /// <summary>
-        /// <see cref="EGraph.Extract"/> recurses through an e-class's children, and its cycle
-        /// guard bounds the chain only by the number of distinct classes -- which unions grow
-        /// past the input expression's own syntactic depth. Past the cap it declines to build,
-        /// the same answer the cycle case already gives, rather than exhausting the stack: a
-        /// <see cref="System.StackOverflowException"/> cannot be caught, so it takes the process
-        /// down instead of failing one call.
+        /// <see cref="EGraph.Extract"/> used to recurse through an e-class's children and decline
+        /// to build past 256 levels, because a <see cref="System.StackOverflowException"/> cannot
+        /// be caught. It is a fixed point from the leaves up now, with no stack to exhaust, so a
+        /// chain three hundred deep extracts as itself -- this test asserted <see langword="null"/>
+        /// for that input while the guard existed.
         /// </summary>
         [Fact]
-        public void ExtractDeclinesToBuildPastItsDepthCap()
+        public void ExtractBuildsAChainDeeperThanTheOldCap()
         {
             Entity deep = "x".ToEntity();
             for (var i = 0; i < 300; i++) deep += 1;
@@ -299,7 +298,7 @@ namespace AngouriMath.Tests.Core.Transformations
 
             var extracted = graph.Extract(root, CostModel.Default.Cost);
 
-            Assert.Null(extracted);
+            Assert.Equal(deep, extracted);
         }
 
         /// <summary>


### PR DESCRIPTION
#1199 recorded `Saturation` overshooting a 2 s wall by up to 35×. Now that the perfect-square
collapse (#1201) relies on a 50 ms budget inside `Simplify`, a budget that can be overshot is the
most important thing the graph work left open. This closes it, with the cause measured rather
than the one I guessed in the issue.

## Where the time went

Instrumenting the loop on the worst input, three layers down:

| layer | finding |
|---|---|
| the saturation loop | 99% in `TryEMatchApply`; `Extract`, `Rebuild`, `Apply`, `Add` ≈ 1% together |
| one attempt | 1,918 ms on a thirteen-member class, returning on its **first** binding |
| that binding's steps | the whole 1,918 ms in **one `graph.Extract` of one bound class**, on a 253-node graph |

The walk was top-down with a `visiting` cycle guard and a memo that fills only on completion. A
graph full of union-made cycles defeats that: any class on the stack blocks memoisation of
everything beneath it, so sibling paths walk the same subgraph again and again — exponential in
practice. My guess in #1199 (the ledger not consulted often enough) was wrong: `Spend()` reads
the clock every call; the problem was a single un-spendable 1.9 s step.

## The fix

- **Extraction is a fixed point from the leaves up**: a round recomputes every class from its
  children's current best, in class order and member order so ties fall as they did, until a
  round changes nothing. No recursion, so no depth guard and no stack to exhaust — a chain 300
  deep extracts as itself where it came back `null` (the test that pinned the `null` is rewritten
  to say so). The result is kept while the graph is unchanged and the cost is the same delegate;
  only a union can change what an existing class extracts as, so `Union` drops it.
- **The e-matcher charges the ledger per binding tried** after the first, so an attempt over a
  thousand-member class is a thousand steps, not one.

## Measured

Same inputs, same budget (20,000 steps / 2 s):

| | before | after |
|---|---|---|
| `x / x * x * 1/2` total | 2,435 ms | **2,000 ms** |
| `x / x * -x` total | 2,595 ms | **2,000 ms** |
| longest single attempt | 1,918 ms | 4 ms |
| longest single extraction | 1,918 ms | 3 ms |

Every Transformations pin holds — the corpus figures, the safe-ceiling 2-of-5, the ablation,
the breadth, the canonical-extraction ties.

## A correction of my own

With extraction no longer the cost, the inputs #1200 called a *stall* are two things:
`x ^ 2 / x`, `x / x * -x` and `x / x * x * 1/2` are **genuine runaways** (10–12k e-nodes in 30 s,
~400 a second), and `2 * x * 1/2` and its relatives plateau at ~560 e-nodes and stop only when
200,000 steps run out. "Bounded at 135–583 e-nodes after thirty seconds" was the slow extraction,
not the graph. `ConstantFoldTest` says so now and its pin is renamed to what it pins — bounded by
the budget, extracting right. #1200 gets the corrected figures.

## Changed answers

None, measured on a build of master (`0285c71a`) and of this branch through the public
`Transformation.CanonicalizationOverGraph` and `Saturation.ProvesEqual`: the 300-deep chain is
`300 + x` on both (the rule pass on either side of the graph folds it before the graph sees it, so
the old `null` never reached a caller), `x / x * -x` is `-x` and `x ^ 2 / x` is `x` on both, and
the two perfect-square proofs succeed on both at 50 ms. What changed is the clock: `x ^ 2 / x`
against a 2 s budget took 2,216 ms on master and 2,006 ms here. No `BREAKING-CHANGES.md` row,
since no value moved.

Part of #746. Fixes #1199.

## Checks

Full suite 9610 passed, 0 failed, 14 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
