### PR TITLE
A series in a power over a factorial is summed in closed form

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -85,6 +85,7 @@ read first.
 | **Silent** | `"0 * (i * +oo)".Evaled`, and every whole zero times a complex infinity | `0` | `NaN` |
 | | `RewriteRules.Common.Rules.Count`, and `RewriteRules.All` by growth | `62`; 124 / 46 / 31 / 123 | `65`; 124 / 49 / 31 / 123 |
 | | `"(x - b) / (x + a) + c / (x + a)".SolveEquation("x")`, and every equation the replacement machinery solves whose condition is spelled from the equation as written | `{ -(-b + c) provided not a + -(-b + c) = 0 }` | `{ -(-b + c) provided not -(-b + c) + a = 0 }` — the same set, the condition's terms in the order the equation had |
+| | `"sum(x^k / k!, k, 0, +oo)".ToEntity().Simplify()`, and every summation to `+oo` of a polynomial in the index times a power with the index in the exponent over a factorial of the index | `sum(x ^ k / k!, k, 0, +oo)` — left as written | `e ^ x`; `sum(3^(k+2) * (k^2 + k + 1) / (k + 3)!, k, 0, +oo)` is `4/3 * e ^ 3 - 41/6` |
 
 ### A cancelled quotient says its operand is defined, not only non-zero
 
@@ -1030,6 +1031,25 @@ order. Measured by the gate on one machine, bytes and time per call:
 | `SolveMediumHard` | 94,415,256 B, 66.8 ms | 1,435,934 B, 13.9 ms |
 | `SolveMedium`, `SolveEasyMedium` | 662,923 B, 456 µs; 97,335 B, 29.7 µs | 452,901 B, 387 µs; 65,232 B, 19.2 µs |
 | `SimplifyHard`, `SimplifyEasy` — the same pre-check, reached through `Simplify`'s factoring candidates | 733,188,536 B, 371 ms; 116,291 B, 71.2 µs | 680,457,400 B, 339 ms; 110,051 B, 66.4 µs |
