### PR TITLE
The two documents that still deferred a scheduling policy say what was measured

### DIFF
--- a/Sources/AngouriMath/Docs/Contributing/EMatching.md
+++ b/Sources/AngouriMath/Docs/Contributing/EMatching.md
@@ -26,6 +26,15 @@ using the reversibility work to avoid firing a rule right next to its own invers
 whichever matcher is underneath — not a consequence of this document. This document is scoped to what
 e-matching actually buys: not materialising a term to find out whether a rule's *shape* matches.
 
+> **Answered since, by measurement rather than by a policy** (#1193, #1194). The one runaway at the
+> widest ceiling is a single inverse pair split across `ExpandMultipleAngle` and `Trigonometric`,
+> bounded to the trigonometric sets; at `RulesUpTo(Rearranges)` every member of that family
+> saturates, because `ExpandMultipleAngle` declares `Expands`. **The growth ceiling is the
+> scheduling policy**: it withholds the expanding direction of every pair whose two directions are
+> declared, and can only protect a pair whose directions *are* declared — which is what declaring a
+> growth for a code-built rule is for (#1195–#1197). `Expands` rules do not join `SafeRules`, and no
+> second mechanism is planned. See `InversePairTable.md` and `RunawayBreadthTest`.
+
 ## Where the patterns actually are
 
 `RewriteRules.All` — the public registry `Transformation.EqualitySaturation` drew `SafeRules` from
@@ -168,8 +177,11 @@ bound are extracted — narrower than falling back on the whole rule.
 
 ## What is deliberately not decided here
 
-**Whether `Growth.Expands` rules ever join `SafeRules`**, and under what scheduling policy — a
-separate document's question, once one exists to answer it.
+**Whether `Growth.Expands` rules ever join `SafeRules`** — decided since, and by measurement: they
+do not, and the growth ceiling is the scheduling policy (see the note under *What this is not
+trying to fix*, above). What the graph does need is a rational folded on insertion (#1198) and an
+extraction that is a fixed point from the leaves up rather than a recursive walk (#1202), both of
+which were found by running the safe ceiling over the corpus rather than over sixteen expressions.
 
 **Whether the local fallback (extract-then-`TryApply`, kept for `Gathered`-containing rules) is worth
 removing later** by also solving e-matching for `GatheredPattern`, or stays permanently as the honest

--- a/Sources/AngouriMath/Docs/Contributing/Transformations.md
+++ b/Sources/AngouriMath/Docs/Contributing/Transformations.md
@@ -244,7 +244,11 @@ So what is left, in dependency order:
   consumer #746 tier 2 names is the inverse-pair table equality saturation needs, since a saturation
   engine keeps both results where this pipeline keeps one and so has to be told which rewrites undo
   each other. `RewriteRuleGrowth` does not answer that: it says which way a rule moves, not which
-  rule is the inverse of which.
+  rule is the inverse of which — though for a pair whose two directions are *declared*, the growth
+  ceiling already withholds the expanding one (#1194), which is as much of the table as saturation
+  has needed so far. The graph itself has its first production caller: the perfect-square collapse
+  asks `Saturation.ProvesEqual` before it asks `Simplify` (#1201), measured as a caller that meets
+  the standing performance condition rather than as a speed-up.
 - **Rendering a step as a sentence** — #746's v5.0. Everything a sentence needs is now on a step
   except one thing: *why the rewrite is allowed*. `Soundness` is declared, not checked, and a rule
   that holds only under an assumption does not say which. That is the same gap


### PR DESCRIPTION
Documentation only. Two contributor documents still carried the tier 2 state as it was before this
week's PRs, and a reader following them would re-open questions that are answered:

- `EMatching.md` deferred whether `Expands` rules ever join `SafeRules` "to a separate document's
  question, once one exists". It now points at the measurement: the growth ceiling *is* the
  scheduling policy (#1193, #1194), `Expands` rules do not join the safe set, and what the graph
  actually needed was a rational folded on insertion (#1198) and an extraction that is a fixed
  point from the leaves up (#1202) — both found by running the safe ceiling over the corpus.
- `Transformations.md`'s "what is left" said the graph had no production caller. It has one
  (#1201), and the bullet says what the growth ceiling already does for a declared inverse pair.

No code, no tests, no changed answers. Part of #746.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
