### PR TITLE
The sort key of a node is spelt once: SimplifyHard -35% allocation

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -30,6 +30,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [AngouriMath/Functions/TreeAnalyzer/RealValued.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[Tests/UnitTests/Core/SortKeyCacheTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [Tests/UnitTests/Calculus/ModulusPhaseTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 

--- a/Sources/AngouriMath/Docs/WhatsNew/version_performance_control.md
+++ b/Sources/AngouriMath/Docs/WhatsNew/version_performance_control.md
@@ -270,6 +270,37 @@ What is left of a `SimplifyHard` level, for whoever comes next: the remaining re
 factorisation at level 2, and the opened angles expanded — at 177, 170 and 82 MB, each a
 recursive simplification of an expanded tree.
 
+## The 1936th: the sort key of a node is spelt once
+
+The same hook, on `SimplifyHard`, attributed this time to the registration steps of
+`Simplificator.Alternate`: the `CanonicalOrder` sort was 174 MB of the run's 735, some 2.6 MB per
+sort of a tree a few hundred nodes wide. `Entity.SortHash` builds a node's key out of the keys of
+every node below it and nothing kept them, so one sort re-spelt each subtree once per ancestor —
+and the simplifier sorts what it registers at every pass of every level, in its own run and in
+the three nested runs its candidates cost. The key is kept on the instance now: one reference per
+node, an array made on the first sort, behind a struct that is equal to every other.
+
+Four shapes were measured, and the three rejected ones are worth the lines. Three lazy slots
+per node saved the same bytes and cost every node some fifty of its own, which the gate saw as
++4–6% on every solve and derivative entry. A dictionary kept for the run, keyed by reference,
+saved the bytes and cost a lookup per node per sort: 369 ms against 266. And a bare array field
+took part in the record's equality, so a tree that had been sorted stopped equalling its unsorted
+twin and the simplifier, which recognises a repeated candidate by equality, never recognised one:
+**30 GB and 57 s**, from a change whose unit test passed. HonkSharp's `LazyPropertyA` exists for
+exactly that reason, and the struct here does what it does.
+
+| benchmark | 1935th | 1936th | allocation | time |
+|---|--:|--:|--:|--:|
+| `SimplifyHard` | 680,457,400 | **442,898,152** | **−34.9%** | 339 → 258 ms |
+| `SimplifyEasy` | 110,051 | 106,643 | −3.1% | 66.4 → 68.8 µs |
+| every solve entry, `Derivate`, `ParseEasy` | | | +0.4% to +0.9% | within noise |
+
+Bytes allocated per call, same machine, both columns measured by the gate in one session. The
+fraction of a percent on the other rows is the one reference per node. Since the 1930th:
+`SimplifyHard` **−88%**. Timings carry the usual rider; the gate's baseline was taken from this
+run. No answer moves: the key is the same string, spelt once, and equality is untouched —
+`SortKeyCacheTest` pins both, and that a `with` copy spells its own key.
+
 ## The 1935th: the solver tries the equation as written
 
 The same hook, on `SolveHard` and attributed to the stages of `AnalyticalEquationSolver.Solve`

--- a/Sources/AngouriMath/Functions/TreeAnalyzer/Sort.Definition.cs
+++ b/Sources/AngouriMath/Functions/TreeAnalyzer/Sort.Definition.cs
@@ -14,8 +14,61 @@ namespace AngouriMath
     partial record Entity
     {
         /// <summary>Hash that is convenient to sort with</summary>
-        internal string SortHash(SortLevel level) =>
-            SortHashName(level) + string.Join("_", DirectChildren.Select(child => child.SortHash(level)).Where(x => x is not ""));
+        /// <remarks>
+        /// Spelt once per instance and level, as <see cref="InnerSimplified"/> and
+        /// <see cref="SimplifiedRate"/> are computed once. The key of a node is built out of the
+        /// keys of every node below it, and the sort asks for the key of every operand of every
+        /// chain it orders, so without the memo one sort of a tree walked and re-spelt each
+        /// subtree once per ancestor -- and the simplifier sorts what it registers at every pass.
+        /// On <c>SimplifyHard</c> that was 174 MB of one run's 735, some 2.6 MB per sort of a
+        /// tree a few hundred nodes wide. A candidate shares most of its subtrees with the
+        /// candidates before it, and a shared subtree's key is now spelt once.
+        /// <para/>
+        /// Three things about the shape of the memo, each measured. It is one reference per node
+        /// and an array made on the first sort, not a lazy slot per level: three slots cost
+        /// every node some fifty bytes, which the gate saw as +4-6% on every solve and derivative
+        /// entry for a saving only the sort ever sees. It is on the instance and not in a
+        /// dictionary kept for the run: keyed by reference the dictionary saved the same bytes
+        /// and cost a lookup per node per sort, 369 ms against 266 for the same input. And the
+        /// array names its owner, because a <c>with</c> copy -- <see cref="WithCodomain"/>, a
+        /// re-differentiation -- carries the original's fields while a number's key spells its
+        /// codomain: a copy finds an array that is not its own and starts one of its own.
+        /// https://github.com/asc-community/AngouriMath/issues/746
+        /// </remarks>
+        internal string SortHash(SortLevel level)
+        {
+            var cache = sortHashes.Keys;
+            if (cache is null || !ReferenceEquals(cache[Owner], this))
+            {
+                // Two threads may each make one; both are right, and whichever lands stays.
+                cache = new object?[Owner + 1];
+                cache[Owner] = this;
+                sortHashes.Keys = cache;
+            }
+            if (cache[(int)level] is string known)
+                return known;
+            var key = SortHashName(level) + string.Join("_", DirectChildren.Select(child => child.SortHash(level)).Where(x => x is not ""));
+            cache[(int)level] = key;
+            return key;
+        }
+        /// <summary>The slot after the three levels, holding the node the array was made for.</summary>
+        private const int Owner = 3;
+        private SortKeyCache sortHashes;
+
+        /// <summary>
+        /// The keys, behind a struct that is equal to every other, for the reason
+        /// <c>LazyPropertyA</c> is: an <see cref="Entity"/> is a record and compares every
+        /// field, so a bare array here made two equal trees unequal the moment one had been
+        /// sorted -- and the simplifier, which recognises a repeated candidate by equality,
+        /// then never recognised one. Measured: 30 GB and 57 s on <c>SimplifyHard</c>.
+        /// </summary>
+        private struct SortKeyCache : IEquatable<SortKeyCache>
+        {
+            internal object?[]? Keys;
+            public bool Equals(SortKeyCache other) => true;
+            public override bool Equals(object? obj) => obj is SortKeyCache;
+            public override int GetHashCode() => 0;
+        }
         private protected abstract string SortHashName(SortLevel level);
     }
 }

--- a/Sources/Tests/DotnetBenchmark/performance-baseline.json
+++ b/Sources/Tests/DotnetBenchmark/performance-baseline.json
@@ -1,82 +1,82 @@
 {
   "comment": "Allocated bytes and mean nanoseconds per operation for the popular use cases of https://github.com/asc-community/AngouriMath/issues/746. Checked by PerformanceGate.cs; see Sources/AngouriMath/Docs/WhatsNew/version_performance_control.md for when updating it is legitimate.",
   "benchmark": "CommonFunctionsInterVersion",
-  "commit": "28dcb9917302396c30ddd3d0c96b71954cbef7fb",
-  "measuredOn": "2026-09-07",
+  "commit": "263c0c1866abe824a692ccf87f9c5acd3a8adc15",
+  "measuredOn": "2026-09-08",
   "runtime": ".NET 10.0.10",
   "machine": "Ubuntu 26.04 LTS, X64, 8 logical cores",
   "cases": {
     "CompileEasy": {
-      "allocatedBytes": 11003,
-      "meanNanoseconds": 189915.3998674665
+      "allocatedBytes": 10970,
+      "meanNanoseconds": 189262.70155552455
     },
     "CompileHard": {
       "allocatedBytes": 20433,
-      "meanNanoseconds": 317361.80247395835
+      "meanNanoseconds": 316154.2491536458
     },
     "Derivate": {
-      "allocatedBytes": 52823,
-      "meanNanoseconds": 13861.021153041294
+      "allocatedBytes": 53239,
+      "meanNanoseconds": 13995.347786458333
     },
     "EvalEasy": {
       "allocatedBytes": 0,
-      "meanNanoseconds": 1.8879165711502235
+      "meanNanoseconds": 1.8789053452866418
     },
     "EvalTrig": {
-      "allocatedBytes": 1341377,
-      "meanNanoseconds": 711527.9987792969
+      "allocatedBytes": 1341457,
+      "meanNanoseconds": 708454.6445963542
     },
     "EvalTrigPrecise": {
-      "allocatedBytes": 12742205,
-      "meanNanoseconds": 22582372.584134616
+      "allocatedBytes": 12742285,
+      "meanNanoseconds": 22644778.078125
     },
     "ParseEasy": {
-      "allocatedBytes": 18125,
-      "meanNanoseconds": 5814.182232157389
+      "allocatedBytes": 18205,
+      "meanNanoseconds": 5754.018038613455
     },
     "ParseHard": {
-      "allocatedBytes": 3531241,
-      "meanNanoseconds": 1385166.6953125
+      "allocatedBytes": 3531505,
+      "meanNanoseconds": 1371757.569561298
     },
     "RunEasy": {
       "allocatedBytes": 0,
-      "meanNanoseconds": 20.092127207914988
+      "meanNanoseconds": 20.060955625772475
     },
     "RunHard": {
       "allocatedBytes": 0,
-      "meanNanoseconds": 292.54727721214294
+      "meanNanoseconds": 296.18873796463015
     },
     "RunMedium": {
       "allocatedBytes": 0,
-      "meanNanoseconds": 174.00879979133606
+      "meanNanoseconds": 163.0917092391423
     },
     "SimplifyEasy": {
-      "allocatedBytes": 110051,
-      "meanNanoseconds": 66419.67370605469
+      "allocatedBytes": 106643,
+      "meanNanoseconds": 68843.41984340122
     },
     "SimplifyHard": {
-      "allocatedBytes": 680457400,
-      "meanNanoseconds": 339196117.2307692
+      "allocatedBytes": 442898152,
+      "meanNanoseconds": 258074398.31578946
     },
     "SolveEasy": {
-      "allocatedBytes": 8864440,
-      "meanNanoseconds": 4847439.122767857
+      "allocatedBytes": 8865872,
+      "meanNanoseconds": 4825788.3984375
     },
     "SolveEasyMedium": {
-      "allocatedBytes": 65232,
-      "meanNanoseconds": 19175.254420689173
+      "allocatedBytes": 65630,
+      "meanNanoseconds": 19396.875710623604
     },
     "SolveHard": {
-      "allocatedBytes": 11818936,
-      "meanNanoseconds": 108568157.4
+      "allocatedBytes": 11884272,
+      "meanNanoseconds": 117348382.75
     },
     "SolveMedium": {
-      "allocatedBytes": 452901,
-      "meanNanoseconds": 387163.33642578125
+      "allocatedBytes": 455893,
+      "meanNanoseconds": 386868.59026227676
     },
     "SolveMediumHard": {
-      "allocatedBytes": 1435934,
-      "meanNanoseconds": 13918494.591517856
+      "allocatedBytes": 1449394,
+      "meanNanoseconds": 13927705.746875
     }
   },
   "ungated": {

--- a/Sources/Tests/UnitTests/Core/SortKeyCacheTest.cs
+++ b/Sources/Tests/UnitTests/Core/SortKeyCacheTest.cs
@@ -1,0 +1,87 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Linq;
+using System.Threading.Tasks;
+using AngouriMath;
+using AngouriMath.Core;
+using AngouriMath.Extensions;
+using Xunit;
+using static AngouriMath.Functions.TreeAnalyzer;
+
+namespace AngouriMath.Tests.Core
+{
+    /// <summary>
+    /// The sort key of a node is spelt once per instance and level and kept on the instance.
+    /// What has to stay true: the key is the same string it always was, a copy made with
+    /// <c>with</c> spells its own key rather than inheriting the original's, and asking from
+    /// several threads at once gives every thread the same string.
+    /// </summary>
+    public sealed class SortKeyCacheTest
+    {
+        [Theory]
+        [InlineData("x + y * sin(x) + 3 / x")]
+        [InlineData("(a + b) * (a - b) + a ^ 2")]
+        public void TheKeyIsTheSameOnEveryAsk(string source)
+        {
+            var expr = source.ToEntity();
+            foreach (var level in new[] { SortLevel.HIGH_LEVEL, SortLevel.MIDDLE_LEVEL, SortLevel.LOW_LEVEL })
+            {
+                var first = expr.SortHash(level);
+                var again = expr.SortHash(level);
+                Assert.Equal(first, again);
+                // The same tree built separately spells the same key: the cache changes nothing.
+                Assert.Equal(first, source.ToEntity().SortHash(level));
+            }
+        }
+
+        // A number's key at the exact level is its printed form, and the printed form carries
+        // a codomain. WithCodomain is `this with { Codomain = ... }`, which copies every field
+        // of the record -- a cache kept on the instance included -- so the copy has to notice
+        // that the cache is not its own.
+        [Fact]
+        public void ACopyWithAnotherCodomainSpellsItsOwnKey()
+        {
+            Entity half = "1/2";
+            var plain = half.SortHash(SortLevel.LOW_LEVEL);
+            var annotated = half.WithCodomain(Domain.Complex);
+            var annotatedKey = annotated.SortHash(SortLevel.LOW_LEVEL);
+            Assert.NotEqual(plain, annotatedKey);
+            Assert.Equal(annotated.Stringize() + " ", annotatedKey);
+            // And the original is not disturbed by the copy having been asked.
+            Assert.Equal(plain, half.SortHash(SortLevel.LOW_LEVEL));
+        }
+
+        // An Entity is a record and compares every field. The cache must not take part: the
+        // simplifier recognises a repeated candidate by equality, and a tree that had been
+        // sorted comparing unequal to the same tree that had not sent SimplifyHard to 30 GB.
+        [Fact]
+        public void SortingDoesNotDisturbEquality()
+        {
+            var sorted = "x + y * sin(x) + 3 / x".ToEntity();
+            var untouched = "x + y * sin(x) + 3 / x".ToEntity();
+            sorted.SortHash(SortLevel.LOW_LEVEL);
+            Assert.Equal(sorted, untouched);
+            Assert.Equal(sorted.GetHashCode(), untouched.GetHashCode());
+            Assert.Single(new System.Collections.Generic.HashSet<Entity> { sorted, untouched });
+            Assert.Equal(sorted.Simplify(), untouched.Simplify());
+        }
+
+        [Fact]
+        public void EveryThreadGetsTheSameKey()
+        {
+            var expr = "x * y + sin(x) ^ 2 * cos(y) + (a + b) / (c - d)".ToEntity();
+            var expected = expr.SortHash(SortLevel.HIGH_LEVEL);
+            var keys = new string[64];
+            Parallel.For(0, keys.Length, i => keys[i] = "x * y + sin(x) ^ 2 * cos(y) + (a + b) / (c - d)".ToEntity().SortHash(SortLevel.HIGH_LEVEL));
+            Assert.All(keys, key => Assert.Equal(expected, key));
+            var same = new string[64];
+            Parallel.For(0, same.Length, i => same[i] = expr.SortHash(SortLevel.MIDDLE_LEVEL));
+            Assert.Single(same.Distinct());
+        }
+    }
+}


### PR DESCRIPTION
Part of #746 — the standing condition on speed. Same method as #1205, #1207 and #1209: a temporary hook attributing allocated bytes, this time to the registration steps of `Simplificator.Alternate` on `SimplifyHard`.

## What the attribution showed

The `CanonicalOrder` sort inside registration was **174 MB of the run's 735**, about 2.6 MB per sort of a tree a few hundred nodes wide. `Entity.SortHash(level)` builds a node's key out of the keys of every node below it, and nothing kept them: one sort re-spelt each subtree once per ancestor, and the simplifier sorts what it registers at every pass of every level — in its own run and in the three nested runs its expand/factor/multiple-angle candidates cost.

## What changes

The key is kept on the instance: one reference per node, an array made on the first sort, with the node the array was made for in its last slot, behind a struct that is equal to every other struct of its kind. Four shapes were measured and the three rejected ones are written beside the one kept:

| shape | `SimplifyHard` | why not |
|---|--:|---|
| three `LazyPropertyA<string>` slots | 449 MB, 266 ms | every node +~50 B: `Derivate` +4.7%, `SolveMediumHard` +5.6%, three more rows over the gate's 3% |
| a `[ThreadStatic]` dictionary for the run, keyed by reference | 439 MB, 369 ms | a lookup per node per sort costs more time than the strings it saves |
| a bare `object?[]?` field with an owner slot | **30 GB, 57 s** | `Entity` is a record; the field took part in equality, a sorted tree stopped equalling its unsorted twin, and the simplifier never recognised a repeated candidate. Its unit test passed. |
| the same array behind an equality-neutral struct | **443 MB, 258 ms** | kept |

The owner slot matters on its own: `WithCodomain` is `this with { Codomain = … }` and a re-differentiation is `this with { Iterations = … }`, both of which copy every field of the record, while a number's key spells its codomain. A copy finds an array that is not its own and starts one.

## Measured

Gate on one machine, both columns in one session:

| | baseline (`574555bf`) | this change | allocation | time |
|---|--:|--:|--:|--:|
| `SimplifyHard` | 680,457,400 B, 339 ms | **442,898,152 B, 258 ms** | **−34.9%** | 0.76x |
| `SimplifyEasy` | 110,051 B, 66.4 µs | 106,643 B, 68.8 µs | −3.1% | 1.04x |
| every solve entry, `Derivate`, `ParseEasy` | | | +0.4% to +0.9% | 1.00x |

The fraction of a percent on the other rows is the one reference per node. Since the 1930th column: `SimplifyHard` −88%. The baseline is updated in the same change.

## Answers

None move: the key is the same string, spelt once. `SortKeyCacheTest` pins that the key is the same on every ask and for a separately built equal tree, that a `with` copy with another codomain spells its own key, that sorting leaves equality and hash codes untouched, and that every thread gets the same key.

## Checks

Full suite in two chunks: 9,666 passed, 0 failed (Calculus 1,322, the rest 8,344).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
