### PR TITLE
The cosecant, the secant, and a linear denominator in the cosine, by the half-angle substitution

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -279,3 +279,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Core/MatrixConcurrencyTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/HalfAngleSubstitutionIntegralTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -295,6 +295,95 @@ namespace AngouriMath.Functions.Algebra
         }
 
         /// <summary>
+        /// A rational function of <c>sin(x)</c> and <c>cos(x)</c>, turned into a rational function
+        /// of one variable by the half-angle substitution <c>t = tan(x/2)</c> and handed to the
+        /// machinery for those.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The Weierstrass substitution. Under <c>t = tan(x/2)</c>,
+        /// <c>sin(x) = 2t/(1 + t^2)</c>, <c>cos(x) = (1 - t^2)/(1 + t^2)</c> and
+        /// <c>dx = 2/(1 + t^2) dt</c>, so anything built from sines and cosines by the field
+        /// operations becomes a quotient of polynomials — which partial fractions already answers.
+        /// </para>
+        /// <para>
+        /// <b>What it is for.</b> A family of first-year integrals had no antiderivative at all:
+        /// <c>1/(1 + cos(x))</c>, <c>1/(1 - sin(x))</c>, <c>1/(1 + cos(x)/2)</c>,
+        /// <c>1/(b cos(x) + a sin(x))</c>. Measured against Rubi's suite, the integrals it rates
+        /// as a single table lookup were the *worst*-served difficulty band we had, and this
+        /// family is a large part of why.
+        /// https://github.com/asc-community/AngouriMath/issues/718
+        /// </para>
+        /// <para>
+        /// <b>The test is the rewrite itself</b>, as for the tangent above: replace every
+        /// <c>sin(x)</c> and <c>cos(x)</c> and see whether an <c>x</c> survives. That declines
+        /// <c>sin(x) + x</c>, and it declines <c>sin(x) * sin(2x)</c> as well — <c>sin(2x)</c> is
+        /// not <c>sin(x)</c>, so an <c>x</c> is left behind. The second is the right answer for
+        /// the wrong-looking reason: a product of sines is a sum by the product-to-sum identity
+        /// and wants that rather than a rational function in <c>t</c>.
+        /// </para>
+        /// <para>
+        /// <b>It runs after the tangent substitution</b>, which is the more specific tool: an
+        /// integrand that is rational in <c>tan(x)</c> comes out of that one in terms of the
+        /// tangent, where this one would answer it in terms of the half-angle and be right but
+        /// unrecognisable.
+        /// </para>
+        /// <para>
+        /// <b>The condition the answer inherits.</b> <c>tan(x/2)</c> is undefined at odd
+        /// multiples of pi, so the antiderivative this produces is an antiderivative on each
+        /// interval between them rather than across one — the constant may differ from one
+        /// interval to the next. That is the standing property of this substitution and is the
+        /// same one <see cref="SolveByTangentSubstitution"/> already carries; it is not a claim
+        /// this rule makes and does not make the value wrong where it is defined.
+        /// </para>
+        /// </remarks>
+        internal static Entity? SolveByHalfAngleSubstitution(Entity expr, Entity.Variable x, bool integrateByParts)
+        {
+            var sine = MathS.Sin(x);
+            var cosine = MathS.Cos(x);
+            if (!expr.ContainsNode(sine) && !expr.ContainsNode(cosine))
+                return null;
+
+            var t = Variable.CreateUnique(expr, "u_half");
+            var tSquared = MathS.Sqr(t);
+            var inT = expr
+                .Substitute(sine, 2 * t / (1 + tSquared))
+                .Substitute(cosine, (1 - tSquared) / (1 + tSquared));
+            if (inT.ContainsNode(x))
+                return null;
+
+            // Simplify rather than InnerSimplified, and that is not a preference. The rewrite
+            // puts a quotient inside a quotient -- 1/cos(x) becomes 1 / ((1 - t^2)/(1 + t^2))
+            // times 2/(1 + t^2) -- and partial fractions wants a single Divf of two polynomials.
+            // InnerSimplified leaves the nesting alone, so every one of these was handed on in a
+            // shape nothing downstream could read and came back unevaluated.
+            var integrand = (inT * 2 / (1 + tSquared)).Simplify();
+
+            // Collapsing the nesting attaches a condition saying the denominator it cleared is
+            // non-zero, and that denominator is 1 + t^2 -- so 1/(1 + cos(x)) comes out as
+            // `1 provided not 1 + t^2 = 0`, which is the answer with a guard on it. The guard is
+            // dropped, and it is worth being exact about why rather than calling it vacuous:
+            // 1 + t^2 is at least 1 for every *real* t and vanishes at t = +-i, so the condition
+            // is not vacuous over the complex plane, which is this library's default codomain.
+            //
+            // It is sound to drop here because of what t is. The substitution is t = tan(x/2),
+            // which this rule only reaches by rewriting a real trigonometric integrand; the
+            // excluded points are not reachable values of it, and they do not appear in the
+            // answer, which is written back in terms of x. The same strip is made for the same
+            // reason in SolveBySubstitution.
+            //
+            // What this does *not* do is assume a condition away in general: the answer is still
+            // an antiderivative on each interval between the poles of tan(x/2), which is the
+            // standing caveat on this substitution and is recorded in the summary above.
+            if (integrand is Providedf(var inner, _))
+                integrand = inner;
+
+            return Integration.ComputeIndefiniteIntegral(integrand, t, integrateByParts) is { } result
+                ? result.Substitute(t, MathS.Tan(x / 2))
+                : null;
+        }
+
+        /// <summary>
         /// Attempts to solve an integral using u-substitution.
         /// Looks for patterns where f(g(x)) * g'(x) can be integrated as F(g(x)).
         /// </summary>

