### PR TITLE
A piecewise case that can never be reached is dropped

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -122,7 +122,37 @@ is the primary spelling anyway and is what the library prints.
 | **Silent** | `"integral(piecewise(2x provided x <= 1/2, 2 - 2x), x, 0, 1)".ToEntity().Simplify()`, and every definite integral of a piecewise whose conditions mention the variable | `1` — the first case's antiderivative at both ends | `1/2` — split at the case boundaries; `piecewise(x provided x < 1, x^2)` from 0 to 2 was `piecewise(2 provided x < 1, 8/3)`, with the integration variable still in it, and is `17/6` |
 | **Silent** | `"integral(x - floor(x), x, 0, 3)".ToEntity().Simplify()`, and every definite integral over numeric bounds whose integrand has `floor(x)` or `ceil(x)` in it | `0` — an antiderivative that took the floor for a constant across its jumps | `3/2` — split at the jumps; `(x - floor(x))^2` from 0 to 4 was `0` and is `4/3` |
 | **Silent** | `"integral((x - floor(x))^2, x, 0, n)".ToEntity().Simplify()`, and every such integral with a symbolic bound or a condition against a symbol | `(n - floor(n)) ^ 3 / 3` — wrong for every whole `n` but 0; `piecewise(x provided x < a, 0)` from 0 to 2 was `piecewise(2 provided x < a, 0)` | left as written |
+| **Silent** | `"sum(piecewise(k provided k < a, 0), k, 0, 5)".ToEntity().Simplify()`, and every piecewise carrying a case whose predicate entails an earlier one | 32 cases, most of them unreachable | 6 — the unreachable ones are dropped, and the value at every `a` is unchanged |
 | | `"integral((x - floor(x)) / floor(x)!, x, 1, +oo)".ToEntity().Simplify()`, and `integral(floor(x), x, 0, 5)` | left as written | `(e - 1) / 2`, `10` |