+
+### A series in a power over a factorial is summed in closed form
+
+`sum(x^k / k!, k, 0, +oo)` was left as written; it is `e^x`. The whole family
+`sum(p(k) * c^(k + s) / (k + a)!, k, m, +oo)` — a polynomial in the index, a power with the index in
+its exponent, a factorial of the index plus a whole number — is `e^c` times a polynomial in `c`:
+shift the index so the factorial is `j!`, and `j^n * c^j / j!` sums to `e^c` times the Touchard
+polynomial `T_n(c)`, the Stirling numbers of the second kind carrying `j^n` into falling
+factorials. A lower bound above the shifted zero subtracts finitely many exact terms. The series
+converges for every `c`, so nothing is attached. The first of the orientation-week questions of
+[#1212](https://github.com/asc-community/AngouriMath/issues/1212); question two's series is the
+second row. Both columns measured on a build, `e2476ac5` against this change.
+
+| | Was | Is |
+|---|---|---|
+| `"sum(3^(k+2) * (k^2 + k + 1) / (k + 3)!, k, 0, +oo)".ToEntity().Simplify()` | left as written | `4/3 * e ^ 3 - 41/6` |
+| `"sum(1 / (2 * n!), n, 1, +oo)".ToEntity().Simplify()` | left as written | `(e - 1) / 2` |
+| `"sum(x^k / k!, k, 0, +oo)".ToEntity().Simplify()`, and `sum(k * x^k / k!, k, 0, +oo)` | left as written | `e ^ x`, `e ^ x * x` |
+| `"sum(1 / k, k, 1, +oo)"`, `sum(k!, k, 0, +oo)`, `sum(x^k / k!, k, n, +oo)`, `sum(3^(2k) / k!, k, 0, +oo)` | left as written | the same — not of the shape, or a symbolic lower bound, or a slope other than one in the exponent |
 
 ## 2.4.0 — since 2.3.0
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -186,6 +186,12 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [Tests/UnitTests/Calculus/ApplicationDerivativeTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[AngouriMath/Functions/Algebra/Polynomials/ExponentialSeries.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/ExponentialSeriesTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [AngouriMath/Functions/Algebra/Polynomials/PolynomialSummation.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 [Tests/UnitTests/Core/ClosedFormSummationTest.cs]

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/ExponentialSeries.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/ExponentialSeries.cs
@@ -1,0 +1,246 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using PeterO.Numbers;
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// A summation to <c>+oo</c> whose summand is a polynomial in the index times a power with
+    /// the index in the exponent, over a factorial of the index: <c>sum(x^k / k!, k, 0, +oo)</c>
+    /// is <c>e^x</c>, and <c>sum(3^(k+2) * (k^2 + k + 1) / (k + 3)!, k, 0, +oo)</c> is
+    /// <c>(8 * e^3 - 41) / 6</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The whole family is <c>e^c</c>. Shift the index so the factorial is <c>j!</c>, and the
+    /// summand is <c>q(j) * c^j / j!</c> for a polynomial <c>q</c>; then
+    /// <c>sum(j^n * c^j / j!, j, 0, +oo) = e^c * T_n(c)</c>, where <c>T_n</c> is the Touchard
+    /// polynomial <c>sum(S(n, m) * c^m, m, 0, n)</c> over the Stirling numbers of the second
+    /// kind -- <c>j^n</c> written in falling factorials, each of which sums to <c>c^m * e^c</c>.
+    /// A lower bound above the shifted zero subtracts the terms below it, which are finitely
+    /// many and exact. The series converges for every <c>c</c>, so no condition is owed.
+    /// </para>
+    /// <para>
+    /// Recognised structurally, on the factors of the simplified summand: exactly one
+    /// <c>(k + a)! ^ (-1)</c> with a whole <c>a</c>, at most one <c>c ^ (k + s)</c> with
+    /// <c>c</c> free of the index, and a polynomial in the index for the rest; anything else
+    /// is left as written. A power whose exponent is not the index plus a constant --
+    /// <c>c^(2k)</c> -- is declined rather than rewritten, and so is a base that is zero.
+    /// The first of the orientation-week questions of
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/1212">#1212</a>.
+    /// </para>
+    /// </remarks>
+    internal static class ExponentialSeries
+    {
+        /// <summary>
+        /// The degree of polynomial this will take; the Stirling table is quadratic in it and
+        /// the answer carries <c>c</c> to that power.
+        /// </summary>
+        private const int MaxDegree = 16;
+
+        /// <summary>
+        /// <c>sum(expression, index, from, +oo)</c> in closed form, or <see langword="null"/>
+        /// where the summand is not of the shape above, the upper bound is not <c>+oo</c>, or
+        /// the lower bound is not a whole number.
+        /// </summary>
+        internal static Entity? ClosedForm(Entity expression, Entity var, Entity from, Entity to)
+        {
+            if (var is not Variable index)
+                return null;
+            if (to.Evaled is not Real { IsFinite: false, IsNaN: false } upper || upper.IsNegative)
+                return null;
+            if (from.Evaled is not Integer lower || !lower.EInteger.CanFitInInt32())
+                return null;
+            var start = lower.EInteger.ToInt32Checked();
+
+            Entity? factorialArgument = null;
+            Entity? @base = null;
+            Entity? exponent = null;
+            Entity polynomial = Integer.One;
+            Entity constant = Integer.One;
+            foreach (var factor in Mulf.LinearChildren(expression.InnerSimplified))
+            {
+                if (!factor.ContainsNode(index))
+                {
+                    constant *= factor;
+                    continue;
+                }
+                switch (factor)
+                {
+                    case Powf(Factorialf(var argument), var power) when factorialArgument is null && power == Integer.MinusOne:
+                        factorialArgument = argument;
+                        break;
+                    case Powf(var b, var e) when @base is null && !b.ContainsNode(index):
+                        @base = b;
+                        exponent = e;
+                        break;
+                    default:
+                        polynomial *= factor;
+                        break;
+                }
+            }
+            if (factorialArgument is null)
+                return null;
+
+            // (k + a)!: the shift that makes it j!, which has to be a whole number. Read off
+            // the tree: `k - k` does not simplify to a bare 0 but to 0 with what it assumes.
+            if (!TryReadShift(factorialArgument, index, out var a))
+                return null;
+            // The shifted range starts at start + a, and a factorial of a negative number is
+            // not a term of anything.
+            if (start + a < 0)
+                return null;
+
+            // c ^ (k + s) is c ^ s * c ^ k; the offset may be symbolic, the slope must be one.
+            Entity c = Integer.One;
+            if (@base is not null)
+            {
+                if (!TryReadOffset(exponent!, index, out var offset))
+                    return null;
+                if (@base.Evaled is Complex value && IsZero(value))
+                    return null;
+                // Not c^0: that would attach `provided not c = 0` for a series whose value at
+                // c = 0 is the constant term, which the formula gives without help.
+                if (offset != Integer.Zero)
+                    constant *= MathS.Pow(@base, offset);
+                c = @base;
+            }
+
+            // q(j) = p(j - a), as coefficients by power of j; each must be free of the index.
+            var shifted = polynomial.Substitute(index, index - Integer.Create(a));
+            // A summand with no polynomial part -- 1 / k!, x^k / k! -- is the constant
+            // polynomial, which the polynomial reader has nothing to read.
+            Dictionary<EInteger, Entity>? monomials;
+            if (!shifted.ContainsNode(index))
+                monomials = new Dictionary<EInteger, Entity> { [EInteger.Zero] = shifted };
+            else if (!TreeAnalyzer.TryGetPolynomial(shifted, index, out monomials))
+                return null;
+            var degree = 0;
+            foreach (var monomial in monomials)
+            {
+                if (monomial.Key.Sign < 0 || !monomial.Key.CanFitInInt32() || monomial.Value.ContainsNode(index))
+                    return null;
+                var power = monomial.Key.ToInt32Checked();
+                if (power > MaxDegree)
+                    return null;
+                if (power > degree)
+                    degree = power;
+            }
+
+            // sum over j >= 0 of q(j) c^j / j! = e^c * sum over n of a_n * T_n(c).
+            var stirling = StirlingSecondKind(degree);
+            Entity touchardSum = Integer.Zero;
+            foreach (var monomial in monomials)
+            {
+                var n = monomial.Key.ToInt32Checked();
+                Entity touchard = Integer.Zero;
+                for (var m = 0; m <= n; m++)
+                    if (!stirling[n][m].IsZero)
+                        // The constant term as a number and not as c^0, for the reason above.
+                        touchard += m == 0 ? Integer.Create(stirling[n][m]) : Integer.Create(stirling[n][m]) * MathS.Pow(c, m);
+                touchardSum += monomial.Value * touchard;
+            }
+            Entity whole = MathS.Pow(MathS.e, c) * touchardSum;
+
+            // The terms below the shifted lower bound, finitely many and exact.
+            Entity below = Integer.Zero;
+            for (var j = 0; j < start + a; j++)
+            {
+                var term = shifted.Substitute(index, Integer.Create(j)) / MathS.Factorial(Integer.Create(j));
+                // c^0 written as nothing, for the reason above.
+                below += j == 0 ? term : term * MathS.Pow(c, j);
+            }
+
+            // Back from j to k: the summand was p(k) c^k / (k + a)!, and c^k is c^j / c^a.
+            var result = constant * (whole - below);
+            if (a != 0)
+                result *= MathS.Pow(c, -a);
+            return result.InnerSimplified;
+        }
+
+        /// <summary>
+        /// <paramref name="argument"/> as <c>index + shift</c> for a whole <c>shift</c>: the
+        /// index itself, or the index plus or minus a whole number, in either order.
+        /// </summary>
+        private static bool TryReadShift(Entity argument, Variable index, out int shift)
+        {
+            shift = 0;
+            if (argument == index)
+                return true;
+            static bool Whole(Entity e, out int value)
+            {
+                value = 0;
+                if (e.Evaled is not Integer whole || !whole.EInteger.CanFitInInt32())
+                    return false;
+                value = whole.EInteger.ToInt32Checked();
+                return true;
+            }
+            switch (argument)
+            {
+                case Sumf(var left, var right) when left == index && Whole(right, out shift):
+                case Sumf(var left2, var right2) when right2 == index && Whole(left2, out shift):
+                    return true;
+                case Minusf(var left, var right) when left == index && Whole(right, out var subtracted):
+                    shift = -subtracted;
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// <paramref name="exponent"/> as <c>index + offset</c> for an <paramref name="offset"/>
+        /// free of the index, which may be symbolic: the index itself, or the index plus or
+        /// minus something without it. Read off the tree for the same reason as the shift.
+        /// </summary>
+        private static bool TryReadOffset(Entity exponent, Variable index, out Entity offset)
+        {
+            offset = Integer.Zero;
+            if (exponent == index)
+                return true;
+            switch (exponent)
+            {
+                case Sumf(var left, var right) when left == index && !right.ContainsNode(index):
+                    offset = right;
+                    return true;
+                case Sumf(var left, var right) when right == index && !left.ContainsNode(index):
+                    offset = left;
+                    return true;
+                case Minusf(var left, var right) when left == index && !right.ContainsNode(index):
+                    offset = -right;
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// <c>S(n, m)</c> for <c>n, m</c> up to <paramref name="degree"/>: the number of ways to
+        /// partition <c>n</c> things into <c>m</c> non-empty parts, by the recurrence
+        /// <c>S(n, m) = m * S(n - 1, m) + S(n - 1, m - 1)</c>.
+        /// </summary>
+        private static EInteger[][] StirlingSecondKind(int degree)
+        {
+            var table = new EInteger[degree + 1][];
+            for (var n = 0; n <= degree; n++)
+            {
+                table[n] = new EInteger[n + 1];
+                for (var m = 0; m <= n; m++)
+                    table[n][m] = EInteger.Zero;
+            }
+            table[0][0] = EInteger.One;
+            for (var n = 1; n <= degree; n++)
+                for (var m = 1; m <= n; m++)
+                    // S(n - 1, n) is zero and outside the row.
+                    table[n][m] = (m < n ? EInteger.FromInt32(m).Multiply(table[n - 1][m]) : EInteger.Zero).Add(table[n - 1][m - 1]);
+            return table;
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
@@ -188,6 +188,7 @@ namespace AngouriMath
             protected override Entity InnerSimplify(bool isExact) =>
                 Expanded(this, Expression, Var, From, To, static (a, b) => a + b, 0, isExact)
                 ?? Functions.PolynomialSummation.ClosedForm(Expression, Var, From, To)
+                ?? Functions.ExponentialSeries.ClosedForm(Expression, Var, From, To)
                 ?? this;
 
             /// <summary>

--- a/Sources/Tests/UnitTests/Calculus/ExponentialSeriesTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ExponentialSeriesTest.cs
@@ -1,0 +1,72 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// https://github.com/asc-community/AngouriMath/issues/1212, question I.1: a summation to
+    /// +oo of a polynomial times a power over a factorial of the index is a closed form in e.
+    /// </summary>
+    public sealed class ExponentialSeriesTest
+    {
+        private static void AgreesTo(string expected, Entity actual, int digits = 25)
+        {
+            Assert.IsNotType<Summationf>(actual);
+            var want = (Real)expected.ToEntity().EvalNumerical();
+            var got = (Real)actual.EvalNumerical();
+            var gap = (want - got).Abs();
+            Assert.True(gap < Real.Create(PeterO.Numbers.EDecimal.Create(1, -digits)),
+                $"{actual} is {got}, expected {want}");
+        }
+
+        [Theory]
+        [InlineData("sum(3^(k+2) * (k^2 + k + 1) / (k + 3)!, k, 0, +oo)", "(8 * e^3 - 41) / 6")]
+        [InlineData("sum(1 / k!, k, 0, +oo)", "e")]
+        [InlineData("sum(1 / (2 * n!), n, 1, +oo)", "(e - 1) / 2")]
+        [InlineData("sum(k / k!, k, 0, +oo)", "e")]
+        [InlineData("sum(k^2 / k!, k, 0, +oo)", "2 * e")]
+        [InlineData("sum(k^3 / k!, k, 0, +oo)", "5 * e")]
+        [InlineData("sum(2^k / k!, k, 3, +oo)", "e^2 - 5")]
+        [InlineData("sum((k^2 + 1) * 3^k / (2 * (k + 1)!), k, 0, +oo)", "(4 * e^3 - 1) / 3")]
+        [InlineData("sum((-1)^k / k!, k, 0, +oo)", "1 / e")]
+        [InlineData("sum(1 / (k + 2)!, k, 0, +oo)", "e - 2")]
+        public void TheSeriesIsAClosedFormInE(string sum, string expected)
+            => AgreesTo(expected, sum.ToEntity().Simplify());
+
+        [Theory]
+        [InlineData("sum(x^k / k!, k, 0, +oo)", "e^x")]
+        [InlineData("sum(x^k / k!, k, 1, +oo)", "e^x - 1")]
+        [InlineData("sum(k * x^k / k!, k, 0, +oo)", "x * e^x")]
+        public void ASymbolicBaseStaysSymbolic(string sum, string expected)
+        {
+            var actual = sum.ToEntity().Simplify();
+            Assert.IsNotType<Summationf>(actual);
+            Assert.Equal(expected.ToEntity().Simplify(), actual);
+        }
+
+        // Not of the shape: no factorial, a factorial in the numerator, a symbolic lower bound,
+        // a power whose exponent is twice the index, a finite upper bound handled elsewhere.
+        [Theory]
+        [InlineData("sum(1 / k, k, 1, +oo)")]
+        [InlineData("sum(k!, k, 0, +oo)")]
+        [InlineData("sum(x^k / k!, k, n, +oo)")]
+        [InlineData("sum(3^(2 * k) / k!, k, 0, +oo)")]
+        [InlineData("sum(1 / (k - 2)!, k, 0, +oo)")]
+        public void WhatIsNotOfTheShapeIsLeftAsWritten(string sum)
+            => Assert.IsType<Summationf>(sum.ToEntity().Simplify());
+
+        [Fact]
+        public void AFiniteRangeIsStillExpanded()
+            => Assert.Equal("5/2".ToEntity(), "sum(1 / k!, k, 0, 2)".ToEntity().Simplify());
+    }
+}


### PR DESCRIPTION
Part of #1212 — item 1 of the plan in [my comment there](https://github.com/asc-community/AngouriMath/issues/1212#issuecomment-5581176922): the exponential-type series.

## What it answers

`sum(p(k) * c^(k + s) / (k + a)!, k, m, +oo)` for a polynomial `p`, a base `c` free of the index (symbolic or numeric, any sign), a whole `a`, a whole lower bound `m` with `m + a >= 0`. Shift the index so the factorial is `j!`; then `j^n * c^j / j!` sums to `e^c * T_n(c)` with `T_n` the Touchard polynomial over the Stirling numbers of the second kind, and the terms below the shifted lower bound are subtracted exactly. Converges for every `c`, so nothing is attached.

| input | was | is |
|---|---|---|
| `sum(3^(k+2) * (k^2 + k + 1) / (k + 3)!, k, 0, +oo)` — question I.1 | left as written | `4/3 * e ^ 3 - 41/6` |
| `sum(1 / (2 * n!), n, 1, +oo)` — the series behind I.2 | left as written | `(e - 1) / 2` |
| `sum(x^k / k!, k, 0, +oo)` | left as written | `e ^ x` |
| `sum(k * x^k / k!, k, 0, +oo)` | left as written | `e ^ x * x` |
| `sum(k^3 / k!, k, 0, +oo)`, `sum((-1)^k / k!, k, 0, +oo)`, `sum(2^k / k!, k, 3, +oo)` | left as written | `5 * e`, `1 / e`, `e ^ 2 - 5` |
| `sum(1 / k, k, 1, +oo)`, `sum(k!, k, 0, +oo)`, `sum(x^k / k!, k, n, +oo)`, `sum(3^(2k) / k!, k, 0, +oo)` | left as written | the same |

## How it is recognised

On the factors of the simplified summand: exactly one `(k + a)! ^ (-1)`, at most one `c ^ (k + s)` with `c` free of the index, a polynomial in the index for the rest, constants aside. Two things worth a line:

- The shift `a` and the offset `s` are read off the tree, not simplified out of `k - k`: since #1174 that is `0` *with what it assumes*, which is right and is not the whole number the identity needs. The first version declined every input for exactly that reason.
- `c^0` is never built: `x ^ 0` simplifies to `1 provided not x = 0`, and the series at `x = 0` is its constant term with no help, so the constant term and a zero shift are written as numbers.

Sits after `PolynomialSummation.ClosedForm` in `Summationf.InnerSimplify`, which declines `+oo` on its own.

## Checks

`ExponentialSeriesTest`: ten numeric closed forms agreeing to 25 digits, three symbolic bases structurally, five non-shapes left as written, a finite range still expanded. Full suite in two chunks: 9,686 passed, 0 failed (Calculus 1,342, the rest 8,344). `BREAKING-CHANGES.md` has the rows, both columns measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