--- a/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
@@ -350,11 +350,6 @@ namespace AngouriMath.Functions.Algebra
             // sqrt(tan(x)) over the derivative of sqrt(tan(x)) simplifies to sin(2x), in which
             // the substitution is no longer visible. This one rewrites rather than divides.
             if ((answer = IndefiniteIntegralSolver.SolveByTangentSubstitution(expr, x, integrateByParts)) is { }) return answer;
-            // The half-angle substitution after the tangent one, which is the more specific tool:
-            // an integrand rational in tan(x) should come back in terms of the tangent rather than
-            // in terms of tan(x/2). Before partial fractions because it is what *produces* the
-            // quotient of polynomials that partial fractions then takes apart.
-            if ((answer = IndefiniteIntegralSolver.SolveByHalfAngleSubstitution(expr, x, integrateByParts)) is { }) return answer;
             if ((answer = IndefiniteIntegralSolver.SolveByPartialFractions(expr, x, integrateByParts)) is { }) return answer;
             // Linearity comes before integration by parts, because it decomposes the problem
             // into strictly simpler ones where by parts searches. It cannot cost an answer:
@@ -370,6 +365,15 @@ namespace AngouriMath.Functions.Algebra
             // Expansion is bounded by MaxExpansionTermCount, which returns null rather than
             // building the terms, so putting it earlier cannot blow the tree up either.
             if ((answer = IndefiniteIntegralSolver.SolveBySplittingSum(expr, x, integrateByParts)) is { }) return answer;
+            // The half-angle substitution goes *after* linearity, and that is not a preference.
+            // It fires on anything built from sines and cosines, and it answers `cos(x) + 1` with
+            // a correct expression in tan(x/2) some forty characters long where splitting the sum
+            // answers `sin(x) + x`. Both are antiderivatives; only one is an answer anybody wants,
+            // and the F# wrapper's test pinned the readable one. So everything that decomposes the
+            // problem into pieces the ordinary rules know gets first refusal, and this sees only
+            // what is left — which is the quotients it was added for, since linearity declines a
+            // quotient and partial fractions declines one that is not a ratio of polynomials.
+            if ((answer = IndefiniteIntegralSolver.SolveByHalfAngleSubstitution(expr, x, integrateByParts)) is { }) return answer;
             if (integrateByParts && (answer = IndefiniteIntegralSolver.SolveIntegratingByParts(expr, x)) is { }) return answer;
             return null;
         }

--- a/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
@@ -350,6 +350,11 @@ namespace AngouriMath.Functions.Algebra
             // sqrt(tan(x)) over the derivative of sqrt(tan(x)) simplifies to sin(2x), in which
             // the substitution is no longer visible. This one rewrites rather than divides.
             if ((answer = IndefiniteIntegralSolver.SolveByTangentSubstitution(expr, x, integrateByParts)) is { }) return answer;
