### PR TITLE
Record the spellings that are known to read as something else

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -15,6 +15,32 @@ read first.
 
 ---
 
+## Spellings known to be at risk — nothing here has changed yet
+
+Every other entry in this file is something that **has** happened, measured on two builds. This
+short section is the opposite: input that parses today, is already known to read as something other
+than what it says, and is therefore a poor thing to build on. It exists so that the warning reaches
+a caller reading this file rather than only the people reading the issue tracker.
+
+The docket of changes waiting for a major version — including these, with the migration argument
+and whatever gets decided — is
+[#1019](https://github.com/asc-community/AngouriMath/issues/1019). Deliberately not restated here,
+so that there is one list rather than two that drift apart.
+
+Measured on `281e0d0c`:
+
+| Written | Reads today as | |
+|---|---|---|
+| `2 \| 6` | `2 or 6` — a disjunction of two numbers | `\|` is an alias for `or`, and is the one spelling in the grammar that already means something *else* in mathematics: divides, "such that", "given", and the delimiter in `\|x\|` |
+| `{ x \| x > 0 }` | `{ x or x > 0 }` — a `FiniteSet` of **one** element, that element a disjunction | ordinary set-builder notation, read as a one-element set |
+| `a != b` | `a! = b` — the factorial of `a`, equated to `b` | `!=` is not a token, so the lexer takes `!` as the postfix factorial and `=` as equality ([#1225](https://github.com/asc-community/AngouriMath/issues/1225)) |
+
+All three are well-formed, silent, and unrelated to what was written. Until they are settled, write
+`or` rather than `|`, `{ x : x > 0 }` for a set builder, and `<>` rather than `!=` — each of which
+is the primary spelling anyway and is what the library prints.
+
+---
+
 ## Unreleased — since 2.4.0
 
 ### At a glance

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -36,6 +36,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [AngouriMath/Functions/TreeAnalyzer/RealValued.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[Tests/UnitTests/Convenience/SpellingsAtRiskTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [Tests/UnitTests/Core/DividesTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 

--- a/Sources/Tests/UnitTests/Convenience/SpellingsAtRiskTest.cs
+++ b/Sources/Tests/UnitTests/Convenience/SpellingsAtRiskTest.cs
@@ -1,0 +1,70 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+using static AngouriMath.Entity;
+
+namespace AngouriMath.Tests.Convenience
+{
+    /// <summary>
+    /// The three spellings <c>BREAKING-CHANGES.md</c> lists under *Spellings known to be at risk*,
+    /// pinned to the readings that section states.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The section says what each of these parses as **today**, which is a claim about the grammar
+    /// and therefore a claim that can go stale. It is here so that it cannot: change any of these
+    /// readings and this test fails, which is the prompt to update the section — or to delete it,
+    /// if what changed is the thing the section is warning about.
+    /// </para>
+    /// <para>
+    /// <b>These assertions are not endorsements.</b> Every one of them records a reading that is
+    /// well-formed, silent and unlike what was written, which is the whole reason the spelling is
+    /// on the list. The docket for changing them is
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/1019">#1019</a> items 6 and 7,
+    /// out of the notation survey on
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/1212">#1212</a>; the
+    /// <c>!=</c> half is <a href="https://github.com/asc-community/AngouriMath/issues/1225">#1225</a>.
+    /// When one of them is settled, the failure here is the reminder that the documentation moves
+    /// with it.
+    /// </para>
+    /// </remarks>
+    public sealed class SpellingsAtRiskTest
+    {
+        // `|` is an alias for `or`, so a divisibility statement is read as a disjunction.
+        [Fact]
+        public void TheBarIsStillDisjunction()
+        {
+            Assert.Equal("2 or 6".ToEntity(), "2 | 6".ToEntity());
+            Assert.IsType<Orf>("2 | 6".ToEntity());
+        }
+
+        // Ordinary set-builder notation, read as a one-element finite set whose element is a
+        // disjunction. The library's own set builder is `{ x : x > 0 }`.
+        [Fact]
+        public void SetBuilderWithABarIsAOneElementFiniteSet()
+        {
+            var written = "{ x | x > 0 }".ToEntity();
+            var set = Assert.IsType<Set.FiniteSet>(written);
+            Assert.Equal("x or x > 0".ToEntity(), Assert.Single(set.Elements));
+            // What was meant, and how to say it today.
+            Assert.IsType<Set.ConditionalSet>("{ x : x > 0 }".ToEntity());
+        }
+
+        // `!=` is not a token, so the lexer takes `!` as the postfix factorial and `=` as
+        // equality. `<>` is the spelling that means what `!=` looks like it means.
+        [Fact]
+        public void NotEqualIsReadAsAFactorialEquation()
+        {
+            Assert.Equal("a! = b".ToEntity(), "a != b".ToEntity());
+            Assert.IsType<Equalsf>("a != b".ToEntity());
+            Assert.Equal("not a = b".ToEntity(), "a <> b".ToEntity());
+        }
+    }
+}


### PR DESCRIPTION
Out of the notation survey you asked for on #1212. **Nothing about the grammar changes here** — this is the finding written down where it will be found.

## What it records

Three inputs parse today, are well-formed, and mean something other than what they say. Measured on `281e0d0c`:

| written | reads today as |
|---|---|
| `2 \| 6` | `2 or 6` — a disjunction of two numbers |
| `{ x \| x > 0 }` | `{ x or x > 0 }` — a `FiniteSet` of **one** element, that element a disjunction |
| `a != b` | `a! = b` — the factorial of `a`, equated to `b` |

The first two because `|` is an alias for `or`, which is the one spelling in the grammar that already means something *else* in mathematics — divides, "such that", "given", and the delimiter in `|x|`. The third because `!=` is not a token, so the lexer takes `!` as the postfix factorial and `=` as equality.

`{x | x > 0}` is the one I would point at: ordinary set-builder notation, read as a one-element set, silently.

## Where it goes, and where it deliberately does not

`BREAKING-CHANGES.md` gains a short section naming the three, so that the warning reaches somebody reading that file and not only somebody reading the issue tracker. It says which spelling to use instead in each case — `or`, `{ x : … }`, `<>`, each of which is the primary spelling anyway.

It **does not** restate the migration argument. The docket for these is #1019, which now carries them as items 6 and 7, and one list is better than two that drift apart — which is the same failure this session has already spent time cleaning up in comments that quoted counts.

## The test is the point of the PR

A section that states how something parses is a claim, and a claim in a document goes stale silently. `SpellingsAtRiskTest` pins all three readings.

The assertions are deliberately **not endorsements** — every one records a reading that the section exists to warn about. That is stated in the file itself, because a future reader finding `Assert.Equal("a! = b", "a != b")` with no explanation would reasonably conclude somebody wanted it that way. When one of these is settled, the failure is the reminder that the documentation moves with it.

## Checks

`SpellingsAtRiskTest`: 3 pass. No production code is touched — the diff is one documentation section, one test, and its `.editorconfig` header entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
