### PR TITLE
A graph transformation stops when its answer has, not only when the graph has

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Saturation.cs
+++ b/Sources/AngouriMath/Core/Transformations/Saturation.cs
@@ -109,8 +109,18 @@ namespace AngouriMath.Core.Transformations
         /// <i>witness</i>, never the answer: what the caller finally extracts is the caller's own
         /// business, and is where a cheapest-form and a canonical-form caller differ.
         /// </param>
+        /// <param name="settled">
+        /// A caller's own stop, asked after every pass that merged something; <see langword="true"/>
+        /// ends the run without the graph's fixed point having been reached. A caller that
+        /// extracts an answer passes "the extraction has not changed for two passes": that is
+        /// the fixed point which matters to it, and it comes where the graph's own may never —
+        /// on a rational coefficient beside a variable, the regrouping rules add a fresh e-node
+        /// to the root's class on every pass while its cheapest member stopped changing on the
+        /// third (<a href="https://github.com/asc-community/AngouriMath/issues/1200">#1200</a>).
+        /// <see cref="ProvesEqual"/> passes nothing: it needs a union, not an extraction.
+        /// </param>
         internal static bool Run(EGraph graph, IReadOnlyList<MatchedRule> rules,
-            BudgetLedger ledger, Func<Entity, double> witnessCost)
+            BudgetLedger ledger, Func<Entity, double> witnessCost, Func<bool>? settled = null)
         {
             var chargedNodes = graph.NodeCount;
             bool ChargeGrowthSinceLastCall()
@@ -220,6 +230,7 @@ namespace AngouriMath.Core.Transformations
                 if (!ledger.Spend()) break;
                 graph.Rebuild();
                 if (!merged) saturated = true;
+                else if (settled is not null && settled()) break;
             }
             return saturated;
         }

--- a/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
+++ b/Sources/AngouriMath/Core/Transformations/Transformation.Catalogue.cs
@@ -470,10 +470,17 @@ namespace AngouriMath.Core.Transformations
         /// <b>What this is not.</b> Not a canonical form <i>for the language</i> — no such thing
         /// exists here, since zero-equivalence is undecidable, and
         /// <c>Docs/Contributing/CanonicalForm.md</c> states that boundary. It is a canonical form
-        /// <i>modulo these rules and this budget</i>: equal trees mean the rules proved the two
-        /// expressions equal, different trees mean they did not, and a budget that ran out is
-        /// reported rather than hidden. Nothing in the library calls this — like
-        /// <see cref="Canonicalization"/> it is offered, not applied.
+        /// <i>modulo these rules, this budget, and the answer having settled</i>: equal trees mean
+        /// the rules proved the two expressions equal, different trees mean they did not, and a
+        /// budget that ran out is reported rather than hidden. The run stops once the least
+        /// member of the input's class has survived two passes unchanged, which is the fixed
+        /// point that matters to an extraction and comes where the graph's own may never — on
+        /// a rational coefficient beside a variable the regrouping rules add a member on every
+        /// pass for as long as they are allowed (<a href="https://github.com/asc-community/AngouriMath/issues/1200">#1200</a>),
+        /// and the answer was settled on the third. Measured on the corpus and on those inputs,
+        /// no answer moved and the nine of them went from two seconds to milliseconds. Nothing
+        /// in the library calls this — like <see cref="Canonicalization"/> it is offered, not
+        /// applied.
         /// </para>
         /// </remarks>
         /// <remarks>
@@ -673,10 +680,31 @@ namespace AngouriMath.Core.Transformations
                 graph.Rebuild();
 
                 var ledger = BudgetLedger.For(Name, budget);
