### PR TITLE
A rule count in a comment is a claim that goes stale silently

### DIFF
--- a/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
+++ b/Sources/AngouriMath/Core/Transformations/Matching/MatchedRule.cs
@@ -21,18 +21,23 @@ namespace AngouriMath.Core.Transformations.Matching
     /// This is what <a href="https://github.com/asc-community/AngouriMath/issues/825">#825</a>
     /// asks for and what a <c>switch</c> arm cannot be. A rule here can be listed, named in a
     /// bug report, tested by itself, and — the part that matters most —
-    /// <b>carry its own <see cref="Soundness"/></b>. Today the tier is declared per rule *set*,
-    /// and since a set's tier is the minimum over its arms, one conditional arm drags eighteen
-    /// unconditional ones down with it; that is why all thirty sets in the registry declare the
-    /// same value and the field distinguishes nothing.
+    /// <b>carry its own <see cref="Soundness"/></b>. A *set's* tier is the minimum over its arms,
+    /// so one conditional arm drags every unconditional one down with it and every set in the
+    /// registry ends up declaring the same value — which is the honest label for a set and a
+    /// useless one for a rule. A rule declares its own, and unlike the set's it distinguishes:
+    /// both tiers are well populated. No count is repeated here, because a number in a comment
+    /// drifts silently; <c>RuleAuthoringGuideTest</c> measures the live ones and fails when they
+    /// move.
     /// </para>
     /// <para>
     /// <b>Where the right-hand side is a pattern too, the rule has two directions rather than
     /// one.</b> <see cref="Reversed"/> is the same rule read the other way, and
-    /// <see cref="Reversal"/> says why a rule has no such reading when it has none. That is
+    /// <see cref="Reversal"/> says why a rule has no such reading when it has none. That was
     /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> tier 2's first
-    /// missing piece, and <c>Docs/Contributing/ReversibleRules.md</c> is the argument for when a
-    /// reversal is licensed.
+    /// missing piece; it is delivered and it has a production consumer, since
+    /// <c>Saturation.RulesUpTo</c> uses a declared inverse pair to keep the collecting direction
+    /// and withhold the expanding one. <c>Docs/Contributing/ReversibleRules.md</c> is the argument
+    /// for when a reversal is licensed.
     /// </para>
     /// </remarks>
     internal sealed class MatchedRule

--- a/Sources/AngouriMath/Core/Transformations/RewriteRule.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteRule.cs
@@ -89,9 +89,12 @@ namespace AngouriMath.Core.Transformations
     /// purpose.</b> This paragraph used to say the tier was absent, on the argument that a rule's
     /// tier is a claim somebody has to argue for and cannot be derived from syntax. That argument
     /// is right and it is not a reason for the property to be missing: where the argument <i>has</i>
-    /// been made, the claim needs somewhere to live. A rule written as data declares one, and 181
-    /// of the 322 such rules are <see cref="Transformations.Soundness.Sound"/> against every set in
-    /// the registry declaring <see cref="Transformations.Soundness.SoundUnderAssumptions"/>. A rule
+    /// been made, the claim needs somewhere to live. A rule written as data declares one, and the
+    /// two tiers are both well populated — most rules are
+    /// <see cref="Transformations.Soundness.Sound"/> — against every set in the registry declaring
+    /// <see cref="Transformations.Soundness.SoundUnderAssumptions"/>, so the per-rule tier says
+    /// something the per-set one cannot. The live counts are measured by
+    /// <c>RuleAuthoringGuideTest</c> rather than quoted here, where they would drift. A rule
     /// read off a <c>switch</c> arm declares nothing, so its <see cref="Soundness"/> is
     /// <see langword="null"/> — which says the set's tier is a fallback rather than a measurement,
     /// where silently copying the set's down would have said the opposite.
@@ -209,9 +212,10 @@ namespace AngouriMath.Core.Transformations
         /// <b>A set's tier is the minimum over its rules, so reading it as every rule's tier
         /// understates most of them.</b> All thirty sets in the registry declare
         /// <see cref="Transformations.Soundness.SoundUnderAssumptions"/>, and one conditional rule
-        /// is enough to make that true of a set of a hundred. Asked per rule instead, <b>181 of the
-        /// 322 rules written as data are <see cref="Transformations.Soundness.Sound"/></b> — they
-        /// hold for every complex argument, with nothing assumed — and 141 are conditional. That
+        /// is enough to make that true of a set of a hundred. Asked per rule instead, <b>most rules
+        /// written as data are <see cref="Transformations.Soundness.Sound"/></b> — they hold for
+        /// every complex argument, with nothing assumed — and the rest are conditional, in numbers
+        /// <c>RuleAuthoringGuideTest</c> measures rather than this comment quoting them. That
         /// difference is invisible at set grain and is what a derivation needs in order to say why
         /// a particular step was allowed.
         /// </para>

--- a/Sources/AngouriMath/Core/Transformations/RewriteStep.cs
+++ b/Sources/AngouriMath/Core/Transformations/RewriteStep.cs
@@ -55,9 +55,10 @@ namespace AngouriMath.Core.Transformations
         /// This read the set's tier and nothing else until a rule could carry one, which made it
         /// the same answer for every step of a set — and a set's tier is the <i>minimum</i> over
         /// its rules, so one conditional rule spoke for a hundred. All thirty sets declare
