### PR TITLE
A quotient is split into coprime blocks before a root is peeled off, and half a minute becomes half a second

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -41,6 +41,42 @@ is the primary spelling anyway and is what the library prints.
 
 ---
 
+## Unreleased — since 2.5.0
+
+### A quotient of polynomials is split into coprime blocks before a root is peeled off
+
+`SolveByPartialFractions` tried `TrySplitOffRationalRoot` before `TrySplitIntoCoprimeParts`. Both
+succeed on a denominator with two repeated factors, so the first one decided, and it is the one that
+hands on an **expanded** remainder — every level of the recursion then re-factorised what the level
+above had just factored. Swapping them is
+[#1235](https://github.com/asc-community/AngouriMath/issues/1235).
+
+**The value of every antiderivative is unchanged**, and each was checked by differentiating it back
+and comparing numerically at five points; the worst relative disagreement is 4e-16. What moves is
+the printed form of the logarithmic terms, and it moves in one direction: a logarithm of a repeated
+factor now keeps the power inside it.
+
+| | Was | Is |
+|---|---|---|
+| `"1/((1+x)^3*(2+x)^3)".ToEntity().Integrate("x")`, the term over the first factor | `6 * ln(x + 1)` | `3 * ln(x ^ 2 + 2 * x + 1)` |
+| `"1/((1+x)^2*(2+x)^2)".ToEntity().Integrate("x")` | `(-2) * ln(x + 1)` | `-ln(x ^ 2 + 2 * x + 1)` |
+| `"1/(x*(-4+x^2)^4)".ToEntity().Integrate("x")`, the term over `x - 2` | `-1/512 * ln(x + -2)` | `-1/1024 * ln(x ^ 2 + (-4) * x + 4)` |
+
+`3 * ln((x+1)^2)` and `6 * ln(x+1)` are the same number wherever the second is real, and the first
+is **also real for `x < -1`**, where the logarithm of the bare factor is not. So a caller reading the
+answer on the far side of a root gets a real expression where it used to get a complex one.
+
+**It is a large speed-up rather than a small one**, which is why it is worth a changed form:
+
+| | Was | Is |
+|---|--:|--:|
+| `1/((1+x)^3*(2+x)^4)` | 29,256 ms | 1,447 ms |
+| `1/((2+x)^3*(3+x)^4)` | 29,179 ms | 551 ms |
+| `1/(x*(-4+x^2)^4)` | 8,472 ms | 1,878 ms |
+| `1/((1+x)^3*(2+x)^3)` | 1,343 ms | 492 ms |
+
+---
+
 ## 2.5.0 — since 2.4.0
 
 Released 2026-09-09. This heading was renamed from “Unreleased” *before* the tag was cut, which is

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -78,17 +78,38 @@ namespace AngouriMath.Functions.Algebra
                 && Integration.ComputeIndefiniteIntegral(properPart, x, integrateByParts) is { } fractionPart)
                 return wholePart + fractionPart;
 
-            if (Functions.PolynomialFactoring.TrySplitOffRationalRoot(
-                    numerator, denominator, x, out var simple, out var restNumerator, out var restDenominator)
-                && Integration.ComputeIndefiniteIntegral(simple, x, integrateByParts) is { } first
-                && Integration.ComputeIndefiniteIntegral(restNumerator / restDenominator, x, integrateByParts) is { } rest)
-                return first + rest;
-
+            // Splitting into coprime blocks comes before peeling one root off, and the order is
+            // load-bearing rather than a preference.
+            //
+            // Both succeed on a denominator with two repeated factors, so whichever runs first
+            // decides, and the one that was first is the expensive one. It takes a single root
+            // out and hands the remainder on **expanded** — for 1/((1+x)^3 * (2+x)^4) that is a
+            // degree-6 denominator written out — so every level of the recursion re-factorises
+            // what the level above had already factored, and the whole cost is in there.
+            // Measured, integrating the pieces each splitter produces for that integrand:
+            //
+            //     peel one root, then the remainder        33,318 ms
+            //     split into coprime blocks, both halves       39 ms
+            //
+            // Neither splitter is slow in itself: both return in under 16 ms. It is what they
+            // hand on that differs, and the coprime split hands on two smaller problems whose
+            // denominators are each a single repeated factor, where peeling hands on one problem
+            // barely smaller than the original.
+            // https://github.com/asc-community/AngouriMath/issues/1235
             if (Functions.PartialFractions.TrySplitIntoCoprimeParts(
                     numerator, denominator, x, out var left, out var right)
                 && Integration.ComputeIndefiniteIntegral(left, x, integrateByParts) is { } overOne
                 && Integration.ComputeIndefiniteIntegral(right, x, integrateByParts) is { } overOther)
                 return overOne + overOther;
