### PR TITLE
An expression can be written as one quotient, and 51 more Rubi integrals come out

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -282,3 +282,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/HalfAngleSubstitutionIntegralTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[AngouriMath/Functions/SingleQuotient.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Core/SingleQuotientTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -357,7 +357,13 @@ namespace AngouriMath.Functions.Algebra
             // times 2/(1 + t^2) -- and partial fractions wants a single Divf of two polynomials.
             // InnerSimplified leaves the nesting alone, so every one of these was handed on in a
             // shape nothing downstream could read and came back unevaluated.
-            var integrand = (inT * 2 / (1 + tSquared)).Simplify();
+            // Combined into one quotient first, because the rewrite puts a quotient inside a
+            // quotient and everything downstream wants a single Divf of two polynomials. Simplify
+            // alone does not do it — it never puts a sum over a common denominator, so
+            // 1/(1 - sin(x)) rewrote to 2/((t^2 + 1)(1 + (-2)t/(t^2 + 1))) and stopped there, one
+            // distribution short of 2/(t^2 - 2t + 1), which is integrated at once.
+            // https://github.com/asc-community/AngouriMath/issues/1239
+            var integrand = Functions.SingleQuotient.Combine(inT * 2 / (1 + tSquared)).Simplify();
 
             // Collapsing the nesting attaches a condition saying the denominator it cleared is
             // non-zero, and that denominator is 1 + t^2 -- so 1/(1 + cos(x)) comes out as

--- a/Sources/AngouriMath/Functions/SingleQuotient.cs
+++ b/Sources/AngouriMath/Functions/SingleQuotient.cs
@@ -1,0 +1,129 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using static AngouriMath.Entity;
+using static AngouriMath.Entity.Number;
+
+namespace AngouriMath.Functions
+{
+    /// <summary>
+    /// Writes an expression as one quotient: a numerator and a denominator with no division
+    /// anywhere inside either.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is what other systems call <c>together</c> or <c>ratsimp</c>, and it is deliberately
+    /// <b>not</b> part of <see cref="Entity.Simplify(int)"/>. Putting a sum over a common
+    /// denominator makes some expressions worse — <c>1/x + 1/y</c> is easier to read than
+    /// <c>(x + y)/(x*y)</c> — which is why every system that has it keeps it as an operation you
+    /// ask for. <c>Simplify</c> here combines nothing: <c>a + b/c</c> comes back as <c>a + b/c</c>.
+    /// https://github.com/asc-community/AngouriMath/issues/1239
+    /// </para>
+    /// <para>
+    /// <b>What it is for.</b> Everything that takes a rational function apart —
+    /// <see cref="PartialFractions"/> and the integrator's rational path — wants its input as a
+    /// single <see cref="Divf"/> of two polynomials, and declines anything else. So a rewrite that
+    /// produces a correct but nested answer is thrown away one step short of being usable. The
+    /// half-angle substitution is the case that exposed it: <c>1/(1 - sin(x))</c> rewrites to
+    /// <c>2/((t^2 + 1)(1 + (-2)t/(t^2 + 1)))</c>, which is <c>2/(t^2 - 2t + 1)</c> after one
+    /// distribution and is integrated at once, and was declined for want of it.
+    /// </para>
+    /// <para>
+    /// <b>No cancellation.</b> The two halves are returned as built, with no common factor taken
+    /// out: <c>x/x</c> comes back as <c>(x, x)</c> and not as <c>(1, 1)</c>. Cancelling needs a
+    /// gcd, which needs to know what the expression is a polynomial <em>in</em>, and this runs
+    /// before anything has decided that. The callers here divide out afterwards anyway, and a
+    /// caller that wants the tidy form asks the simplifier for it.
+    /// </para>
+    /// <para>
+    /// <b>It always terminates and never grows without bound</b>, because it recurses only into
+    /// the operands of the node it is given and each recursion is on a strictly smaller tree. What
+    /// it can do is make the tree bigger — combining a sum of <c>n</c> quotients multiplies the
+    /// denominators — so <see cref="Of"/> is a transformation to ask for rather than one to apply
+    /// on the way past.
+    /// </para>
+    /// </remarks>
+    internal static class SingleQuotient
+    {
+        /// <summary>
+        /// The expression as <c>Numerator / Denominator</c>. The denominator is <c>1</c> for an
+        /// expression that had no division in it, which is the signal that nothing was combined.
+        /// </summary>
+        internal static (Entity Numerator, Entity Denominator) Of(Entity expr)
+        {
+            switch (expr)
+            {
+                case Divf(var dividend, var divisor):
+                {
+                    var (an, ad) = Of(dividend);
+                    var (bn, bd) = Of(divisor);
+                    // (an/ad) / (bn/bd) = (an * bd) / (ad * bn)
+                    return (Times(an, bd), Times(ad, bn));
+                }
+
+                case Mulf(var left, var right):
+                {
+                    var (an, ad) = Of(left);
+                    var (bn, bd) = Of(right);
+                    return (Times(an, bn), Times(ad, bd));
+                }
+
+                case Sumf(var augend, var addend):
+                {
+                    var (an, ad) = Of(augend);
+                    var (bn, bd) = Of(addend);
+                    return (Plus(Times(an, bd), Times(bn, ad)), Times(ad, bd));
+                }
+
+                case Minusf(var minuend, var subtrahend):
+                {
+                    var (an, ad) = Of(minuend);
+                    var (bn, bd) = Of(subtrahend);
+                    return (Minus(Times(an, bd), Times(bn, ad)), Times(ad, bd));
+                }
+
+                // A whole power distributes over the quotient, and a negative one turns it over.
+                // Anything else — a symbolic or fractional exponent — is left whole, since
+                // (a/b)^(1/2) is not sqrt(a)/sqrt(b) on the branch cut.
+                case Powf(var @base, Integer power):
+                {
+                    var (bn, bd) = Of(@base);
+                    if (bd == Integer.One && power.EInteger.Sign >= 0)
+                        return (expr, Integer.One);
+                    return power.EInteger.Sign >= 0
+                        ? (MathS.Pow(bn, power), MathS.Pow(bd, power))
+                        : (MathS.Pow(bd, -power), MathS.Pow(bn, -power));
+                }
+
+                default:
+                    return (expr, Integer.One);
+            }
+        }
+
+        /// <summary>
+        /// <paramref name="expr"/> rewritten as a single quotient, or unchanged where it had no
+        /// division in it to combine.
+        /// </summary>
+        internal static Entity Combine(Entity expr)
+        {
+            var (numerator, denominator) = Of(expr);
+            return denominator == Integer.One ? numerator : numerator / denominator;
+        }
+
+        // Multiplying and adding through `1` and `0` rather than building the nodes keeps the
+        // result readable, and keeps the common case -- an expression with one division in it --
+        // from coming back wrapped in a chain of `* 1`.
+        private static Entity Times(Entity a, Entity b) =>
+            a == Integer.One ? b : b == Integer.One ? a : a * b;
+
+        private static Entity Plus(Entity a, Entity b) =>
+            a == Integer.Create(0) ? b : b == Integer.Create(0) ? a : a + b;
+
+        private static Entity Minus(Entity a, Entity b) =>
+            b == Integer.Create(0) ? a : a - b;
+    }
+}

--- a/Sources/Tests/UnitTests/Calculus/HalfAngleSubstitutionIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/HalfAngleSubstitutionIntegralTest.cs
@@ -88,6 +88,37 @@ namespace AngouriMath.Tests.Calculus
         public void ALinearDenominatorInCosine(string integrand) => DifferentiatesBack(integrand);
 
         /// <summary>
+        /// The rest of the family: any quotient whose denominator is linear in the sine, the
+        /// cosine or both.
+        /// </summary>
+        /// <remarks>
+        /// Every one of these rewrote correctly and was then declined, because the rewrite leaves
+        /// a sum with a fraction in it — <c>1/(1 - sin(x))</c> becomes
+        /// <c>2/((t^2 + 1)(1 + (-2)t/(t^2 + 1)))</c> — and nothing put that over a common
+        /// denominator. <c>Simplify</c> does not; it never combines a sum, by design. Writing the
+        /// rewritten integrand as a single quotient first is what turns that into
+        /// <c>2/(t^2 - 2t + 1)</c>, which the rational integrator answers at once.
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1239">#1239</a>
+        /// </remarks>
+        [Theory]
+        [InlineData("1/(1 - sin(x))")]
+        [InlineData("1/(2 + cos(x))")]
+        [InlineData("1/(1 + cos(x)/2)")]
+        [InlineData("1/(3 + 5*sin(x))")]
+        [InlineData("1/(2*cos(x) + 3*sin(x))")]
+        [InlineData("1/(sin(x) + cos(x))")]
+        public void ADenominatorLinearInEither(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// A numerator that mentions the sine too, so the rewrite produces an <b>improper</b>
+        /// rational function and the long division in front of partial fractions has to run
+        /// before anything else can. The answer carries an <c>x</c> term from the whole part.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x)/(1 + sin(x))")]
+        public void AnImproperQuotientAfterTheRewrite(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
         /// Declined, and each for its own reason, so that the boundary is recorded rather than
         /// assumed. <c>sin(x) + x</c> is not a function of the sine alone. <c>sin(x)*sin(2*x)</c>
         /// leaves an <c>x</c> behind because <c>sin(2x)</c> is not <c>sin(x)</c> — the right

--- a/Sources/Tests/UnitTests/Core/SingleQuotientTest.cs
+++ b/Sources/Tests/UnitTests/Core/SingleQuotientTest.cs
@@ -1,0 +1,137 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using AngouriMath.Functions;
+using Xunit;
+
+namespace AngouriMath.Tests.Core
+{
+    /// <summary>
+    /// Writing an expression as one quotient, which is what other systems call <c>together</c> or
+    /// <c>ratsimp</c> and what <see cref="Entity.Simplify(int)"/> deliberately does not do.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/1239">#1239</a>
+    /// </summary>
+    /// <remarks>
+    /// Checked by value rather than by printed form. The point of this is the *shape* — a single
+    /// division at the root — and the shape it produces is not canonical, so asserting a spelling
+    /// would pin whatever the arithmetic happened to build rather than what was asked for. Each
+    /// case therefore asserts two things: the result has no division below the root, and it agrees
+    /// numerically with what it came from.
+    /// </remarks>
+    [Trait("Area", "Core")]
+    public sealed class SingleQuotientTest
+    {
+        private static readonly double[] Points = { 0.37, 1.13, 2.71, -0.8 };
+
+        /// <summary>
+        /// True when a division appears anywhere below the root, which is exactly what this is
+        /// supposed to remove.
+        /// </summary>
+        private static bool HasNestedDivision(Entity expr)
+        {
+            var root = expr is Entity.Divf(var numerator, var denominator) ? new[] { numerator, denominator } : new[] { expr };
+            foreach (var part in root)
+                foreach (var node in part.Nodes)
+                    if (node is Entity.Divf)
+                        return true;
+            return false;
+        }
+
+        private static void CombinesTo(string source)
+        {
+            var original = source.ToEntity();
+            var combined = SingleQuotient.Combine(original);
+
+            Assert.False(HasNestedDivision(combined),
+                $"{source} came back as {combined}, which still has a division inside it");
+
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var want = original.Substitute("t", at).EvalNumerical();
+                var got = combined.Substitute("t", at).EvalNumerical();
+                if (want.IsNaN || got.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-12,
+                    $"{source} is {want} at t = {at}, and {combined} is {got}");
+            }
+            Assert.True(compared >= 3,
+                $"only {compared} of {Points.Length} points were comparable for {source}");
+        }
+
+        /// <summary>A sum with one fraction in it, which <c>Simplify</c> leaves split.</summary>
+        [Theory]
+        [InlineData("1 + 2/(1+t^2)")]
+        [InlineData("3 + 10*t/(t^2+1)")]
+        [InlineData("t - 1/t")]
+        public void ASumWithAFraction(string source) => CombinesTo(source);
+
+        /// <summary>A sum of two fractions, which needs both denominators.</summary>
+        [Theory]
+        [InlineData("1/(t^2+1) + 1/(t+1)")]
+        [InlineData("1/t + 1/(t+1) + 1/(t+2)")]
+        public void ASumOfFractions(string source) => CombinesTo(source);
+
+        /// <summary>A fraction inside a fraction, which is the shape the half-angle rewrite makes.</summary>
+        [Theory]
+        [InlineData("1/(1 + 2/(1+t^2))")]
+        [InlineData("2/((t^2+1) * (1 + (-2)*t/(t^2+1)))")]
+        [InlineData("(1/t) / (1/(t+1))")]
+        public void AFractionInsideAFraction(string source) => CombinesTo(source);
+
+        /// <summary>A whole power of a quotient distributes; a negative one turns it over.</summary>
+        [Theory]
+        [InlineData("(1/t)^3")]
+        [InlineData("(t/(t+1))^(-2)")]
+        public void AWholePowerOfAQuotient(string source) => CombinesTo(source);
+
+        /// <summary>
+        /// Nothing to combine, so nothing is done — the denominator comes back as <c>1</c> and the
+        /// expression is handed straight back rather than wrapped in a division by one.
+        /// </summary>
+        [Theory]
+        [InlineData("t^2 + 2*t + 1")]
+        [InlineData("sin(t) + 3")]
+        public void NothingToCombine(string source)
+        {
+            var original = source.ToEntity();
+            var (_, denominator) = SingleQuotient.Of(original);
+            Assert.Equal(Entity.Number.Integer.One, denominator);
+            Assert.Equal(original, SingleQuotient.Combine(original));
+        }
+
+        /// <summary>
+        /// A fractional exponent is left whole, because <c>(a/b)^(1/2)</c> is not
+        /// <c>sqrt(a)/sqrt(b)</c> across the branch cut, and this must not assert that it is.
+        /// </summary>
+        [Fact]
+        public void AFractionalPowerIsLeftAlone()
+        {
+            var original = "(t/(t+1))^(1/2)".ToEntity();
+            var (_, denominator) = SingleQuotient.Of(original);
+            Assert.Equal(Entity.Number.Integer.One, denominator);
+        }
+
+        /// <summary>
+        /// Nothing is cancelled, and that is deliberate: cancelling needs a gcd, which needs to
+        /// know what the expression is a polynomial in, and this runs before anything has decided
+        /// that. <c>t/t</c> comes back as a quotient rather than as <c>1</c>.
+        /// </summary>
+        [Fact]
+        public void NothingIsCancelled()
+        {
+            var (numerator, denominator) = SingleQuotient.Of("(1/t) * t".ToEntity());
+            Assert.Equal("t".ToEntity(), numerator);
+            Assert.Equal("t".ToEntity(), denominator);
+        }
+    }
+}


### PR DESCRIPTION
Part of #1239, and the second half of #1238.

Nothing wrote an expression as a **single quotient**. `Simplify` never puts a sum over a common denominator, at any level — even `a + b/c` comes back as `a + b/c` — and that is deliberate, since combining makes some expressions worse. It is why every system that has the operation keeps it separate: `together` in SymPy, `ratsimp` in Maxima. We did not have it at all.

Everything that takes a rational function apart wants a single `Divf` of two polynomials and declines anything else, so a rewrite that produced a correct but nested answer was thrown away one step short of being usable.

## Measured

Rubi's independent test suites, same corpus and flags, one machine, both runs today:

| build | solved |
|---|--:|
| `origin/master` | 777 / 1774 |
| with this | **828 / 1774** |

**Fifty-one problems.** By Rubi's own difficulty rating, the band it calls a single table lookup goes from 58% to **65%**, and the 2–3 band from 52% to 57%.

The whole family the half-angle substitution was added for now comes out, where before only three of it did:

```
1/(1 - sin(x))        1/(2 + cos(x))          1/(1 + cos(x)/2)
1/(3 + 5*sin(x))      1/(2cos(x) + 3sin(x))   1/(sin(x) + cos(x))
sin(x)/(1 + sin(x))
```

`1/(1 - sin(x))` is the one that shows the mechanism: it rewrote to `2/((t^2 + 1)(1 + (-2)t/(t^2 + 1)))`, which is `2/(t^2 - 2t + 1)` after one distribution and is integrated at once.

## Two decisions in the helper

**It cancels nothing.** `x/x` comes back as `(x, x)`, not `(1, 1)`. Cancelling needs a gcd, which needs to know what the expression is a polynomial *in*, and this runs before anything has decided that. The callers divide out afterwards anyway.

**A fractional exponent is left whole**, because `(a/b)^(1/2)` is not `sqrt(a)/sqrt(b)` across the branch cut and this must not assert that it is. A whole power distributes; a negative whole power turns the quotient over.

## Scope

Internal. The public spelling is a naming decision and is proposed on #1239 rather than taken here.

## Checked

The helper has its own tests, asserting the *shape* — no division below the root — and agreement by value at four points, never a printed form, since what it builds is not canonical. Integrals are checked by differentiating back at five points.

Suites run rather than assumed: `UnitTests` 8,513 and 1,500, `FSharpWrapperUnitTests` 134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
