### PR TITLE
A logarithm of a perfect power takes the exponent out, so related logarithms collect

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -87,6 +87,7 @@ read first.
 | | `"(x - b) / (x + a) + c / (x + a)".SolveEquation("x")`, and every equation the replacement machinery solves whose condition is spelled from the equation as written | `{ -(-b + c) provided not a + -(-b + c) = 0 }` | `{ -(-b + c) provided not -(-b + c) + a = 0 }` — the same set, the condition's terms in the order the equation had |
 | | `"sum(x^k / k!, k, 0, +oo)".ToEntity().Simplify()`, and every summation to `+oo` of a polynomial in the index times a power with the index in the exponent over a factorial of the index | `sum(x ^ k / k!, k, 0, +oo)` — left as written | `e ^ x`; `sum(3^(k+2) * (k^2 + k + 1) / (k + 3)!, k, 0, +oo)` is `4/3 * e ^ 3 - 41/6` |
 | | `"sum(N! / (k! * (N - k)!) * x^k, k, 0, N)".ToEntity().Simplify()`, and every binomial sum with a power or a cosine or sine of the index as its weight | `sum(N! / (k! * (N - k)!) * x ^ k, k, 0, N)` — left as written | `piecewise((1 + x) ^ N provided N >= 0, 0)`; with `cos(k * pi / 3)`, `piecewise(2 ^ N * cos(pi / 6) ^ N * cos(N * pi / 6) provided N >= 0, 0)` |
+| | `"ln(4/3) + ln(16/9) / 2".ToEntity().Simplify()`, and every sum of logarithms of rational literals one of which is a perfect power of another | `ln(4/3) + ln(16/9) / 2` — left as written | `2 * ln(4/3)`; the integral it came from, `integral((2x^2+x+1)/(x^3+x^2+x+1), x, 3/4, 4/3)`, answers `ln(16/9)` |
 
 ### A cancelled quotient says its operand is defined, not only non-zero
 
@@ -1071,6 +1072,25 @@ build, `e2476ac5` against this change.
 | `"sum(N! / (k! * (N - k)!) * x^k, k, 0, N)".ToEntity().Simplify()`, and with `x^k * y^(N - k)` | left as written | `piecewise((1 + x) ^ N provided N >= 0, 0)`, `piecewise((x + y) ^ N provided N >= 0, 0)` |
 | `"sum(300! / (k! * (300 - k)!), k, 0, 300)".ToEntity().Simplify()`, and every concrete range past the hundred-term expansion | left as written | `2 ^ 300`, the 91-digit integer |
 | `"sum(N! / (k! * (N - k)!) * k, k, 0, N)"`, and a trigonometric weight beside a power, a lower bound other than 0, a coefficient whose `N` is not the upper bound | left as written | the same |
+
+### A logarithm of a perfect power takes the exponent out
+
+`ln(4/3) + ln(16/9) / 2` was left as written; it is `2 ln(4/3)`. The rule that reads `log(a, b^n)` as
+`n log(a, b)` could not see a rational literal that is a power without saying so, and `16/9` is
+`(4/3)^2`. A logarithm of a positive rational literal that is a perfect power is now offered as the
+exponent times the logarithm of the root — the largest exponent that fits, read exactly on numerators
+and denominators within 64 bits. A positive root only: `-8` is `(-2)^3`, but `ln(-8)` is
+`ln 8 + i pi` where `3 ln(-2)` is `3 ln 2 + 3 i pi`, so a negative root is refused. The form is longer
+on its own, so alone a literal stays as written; it is what lets logarithms of related literals
+collect. Question I.5 of [#1212](https://github.com/asc-community/AngouriMath/issues/1212). Both
+columns measured on a build, `60545afa` against this change.
+
+| | Was | Is |
+|---|---|---|
+| `"ln(4/3) + ln(16/9) / 2".ToEntity().Simplify()` | `ln(4/3) + ln(16/9) / 2` | `2 * ln(4/3)` |
+| `"integral((2x^2+x+1)/(x^3+x^2+x+1), x, 3/4, 4/3)".ToEntity().Simplify()` | `ln(4/3) + ln(16/9) / 2` | `ln(16/9)` |
+| `"ln(16/9)"`, `ln(64)`, `ln(8) - 3 * ln(2)`, `log(3, 81) / 4` | `ln(16/9)`, `ln(64)`, `0`, `1` | the same |
+| `RewriteRules.Power.Rules.Count`, and `RewriteRules.All` by growth | `31`; 124 / 49 / 31 / 123 | `32`; 124 / 49 / 32 / 123 |
 
 ## 2.4.0 — since 2.3.0
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -27,6 +27,12 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [AngouriMath/Functions/Simplification/NumericContent.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[AngouriMath/Functions/TreeAnalyzer/PerfectPower.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Common/LogarithmOfAPerfectPowerTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [AngouriMath/Functions/TreeAnalyzer/RealValued.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 

--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRules.cs
@@ -3165,6 +3165,23 @@ namespace AngouriMath.Core.Transformations.Matching
                 // A logarithm and a power become a product and a logarithm, one node for one, and
                 // each of the three holes is used once on both sides.
                 growth: RewriteRuleGrowth.Rearranges),
+            // The same identity for a rational literal that is a power without saying so, with a
+            // positive root only, so that the principal branch has nothing to discard.
+            // https://github.com/asc-community/AngouriMath/issues/1212
+            new MatchedRule(
+                "a-logarithm-of-a-perfect-power-takes-the-exponent-out",
+                MatchPattern.Node<Logf>(MatchPattern.Any("a"),
+                    MatchPattern.Any<Rational>("r", r => Functions.TreeAnalyzer.TryPerfectPower(r, out _, out _))),
+                bound =>
+                {
+                    Functions.TreeAnalyzer.TryPerfectPower((Rational)bound["r"], out var root, out var exponent);
+                    return Integer.Create(exponent) * MathS.Log(bound["a"], root);
+                },
+                Soundness.Sound,
+                description: "log(a, r) = n * log(a, root) where r = root ^ n",
+                // One literal becomes a product of a literal and a logarithm of a literal: two
+                // nodes more, whatever the base is.
+                growth: RewriteRuleGrowth.Expands),
 
             // The condition to carry is the node's own: log(-3, -3) is 1 where a written-out
             // `a > 0` calls it undefined, and log(1, 1) is NaN where that guard calls it 1.

--- a/Sources/AngouriMath/Core/Transformations/Saturation.cs
+++ b/Sources/AngouriMath/Core/Transformations/Saturation.cs
@@ -44,7 +44,7 @@ namespace AngouriMath.Core.Transformations
         /// ceiling should refuse — it means the rule's growth was not judged, because its
         /// replacement is code rather than a written pattern, so admitting it accepts a rewrite
         /// nobody measured. But it is where the rules are: of the 324 rules in
-        /// <see cref="MatchedRules"/>, <b>124 collect, 49 rearrange, 31 expand and 123 are
+        /// <see cref="MatchedRules"/>, <b>124 collect, 49 rearrange, 32 expand and 123 are
         /// unjudged</b>. A ceiling that refuses the fourth value still refuses 38% of the library,
         /// and what is left could not do much when this was written — over six expression pairs
         /// equal only through a larger intermediate form, the

--- a/Sources/AngouriMath/Docs/Contributing/WritingARule.md
+++ b/Sources/AngouriMath/Docs/Contributing/WritingARule.md
@@ -18,7 +18,7 @@ effect". This is how to supply those seven things.
 ## Where a rule goes
 
 `Core/Transformations/Matching/MatchedRules.cs`, as a value in a `MatchedRuleSet`. **33** sets and
-**327** rules live there today.
+**328** rules live there today.
 
 The `switch` statements in `Functions/Simplification/Patterns` are the older form. **All thirty
 registered sets now run as data and describe what they run**; none executes its `switch` any more.
@@ -64,7 +64,7 @@ in a name and putting the identity in brackets after it:
 2. Tangent is sine over cosine (tan(a) = sin(a) / cos(a)), so tan(x) becomes sin(x) / cos(x).
 ```
 
-So the name has to be a clause that survives being read that way. **All 298 distinct rule names are,
+So the name has to be a clause that survives being read that way. **All 299 distinct rule names are,
 and `StepAsASentenceTest` holds them to it** — a name with a capital, a bracket or an underscore
 fails that test rather than degrading the prose quietly.
 
@@ -91,7 +91,7 @@ debugged for an afternoon.
 | `Left.ToString()` | `Divf(var a, Divf(var b, var c))` — how the matcher spells it |
 
 Write the identity with `=`, not `->`: it is an equality, and the arrow belongs to the direction the
-rule happens to be applied in. **324** rules carry one today; a new rule should.
+rule happens to be applied in. **325** rules carry one today; a new rule should.
 
 ## The pattern language
 
@@ -123,7 +123,7 @@ matches and silently builds nothing. `BuildableNodeTypesTest` is the list.
 
 ## Replacement: a pattern, or code
 
-**35** of the 327 rules have a pattern on both sides. The rest build their answer in code, and both
+**35** of the 328 rules have a pattern on both sides. The rest build their answer in code, and both
 are legitimate — but the choice costs two things, so make it deliberately.
 
 A pattern replacement gets:
@@ -224,7 +224,7 @@ limit, against nothing for handing the node over.
 | `SoundUnderAssumptions` | holds given something the rule does not check |
 | `Heuristic` | usually right |
 
-**185** of the 327 rules are `Sound` and **142** are conditional. Every one of the thirty registered
+**186** of the 328 rules are `Sound` and **142** are conditional. Every one of the thirty registered
 *sets* declares `SoundUnderAssumptions`, because a set's tier is the **minimum** over its rules — so
 the set grain says nothing and the rule grain says everything. A derivation reports the rule's tier
 (`RewriteStep.Soundness`), which is why getting it right matters beyond the label.

--- a/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Power.cs
+++ b/Sources/AngouriMath/Functions/Simplification/Patterns/Patterns.Power.cs
@@ -214,6 +214,14 @@ namespace AngouriMath.Functions
             // second way in that the logarithm gathering below takes.
             Logf(var any1, Powf(var any2, var any3))
                 when MayTakeLogOfPower(any2, any3) => any3 * MathS.Log(any1, any2),
+            // The same identity for a rational literal that is a power without saying so:
+            // ln(16/9) is 2 ln(4/3), which is longer on its own and is what lets
+            // ln(4/3) + ln(16/9) / 2 collect to 2 ln(4/3). A positive root only, so the
+            // principal branch has nothing to discard; the metric decides whether the longer
+            // form is kept. https://github.com/asc-community/AngouriMath/issues/1212
+            Logf(var any1, Rational literal)
+                when TreeAnalyzer.TryPerfectPower(literal, out var root, out var exponent)
+                => Integer.Create(exponent) * MathS.Log(any1, root),
             // log_b(b) is 1 wherever it is defined at all, so the condition to carry is the
             // node's own and not one written out here. Asserting `any1 > 0` stated the real
             // reading inside the rule and was wrong in both directions at once: undefined at

--- a/Sources/AngouriMath/Functions/TreeAnalyzer/PerfectPower.cs
+++ b/Sources/AngouriMath/Functions/TreeAnalyzer/PerfectPower.cs
@@ -1,0 +1,72 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using PeterO.Numbers;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Functions
+{
+    internal static partial class TreeAnalyzer
+    {
+        /// <summary>
+        /// The largest exponent this looks for. A perfect power past it is one nobody wrote
+        /// by hand.
+        /// </summary>
+        private const int LargestExponentToRead = 64;
+
+        /// <summary>
+        /// <paramref name="value"/> as <c>root ^ exponent</c> for a positive rational
+        /// <paramref name="root"/> and the largest whole <paramref name="exponent"/> of at least
+        /// 2 that fits: <c>16/9</c> is <c>(4/3)^2</c>, <c>64</c> is <c>2^6</c>, <c>1/8</c> is
+        /// <c>(1/2)^3</c>. Only for a positive value whose numerator and denominator both fit in
+        /// 64 bits; anything else is not a perfect power for this purpose.
+        /// </summary>
+        /// <remarks>
+        /// Positive only, deliberately: <c>-8</c> is <c>(-2)^3</c> and <c>ln(-8)</c> is
+        /// <c>ln 8 + i pi</c> while <c>3 ln(-2)</c> is <c>3 ln 2 + 3 i pi</c>, so the identity a
+        /// caller wants this for does not survive a negative root.
+        /// </remarks>
+        internal static bool TryPerfectPower(Rational value, out Rational root, out int exponent)
+        {
+            root = value;
+            exponent = 1;
+            var numerator = value.ERational.Numerator;
+            var denominator = value.ERational.Denominator;
+            if (numerator.Sign <= 0 || !numerator.CanFitInInt64() || !denominator.CanFitInInt64())
+                return false;
+            if (numerator.Equals(EInteger.One) && denominator.Equals(EInteger.One))
+                return false;
+            for (var e = LargestExponentToRead; e >= 2; e--)
+            {
+                if (IntegerRoot(numerator, e) is not { } top || IntegerRoot(denominator, e) is not { } bottom)
+                    continue;
+                root = Rational.Create(ERational.Create(top, bottom));
+                exponent = e;
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// The whole <c>e</c>-th root of <paramref name="n"/>, or <see langword="null"/> where
+        /// there is none: a floating estimate, then the neighbours checked exactly.
+        /// </summary>
+        private static EInteger? IntegerRoot(EInteger n, int e)
+        {
+            if (n.Equals(EInteger.One))
+                return EInteger.One;
+            var estimate = (long)System.Math.Round(System.Math.Pow((double)n.ToInt64Checked(), 1.0 / e));
+            for (var candidate = System.Math.Max(2, estimate - 1); candidate <= estimate + 1; candidate++)
+            {
+                var whole = EInteger.FromInt64(candidate);
+                if (whole.Pow(e).Equals(n))
+                    return whole;
+            }
+            return null;
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Common/LogarithmOfAPerfectPowerTest.cs
+++ b/Sources/Tests/UnitTests/Common/LogarithmOfAPerfectPowerTest.cs
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using AngouriMath.Functions;
+using Xunit;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Tests.Common
+{
+    /// <summary>
+    /// https://github.com/asc-community/AngouriMath/issues/1212, question I.5's presentation:
+    /// a logarithm of a rational literal that is a perfect power takes the exponent out, which
+    /// is longer on its own and is what lets two logarithms of related literals collect.
+    /// </summary>
+    public sealed class LogarithmOfAPerfectPowerTest
+    {
+        [Theory]
+        [InlineData("16/9", "4/3", 2)]
+        [InlineData("64", "2", 6)]
+        [InlineData("1/8", "1/2", 3)]
+        [InlineData("27/8", "3/2", 3)]
+        [InlineData("10000", "10", 4)]
+        public void APerfectPowerIsRead(string value, string root, int exponent)
+        {
+            Assert.True(TreeAnalyzer.TryPerfectPower((Rational)value.ToEntity(), out var readRoot, out var readExponent));
+            Assert.Equal(root.ToEntity(), readRoot);
+            Assert.Equal(exponent, readExponent);
+        }
+
+        [Theory]
+        [InlineData("6")]
+        [InlineData("12/5")]
+        [InlineData("1")]
+        [InlineData("-8")]
+        [InlineData("0")]
+        public void WhatIsNotAPerfectPowerIsNot(string value)
+            => Assert.False(TreeAnalyzer.TryPerfectPower((Rational)value.ToEntity(), out _, out _));
+
+        // The sheet's integral: ln(4/3) + ln(16/9) / 2 is 2 ln(4/3), which the metric then
+        // prefers as the single literal ln(16/9).
+        [Fact]
+        public void TheOrientationWeekIntegralCollects()
+            => Assert.Equal("ln(16/9)".ToEntity(), "integral((2x^2+x+1)/(x^3+x^2+x+1), x, 3/4, 4/3)".ToEntity().Simplify());
+
+        [Theory]
+        [InlineData("ln(4/3) + ln(16/9) / 2", "2 * ln(4/3)")]
+        [InlineData("ln(8) - 3 * ln(2)", "0")]
+        [InlineData("log(3, 81) / 4", "log(3, 3)")]
+        public void RelatedLogarithmsCollect(string expr, string expected)
+            => Assert.Equal(expected.ToEntity().Simplify(), expr.ToEntity().Simplify());
+
+        // On its own the longer form loses to the literal: the rule is offered, not taken.
+        [Theory]
+        [InlineData("ln(16/9)")]
+        [InlineData("ln(64)")]
+        public void AloneTheLiteralStays(string expr)
+            => Assert.Equal(expr.ToEntity(), expr.ToEntity().Simplify());
+    }
+}

--- a/Sources/Tests/UnitTests/Core/Transformations/AddressableRulesTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/AddressableRulesTest.cs
@@ -299,7 +299,7 @@ namespace AngouriMath.Tests.Core.Transformations
             // are thirty-three; NumericNeat's sixteen are eleven, six of them being three rules
             // written once per side a negative factor can sit on; and the two factorial sets are
             // eight arms each written as three. Every other repointed set is one arm for one rule.
-            Assert.Equal(324, withRules.Sum(set => set.Rules.Count));
+            Assert.Equal(325, withRules.Sum(set => set.Rules.Count));
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/ReversibleRuleTest.cs
@@ -180,6 +180,7 @@ namespace AngouriMath.Tests.Core.Transformations
                     "a-lessorequal-with-a-number-on-the-left-turns-round: ReplacementIsCode",
                     "a-lessorequal-with-zero-on-the-left-turns-round: ReplacementIsCode",
                     "a-logarithm-in-a-reciprocal-base-negates: ReplacementIsCode",
+                    "a-logarithm-of-a-perfect-power-takes-the-exponent-out: ReplacementIsCode",
                     "a-logarithm-of-a-reciprocal-in-a-reciprocal-base-turns-round-twice: ReplacementIsCode",
                     "a-logarithm-of-a-reciprocal-negates: ReplacementIsCode",
                     "a-logarithm-of-its-own-base-is-one-where-it-is-defined: ReplacementIsCode",

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleAuthoringGuideTest.cs
@@ -43,7 +43,7 @@ namespace AngouriMath.Tests.Core.Transformations
         public void WhereARuleGoes()
         {
             Stated(33, MatchedRules.All.Count, "the number of rule sets written as data");
-            Stated(327, MatchedRules.All.Sum(set => set.Rules.Count), "the number of rules written as data");
+            Stated(328, MatchedRules.All.Sum(set => set.Rules.Count), "the number of rules written as data");
             Stated(30, RewriteRules.All.Count, "the number of registered sets");
             // Two families register under one name and run a data set under another --
             // CommonDenominator over MatchedRules.CommonDenominator(level), CanonicalOrder over
@@ -64,7 +64,7 @@ namespace AngouriMath.Tests.Core.Transformations
         {
             var names = MatchedRules.All.SelectMany(set => set.Rules)
                 .Select(rule => rule.Name).Distinct(StringComparer.Ordinal).ToList();
-            Stated(298, names.Count, "the number of distinct rule names");
+            Stated(299, names.Count, "the number of distinct rule names");
 
             var words = names.Select(name => name.Split('-').Length).ToList();
             Stated(4, words.Min(), "the shortest rule name in words");
@@ -73,7 +73,7 @@ namespace AngouriMath.Tests.Core.Transformations
 
         [Fact]
         public void TheIdentityIsNotTheName()
-            => Stated(324,
+            => Stated(325,
                 MatchedRules.All.SelectMany(set => set.Rules).Count(rule => rule.Description is not null),
                 "how many rules carry an identity");
 
@@ -101,7 +101,7 @@ namespace AngouriMath.Tests.Core.Transformations
                 "how many rules are declared Collects");
             Stated(49, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Rearranges),
                 "how many rules are declared Rearranges");
-            Stated(31, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Expands),
+            Stated(32, rules.Count(rule => rule.Growth is RewriteRuleGrowth.Expands),
                 "how many rules are declared Expands");
 
             // And the two the document names. By their own names rather than by what the prose
@@ -130,7 +130,7 @@ namespace AngouriMath.Tests.Core.Transformations
         public void SoundnessIsPerRule()
         {
             var rules = MatchedRules.All.SelectMany(set => set.Rules).ToList();
-            Stated(185, rules.Count(rule => rule.Soundness is Soundness.Sound),
+            Stated(186, rules.Count(rule => rule.Soundness is Soundness.Sound),
                 "how many rules are Sound");
             Stated(142, rules.Count(rule => rule.Soundness is Soundness.SoundUnderAssumptions),
                 "how many rules are SoundUnderAssumptions");

--- a/Sources/Tests/UnitTests/Core/Transformations/RuleMetadataTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RuleMetadataTest.cs
@@ -88,8 +88,8 @@ namespace AngouriMath.Tests.Core.Transformations
         public void SoundnessIsFinerPerRuleThanPerSet()
         {
             var rules = MatchedRules.All.SelectMany(set => set.Rules).ToList();
-            Assert.Equal(327, rules.Count);
-            Assert.Equal(185,rules.Count(rule => rule.Soundness is Soundness.Sound));
+            Assert.Equal(328, rules.Count);
+            Assert.Equal(186,rules.Count(rule => rule.Soundness is Soundness.Sound));
             Assert.Equal(142, rules.Count(rule => rule.Soundness is Soundness.SoundUnderAssumptions));
 
             // And every set still reports the weakest of them, which is what makes the set grain
@@ -174,7 +174,7 @@ namespace AngouriMath.Tests.Core.Transformations
             var repointed = RewriteRules.All
                 .Where(set => set.Rules.Count > 0 && set.Rules.All(rule => rule.Soundness is not null))
                 .ToList();
-            Assert.Equal(324, repointed.Sum(set => set.Rules.Count));
+            Assert.Equal(325, repointed.Sum(set => set.Rules.Count));
             Assert.All(repointed, set => Assert.All(set.Rules, rule => Assert.NotNull(rule.Description)));
         }
 

--- a/Sources/Tests/UnitTests/Core/Transformations/StepAsASentenceTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/StepAsASentenceTest.cs
@@ -59,7 +59,7 @@ namespace AngouriMath.Tests.Core.Transformations
         {
             var names = MatchedRules.All.SelectMany(set => set.Rules).Select(rule => rule.Name)
                 .Distinct(StringComparer.Ordinal).ToList();
-            Assert.Equal(298, names.Count);
+            Assert.Equal(299, names.Count);
             Assert.All(names, name => Assert.True(Explanation.IsProse(name),
                 $"'{name}' is a rule name that does not read as a phrase in English"));
 


### PR DESCRIPTION
Part of #1212 — the first of the small items in [my comment there](https://github.com/asc-community/AngouriMath/issues/1212#issuecomment-5581176922): question I.5's presentation.

## What changes

`ln(4/3) + ln(16/9) / 2` was left as written; it is `2 ln(4/3)`, which the metric then prefers as the single literal `ln(16/9)`. The rule that reads `log(a, b^n)` as `n log(a, b)` could not see a rational literal that is a power without saying so.

A new rule in `Power`, in both spellings: a logarithm of a **positive** rational literal that is a perfect power is offered as the exponent times the logarithm of the root — `ln(16/9)` as `2 ln(4/3)`, `ln(64)` as `6 ln(2)`, `ln(1/8)` as `3 ln(1/2)`. The largest exponent that fits is read exactly, on numerators and denominators within 64 bits (`TreeAnalyzer.TryPerfectPower`). A positive root only: `-8` is `(-2)^3`, but `ln(-8)` is `ln 8 + iπ` where `3 ln(-2)` is `3 ln 2 + 3iπ`, so a negative root is refused rather than assumed. `Sound`, `Expands` (+2 nodes), so it is offered to the metric and never taken on its own.

| input | was | is |
|---|---|---|
| `integral((2x^2+x+1)/(x^3+x^2+x+1), x, 3/4, 4/3)` — question I.5 | `ln(4/3) + ln(16/9) / 2` | `ln(16/9)` |
| `ln(4/3) + ln(16/9) / 2` | `ln(4/3) + ln(16/9) / 2` | `2 * ln(4/3)` |
| `ln(8) - 3 ln(2)`, `log(3, 81) / 4` | `0`, `1` | the same |
| `ln(16/9)`, `ln(64)` alone | the literal | the literal — the longer form loses |

## Checks

`LogarithmOfAPerfectPowerTest`: five perfect powers read, five non-powers refused (including `-8`, `1`, `0`), the sheet's integral, three collections, two literals left alone. The rule census moves by one (`WritingARule.md`, the guide tests, `ReversibleRuleTest`, the `Saturation` remark). Full suite in two chunks: 9,715 passed, 0 failed (Calculus 1,355, the rest 8,360).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
