### PR TITLE
The prime cache is read outside the lock it is written under

### DIFF
--- a/Sources/AngouriMath/Functions/NumberTheory/Primes.cs
+++ b/Sources/AngouriMath/Functions/NumberTheory/Primes.cs
@@ -14,7 +14,35 @@ namespace AngouriMath.Functions
     internal static class Primes
     {
         [ConstantField] private static readonly object addingPrimes = new();
+        /// <summary>
+        /// The primes found so far. Grown only under <see cref="addingPrimes"/>, and read only
+        /// from inside that lock — <see cref="GetPrime"/> reads <see cref="published"/> instead.
+        /// </summary>
         [ConcurrentField] private static readonly List<(Integer actual, int? cache)> primes = new(capacity: 20) { (2, 2), (3, 3), (5, 5), (7, 7), (11, 11) };
+
+        /// <summary>
+        /// The same primes as a snapshot nobody mutates, for readers outside the lock.
+        /// </summary>
+        /// <remarks>
+        /// <c>GetPrime</c> used to call <see cref="EnsurePrimesExist"/> and then index
+        /// <see cref="primes"/> after the lock had been released, which is not safe for a
+        /// <see cref="List{T}"/> that another thread may be growing: <c>Add</c> reallocates the
+        /// backing array, so the reader can see the new <c>Count</c> against the old array and
+        /// come back with a different element. A wrong prime is a well-formed integer and
+        /// propagates into factorisation rather than throwing. Publishing an array by a single
+        /// reference write keeps the read lock-free and correct: a reader takes the reference
+        /// once, which is atomic, and then indexes something that is never written again.
+        /// </remarks>
+        [ConcurrentField] private static volatile Integer[] published = ToSnapshot();
+
+        /// <summary>The current <see cref="primes"/> as an array. Call under the lock.</summary>
+        private static Integer[] ToSnapshot()
+        {
+            var snapshot = new Integer[primes.Count];
+            for (var i = 0; i < snapshot.Length; i++)
+                snapshot[i] = primes[i].actual;
+            return snapshot;
+        }
 
 
         private static void EnsurePrimesExist(int index)
@@ -36,6 +64,10 @@ namespace AngouriMath.Functions
                     while (primes.Count <= index)
                         AddPrimeI();
                 }
+
+                // The publishing write, still under the lock. Everything above happened to a
+                // list no reader outside it has.
+                published = ToSnapshot();
             }
 
             static bool IsPrimeC(int num)
@@ -75,8 +107,12 @@ namespace AngouriMath.Functions
 
         internal static Integer GetPrime(int index)
         {
+            // One volatile read, then an array that is never written again.
+            var snapshot = published;
+            if (index < snapshot.Length)
+                return snapshot[index];
             EnsurePrimesExist(index);
-            return primes[index].actual;
+            return published[index];
         }
     }
 }


### PR DESCRIPTION
The same defect as #1227, in a third place. Found by auditing shared mutable state for #1219, which this does **not** claim to explain.

## The defect

`GetPrime` called `EnsurePrimesExist`, which grows the list under a lock, and then indexed the list after that lock had been released:

```csharp
EnsurePrimesExist(index);
return primes[index].actual;   // outside the lock
```

`List<T>` is [documented](https://learn.microsoft.com/dotnet/api/system.collections.generic.list-1#thread-safety) as safe for concurrent readers only while nobody writes. `Add` reallocates the backing array when it grows, so a reader outside the lock can observe the incremented `Count` against the array from before the reallocation and come back with **a different element**.

A wrong prime is a well-formed integer. It does not throw — it propagates into factorisation, `phi` and `CountDivisors`.

## The fix

The same shape as #1227. The list is still grown under the lock; a snapshot array is published by a single reference write at the end of it. A reader takes that reference once — atomic — and then indexes an array that is never written again, so it sees either the old complete snapshot or the new one.

The read path takes no lock, which it did not before either; the difference is that now it is correct rather than lucky.

Everything else in the file already read the list from **inside** the lock and is untouched — `IsPrimeC`, `IsPrimeI`, `AddPrimeC` and `AddPrimeI` all run within `EnsurePrimesExist`.

## Why this keeps turning up

Three instances now of one pattern: a cache grown under a lock, read without one, on the argument that the fast path only reads. The read is the unsafe half. Worth a look at any other `static readonly List`/`Dictionary` used as a memo — I audited the ones reachable from evaluation and these were the ones that were wrong.

## Checks

No new test. The one on #1227 established that this race is not reproducible in a unit test — the cache grows monotonically, so the window is one reallocation wide and gone before other threads arrive — and I would rather not add a test that cannot fail. The argument is the documented contract of `List<T>`.

Suite: **8480** in the non-Calculus chunk, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura