### PR TITLE
A geometric series is summed in closed form

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -88,6 +88,7 @@ read first.
 | | `"sum(x^k / k!, k, 0, +oo)".ToEntity().Simplify()`, and every summation to `+oo` of a polynomial in the index times a power with the index in the exponent over a factorial of the index | `sum(x ^ k / k!, k, 0, +oo)` — left as written | `e ^ x`; `sum(3^(k+2) * (k^2 + k + 1) / (k + 3)!, k, 0, +oo)` is `4/3 * e ^ 3 - 41/6` |
 | | `"sum(N! / (k! * (N - k)!) * x^k, k, 0, N)".ToEntity().Simplify()`, and every binomial sum with a power or a cosine or sine of the index as its weight | `sum(N! / (k! * (N - k)!) * x ^ k, k, 0, N)` — left as written | `piecewise((1 + x) ^ N provided N >= 0, 0)`; with `cos(k * pi / 3)`, `piecewise(2 ^ N * cos(pi / 6) ^ N * cos(N * pi / 6) provided N >= 0, 0)` |
 | | `"ln(4/3) + ln(16/9) / 2".ToEntity().Simplify()`, and every sum of logarithms of rational literals one of which is a perfect power of another | `ln(4/3) + ln(16/9) / 2` — left as written | `2 * ln(4/3)`; the integral it came from, `integral((2x^2+x+1)/(x^3+x^2+x+1), x, 3/4, 4/3)`, answers `ln(16/9)` |
+| | `"sum(x^k, k, 0, +oo)".ToEntity().Simplify()`, and every summation of a power with the index in the exponent times something free of the index, to a bound or to `+oo` | left as written | `1 / (1 - x) provided abs(x) < 1`; `sum(2^(-k), k, 0, +oo)` is `2`, `sum(x^k, k, 0, n)` is a piecewise with the ratio 1 and the empty range as cases of their own, and `integral(2^(-floor(x)), x, 0, +oo)` is `2` |
 | **Silent** | `"integral(piecewise(2x provided x <= 1/2, 2 - 2x), x, 0, 1)".ToEntity().Simplify()`, and every definite integral of a piecewise whose conditions mention the variable | `1` — the first case's antiderivative at both ends | `1/2` — split at the case boundaries; `piecewise(x provided x < 1, x^2)` from 0 to 2 was `piecewise(2 provided x < 1, 8/3)`, with the integration variable still in it, and is `17/6` |
 | **Silent** | `"integral(x - floor(x), x, 0, 3)".ToEntity().Simplify()`, and every definite integral over numeric bounds whose integrand has `floor(x)` or `ceil(x)` in it | `0` — an antiderivative that took the floor for a constant across its jumps | `3/2` — split at the jumps; `(x - floor(x))^2` from 0 to 4 was `0` and is `4/3` |
 | **Silent** | `"integral((x - floor(x))^2, x, 0, n)".ToEntity().Simplify()`, and every such integral with a symbolic bound or a condition against a symbol | `(n - floor(n)) ^ 3 / 3` — wrong for every whole `n` but 0; `piecewise(x provided x < a, 0)` from 0 to 2 was `piecewise(2 provided x < a, 0)` | left as written |
@@ -1096,6 +1097,33 @@ columns measured on a build, `60545afa` against this change.
 | `"ln(16/9)"`, `ln(64)`, `ln(8) - 3 * ln(2)`, `log(3, 81) / 4` | `ln(16/9)`, `ln(64)`, `0`, `1` | the same |
 | `RewriteRules.Power.Rules.Count`, and `RewriteRules.All` by growth | `31`; 124 / 49 / 31 / 123 | `32`; 124 / 49 / 32 / 123 |
 