-        /// <see cref="Transformations.Soundness.SoundUnderAssumptions"/> and 181 of the 322 rules
-        /// written as data are <see cref="Transformations.Soundness.Sound"/>; a step that fires one
-        /// of those 181 now says so.
+        /// <see cref="Transformations.Soundness.SoundUnderAssumptions"/> while most rules written
+        /// as data are <see cref="Transformations.Soundness.Sound"/>; a step that fires one of
+        /// those now says so. <c>RuleAuthoringGuideTest</c> measures how many, so that the figure
+        /// cannot go stale in a comment.
         /// </para>
         /// <para>
         /// The fallback is not a claim about the rule. Where <see cref="Rule"/> is null, or is an

--- a/Sources/Tests/UnitTests/Core/Transformations/RewriteRecordingTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RewriteRecordingTest.cs
@@ -342,8 +342,8 @@ namespace AngouriMath.Tests.Core.Transformations
                 // And nothing may claim a proof it has not got. This asserted `NotEqual(Sound)` --
                 // that every step was conditional -- which was true only because a step reported
                 // its *set's* tier, and a set's tier is the minimum over its rules. A step now
-                // reports the tier of the rule that fired, and 181 of the 322 rules written as
-                // data really are Sound, so the assertion is that the tier is one of the two the
+                // reports the tier of the rule that fired, and most rules written as data really
+                // are Sound, so the assertion is that the tier is one of the two the
                 // simplifier is allowed to apply rather than that it is always the weaker.
                 Assert.True(step.Soundness is Soundness.Sound or Soundness.SoundUnderAssumptions,
                     $"{step.RuleSet.Name}/{step.Rule?.Name} claims {step.Soundness}");

--- a/Sources/Tests/UnitTests/Core/Transformations/RulePriorityTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/RulePriorityTest.cs
@@ -143,7 +143,7 @@ namespace AngouriMath.Tests.Core.Transformations
         /// </summary>
         /// <remarks>
         /// <para>
-        /// Over all 322 rules rather than within a set, because the relation is about patterns and
+        /// Over every rule rather than within a set, because the relation is about patterns and
         /// nothing about it stops at a set boundary: <b>961</b> ordered pairs claim subsumption,
         /// <b>501</b> of them are put to the test by the corpus containing something the narrower
         /// pattern matches, and none is contradicted across <b>85,153</b> nodes. All three counts

--- a/Sources/Tests/UnitTests/Core/Transformations/StepAsASentenceTest.cs
+++ b/Sources/Tests/UnitTests/Core/Transformations/StepAsASentenceTest.cs
@@ -172,10 +172,11 @@ namespace AngouriMath.Tests.Core.Transformations
         /// <remarks>
         /// A set's tier is the minimum over its rules, so reading it as every rewrite's tier
         /// understates most of them: all thirty sets declare
-        /// <see cref="Soundness.SoundUnderAssumptions"/> while 181 of the 322 rules written as data
-        /// are <see cref="Soundness.Sound"/>. This is the step grain
-        /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> tier 5 records
-        /// as missing.
+        /// <see cref="Soundness.SoundUnderAssumptions"/> while most rules written as data are
+        /// <see cref="Soundness.Sound"/> — <c>RuleAuthoringGuideTest</c> holds the live counts, so
+        /// that no number here can go stale. This is the step grain
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/746">#746</a> tier 5
+        /// recorded as missing, and this test is it not being missing any more.
         /// </remarks>
         [Fact]
         public void ARewriteReportsItsOwnTierWhereItHasOne()


### PR DESCRIPTION
Found while auditing #746 tier 2 against the code rather than against the roadmap's table. No behaviour changes — six comments were asserting things about the rule registry that stopped being true.

## The drifting pair

Six places quoted **"181 of the 322 rules written as data are `Sound`"**. The registry has moved on. The only place a count of this kind is allowed to live is `RuleAuthoringGuideTest`, which measures the live figure and **fails the build when it moves** — that test exists precisely because, in its own words, a guide is read by somebody "in no position to notice" a number went stale two releases ago. None of these six was that place.

So none of them is given a fresher number either, which would drift in its turn. Each states the shape of the fact and points at the test that measures it.

## Two were wrong about more than a number

- **`MatchedRule`** said the soundness tier "is declared per rule *set*" and that **"the field distinguishes nothing"**. That was written before a rule could carry its own tier. It is false now in both halves: the two tiers are both well populated, and `DerivationPath` reads the per-rule tier, taking the weakest across a step. The comment was describing the problem the class was built to solve, in the present tense, inside the class that solved it.
- The same comment called the rule **reversal** "#746 tier 2's *first missing piece*". It is delivered and it has a production consumer: `Saturation.RulesUpTo` uses a declared inverse pair to keep the collecting direction and withhold the expanding one, which is what stops `sin(2x)` ⇄ `2 sin x cos x` running away at the widest ceiling.
- **`StepAsASentenceTest`** described the per-step justification grain as what "#746 tier 5 records as missing" — while being the test that demonstrates it is not missing.

`RuleMetadataTest` quotes the old 27-of-30 figure too and is **left alone**: it narrates the number as history and immediately says both figures are now 30 and 0, which is correct and worth keeping.

## Checks

853 tests in `Core.Transformations` pass, and no `cref` broke (0 × CS1574). Comments only — no production logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