+            // The half-angle substitution after the tangent one, which is the more specific tool:
+            // an integrand rational in tan(x) should come back in terms of the tangent rather than
+            // in terms of tan(x/2). Before partial fractions because it is what *produces* the
+            // quotient of polynomials that partial fractions then takes apart.
+            if ((answer = IndefiniteIntegralSolver.SolveByHalfAngleSubstitution(expr, x, integrateByParts)) is { }) return answer;
             if ((answer = IndefiniteIntegralSolver.SolveByPartialFractions(expr, x, integrateByParts)) is { }) return answer;
             // Linearity comes before integration by parts, because it decomposes the problem
             // into strictly simpler ones where by parts searches. It cannot cost an answer:

--- a/Sources/Tests/UnitTests/Calculus/HalfAngleSubstitutionIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/HalfAngleSubstitutionIntegralTest.cs
@@ -108,5 +108,26 @@ namespace AngouriMath.Tests.Calculus
             // not come from this substitution — no half-angle appears in it.
             Assert.DoesNotContain("tan(x / 2)", integral.Stringize());
         }
+
+        /// <summary>
+        /// A sum this rule *could* answer and must not, because splitting it answers it better.
+        /// </summary>
+        /// <remarks>
+        /// <c>cos(x) + 1</c> is a function of the cosine alone, so the rewrite succeeds and
+        /// produces a correct antiderivative in <c>tan(x/2)</c> about forty characters long, where
+        /// linearity gives <c>sin(x) + x</c>. Both are antiderivatives and only one is an answer
+        /// anybody wants. This is why the rule runs after <c>SolveBySplittingSum</c>; it was
+        /// caught by the F# wrapper's own test, which pins the readable form, and not by anything
+        /// here — hence this.
+        /// </remarks>
+        [Theory]
+        [InlineData("cos(x) + 1")]
+        [InlineData("sin(x) + cos(x)")]
+        [InlineData("2 * cos(x)")]
+        public void ASumTheOrdinaryRulesAnswerBetter(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("tan(x / 2)", integral.Stringize());
+        }
     }
 }

--- a/Sources/Tests/UnitTests/Calculus/HalfAngleSubstitutionIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/HalfAngleSubstitutionIntegralTest.cs
@@ -1,0 +1,112 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// Integrands built from <c>sin(x)</c> and <c>cos(x)</c> by the field operations, which the
+    /// half-angle substitution <c>t = tan(x/2)</c> turns into a rational function —
+    /// <c>sin(x) = 2t/(1 + t^2)</c>, <c>cos(x) = (1 - t^2)/(1 + t^2)</c>, <c>dx = 2/(1 + t^2) dt</c>.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These are first-year table entries and none of them had an antiderivative. Measured against
+    /// Rubi's suite, the band it rates as a <em>single table lookup</em> was the worst-served
+    /// difficulty we had — 58%, barely above the 52% for problems needing two or three rules — and
+    /// this family is a large part of why.
+    /// </para>
+    /// <para>
+    /// Checked by differentiating back and comparing at points, never against a printed form: the
+    /// answers come out in terms of <c>tan(x/2)</c> and their shape says nothing about whether
+    /// they differentiate back. <c>int 1/cos(x)</c> in particular comes out as a logarithm of a
+    /// quotient of two linear expressions in <c>tan(x/2)</c>, which is correct and is not what a
+    /// textbook prints.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class HalfAngleSubstitutionIntegralTest
+    {
+        /// <summary>
+        /// Points inside one branch of <c>tan(x/2)</c>, which has poles at odd multiples of pi.
+        /// They stay on <c>(0, pi)</c> and away from both ends, since the substitution produces an
+        /// antiderivative per branch rather than one across a pole.
+        /// </summary>
+        private static readonly double[] Points = { 0.4, 0.9, 1.3, 1.9, 2.4 };
+
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 4,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}, "
+                + "so this asserts almost nothing");
+        }
+
+        /// <summary>
+        /// The cosecant and the secant. Both are table entries in every calculus text and neither
+        /// had an antiderivative; <c>1/sin(x)^2</c> did, through the rule for the cotangent, which
+        /// is what made the gap easy to miss.
+        /// </summary>
+        [Theory]
+        [InlineData("1/sin(x)")]
+        [InlineData("1/cos(x)")]
+        public void TheCosecantAndTheSecant(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// A quotient whose denominator is linear in one of the two, where the substitution
+        /// produces something the rational integrator answers directly. <c>1/(1 + cos(x))</c>
+        /// becomes <c>int 1 dt</c> exactly, so the answer is <c>tan(x/2)</c>.
+        /// </summary>
+        [Theory]
+        [InlineData("1/(1 + cos(x))")]
+        public void ALinearDenominatorInCosine(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// Declined, and each for its own reason, so that the boundary is recorded rather than
+        /// assumed. <c>sin(x) + x</c> is not a function of the sine alone. <c>sin(x)*sin(2*x)</c>
+        /// leaves an <c>x</c> behind because <c>sin(2x)</c> is not <c>sin(x)</c> — the right
+        /// outcome, since a product of sines wants the product-to-sum identity rather than a
+        /// rational function in <c>t</c>.
+        /// </summary>
+        /// <remarks>
+        /// These assert only that the rule does not fire wrongly. Should either later be answered
+        /// by something else, this test moves to the group above rather than being deleted.
+        /// </remarks>
+        [Theory]
+        [InlineData("sin(x) + x")]
+        [InlineData("sin(x) * sin(2*x)")]
+        public void NotAFunctionOfSineAndCosineAlone(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            // `sin(x) + x` is answered by linearity, so what is asserted is that the answer does
+            // not come from this substitution — no half-angle appears in it.
+            Assert.DoesNotContain("tan(x / 2)", integral.Stringize());
+        }
+    }
+}


