### PR TITLE
The factorial cache is read outside the lock it is written under

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -39,6 +39,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [Tests/UnitTests/Convenience/SpellingsAtRiskTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[Tests/UnitTests/Core/FactorialCacheIsThreadSafeTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [Tests/UnitTests/Core/DividesTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 

--- a/Sources/AngouriMath/Functions/InternalAMExtensions.cs
+++ b/Sources/AngouriMath/Functions/InternalAMExtensions.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Numerics;
+using System.Collections.Concurrent;
 using AngouriMath.Core.Exceptions;
 using PeterO.Numbers;
 using AngouriMath.Extensions;
@@ -649,17 +650,39 @@ namespace AngouriMath
 
         // Based on https://github.com/eobermuhlner/big-math/blob/ba75e9a80f040224cfeef3c2ac06390179712443/ch.obermuhlner.math.big/src/main/java/ch/obermuhlner/math/big/BigDecimalMath.java
 
-        static IEnumerable<EInteger> GenerateFactorials()
-        {
-            var i = 0;
-            var result = EInteger.One;
-            yield return result;
-            while (true)
-                yield return result *= ++i;
-        }
-        [ConstantField] static readonly IEnumerator<EInteger> factorialCacheGenerator = GenerateFactorials().GetEnumerator();
-        [ConstantField] static readonly List<EInteger> factorialCache = new List<EInteger>();
-        [ConstantField] static readonly Dictionary<int, EDecimal[]> spougeFactorialConstantsCache = new Dictionary<int, EDecimal[]>();
+        /// <summary>
+        /// The factorials computed so far, as a snapshot nobody mutates: <c>[i]</c> is <c>i!</c>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This was a <see cref="List{T}"/> grown in place under a lock, read without one. That is
+        /// not a safe pattern for <see cref="List{T}"/> and the failure is silent rather than an
+        /// exception: <c>Add</c> reallocates the backing array, so a reader outside the lock can
+        /// see the <em>new</em> <c>Count</c> against the <em>old</em> array and return a value for
+        /// a different index — a wrong factorial, well-formed and enormous, from a method that
+        /// cannot fail. The last <c>return</c> was outside the lock as well.
+        /// </para>
+        /// <para>
+        /// An array published by a single reference write fixes it without making readers wait.
+        /// A reader takes the reference once — that read is atomic — and then indexes an array
+        /// that is never written again, so it sees either the old complete snapshot or the new
+        /// one and never a half-grown one. The shared <see cref="IEnumerator{T}"/> that used to
+        /// carry the running product went with it: one enumerator advanced from several threads
+        /// is the same defect in a second place.
+        /// </para>
+        /// </remarks>
+        [ConcurrentField] static volatile EInteger[] factorialCache = new[] { EInteger.One };
+
+        /// <summary>What the writers of <see cref="factorialCache"/> take; readers take nothing.</summary>
+        [ConstantField] static readonly object factorialCacheLock = new object();
+
+        /// <summary>
+        /// Spouge's constants per precision. A <see cref="ConcurrentDictionary{TKey, TValue}"/>
+        /// because the reader here had the same shape as the one above — an unsynchronised
+        /// <c>TryGetValue</c> racing an <c>Add</c> made under a lock, which for
+        /// <see cref="Dictionary{TKey, TValue}"/> is undefined rather than merely stale.
+        /// </summary>
+        [ConcurrentField] static readonly ConcurrentDictionary<int, EDecimal[]> spougeFactorialConstantsCache = new ConcurrentDictionary<int, EDecimal[]>();
 
         /**
             <summary>
@@ -674,19 +697,25 @@ namespace AngouriMath
         {
             if (n < 0)
                 throw new ArgumentOutOfRangeException(nameof(n), "Illegal factorial(n) for n < 0: n = " + n);
-            if (n < factorialCache.Count)
-                return factorialCache[n];
-            lock (factorialCache)
+            // One volatile read, then an array that is never written again.
+            var cache = factorialCache;
+            if (n < cache.Length)
+                return cache[n];
+            lock (factorialCacheLock)
             {
-                if (n < factorialCache.Count)
-                    return factorialCache[n];
-                for (var i = factorialCache.Count - 1; i < n; i++)
-                {
-                    factorialCacheGenerator.MoveNext();
-                    factorialCache.Add(factorialCacheGenerator.Current);
-                }
+                // Re-read inside the lock: another writer may have published a longer one.
+                cache = factorialCache;
+                if (n < cache.Length)
+                    return cache[n];
+                var grown = new EInteger[n + 1];
+                Array.Copy(cache, grown, cache.Length);
+                var running = grown[cache.Length - 1];
+                for (var i = cache.Length; i <= n; i++)
+                    grown[i] = running *= i;
+                // The publishing write. Everything above happened to an array no reader has.
+                factorialCache = grown;
+                return grown[n];
             }
-            return factorialCache[n];
         }
 
         public static EInteger Factorial(this EInteger n) =>
@@ -759,14 +788,12 @@ namespace AngouriMath
             return result.RoundToPrecision(mathContext);
         }
 
+        // GetOrAdd may run the factory more than once for one key under contention, and that is
+        // harmless here: the constants are a pure function of `a`, so the losers are wasted work
+        // rather than a different answer. What it cannot do is hand back another key's entry.
         internal static EDecimal[] GetSpougeFactorialConstants(int a)
-        {
-            if (spougeFactorialConstantsCache.TryGetValue(a, out var list))
-                return list;
-            lock (spougeFactorialConstantsCache)
+            => spougeFactorialConstantsCache.GetOrAdd(a, static a =>
             {
-                if (spougeFactorialConstantsCache.TryGetValue(a, out list))
-                    return list;
                 var constants = new EDecimal[a];
                 var mc = EContext.ForPrecision(a * 15 / 10);
 
@@ -785,10 +812,8 @@ namespace AngouriMath
                     negative = !negative;
                 }
 
-                spougeFactorialConstantsCache.Add(a, constants);
                 return constants;
-            }
-        }
+            });
         /**
 	     * <summary>
 	     * Calculates the gamma function of the specified <see cref="EDecimal"/>.

--- a/Sources/Tests/UnitTests/Core/FactorialCacheIsThreadSafeTest.cs
+++ b/Sources/Tests/UnitTests/Core/FactorialCacheIsThreadSafeTest.cs
@@ -1,0 +1,87 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using PeterO.Numbers;
+using Xunit;
+
+namespace AngouriMath.Tests.Core
+{
+    /// <summary>
+    /// <c>InternalAMExtensions.Factorial(int)</c> returns the factorial that was asked for, however
+    /// many threads are growing its cache at the same time.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The cache used to be a <c>List</c> grown in place under a lock and read without one, which
+    /// is not safe for <c>List</c> and fails silently rather than loudly: <c>Add</c> reallocates
+    /// the backing array, so a reader outside the lock could see the new <c>Count</c> against the
+    /// old array and come back with the value at a different index. A wrong factorial is a
+    /// well-formed enormous integer, so it does not throw — it propagates.
+    /// </para>
+    /// <para>
+    /// <b>This test does not reproduce the race, and it was checked against the old
+    /// implementation rather than assumed to.</b> Reverted to the <c>List</c> version it still
+    /// passes, because the cache grows monotonically: the first thread to ask for the highest
+    /// index fills everything in one pass, so the window in which a reader can see a new
+    /// <c>Count</c> against an old array is one reallocation wide and is gone before the other
+    /// threads arrive. A test that only fails sometimes would be worse than none, so no attempt is
+    /// made to widen it.
+    /// </para>
+    /// <para>
+    /// What it is, then, is a correctness test that happens to exercise the growth path from many
+    /// threads: it would catch a gross regression — factorials coming back wrong, an exception out
+    /// of the cache — and it is honest about not catching the interleaving it is named for. The
+    /// argument for the implementation it guards is that <c>List</c> is documented as unsafe for
+    /// concurrent read and write, which is a property of the contract rather than of any run.
+    /// </para>
+    /// </remarks>
+    public sealed class FactorialCacheIsThreadSafeTest
+    {
+        /// <summary>Above anything another test is likely to have cached, so growth really runs.</summary>
+        private const int From = 4000;
+        private const int To = 4200;
+
+        [Fact]
+        public void EveryThreadGetsTheFactorialItAskedFor()
+        {
+            // Independently computed, in one thread, without touching the cache under test.
+            var expected = new EInteger[To + 1];
+            expected[0] = EInteger.One;
+            for (var i = 1; i <= To; i++)
+                expected[i] = expected[i - 1].Multiply(EInteger.FromInt32(i));
+
+            var wrong = new ConcurrentBag<string>();
+            Parallel.For(0, 64, worker =>
+            {
+                // Each worker walks the range from a different offset, so the growth path is
+                // entered by several of them at once rather than by one that then wins a race.
+                for (var step = 0; step <= To - From; step++)
+                {
+                    var n = From + (step + worker * 7) % (To - From + 1);
+                    var got = AngouriMath.InternalAMExtensions.Factorial(n);
+                    if (!got.Equals(expected[n]))
+                        wrong.Add($"{n}! came back as a different number");
+                }
+            });
+
+            Assert.True(wrong.IsEmpty, string.Join("; ", wrong));
+        }
+
+        /// <summary>The values themselves are right, single-threaded, at the edges that matter.</summary>
+        [Theory]
+        [InlineData(0, "1")]
+        [InlineData(1, "1")]
+        [InlineData(2, "2")]
+        [InlineData(5, "120")]
+        [InlineData(20, "2432902008176640000")]
+        public void TheFactorialsAreCorrect(int n, string expected)
+            => Assert.Equal(EInteger.FromString(expected), AngouriMath.InternalAMExtensions.Factorial(n));
+    }
+}


### PR DESCRIPTION
Found while looking for the shared state behind #1219. **It is not a fix for #1219** — see the last section, which is the part I would most like you to push back on.

## The defect

`Factorial(int)` kept its results in a `List` grown in place under a lock and read without one:

```csharp
if (n < factorialCache.Count)      // unsynchronised
    return factorialCache[n];      // unsynchronised
lock (factorialCache)
{
    ...
    factorialCache.Add(factorialCacheGenerator.Current);
}
return factorialCache[n];          // outside the lock again
```

`List<T>` is [documented](https://learn.microsoft.com/dotnet/api/system.collections.generic.list-1#thread-safety) as safe for concurrent readers *only while nobody writes*. Here somebody does. `Add` reallocates the backing array when it grows, so a reader outside the lock can observe the incremented `Count` against the array from before the reallocation and return **the value at a different index**.

The consequence is the bad kind: a wrong factorial is a well-formed, enormous integer coming out of a method that cannot fail. Nothing throws. It propagates into whatever expression is being simplified.

`factorialCacheGenerator` — one `IEnumerator<EInteger>` carrying the running product, advanced from every thread — was the same defect standing next to it.

`GetSpougeFactorialConstants` had the identical shape one screen down: an unsynchronised `TryGetValue` racing an `Add` made under a lock. For `Dictionary` a concurrent read against a write is undefined rather than merely stale, and a resize can return another key's entry.

## The fix

**Publish an immutable snapshot instead of mutating a shared one.** A reader takes the array reference once — a reference read is atomic — and then indexes an array that is never written again, so it sees either the old complete snapshot or the new complete one and never a half-grown one. Writers build a longer array under a private lock and publish it with a single reference write.

Readers no longer take a lock at all, which they effectively were not doing before anyway, only now it is correct. The shared enumerator is gone; the running product lives in the local that builds the new array. Spouge's constants become a `ConcurrentDictionary` with `GetOrAdd` — the factory can run twice for one key under contention, which is wasted work rather than a different answer, since the constants are a pure function of the precision.

## What I did not establish

**The accompanying test does not reproduce the race, and I checked that rather than assuming it.** Reverted to the `List` implementation it still passes, because the cache grows monotonically: the first thread to ask for the highest index fills everything in one pass, so the window where a reader sees a new `Count` against an old array is one reallocation wide and is gone before the other threads arrive. I did not widen it, because a test that fails only sometimes is worse than no test. The file says this about itself rather than implying otherwise.

So the argument for this change is the documented contract of `List` and `Dictionary`, not an observed failure. If you would rather have a reproduction before touching it, that is a fair position and I will drop the PR.

**And I am not claiming this is #1219.** It is the same class of defect — a shared cache handing back another computation's value — and the corrupted numbers there are consistent with factorials. But the determinant path does not obviously call `Factorial`, so the mechanism connecting them is missing, and today's lesson on the sibling issue is that several hypotheses explain every measurement. #1219 stays open and unexplained.

## Checks

Full suite in two chunks: **8477 and 1485** pass. The new test is six cases: five single-threaded values at the edges, and one that exercises the growth path from 64 threads and asserts every answer is the factorial that was asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
