### PR TITLE
A binomial sum with a power or a trigonometric weight is closed

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -86,6 +86,7 @@ read first.
 | | `RewriteRules.Common.Rules.Count`, and `RewriteRules.All` by growth | `62`; 124 / 46 / 31 / 123 | `65`; 124 / 49 / 31 / 123 |
 | | `"(x - b) / (x + a) + c / (x + a)".SolveEquation("x")`, and every equation the replacement machinery solves whose condition is spelled from the equation as written | `{ -(-b + c) provided not a + -(-b + c) = 0 }` | `{ -(-b + c) provided not -(-b + c) + a = 0 }` — the same set, the condition's terms in the order the equation had |
 | | `"sum(x^k / k!, k, 0, +oo)".ToEntity().Simplify()`, and every summation to `+oo` of a polynomial in the index times a power with the index in the exponent over a factorial of the index | `sum(x ^ k / k!, k, 0, +oo)` — left as written | `e ^ x`; `sum(3^(k+2) * (k^2 + k + 1) / (k + 3)!, k, 0, +oo)` is `4/3 * e ^ 3 - 41/6` |
+| | `"sum(N! / (k! * (N - k)!) * x^k, k, 0, N)".ToEntity().Simplify()`, and every binomial sum with a power or a cosine or sine of the index as its weight | `sum(N! / (k! * (N - k)!) * x ^ k, k, 0, N)` — left as written | `piecewise((1 + x) ^ N provided N >= 0, 0)`; with `cos(k * pi / 3)`, `piecewise(2 ^ N * cos(pi / 6) ^ N * cos(N * pi / 6) provided N >= 0, 0)` |
 
 ### A cancelled quotient says its operand is defined, not only non-zero
 
@@ -1050,6 +1051,26 @@ second row. Both columns measured on a build, `e2476ac5` against this change.
 | `"sum(1 / (2 * n!), n, 1, +oo)".ToEntity().Simplify()` | left as written | `(e - 1) / 2` |
 | `"sum(x^k / k!, k, 0, +oo)".ToEntity().Simplify()`, and `sum(k * x^k / k!, k, 0, +oo)` | left as written | `e ^ x`, `e ^ x * x` |
 | `"sum(1 / k, k, 1, +oo)"`, `sum(k!, k, 0, +oo)`, `sum(x^k / k!, k, n, +oo)`, `sum(3^(2k) / k!, k, 0, +oo)` | left as written | the same — not of the shape, or a symbolic lower bound, or a slope other than one in the exponent |