### PR DESCRIPTION
Part of #718.

`int 1/sin(x)` and `int 1/cos(x)` had **no antiderivative**. They are table entries in every calculus text, and the gap was easy to miss because the neighbours are answered: `tan(x)` comes out, and so does `1/sin(x)^2` through the cotangent rule.

## Why this family, measured rather than chosen

With `intbench` able to finish a run for the first time, the band Rubi rates as a **single table lookup** is the worst-served difficulty we have:

| Rubi steps | solved | rate |
|---|---|--:|
| 1 (table lookup) | 156 / 268 | **58%** |
| 2–3 | 439 / 851 | 52% |
| 4–6 | 124 / 432 | 29% |

A one-step lookup should be our best band, not a point above our second. Reading the 112 that fail, they cluster on rational functions of sine and cosine.

## What it does

Under `t = tan(x/2)`: `sin(x) = 2t/(1+t^2)`, `cos(x) = (1-t^2)/(1+t^2)`, `dx = 2/(1+t^2) dt`. So an integrand built from sines and cosines by the field operations becomes a quotient of polynomials — which partial fractions already answers, and answers 50x faster since #1236.

```
1/sin(x)       ->  ln(tan(x/2))
1/(1+cos(x))   ->  tan(x/2)
1/cos(x)       ->  a logarithm of a quotient linear in tan(x/2)
```

## Two judgement calls, stated rather than buried

**`Simplify` rather than `InnerSimplified`** on the rewritten integrand. The rewrite puts a quotient inside a quotient, and partial fractions wants one `Divf` of two polynomials; `InnerSimplified` leaves the nesting, so every one of these was handed on in a shape nothing downstream could read.

**The `Providedf` is dropped**, and it is worth being exact rather than calling it vacuous. It says `1 + t^2 != 0`, which fails at `t = ±i` — and complex is this library's default codomain. It is sound to drop because of what `t` is here: `t = tan(x/2)`, reached by rewriting a *real* trigonometric integrand, so the excluded points are not reachable values of it and do not appear in the answer, which is written back in terms of `x`.

The answer is an antiderivative on each interval between the poles of `tan(x/2)` rather than across one. That is the standing property of this substitution and the same one `SolveByTangentSubstitution` already carries.

## What it does not reach, and why that is not this rule's fault

`1/(1-sin(x))`, `1/(1+cos(x)/2)`, `1/(2cos(x)+3sin(x))` still decline. They rewrite correctly and then stop, because **`Simplify` never puts a sum over a common denominator** — even `a + b/c` is left split. That is the operation other systems call `together` or `ratsimp`, we do not have it, and it is what the rest of this family needs. Filing it separately.

## Checked

Every answer differentiated back and compared at five points inside one branch, never against a printed form. Two cases assert the rule correctly *declines*: `sin(x) + x` is not a function of the sine alone, and `sin(x)*sin(2x)` leaves an `x` behind because `sin(2x)` is not `sin(x)` — the right outcome, since a product of sines wants product-to-sum. Full suite green: 8,499 and 1,485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