+
+### A piecewise case that can never be reached is dropped
+
+A piecewise takes its **first** matching case, so a case whose predicate entails an earlier one is
+unreachable: wherever the later predicate holds the earlier one holds too, and the earlier case is
+taken. That was already applied where two predicates were *equal*; it is now applied wherever the
+entailment can be proven, which is what `2 < a` after `1 < a` is.
+
+Where it shows most is a binder distributed over a piecewise, which produces one case per **subset**
+of the conditions — `2^n` of them, the great majority unreachable. Summing
+`piecewise(k provided k < a, 0)` over `k` from 0 to 5 gave **32 cases**; six of them are reachable,
+which is one per interval that `a` can fall in, and six is what it gives now.
+
+The test is one-directional and deliberately incomplete: entailment between arbitrary predicates is
+not decidable, so the answers are "proven" and "not proven", and only the first drops a case. A
+missed entailment costs a longer answer; a wrong one would delete a reachable case and change the
+value, so nothing here is a heuristic. Comparisons of one expression against numbers are compared
+by their bounds, a conjunction is at least as strong as either half, and a disjunction is at most as
+strong as both. `>` after `>=` at the same bound is **kept**, the two differing exactly at the
+endpoint. Question I.3 of [#1212](https://github.com/asc-community/AngouriMath/issues/1212). Both
+columns measured on a build, `c2ab5da1` against this change.
+
+| | Was | Is |
+|---|---|---|
+| `"sum(piecewise(k provided k < a, 0), k, 0, 5)".ToEntity().Simplify()` | 32 cases | 6 — one per interval `a` can fall in, and the same value at every `a` |
+| `"sum(piecewise(k provided k < a, 0), k, 0, 2)".ToEntity().Simplify()` | `piecewise(3 provided (1 < a and 2 < a), 1 provided (1 < a), 2 provided (2 < a), 0 provided True)` | the same without `2 provided (2 < a)`, which `1 < a` had already caught |
+| `"piecewise(1 provided x > 1, 2 provided x > 2, 3)"`, and the same with `x < 2` before `x < 1` | 3 cases | 2 |
+| `"piecewise(1 provided x > 1, 2 provided x > 1 and x < 5, 3)"` | 3 cases | 2 — a conjunction is at least as strong as either half |
+| `"piecewise(1 provided x > 2, 2 provided x > 1, 3)"`, `piecewise(1 provided x > 1, 2 provided x >= 1, 3)` | 3 cases | the same — a looser bound after a tighter one is reachable, and so is `>=` after `>` at one bound |
 
 ### A cancelled quotient says its operand is defined, not only non-zero
 

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -33,6 +33,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [Tests/UnitTests/Common/LogarithmOfAPerfectPowerTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[AngouriMath/Functions/PredicateEntailment.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [AngouriMath/Functions/TreeAnalyzer/RealValued.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
@@ -40,6 +43,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
 [Tests/UnitTests/Core/FactorialCacheIsThreadSafeTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Core/UnreachablePiecewiseCaseTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
 [Tests/UnitTests/Core/DividesTest.cs]

--- a/Sources/AngouriMath/Functions/Evaluation/Evaluation.Omni/Evaluation.Omni.Classes.cs
+++ b/Sources/AngouriMath/Functions/Evaluation/Evaluation.Omni/Evaluation.Omni.Classes.cs
@@ -208,8 +208,13 @@ namespace AngouriMath
                     // https://github.com/asc-community/AngouriMath/issues/327
 
                     // A predicate that already guards an earlier case can never reach this
-                    // one: wherever it holds, the earlier case is taken.
-                    if (res.Any(seen => seen.Predicate == toAdd.Predicate))
+                    // one: wherever it holds, the earlier case is taken. Equality is the
+                    // special case; what is asked is whether this predicate *entails* an
+                    // earlier one, so that `2 < a` is dropped after `1 < a`. Distributing a
+                    // binder over a piecewise produces one case per subset of the conditions
+                    // and most of them are unreachable exactly this way.
+                    // https://github.com/asc-community/AngouriMath/issues/1212
+                    if (res.Any(seen => Functions.PredicateEntailment.Entails(toAdd.Predicate, seen.Predicate)))
                     {
                         // Not `continue` -- a decidably true predicate still ends the list,
                         // and skipping that check here would carry unreachable cases past it.

--- a/Sources/AngouriMath/Functions/PredicateEntailment.cs
+++ b/Sources/AngouriMath/Functions/PredicateEntailment.cs
@@ -1,0 +1,149 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// Whether one predicate being true forces another to be true, decided structurally and
+    /// only where it can be proven.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Written for <see cref="Entity.Piecewise"/>, which takes its first matching case and can
+    /// therefore drop any case whose predicate entails an earlier one: wherever the later
+    /// predicate holds the earlier one holds too, so the earlier case is taken and the later is
+    /// unreachable. That rule was already applied for predicates that are <em>equal</em>; this is
+    /// the same rule with a wider notion of "already covered".
+    /// </para>
+    /// <para>
+    /// <b>One-directional and deliberately incomplete.</b> Entailment between arbitrary predicates
+    /// is not decidable, so the only answers here are "proven" and "not proven", and the second is
+    /// answered <see langword="false"/>. A false negative costs a case that could have been
+    /// dropped, which is a longer answer; a false positive would delete a reachable case, which is
+    /// a wrong one. Everything below is therefore a sufficient condition, never a heuristic.
+    /// </para>
+    /// <para>
+    /// <b>Three-valued logic does not complicate it.</b> A case is *taken* only when its predicate
+    /// is true, so the only thing that has to hold is that a true antecedent forces a true
+    /// consequent. What either predicate does when it is <c>NaN</c> — over a non-real argument, say
+    /// — never arises, because a case with a <c>NaN</c> predicate is not taken either way.
+    /// </para>
+    /// <para>
+    /// Part of question I.3 of
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/1212">#1212</a>, where
+    /// distributing a binder over a piecewise produces one case per subset of the conditions and
+    /// most of them are unreachable.
+    /// </para>
+    /// </remarks>
+    internal static class PredicateEntailment
+    {
+        /// <summary>
+        /// Whether <paramref name="stronger"/> being true forces <paramref name="weaker"/> to be
+        /// true. <see langword="false"/> wherever that is not proven, including where it is true
+        /// but not by one of the shapes below.
+        /// </summary>
+        internal static bool Entails(Entity stronger, Entity weaker)
+        {
+            if (stronger == weaker)
+                return true;
+            return (stronger, weaker) switch
+            {
+                // To force a conjunction is to force both halves of it.
+                (_, Andf(var left, var right)) => Entails(stronger, left) && Entails(stronger, right),
+                // A conjunction is at least as strong as either half.
+                (Andf(var left, var right), _) => Entails(left, weaker) || Entails(right, weaker),
+                // A disjunction forces something only if both halves do.
+                (Orf(var left, var right), _) => Entails(left, weaker) && Entails(right, weaker),
+                // Forcing either half of a disjunction forces the disjunction.
+                (_, Orf(var left, var right)) => Entails(stronger, left) || Entails(stronger, right),
+                _ => ComparisonEntails(stronger, weaker)
+            };
+        }
+
+        /// <summary>
+        /// Two comparisons of the same expression against numbers: <c>a &gt; 2</c> forces
+        /// <c>a &gt; 1</c>, and <c>a &gt;= 2</c> forces <c>a &gt; 1</c>, but not the other way
+        /// about. Both are read into the same shape first, so that <c>1 &lt; a</c> and
+        /// <c>a &gt; 1</c> are the one statement they are.
+        /// </summary>
+        private static bool ComparisonEntails(Entity stronger, Entity weaker)
+        {
+            if (!TryRead(stronger, out var strongSubject, out var strongAbove, out var strongBound, out var strongStrict)
+                || !TryRead(weaker, out var weakSubject, out var weakAbove, out var weakBound, out var weakStrict))
+                return false;
+            // The same unknown, and both bounding it from the same side. A lower bound says
+            // nothing about an upper one.
+            if (strongSubject != weakSubject || strongAbove != weakAbove)
+                return false;
+            var comparison = strongBound.EDecimal.CompareTo(weakBound.EDecimal);
+            // Bounding from below: `subject > s` forces `subject > w` when s is at least w, and
+            // where the bounds are equal only if the stronger is no looser about the endpoint.
+            // Bounding from above the comparison is the other way round.
+            var atLeastAsTight = strongAbove ? comparison >= 0 : comparison <= 0;
+            if (!atLeastAsTight)
+                return false;
+            // At the same bound, `>=` does not force `>` -- they differ exactly at the endpoint.
+            return comparison != 0 || strongStrict || !weakStrict;
+        }
+
+        /// <summary>
+        /// A comparison as "this expression is above / below this number", or
+        /// <see langword="false"/> where it is not one. <paramref name="above"/> is whether the
+        /// subject is bounded from below, <paramref name="strict"/> whether the endpoint itself
+        /// is excluded.
+        /// </summary>
+        private static bool TryRead(Entity predicate, out Entity subject, out bool above, out Real bound, out bool strict)
+        {
+            subject = predicate;
+            above = false;
+            bound = Integer.Zero;
+            strict = false;
+            switch (predicate)
+            {
+                // subject > bound, subject >= bound
+                case Greaterf(var left, var right) when Number(right) is { } b:
+                    (subject, above, bound, strict) = (left, true, b, true);
+                    return true;
+                case GreaterOrEqualf(var left, var right) when Number(right) is { } b:
+                    (subject, above, bound, strict) = (left, true, b, false);
+                    return true;
+                // bound < subject, bound <= subject -- the same two, written the other way.
+                case Lessf(var left, var right) when Number(left) is { } b:
+                    (subject, above, bound, strict) = (right, true, b, true);
+                    return true;
+                case LessOrEqualf(var left, var right) when Number(left) is { } b:
+                    (subject, above, bound, strict) = (right, true, b, false);
+                    return true;
+                // subject < bound, subject <= bound
+                case Lessf(var left, var right) when Number(right) is { } b:
+                    (subject, above, bound, strict) = (left, false, b, true);
+                    return true;
+                case LessOrEqualf(var left, var right) when Number(right) is { } b:
+                    (subject, above, bound, strict) = (left, false, b, false);
+                    return true;
+                // bound > subject, bound >= subject
+                case Greaterf(var left, var right) when Number(left) is { } b:
+                    (subject, above, bound, strict) = (right, false, b, true);
+                    return true;
+                case GreaterOrEqualf(var left, var right) when Number(left) is { } b:
+                    (subject, above, bound, strict) = (right, false, b, false);
+                    return true;
+                default:
+                    return false;
+            }
+
+            // A finite real literal, which is what a bound has to be for the comparison of two
+            // of them to mean anything. `+oo` is excluded deliberately: it is a value here, and
+            // reasoning about it as an endpoint is not what this is for.
+            static Real? Number(Entity what)
+                => what.Evaled is Real { IsFinite: true } real ? real : null;
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Core/UnreachablePiecewiseCaseTest.cs
+++ b/Sources/Tests/UnitTests/Core/UnreachablePiecewiseCaseTest.cs
@@ -1,0 +1,99 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System.Linq;
+using AngouriMath;
+using AngouriMath.Extensions;
+using Xunit;
+using static AngouriMath.Entity;
+
+namespace AngouriMath.Tests.Core
+{
+    /// <summary>
+    /// A piecewise takes its first matching case, so a case whose predicate entails an earlier
+    /// one is unreachable and is dropped. https://github.com/asc-community/AngouriMath/issues/1212
+    /// </summary>
+    /// <remarks>
+    /// The count assertions below are the point of the change, but the value assertions are what
+    /// make it safe: dropping a case that was reachable would shorten the answer and change it,
+    /// and a test that only counted cases could not tell the two apart.
+    /// </remarks>
+    public sealed class UnreachablePiecewiseCaseTest
+    {
+        private static int CaseCount(Entity piecewise)
+            => Assert.IsType<Piecewise>(piecewise).Cases.Count();
+
+        // Distributing a binder over a piecewise gives one case per subset of the conditions.
+        // Most are unreachable: `2 < a` cannot be reached past `1 < a`.
+        [Fact]
+        public void ASummedPiecewiseKeepsOnlyItsReachableCases()
+        {
+            var summed = "sum(piecewise(k provided k < a, 0), k, 0, 5)".ToEntity().Simplify();
+            Assert.Equal(6, CaseCount(summed));
+
+            // And it answers what the sum actually is: the k below a, added up.
+            foreach (var (a, expected) in new[]
+                { (0.5, 0), (1.5, 1), (2.5, 3), (3.5, 6), (4.5, 10), (5.5, 15), (6.5, 15) })
+                Assert.Equal(
+                    Number.Integer.Create(expected),
+                    summed.Substitute("a", a.ToString(System.Globalization.CultureInfo.InvariantCulture).ToEntity()).Evaled);
+        }
+
+        [Fact]
+        public void TheSameOverAShorterRange()
+        {
+            var summed = "sum(piecewise(k provided k < a, 0), k, 0, 2)".ToEntity().Simplify();
+            Assert.Equal(3, CaseCount(summed));
+            foreach (var (a, expected) in new[] { (0.5, 0), (1.5, 1), (2.5, 3), (3.5, 3) })
+                Assert.Equal(
+                    Number.Integer.Create(expected),
+                    summed.Substitute("a", a.ToString(System.Globalization.CultureInfo.InvariantCulture).ToEntity()).Evaled);
+        }
+
+        // A tighter bound after a looser one on the same side is unreachable.
+        [Theory]
+        [InlineData("piecewise(1 provided x > 1, 2 provided x > 2, 3)", 2)]
+        [InlineData("piecewise(1 provided x > 1, 2 provided x >= 2, 3)", 2)]
+        [InlineData("piecewise(1 provided x >= 1, 2 provided x > 1, 3)", 2)]
+        [InlineData("piecewise(1 provided x < 2, 2 provided x < 1, 3)", 2)]
+        [InlineData("piecewise(1 provided 1 < x, 2 provided 2 < x, 3)", 2)]
+        public void ATighterBoundAfterALooserOneIsDropped(string written, int expected)
+            => Assert.Equal(expected, CaseCount(written.ToEntity().Simplify()));
+
+        // The other order is not unreachable and must survive: a looser bound after a tighter
+        // one still catches the values between them.
+        [Theory]
+        [InlineData("piecewise(1 provided x > 2, 2 provided x > 1, 3)", 3)]
+        [InlineData("piecewise(1 provided x < 1, 2 provided x < 2, 3)", 3)]
+        // `>` after `>=` at the same bound differs exactly at the endpoint, so it is reachable.
+        [InlineData("piecewise(1 provided x > 1, 2 provided x >= 1, 3)", 3)]
+        // Opposite sides say nothing about each other.
+        [InlineData("piecewise(1 provided x > 1, 2 provided x < 5, 3)", 3)]
+        public void WhatIsStillReachableIsKept(string written, int expected)
+            => Assert.Equal(expected, CaseCount(written.ToEntity().Simplify()));
+
+        // A looser bound after a tighter one keeps the values between them, which is the
+        // property the count above is standing in for.
+        [Fact]
+        public void ALooserBoundAfterATighterOneStillAnswersBetweenThem()
+        {
+            var piecewise = "piecewise(1 provided x > 2, 2 provided x > 1, 3)".ToEntity().Simplify();
+            Assert.Equal(Number.Integer.Create(1), piecewise.Substitute("x", 3).Evaled);
+            Assert.Equal(Number.Integer.Create(2), piecewise.Substitute("x", 1.5.ToString(System.Globalization.CultureInfo.InvariantCulture).ToEntity()).Evaled);
+            Assert.Equal(Number.Integer.Create(3), piecewise.Substitute("x", 0).Evaled);
+        }
+
+        // A conjunction is at least as strong as either half, and a disjunction is at most.
+        [Theory]
+        [InlineData("piecewise(1 provided x > 1, 2 provided x > 1 and x < 5, 3)", 2)]
+        [InlineData("piecewise(1 provided x > 1 or x < 0, 2 provided x > 1, 3)", 2)]
+        // But a disjunction after one of its halves is reachable through the other half.
+        [InlineData("piecewise(1 provided x > 1, 2 provided x > 1 or x < 0, 3)", 3)]
+        public void ConjunctionsAndDisjunctionsAreComparedToo(string written, int expected)
+            => Assert.Equal(expected, CaseCount(written.ToEntity().Simplify()));
+    }
+}


### PR DESCRIPTION
Question I.3 of #1212, and the measurement I posted there: distributing a binder over a piecewise produced **32 cases where six are reachable**.

## What was wrong

A piecewise takes its **first** matching case. So a case whose predicate entails an earlier one can never be reached — wherever the later predicate holds, the earlier one holds too and the earlier case is taken.

That rule was already in `Piecewise.InnerSimplify`, but only for predicates that are *equal*:

```csharp
if (res.Any(seen => seen.Predicate == toAdd.Predicate))
```

Equality is the special case. `2 < a` after `1 < a` is the general one, and it was kept. Measured on `c2ab5da1`:

```
sum(piecewise(k provided k < a, 0), k, 0, 2)
  → piecewise(3 provided (1 < a and 2 < a), 1 provided (1 < a), 2 provided (2 < a), 0 provided True)
```

Correct, but `2 < a` implies `1 < a`, so the third case is dead. Over `k` from 0 to 5 that compounds to one case per **subset** of the conditions — 32, of which six are reachable, one per interval `a` can fall in.

## The change

`PredicateEntailment.Entails`, consulted where the equality test used to be. Six is what the 0-to-5 sum gives now.

**It is one-directional and deliberately incomplete.** Entailment between arbitrary predicates is not decidable, so the only answers are "proven" and "not proven", and only the first drops a case. A missed entailment costs a longer answer; a wrong one would delete a reachable case and change the value. Everything in there is therefore a sufficient condition rather than a heuristic:

- comparisons of one expression against numbers, compared by their bounds — `a > 2` forces `a > 1`;
- a conjunction is at least as strong as either half;
- a disjunction is at most as strong as both;
- **`>` after `>=` at the same bound is kept**, since the two differ exactly at the endpoint.

**Three-valued logic does not complicate it.** A case is *taken* only when its predicate is true, so all that must hold is that a true antecedent forces a true consequent. What either predicate does when it is `NaN` — over a non-real argument — never arises, because such a case is not taken either way.

## Where it deliberately does not go

I did not add a rewrite rule to simplify the conditions themselves: `1 < a and 2 < a` is still written that way rather than collapsed to `2 < a`. That is a genuine improvement and a separate one — it needs the simplification contract, both spellings of a rule, and the census pins moved — and it is not what makes the answer long. Unreachability is.

## Measured

Both columns on builds, `c2ab5da1` against this branch:

| | was | is |
|---|---|---|
| `sum(piecewise(k provided k < a, 0), k, 0, 5)` | 32 cases | **6** |
| `sum(piecewise(k provided k < a, 0), k, 0, 2)` | 4 cases | 3 |
| `piecewise(1 provided x > 1, 2 provided x > 2, 3)`, and `x < 2` before `x < 1` | 3 | 2 |
| `piecewise(1 provided x > 1, 2 provided x > 1 and x < 5, 3)` | 3 | 2 |
| `piecewise(1 provided x > 2, 2 provided x > 1, 3)`, `piecewise(1 provided x > 1, 2 provided x >= 1, 3)` | 3 | the same — both still reachable |

## Checks

`UnreachablePiecewiseCaseTest`, 15 cases. The counts are the point of the change but **the value assertions are what make it safe**: the summed piecewise is evaluated at seven values of `a` spanning every interval and compared against the sum it stands for, because dropping a reachable case would shorten the answer *and* change it, and a test that only counted cases could not tell those apart. Four cases assert that something still reachable is kept.

Full suite in two chunks: **8495 and 1485** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