-                Saturation.Run(graph, SafeRules, ledger, costModel.Cost);
+                // Stop once the answer has: after two passes in which the cheapest member of the
+                // root's class did not change, further merging can only add members this
+                // extraction would not choose. That is the fixed point a caller who extracts
+                // cares about, and on #1200's inputs it comes on the third pass where the
+                // graph's own never does. Measured on the corpus, no answer moves.
+                Entity? last = null;
+                var unchanged = 0;
+                bool Settled()
+                {
+                    var now = graph.Extract(root, costModel.Cost);
+                    unchanged = now is not null && now.Equals(last) ? unchanged + 1 : 0;
+                    last = now;
+                    return unchanged >= SettledPasses;
+                }
+                Saturation.Run(graph, SafeRules, ledger, costModel.Cost, Settled);
                 ledger.Report();
                 return graph.Extract(root, costModel.Cost) ?? input;
             }
+
+            /// <summary>
+            /// How many consecutive passes the extracted answer must survive unchanged before
+            /// the run stops on the answer rather than on the graph. Two, not one: a pass can
+            /// leave the cheapest member alone while adding what the next pass will improve on.
+            /// </summary>
+            private const int SettledPasses = 2;
         }
 
         /// <summary>
@@ -711,7 +739,18 @@ namespace AngouriMath.Core.Transformations
                 graph.Rebuild();
 
                 var ledger = BudgetLedger.For(Name, budget);
-                Saturation.Run(graph, rules, ledger, CostModel.Default.Cost);
+                // The same stop as EqualitySaturationTransformation's, on the least member
+                // rather than the cheapest, since that is what this extracts.
+                Entity? last = null;
+                var unchanged = 0;
+                bool Settled()
+                {
+                    var now = graph.ExtractLeast(root, EntityOrder.Canonical);
+                    unchanged = now is not null && now.Equals(last) ? unchanged + 1 : 0;
+                    last = now;
+                    return unchanged >= 2;
+                }
+                Saturation.Run(graph, rules, ledger, CostModel.Default.Cost, Settled);
                 ledger.Report();
 
                 // The least member, not the cheapest: a cost model ties, and a tie would make the


### PR DESCRIPTION
The runaways of #1200, made cheap for the callers that matter — without pretending the rules are
confluent.

## What the trace showed

`x ^ 2 / x` at the safe ceiling: the root's class extracts `x` from pass 3 and never stops gaining
members — the quotient-regrouping rules (`a/(b/c)`, `(a/b)·c`, `(a/b)/(c/d)`…) recombine members
across classes, so every pass adds fresh e-nodes for as long as the budget allows (nodes 68 → 247
in one pass; 12k in 30 s). A caller who extracts an answer paid the whole budget for an answer it
had in milliseconds.

## What changes

`Saturation.Run` takes a caller's own stop, asked after every pass that merged something. The two
transformations that *extract* — `EqualitySaturation` (cheapest member) and
`CanonicalizationOverGraph` (least member) — pass "the extraction has not changed for two passes".
Two, not one: a pass can leave the chosen member alone while adding what the next pass improves
on. `ProvesEqual` passes nothing — it needs a union, not an extraction — so the perfect-square
caller (#1201) is unaffected.

## Measured

Corpus gate's 40 problems + the 9 inputs of #1200 + the 5 pinned ordinary ones, through both
public transformations, before and after:

| | before | after |
|---|--:|--:|
| **every answer** | | **identical** |
| all 54 inputs, both transformations | 13,495 ms | **320 ms** |
| `x / x * -x` | 1,869 ms | 10 ms |
| `x ^ 2 / x` | 2,010 ms | 3 ms |
| `x / x * x * 1/2` | 2,011 ms | 12 ms |
| `2 ^ (-1) / sqrt(1/2)` (saturation) | 998 ms | 2 ms |

The remark on `CanonicalizationOverGraph` now says what its canonical form is modulo: these rules,
this budget, *and the answer having settled*. No `BREAKING-CHANGES.md` row: no value moved.

## What it does not do

It does not make the coefficient rules confluent; the bare graph still runs away on this family
and `ConstantFoldTest` still pins that. #1200 stays open as the question about the rules — a
normal form for a coefficient's spellings, or an orientation — with its practical cost gone.

Part of #746.

## Checks

Full suite 9610 passed, 0 failed, 14 skipped — every pin on the bare graph (ablation, breadth, constant fold, canonical extraction) unchanged, since `Saturation.Run` without a stop is what they call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