+### A geometric series is summed in closed form
+
+`sum(x^k, k, 0, +oo)` was left as written, and so was every other sum of a power with the index in
+the exponent: `sum(2^(-k), k, 0, +oo)`, `sum(x^k, k, 0, n)`, and `sum(2^k, k, 0, 200)`, whose range is
+past the hundred terms that are expanded one by one. A summand that is `C * b^(m k + s)` — a base
+free of the index, an exponent that is the index times a whole number plus something free of it,
+and every other factor free of the index — is now summed as a geometric series with the ratio
+`b^m`. Between two bounds the sum is `C b^s (r^a - r^(b + 1)) / (1 - r)` where the range is not
+empty and the ratio is not 1, the number of terms times the constant where the ratio is 1, and `0`
+for an empty range; a numeric ratio picks its branch and a symbolic one is offered all three as a
+piecewise, the way a polynomial summand is offered the empty range. To `+oo` the series converges
+exactly when `|r| < 1`: a numeric ratio outside that is left as written — infinite or without a
+value, and which is not this reader's to say — and a symbolic ratio carries `provided abs(r) < 1`.
+A polynomial factor in the index, `k x^k`, is not this family and stays as written. The sum the
+step integral of `2^(-floor(x))` leaves, from question I.2 of
+[#1212](https://github.com/asc-community/AngouriMath/issues/1212). Both columns measured on a
+build, `27ed5b53` against this change.
+
+| | Was | Is |
+|---|---|---|
+| `"sum(2^(-k), k, 0, +oo)".ToEntity().Simplify()`, `sum(1 / 2^k, k, 1, +oo)`, `sum((-1/2)^k, k, 0, +oo)` | left as written | `2`, `1`, `2/3` |
+| `"sum(x^k, k, 0, +oo)".ToEntity().Simplify()`, and from 1 | left as written | `1 / (1 - x) provided abs(x) < 1`, `x / (1 - x) provided abs(x) < 1` |
+| `"sum(x^k, k, 0, n)".ToEntity().Simplify()` | left as written | `piecewise((n + 1) provided (x = 1 and n >= -1), ((1 - x ^ (n + 1)) / (1 - x)) provided (n >= -1), 0 provided True)` |
+| `"sum(2^k, k, a, n)".ToEntity().Simplify()`, and `sum(2^k, k, 0, 200)` | left as written | `piecewise((2 ^ (n + 1) - 2 ^ a) provided (n >= a - 1), 0 provided True)`, `2^201 - 1` as a number |
+| `"integral(2^(-floor(x)), x, 0, +oo)".ToEntity().Simplify()` | left as written | `2` |
+| `"sum(2^k, k, 0, +oo)"`, `sum((-1)^k, k, 0, +oo)`, `sum(k * (1/2)^k, k, 0, +oo)`, `sum(2^k, k, 0, 5)` | left as written; `63` | the same |
+
 ### An integral across a jump is split at the jumps, never taken through an antiderivative
 
 `F(b) - F(a)` is the integral only where `F` is continuous on `[a, b]`, and the definite integral
@@ -1137,7 +1165,7 @@ depend on where the jumps fall. Offered only where every piece resolves. Questio
 | `"integral((x - floor(x)) / floor(x)!, x, 1, +oo)".ToEntity().Simplify()` | left as written | `(e - 1) / 2` |
 | `"integral(floor(x), x, 0, 5)"`, `integral(floor(x) * x, x, 0, 3)`, `integral(floor(x) / (floor(x) + 1)!, x, 0, +oo)` | left as written | `10`, `13/2`, `1` |
 | `"integral(floor(x), x, 1/2, 2)"`, `integral(x - floor(x), x, 0, 5/2)`, `integral(ceil(x) - x, x, 1/2, 2)` | left as written | `1`, `9/8`, `5/8` |
-| `"integral(2^(-floor(x)), x, 0, +oo)"`, `integral(floor(x^2), x, 0, 2)` | left as written | the same — a geometric series has no closed form here yet; a floor of something other than the variable is not a step this reads |
+| `"integral(floor(x^2), x, 0, 2)"` | left as written | the same — a floor of something other than the variable is not a step this reads. `integral(2^(-floor(x)), x, 0, +oo)` was left as written here for want of a geometric series, and is `2` as of the section above |
 
 ## 2.4.0 — since 2.3.0
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -198,6 +198,12 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [Tests/UnitTests/Calculus/ExponentialSeriesTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[AngouriMath/Functions/Algebra/Polynomials/GeometricSeries.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/GeometricSeriesTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [AngouriMath/Functions/Algebra/Polynomials/BinomialSum.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/GeometricSeries.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/GeometricSeries.cs
@@ -1,0 +1,179 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using PeterO.Numbers;
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// A summation whose summand is a power with the index in the exponent, times something free
+    /// of the index: <c>sum(x^k, k, 0, n)</c> is <c>(1 - x^(n + 1)) / (1 - x)</c>, and
+    /// <c>sum(2^(-k), k, 0, +oo)</c> is <c>2</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The summand is read as <c>C * b^(m k + s)</c>, which is <c>C b^s * r^k</c> with the ratio
+    /// <c>r = b^m</c> for a whole non-zero <c>m</c>. Between two bounds the sum is
+    /// <c>C b^s (r^a - r^(b + 1)) / (1 - r)</c>, which holds for every pair of integers with
+    /// <c>b >= a - 1</c> and every ratio but 1 -- at <c>r = 1</c> the sum is the number of terms
+    /// times the constant, and below <c>b = a - 1</c> the range is empty, which this library
+    /// answers with <c>0</c>. Where the ratio is a number the branch that applies is known; where it
+    /// is symbolic, both are offered as a piecewise, the way
+    /// <see cref="PolynomialSummation"/> offers the empty range.
+    /// </para>
+    /// <para>
+    /// To <c>+oo</c> the series converges exactly when <c>|r| &lt; 1</c>, to <c>C b^s r^a / (1 - r)</c>.
+    /// A numeric ratio outside that is left as written -- the sum is infinite or has no value,
+    /// and which of the two is not this reader's to say -- and a symbolic ratio carries the
+    /// condition, since outside it the sum has no value the formula could be standing for.
+    /// </para>
+    /// <para>
+    /// Recognised structurally, on the factors of the simplified summand: exactly one power whose
+    /// base is free of the index and whose exponent is the index times a whole number plus
+    /// something free of the index; every other factor free of the index. A polynomial factor in
+    /// the index -- <c>k x^k</c> -- is not this family and is declined, and so is a base that is
+    /// zero or a ratio that is a number and 1. Part of question I.2 of
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/1212">#1212</a>, where the
+    /// step integral of <c>2^(-floor(x))</c> leaves this sum.
+    /// </para>
+    /// </remarks>
+    internal static class GeometricSeries
+    {
+        /// <summary>
+        /// <c>sum(expression, index, from, to)</c> in closed form, or <see langword="null"/>
+        /// where the summand is not of the shape above, or a bound is a number that is neither
+        /// whole nor <c>+oo</c>.
+        /// </summary>
+        internal static Entity? ClosedForm(Entity expression, Entity var, Entity from, Entity to)
+        {
+            if (var is not Variable index)
+                return null;
+            if (!PolynomialSummation.IsWholeOrSymbolic(from))
+                return null;
+            var toInfinity = to.Evaled is Real { IsFinite: false, IsNaN: false, IsNegative: false };
+            if (!toInfinity && !PolynomialSummation.IsWholeOrSymbolic(to))
+                return null;
+
+            Entity? @base = null;
+            Entity? exponent = null;
+            Entity constant = Integer.One;
+            foreach (var factor in Mulf.LinearChildren(expression.InnerSimplified))
+            {
+                if (!factor.ContainsNode(index))
+                {
+                    constant *= factor;
+                    continue;
+                }
+                if (factor is Powf(var b, var e) && @base is null && !b.ContainsNode(index))
+                {
+                    @base = b;
+                    exponent = e;
+                }
+                else
+                    return null;
+            }
+            if (@base is null || !TryReadLinear(exponent!, index, out var slope, out var offset))
+                return null;
+            if (@base.Evaled is Complex value && IsZero(value))
+                return null;
+
+            // C b^(m k + s) = (C b^s) r^k with r = b^m. Not b^0: that would attach
+            // `provided not b = 0`, which a base already known not to be zero does not need.
+            if (offset != Integer.Zero)
+                constant *= MathS.Pow(@base, offset);
+            var ratio = slope == 1 ? @base : MathS.Pow(@base, Integer.Create(slope));
+            var ratioIsANumber = ratio.Evaled is Complex;
+            if (ratioIsANumber && ratio.Evaled == Integer.One)
+                return null;
+
+            if (toInfinity)
+            {
+                Entity limit = constant * PowerAt(ratio, from) / (Integer.One - ratio);
+                if (ratioIsANumber)
+                    return ((Complex)ratio.Evaled).Abs() < 1 ? limit.InnerSimplified : null;
+                return new Providedf(limit, new Lessf(MathS.Abs(ratio), Integer.One)).InnerSimplified;
+            }
+
+            // The terms from a to b, as the difference of two tails of the same series.
+            Entity closed = constant * (PowerAt(ratio, from) - PowerAt(ratio, to + Integer.One)) / (Integer.One - ratio);
+            var nonEmpty = new GreaterOrEqualf(to, from - Integer.One);
+            if (ratioIsANumber)
+                return MathS.Piecewise(new[]
+                {
+                    new Providedf(closed, nonEmpty),
+                    new Providedf(Integer.Zero, Entity.Boolean.True),
+                }).InnerSimplified;
+            Entity constantTerms = constant * (to - from + Integer.One);
+            return MathS.Piecewise(new[]
+            {
+                new Providedf(constantTerms, new Andf(new Equalsf(ratio, Integer.One), nonEmpty)),
+                new Providedf(closed, nonEmpty),
+                new Providedf(Integer.Zero, Entity.Boolean.True),
+            }).InnerSimplified;
+        }
+
+        /// <summary>
+        /// <c>ratio ^ bound</c>, as the number 1 where the bound is 0: <c>r^0</c> would attach
+        /// <c>provided not r = 0</c> to a sum whose value at <c>r = 0</c> is its first term,
+        /// which the formula gives without help.
+        /// </summary>
+        private static Entity PowerAt(Entity ratio, Entity bound)
+            => bound.Evaled == Integer.Zero ? Integer.One : MathS.Pow(ratio, bound);
+
+        /// <summary>
+        /// <paramref name="exponent"/> as <c>slope * index + offset</c> for a whole non-zero
+        /// <paramref name="slope"/> and an <paramref name="offset"/> free of the index, which may
+        /// be symbolic. Read off the tree: <c>k - k</c> does not simplify to a bare 0 but to 0
+        /// with what it assumes, so the exponent is not rewritten to find out.
+        /// </summary>
+        private static bool TryReadLinear(Entity exponent, Variable index, out int slope, out Entity offset)
+        {
+            offset = Integer.Zero;
+            switch (exponent)
+            {
+                case Sumf(var left, var right) when !right.ContainsNode(index) && TryReadSlope(left, index, out slope):
+                    offset = right;
+                    return true;
+                case Sumf(var left, var right) when !left.ContainsNode(index) && TryReadSlope(right, index, out slope):
+                    offset = left;
+                    return true;
+                case Minusf(var left, var right) when !right.ContainsNode(index) && TryReadSlope(left, index, out slope):
+                    offset = -right;
+                    return true;
+                case Minusf(var left, var right) when !left.ContainsNode(index) && TryReadSlope(right, index, out slope):
+                    offset = left;
+                    slope = -slope;
+                    return true;
+                default:
+                    return TryReadSlope(exponent, index, out slope);
+            }
+        }
+
+        /// <summary>
+        /// <paramref name="term"/> as <c>slope * index</c> for a whole non-zero
+        /// <paramref name="slope"/>: the index itself, or the index times a whole literal.
+        /// </summary>
+        private static bool TryReadSlope(Entity term, Variable index, out int slope)
+        {
+            slope = 1;
+            if (term == index)
+                return true;
+            var literal = term switch
+            {
+                Mulf(Integer m, var k) when k == index => m,
+                Mulf(var k, Integer m) when k == index => m,
+                _ => null,
+            };
+            if (literal is null || literal.EInteger.IsZero || !literal.EInteger.CanFitInInt32())
+                return false;
+            slope = literal.EInteger.ToInt32Checked();
+            return true;
+        }
+    }
+}

--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Continuous/Evaluation.Continuous.Calculus.Classes.cs
@@ -206,6 +206,7 @@ namespace AngouriMath
                 ?? Functions.PolynomialSummation.ClosedForm(Expression, Var, From, To)
                 ?? Functions.ExponentialSeries.ClosedForm(Expression, Var, From, To)
                 ?? Functions.BinomialSum.ClosedForm(Expression, Var, From, To)
+                ?? Functions.GeometricSeries.ClosedForm(Expression, Var, From, To)
                 ?? this;
 
             /// <summary>

--- a/Sources/Tests/UnitTests/Calculus/BreakpointIntegrationTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/BreakpointIntegrationTest.cs
@@ -102,11 +102,14 @@ namespace AngouriMath.Tests.Calculus
             Assert.Equal("2".ToEntity(), value.Substitute("n", 6).Simplify());
         }
 
-        // The split is exact but the sum it leaves has no closed form here yet -- a geometric
-        // series -- so the integral stays as written rather than becoming an unevaluated sum.
+        // The split leaves a geometric series, which is summed in closed form; a sum the closed
+        // forms cannot answer leaves the integral as written rather than an unevaluated sum.
         [Fact]
-        public void ASumWithoutAClosedFormLeavesTheIntegralAsWritten()
-            => Assert.IsType<Integralf>("integral(2^(-floor(x)), x, 0, +oo)".ToEntity().Simplify());
+        public void TheSumTheSplitLeavesIsAnsweredOrTheIntegralStays()
+        {
+            Assert.Equal("2".ToEntity(), "integral(2^(-floor(x)), x, 0, +oo)".ToEntity().Simplify());
+            Assert.IsType<Integralf>("integral(floor(x)^floor(x), x, 1, +oo)".ToEntity().Simplify());
+        }
 
         // Not split and not integrated either: a floor of something other than the variable
         // is not a break this reads, and an integrand the unit interval cannot integrate stays.

--- a/Sources/Tests/UnitTests/Calculus/BreakpointIntegrationTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/BreakpointIntegrationTest.cs
@@ -102,8 +102,11 @@ namespace AngouriMath.Tests.Calculus
             Assert.Equal("2".ToEntity(), value.Substitute("n", 6).Simplify());
         }
 
-        // The split leaves a geometric series, which is summed in closed form; a sum the closed
-        // forms cannot answer leaves the integral as written rather than an unevaluated sum.
+        // The split leaves a geometric series, which is summed in closed form. A sum the closed
+        // forms do not answer yet leaves the integral as written rather than an unevaluated sum:
+        // the second one is sum(n^n, n, 1, +oo), whose terms do not tend to zero, so it is +oo --
+        // the answer a divergence test would give, and there is none yet. Not a verdict that it
+        // cannot be answered; the day it is, this line moves to the value.
         [Fact]
         public void TheSumTheSplitLeavesIsAnsweredOrTheIntegralStays()
         {

--- a/Sources/Tests/UnitTests/Calculus/GeometricSeriesTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/GeometricSeriesTest.cs
@@ -1,0 +1,101 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+using static AngouriMath.Entity;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// A summation of a power with the index in the exponent is summed in closed form: the
+    /// geometric series, to a bound or to <c>+oo</c>. Part of question I.2 of
+    /// https://github.com/asc-community/AngouriMath/issues/1212.
+    /// </summary>
+    public sealed class GeometricSeriesTest
+    {
+        [Theory]
+        [InlineData("sum(2^(-k), k, 0, +oo)", "2")]
+        [InlineData("sum(1 / 2^k, k, 1, +oo)", "1")]
+        [InlineData("sum(3 * (1/2)^k, k, 0, +oo)", "6")]
+        [InlineData("sum((-1/2)^k, k, 0, +oo)", "2/3")]
+        [InlineData("sum(2^(-2k), k, 0, +oo)", "4/3")]
+        [InlineData("sum(2^(1 - k), k, 0, +oo)", "4")]
+        [InlineData("sum((1/3)^(k + 2), k, 0, +oo)", "1/6")]
+        public void ASeriesWithANumericRatioBelowOneIsSummed(string sum, string expected)
+            => Assert.Equal(expected.ToEntity(), sum.ToEntity().Simplify());
+
+        [Fact]
+        public void ASeriesWithASymbolicRatioCarriesItsCondition()
+        {
+            var value = "sum(x^k, k, 0, +oo)".ToEntity().Simplify();
+            Assert.IsNotType<Summationf>(value);
+            Assert.Equal("2".ToEntity(), value.Substitute("x", "1/2").Simplify());
+            Assert.Equal("2/3".ToEntity(), value.Substitute("x", "-1/2").Simplify());
+            // At x = 0 the sum is its first term, and the answer must not carry `not x = 0`
+            // from an x^0 it never needed to write.
+            Assert.Equal("1".ToEntity(), value.Substitute("x", "0").Simplify());
+            Assert.Equal("3/2".ToEntity(), "sum(x^k, k, 1, +oo)".ToEntity().Simplify().Substitute("x", "3/5").Simplify());
+        }
+
+        // Outside the disc the series has no sum, and a substitution says so rather than
+        // answering with the formula.
+        [Fact]
+        public void OutsideTheDiscTheFormulaIsNotAnswered()
+        {
+            var value = "sum(x^k, k, 0, +oo)".ToEntity().Simplify();
+            Assert.NotEqual("-1".ToEntity(), value.Substitute("x", "2").Simplify());
+        }
+
+        // A finite range past the hundred terms that are expanded term by term.
+        [Theory]
+        [InlineData("sum(2^k, k, 0, 200)", "2^201 - 1")]
+        [InlineData("sum(3 * 2^(2k + 1), k, 0, 150)", "2 * (4^151 - 1)")]
+        [InlineData("sum((1/2)^k, k, 5, 400)", "(1/2)^4 - (1/2)^400")]
+        public void AFiniteRangeIsSummedInClosedForm(string sum, string expected)
+            => Assert.Equal(expected.ToEntity().Simplify(), sum.ToEntity().Simplify());
+
+        // A symbolic bound: the formula where the range is not empty and the ratio is not 1,
+        // the number of terms where it is 1, and 0 for an empty range.
+        [Theory]
+        [InlineData("2", "3", "15")]
+        [InlineData("1", "3", "4")]
+        [InlineData("1/2", "2", "7/4")]
+        [InlineData("2", "-2", "0")]
+        [InlineData("1", "-1", "0")]
+        [InlineData("0", "3", "1")]
+        public void ASymbolicBoundIsAnsweredAsAPiecewise(string x, string n, string expected)
+        {
+            var value = "sum(x^k, k, 0, n)".ToEntity().Simplify();
+            Assert.IsNotType<Summationf>(value);
+            Assert.Equal(expected.ToEntity(), value.Substitute("x", x).Substitute("n", n).Simplify());
+        }
+
+        [Theory]
+        [InlineData("2", "4", "28")]
+        [InlineData("3", "1", "0")]
+        public void ASymbolicLowerBoundIsAnsweredToo(string a, string n, string expected)
+        {
+            var value = "sum(2^k, k, a, n)".ToEntity().Simplify();
+            Assert.IsNotType<Summationf>(value);
+            Assert.Equal(expected.ToEntity(), value.Substitute("a", a).Substitute("n", n).Simplify());
+        }
+
+        // Not this family: a ratio at or beyond 1 to +oo, a polynomial beside the power, an
+        // exponent that is not linear in the index, a base with the index in it.
+        [Theory]
+        [InlineData("sum(2^k, k, 0, +oo)")]
+        [InlineData("sum((-1)^k, k, 0, +oo)")]
+        [InlineData("sum(k * (1/2)^k, k, 0, +oo)")]
+        [InlineData("sum(2^(k^2), k, 0, 200)")]
+        [InlineData("sum(k^k, k, 1, 200)")]
+        [InlineData("sum(2^k, k, 0, 5/2)")]
+        public void WhatIsNotAGeometricSeriesIsLeftAsWritten(string sum)
+            => Assert.IsType<Summationf>(sum.ToEntity().Simplify());
+    }
+}

--- a/Sources/Tests/UnitTests/Convenience/SyntaxDocumentedTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/SyntaxDocumentedTest.cs
@@ -358,7 +358,7 @@ namespace AngouriMath.Tests.Convenience
         [Theory]
         [InlineData("sum(k, k, 1, 5/2)")]
         [InlineData("sum(k, k, 1, +oo)")]
-        [InlineData("sum(2 ^ k, k, 1, n)")]
+        [InlineData("sum(k ^ k, k, 1, n)")]
         public void ARangeThatIsNotAnIntegerOneStaysAsWritten(string written) =>
             Assert.Equal(written.ToEntity(), written.ToEntity().Simplify());
 

--- a/Sources/Tests/UnitTests/Core/ClosedFormSummationTest.cs
+++ b/Sources/Tests/UnitTests/Core/ClosedFormSummationTest.cs
@@ -143,7 +143,6 @@ namespace AngouriMath.Tests.Core
         /// closed form in the literature and none of them is this method's.
         /// </summary>
         [Theory]
-        [InlineData("sum(2 ^ k, k, 1, n)")]
         [InlineData("sum(1 / k, k, 1, n)")]
         [InlineData("sum(1 / k ^ 2, k, 1, n)")]
         [InlineData("sum(sin(k), k, 1, n)")]

--- a/Sources/Tests/UnitTests/Core/SummationProductTest.cs
+++ b/Sources/Tests/UnitTests/Core/SummationProductTest.cs
@@ -58,7 +58,7 @@ namespace AngouriMath.Tests.Core
         /// else is still carried.
         /// </summary>
         [Theory]
-        [InlineData("sum(2 ^ k, k, 1, n)")]
+        [InlineData("sum(k ^ k, k, 1, n)")]
         [InlineData("sum(1 / k, k, 1, n)")]
         [InlineData("sum(sin(k), k, 1, n)")]
         public void ASymbolicBoundIsCarried(string expression)


### PR DESCRIPTION
Part of #1212 — the sum that question I.2's step integral leaves once #1215 splits it, and the last of the summation closed forms the plan there named (polynomial #1152, exponential #1213, binomial #1214).

## What was left as written

Measured on `27ed5b53`:

| | master |
|---|---|
| `sum(2^(-k), k, 0, +oo)`, `sum(1 / 2^k, k, 1, +oo)`, `sum((-1/2)^k, k, 0, +oo)` | left as written |
| `sum(x^k, k, 0, +oo)`, `sum(x^k, k, 0, n)`, `sum(2^k, k, a, n)` | left as written |
| `sum(2^k, k, 0, 200)` — past the hundred terms expanded one by one | left as written |
| `integral(2^(-floor(x)), x, 0, +oo)` | left as written (#1215 split it and declined the sum) |

## What changes

`GeometricSeries.ClosedForm`, last in the `Summationf` chain. The summand is read structurally as `C * b^(m k + s)`: one power whose base is free of the index and whose exponent is the index times a whole number plus something free of it, every other factor free of the index. The ratio is `r = b^m`.

- **Between two bounds:** `C b^s (r^a - r^(b + 1)) / (1 - r)` holds where the range is not empty and `r ≠ 1`; at `r = 1` the sum is the number of terms times the constant; below `b = a - 1` the range is empty and this library answers `0`. A numeric ratio picks its branch; a symbolic one is offered all three as a piecewise, the way `PolynomialSummation` offers the empty range — `sum(x^k, k, 0, n)` is `piecewise((n + 1) provided (x = 1 and n >= -1), ((1 - x^(n + 1)) / (1 - x)) provided (n >= -1), 0)`.
- **To `+oo`:** converges exactly when `|r| < 1`. A numeric ratio outside that is left as written — the sum is infinite or has no value, and which of the two is not this reader's to say. A symbolic ratio carries the condition: `sum(x^k, k, 0, +oo)` is `1 / (1 - x) provided abs(x) < 1`.
- **Not this family:** a polynomial factor in the index (`k x^k`), an exponent that is not linear in the index, a base with the index in it, a bound that is a number and not whole. All stay as written.
- `r^0` is written as the number 1 rather than built, since a power carries `provided not r = 0` and the sum at `r = 0` is its first term — the first cut answered `sum(x^k, k, 0, +oo)` with `and not x = 0` attached, which is false at a point where the sum is 1.

Three tests pinned `sum(2^k, k, 1, n)` as their example of a sum without a closed form; they use `k^k` now. The #1215 test that recorded `integral(2^(-floor(x)), x, 0, +oo)` staying as written for want of this sum now records `2`.

## Measured

Both columns on builds — `27ed5b53` against this branch:

| | was | is |
|---|---|---|
| `sum(2^(-k), k, 0, +oo)`, `sum(1 / 2^k, k, 1, +oo)`, `sum((-1/2)^k, k, 0, +oo)` | left as written | `2`, `1`, `2/3` |
| `sum(x^k, k, 0, +oo)`; from 1 | left as written | `1 / (1 - x) provided abs(x) < 1`; `x / (1 - x) provided abs(x) < 1` |
| `sum(x^k, k, 0, n)` | left as written | the three-case piecewise above |
| `sum(2^k, k, a, n)`; `sum(2^k, k, 0, 200)` | left as written | `piecewise((2^(n + 1) - 2^a) provided (n >= a - 1), 0)`; `2^201 - 1` as a number |
| `integral(2^(-floor(x)), x, 0, +oo)` | left as written | `2` |
| `sum(2^k, k, 0, +oo)`, `sum((-1)^k, k, 0, +oo)`, `sum(k * (1/2)^k, k, 0, +oo)`, `sum(2^k, k, 0, 5)` | left as written; `63` | the same |

## Checks

`GeometricSeriesTest`: seven numeric series, the symbolic ratio with its condition and its value at 0, outside the disc, three finite ranges past a hundred terms, six symbolic-bound substitutions, two symbolic lower bounds, six non-shapes. Full suite in two chunks: 8359 and 1412 pass.

One thing seen once and not reproduced, noted rather than hidden: in the first chunk run on this branch `FractionFreeDeterminantTest.EliminationAgreesWithLaplaceWhereverBothApply` reported one 4×4 whose Laplace determinant came back with two ninety-digit integers in it. It passes alone, passed on the rerun of the same chunk, and passes on master's build of the chunk; the test is seeded, so the input is fixed and the difference is scheduling. Nothing in this branch is on that path; filed as #1219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