+
+### A binomial sum with a power or a trigonometric weight is closed
+
+`sum(N! / (k! (N - k)!) x^k, k, 0, N)` was left as written for a symbolic `N`; it is `(1 + x)^N`,
+the binomial theorem read backwards, and with `x^k y^(N-k)` it is `(x + y)^N`. With `cos(k t)`
+the sum is the real part of `(1 + e^(it))^N`, and `1 + e^(it) = 2 cos(t/2) e^(it/2)` exactly, so it is
+`(2 cos(t/2))^N cos(N t/2)`; with `sin(k t)` the same with the sine. Both are algebra on the two
+conjugate sums and hold for every complex `t`. The top factorial is optional, since
+`sum(x^k / (k! (N - k)!))` is `(1 + x)^N / N!`, and a concrete one has folded into a number before
+the factors are read. A symbolic `N` carries `N >= 0` with the empty-range branch, for the reason
+`sum(k, k, 1, n)` does. Question II.3 of
+[#1212](https://github.com/asc-community/AngouriMath/issues/1212). Both columns measured on a
+build, `e2476ac5` against this change.
+
+| | Was | Is |
+|---|---|---|
+| `"sum(N! / (k! * (N - k)!) * cos(k * pi / 3), k, 0, N)".ToEntity().Simplify()` | left as written | `piecewise(2 ^ N * cos(pi / 6) ^ N * cos(N * pi / 6) provided N >= 0, 0)` — `3^(N/2) cos(N pi / 6)` |
+| `"sum(N! / (k! * (N - k)!) * x^k, k, 0, N)".ToEntity().Simplify()`, and with `x^k * y^(N - k)` | left as written | `piecewise((1 + x) ^ N provided N >= 0, 0)`, `piecewise((x + y) ^ N provided N >= 0, 0)` |
+| `"sum(300! / (k! * (300 - k)!), k, 0, 300)".ToEntity().Simplify()`, and every concrete range past the hundred-term expansion | left as written | `2 ^ 300`, the 91-digit integer |
+| `"sum(N! / (k! * (N - k)!) * k, k, 0, N)"`, and a trigonometric weight beside a power, a lower bound other than 0, a coefficient whose `N` is not the upper bound | left as written | the same |
 
 ## 2.4.0 — since 2.3.0
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -192,6 +192,12 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [Tests/UnitTests/Calculus/ExponentialSeriesTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[AngouriMath/Functions/Algebra/Polynomials/BinomialSum.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/BinomialSumTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [AngouriMath/Functions/Algebra/Polynomials/PolynomialSummation.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 [Tests/UnitTests/Core/ClosedFormSummationTest.cs]

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/BinomialSum.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/BinomialSum.cs
@@ -1,0 +1,162 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// A summation over <c>k</c> from <c>0</c> to <c>N</c> of the binomial coefficient
+    /// <c>N! / (k! (N - k)!)</c> times a power or a trigonometric weight, in closed form:
+    /// <c>sum(N! / (k! (N - k)!) x^k, k, 0, N)</c> is <c>(1 + x)^N</c>, and
+    /// <c>sum(N! / (k! (N - k)!) cos(k t), k, 0, N)</c> is <c>(2 cos(t/2))^N cos(N t / 2)</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The binomial theorem read backwards. With weights <c>x^k y^(N-k)</c> the sum is
+    /// <c>(x + y)^N</c>, either power optional. With <c>cos(k t)</c> it is the real part of
+    /// <c>(1 + e^(i t))^N</c>, and <c>1 + e^(i t) = 2 cos(t/2) e^(i t/2)</c> exactly, so the sum is
+    /// <c>(2 cos(t/2))^N cos(N t/2)</c>; with <c>sin(k t)</c> the same with the sine. Both hold for
+    /// every complex <c>t</c>, since <c>cos z = (e^(iz) + e^(-iz)) / 2</c> is the definition
+    /// and the two conjugate sums add: no assumption on <c>t</c> is owed.
+    /// </para>
+    /// <para>
+    /// The one condition is the range: for <c>N</c> below zero the summation is empty and this
+    /// library answers an empty range with 0, while the formula does not, so a symbolic
+    /// <c>N</c> gets the same piecewise <see cref="PolynomialSummation"/> attaches. Recognised
+    /// structurally, on the factors of the simplified summand: the three factorials with
+    /// <c>N</c> the upper bound as written, at most one power in <c>k</c>, at most one in
+    /// <c>N - k</c>, at most one cosine or sine of <c>k</c> times something free of it, and
+    /// nothing else that mentions <c>k</c>. A trigonometric weight beside a power is declined:
+    /// the closed form then needs the modulus and argument of <c>y + x e^(i t)</c>, which is
+    /// not a simplification. Question II.3 of
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/1212">#1212</a>.
+    /// </para>
+    /// </remarks>
+    internal static class BinomialSum
+    {
+        internal static Entity? ClosedForm(Entity expression, Entity var, Entity from, Entity to)
+        {
+            if (var is not Variable index)
+                return null;
+            if (from.Evaled is not Integer { IsZero: true })
+                return null;
+            if (to.ContainsNode(index) || !PolynomialSummation.IsWholeOrSymbolic(to))
+                return null;
+            var upper = to.InnerSimplified;
+
+            var sawTop = false;
+            var sawBottomK = false;
+            var sawBottomRest = false;
+            Entity? powerOfK = null;
+            Entity? powerOfRest = null;
+            Entity? angle = null;
+            var sine = false;
+            Entity constant = Integer.One;
+            foreach (var factor in Mulf.LinearChildren(expression.InnerSimplified))
+            {
+                if (!factor.ContainsNode(index))
+                {
+                    if (!sawTop && factor is Factorialf(var top) && top == upper)
+                        sawTop = true;
+                    else
+                        constant *= factor;
+                    continue;
+                }
+                switch (factor)
+                {
+                    case Powf(Factorialf(var argument), var power) when power == Integer.MinusOne && argument == index && !sawBottomK:
+                        sawBottomK = true;
+                        break;
+                    case Powf(Factorialf(var argument), var power) when power == Integer.MinusOne && IsUpperMinusIndex(argument, upper, index) && !sawBottomRest:
+                        sawBottomRest = true;
+                        break;
+                    case Powf(var b, var e) when !b.ContainsNode(index) && e == index && powerOfK is null:
+                        powerOfK = b;
+                        break;
+                    case Powf(var b, var e) when !b.ContainsNode(index) && IsUpperMinusIndex(e, upper, index) && powerOfRest is null:
+                        powerOfRest = b;
+                        break;
+                    case Cosf(var argument) when angle is null && TryReadAngle(argument, index, out angle):
+                        break;
+                    case Sinf(var argument) when angle is null && TryReadAngle(argument, index, out angle):
+                        sine = true;
+                        break;
+                    default:
+                        return null;
+                }
+            }
+            if (!sawBottomK || !sawBottomRest)
+                return null;
+            if (angle is not null && (powerOfK is not null || powerOfRest is not null))
+                return null;
+
+            Entity closed;
+            if (angle is null)
+                closed = MathS.Pow((powerOfK ?? Integer.One) + (powerOfRest ?? Integer.One), upper);
+            else
+            {
+                var half = angle / 2;
+                var magnitude = MathS.Pow(2 * MathS.Cos(half), upper);
+                closed = magnitude * (sine ? MathS.Sin(upper * half) : MathS.Cos(upper * half));
+            }
+            // sum(x^k / (k! (N - k)!)) is (1 + x)^N / N!: the top factorial is a constant the
+            // theorem does not need, and a concrete one has folded into a number before the
+            // factors are read -- 300! is not a Factorialf by the time it gets here.
+            if (!sawTop)
+                closed /= MathS.Factorial(upper);
+            closed = (constant * closed).InnerSimplified;
+
+            // A concrete N is whole and non-negative here, or the range would have been
+            // written out or refused; a symbolic one may still be anything.
+            if (upper.Evaled is Integer)
+                return closed;
+            return MathS.Piecewise(new[]
+            {
+                new Providedf(closed, new GreaterOrEqualf(upper, Integer.Zero)),
+                new Providedf(Integer.Zero, Entity.Boolean.True),
+            }).InnerSimplified;
+        }
+
+        /// <summary>Whether <paramref name="e"/> is <c>upper - index</c> as written.</summary>
+        private static bool IsUpperMinusIndex(Entity e, Entity upper, Variable index)
+            => e is Minusf(var left, var right) && left == upper && right == index;
+
+        /// <summary>
+        /// <paramref name="argument"/> as <c>index * angle</c> for an <paramref name="angle"/>
+        /// free of the index: the index alone (angle 1), or a product of it with something.
+        /// </summary>
+        private static bool TryReadAngle(Entity argument, Variable index, out Entity angle)
+        {
+            angle = Integer.One;
+            if (argument == index)
+                return true;
+            if (argument is Mulf(var left, var right))
+            {
+                if (left == index && !right.ContainsNode(index))
+                {
+                    angle = right;
+                    return true;
+                }
+                if (right == index && !left.ContainsNode(index))
+                {
+                    angle = left;
+                    return true;
+                }
+                // k * pi / 3 arrives as (k * pi) / 3, a quotient over a product.
+            }
+            if (argument is Divf(var dividend, var divisor) && !divisor.ContainsNode(index)
+                && TryReadAngle(dividend, index, out var inner))
+            {
+                angle = inner / divisor;
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
@@ -189,6 +189,7 @@ namespace AngouriMath
                 Expanded(this, Expression, Var, From, To, static (a, b) => a + b, 0, isExact)
                 ?? Functions.PolynomialSummation.ClosedForm(Expression, Var, From, To)
                 ?? Functions.ExponentialSeries.ClosedForm(Expression, Var, From, To)
+                ?? Functions.BinomialSum.ClosedForm(Expression, Var, From, To)
                 ?? this;
 
             /// <summary>

--- a/Sources/Tests/UnitTests/Calculus/BinomialSumTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/BinomialSumTest.cs
@@ -1,0 +1,87 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// https://github.com/asc-community/AngouriMath/issues/1212, question II.3: a binomial sum
+    /// with a power or a trigonometric weight is the binomial theorem read backwards.
+    /// </summary>
+    public sealed class BinomialSumTest
+    {
+        private const string Binomial = "N! / (k! * (N - k)!)";
+
+        private static void AgreesAt(string sum, string expected, params int[] ns)
+        {
+            var closed = sum.ToEntity().Simplify();
+            Assert.IsNotType<Summationf>(closed);
+            foreach (var n in ns)
+            {
+                var want = expected.ToEntity().Substitute("N", n).EvalNumerical();
+                var got = closed.Substitute("N", n).EvalNumerical();
+                Assert.True(((Complex)(want - got)).Abs() < Real.Create(PeterO.Numbers.EDecimal.Create(1, -20)),
+                    $"at N = {n}: {closed} is {got}, expected {want}");
+            }
+        }
+
+        [Fact]
+        public void TheOrientationWeekSumIsAPowerOfThreeTimesACosine()
+            => AgreesAt($"sum({Binomial} * cos(k * pi / 3), k, 0, N)", "3^(N/2) * cos(N * pi / 6)", 0, 1, 2, 3, 6, 7, 12);
+
+        [Theory]
+        [InlineData("sum(N! / (k! * (N - k)!), k, 0, N)", "2^N")]
+        [InlineData("sum(N! / (k! * (N - k)!) * x^k, k, 0, N)", "(1 + x)^N")]
+        [InlineData("sum(N! * x^k * y^(N - k) / (k! * (N - k)!), k, 0, N)", "(x + y)^N")]
+        [InlineData("sum(N! / (k! * (N - k)!) * 3^k, k, 0, N)", "4^N")]
+        [InlineData("sum(N! / (k! * (N - k)!) * sin(k * t), k, 0, N)", "(2 * cos(t / 2))^N * sin(N * t / 2)")]
+        [InlineData("sum(N! / (k! * (N - k)!) * cos(k), k, 0, N)", "(2 * cos(1/2))^N * cos(N / 2)")]
+        [InlineData("sum(x^k / (k! * (N - k)!), k, 0, N)", "(1 + x)^N / N!")]
+        public void ABinomialSumIsClosed(string sum, string expected)
+        {
+            var closed = sum.ToEntity().Simplify();
+            Assert.IsNotType<Summationf>(closed);
+            foreach (var n in new[] { 0, 1, 2, 5 })
+            {
+                var want = expected.ToEntity().Substitute("N", n).Substitute("x", "3/7").Substitute("y", "2").Substitute("t", "0.7").EvalNumerical();
+                var got = closed.Substitute("N", n).Substitute("x", "3/7").Substitute("y", "2").Substitute("t", "0.7").EvalNumerical();
+                Assert.True(((Complex)(want - got)).Abs() < Real.Create(PeterO.Numbers.EDecimal.Create(1, -20)),
+                    $"at N = {n}: {closed} is {got}, expected {want}");
+            }
+        }
+
+        // The range is empty below zero and this library answers an empty range with 0, which
+        // the formula does not; so a symbolic upper bound carries the condition.
+        [Fact]
+        public void ASymbolicUpperBoundCarriesTheRange()
+        {
+            var closed = $"sum({Binomial} * x^k, k, 0, N)".ToEntity().Simplify();
+            Assert.Equal(0, closed.Substitute("N", -1).Substitute("x", 2).Simplify());
+            Assert.Equal(9, closed.Substitute("N", 2).Substitute("x", 2).Simplify());
+        }
+
+        // A concrete bound past the expansion's hundred terms is answered by the closed form.
+        [Fact]
+        public void AConcreteLongRangeIsClosed()
+            => Assert.Equal("2^300".ToEntity().Evaled, "sum(300! / (k! * (300 - k)!), k, 0, 300)".ToEntity().Simplify().Evaled);
+
+        // Not of the shape: a polynomial weight, a trigonometric weight beside a power, a lower
+        // bound that is not zero, a coefficient whose N is not the upper bound.
+        [Theory]
+        [InlineData("sum(N! / (k! * (N - k)!) * k, k, 0, N)")]
+        [InlineData("sum(N! / (k! * (N - k)!) * x^k * cos(k * t), k, 0, N)")]
+        [InlineData("sum(N! / (k! * (N - k)!), k, 1, N)")]
+        [InlineData("sum(M! / (k! * (M - k)!), k, 0, N)")]
+        public void WhatIsNotOfTheShapeIsLeftAsWritten(string sum)
+            => Assert.IsType<Summationf>(sum.ToEntity().Simplify());
+    }
+}


### PR DESCRIPTION
Part of #1212 — item 2 of the plan in [my comment there](https://github.com/asc-community/AngouriMath/issues/1212#issuecomment-5581176922): binomial sums. Independent of #1213; the two touch the same fall-through line in `Summationf.InnerSimplify`, so whichever merges second gets a one-line conflict.

## What it answers

`sum(N! / (k! (N - k)!) · w(k), k, 0, N)` for a weight `w` that is a power in `k`, a power in `N - k`, both, or a cosine or sine of `k` times something free of `k`:

| input | was | is |
|---|---|---|
| `sum(N! / (k! (N - k)!) cos(k pi / 3), k, 0, N)` — question II.3 | left as written | `2^N cos(pi/6)^N cos(N pi/6)` = `3^(N/2) cos(N pi/6)`, under `N >= 0` |
| `sum(N! / (k! (N - k)!) x^k, k, 0, N)` | left as written | `(1 + x)^N` under `N >= 0` |
| `sum(N! x^k y^(N - k) / (k! (N - k)!), k, 0, N)` | left as written | `(x + y)^N` |
| `sum(N! / (k! (N - k)!) sin(k t), k, 0, N)` | left as written | `(2 cos(t/2))^N sin(N t/2)` |
| `sum(x^k / (k! (N - k)!), k, 0, N)` | left as written | `(1 + x)^N / N!` |
| `sum(300! / (k! (300 - k)!), k, 0, 300)` — past the expansion's hundred terms | left as written | `2^300` |
| a polynomial weight, a trigonometric weight beside a power, a lower bound other than 0, an `N` that is not the upper bound | left as written | the same |

The trigonometric form is `Re (1 + e^(it))^N` with `1 + e^(it) = 2 cos(t/2) e^(it/2)`, which is algebra on the two conjugate sums and holds for every complex `t`; nothing is assumed. The condition `N >= 0` with the empty-range branch is the one `PolynomialSummation` attaches and for the same reason: the library answers an empty range with 0 and the formula does not.

## Checks

`BinomialSumTest`: the sheet's sum against `3^(N/2) cos(N pi/6)` at seven values of `N`, six closed forms at four values each, the range condition, the concrete long range, four non-shapes. Full suite in two chunks: 9,680 passed, 0 failed (Calculus 1,336, the rest 8,344). `BREAKING-CHANGES.md` has the rows, both columns measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