+
+            // Still needed, and not only as a fallback: the coprime split declines a denominator
+            // that is a single repeated factor, or that has no second coprime block to split off,
+            // and those are exactly what the recursion above descends into.
+            if (Functions.PolynomialFactoring.TrySplitOffRationalRoot(
+                    numerator, denominator, x, out var simple, out var restNumerator, out var restDenominator)
+                && Integration.ComputeIndefiniteIntegral(simple, x, integrateByParts) is { } first
+                && Integration.ComputeIndefiniteIntegral(restNumerator / restDenominator, x, integrateByParts) is { } rest)
+                return first + rest;
 
             if (Functions.PartialFractions.TrySplitBiquadraticOverTheReals(
                     numerator, denominator, x, out var overOneReal, out var overOtherReal)


### PR DESCRIPTION
Fixes #1235.

Integrating `1/((2+x)^3*(3+x)^4)` took **29 seconds**. It is *answered*, so this was search cost rather than a gap, and all of it was in the order two splitters inside `SolveByPartialFractions` are tried in.

## Two hypotheses died on measurement first

Both were the obvious one, which is why they are worth recording.

**Not the order of the solvers.** `SolveByPartialFractions` runs sixth, behind the substitution search — the classic shape of a cheap solver starved by an expensive one. On this integrand the substitution search returns in **1 ms** and the polynomial-term rule in **0 ms**.

**Not the splitting.** Timed directly: `TrySplitOffRationalRoot` 0 ms, `TrySplitIntoCoprimeParts` 1 ms.

## It is what each splitter hands on

Both succeed here, so whichever runs first decides, and the one that ran first hands on an **expanded** remainder — `x^6 + 10x^5 + 41x^4 + 88x^3 + 104x^2 + 64x + 16` rather than `(x+1)^2 (x+2)^4`. Every level of the recursion then re-factorises what the level above had just factored, on a problem barely smaller than the one it started with.

| split | pieces | integrating them |
|---|---|--:|
| peel one root | `1/(x+1)^3` and a degree-6 remainder | **33,318 ms** |
| coprime blocks | one over `(x+1)^3`, one over `(x+2)^4` | **39 ms** |

`TrySplitOffRationalRoot` stays, and not merely as a fallback: the coprime split declines a denominator that is a single repeated factor, which is exactly what the recursion descends into.

## Measured

| | Was | Is |
|---|--:|--:|
| `1/((1+x)^3*(2+x)^4)` | 29,256 ms | **1,447 ms** |
| `1/((2+x)^3*(3+x)^4)` | 29,179 ms | **551 ms** |
| `1/(x*(-4+x^2)^4)` | 8,472 ms | 1,878 ms |
| `1/((1+x)^3*(2+x)^3)` | 1,343 ms | 492 ms |

Every antiderivative was differentiated back and compared numerically at five points away from the poles; worst relative disagreement **4e-16**. Full suite green: 8,499 and 1,485.

## The printed form changes, so there is a row for it

A logarithm of a repeated factor now keeps the power inside it — `6 * ln(x + 1)` becomes `3 * ln(x^2 + 2*x + 1)`. Same number wherever the second is real, and **also real for `x < -1`**, where the logarithm of the bare factor is not. `BREAKING-CHANGES.md` gains an `Unreleased — since 2.5.0` section with the three shapes that move.

This is not a regression: 2.4.0 is slower on all of these. It surfaced while I was measuring something else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura