### PR TITLE
A product of trigonometric functions of different arguments is a sum, and 21 more Rubi integrals come out

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -292,6 +292,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [Tests/UnitTests/Calculus/LinearRadicalSubstitutionIntegralTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[Tests/UnitTests/Calculus/ProductToSumIntegralTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [Tests/UnitTests/Calculus/ExponentialSubstitutionIntegralTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -479,6 +479,90 @@ namespace AngouriMath.Functions.Algebra
         }
 
         /// <summary>
+        /// A product of sines and cosines of <b>different</b> arguments, rewritten as a sum by the
+        /// product-to-sum identities and then integrated term by term.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>sin(A)sin(B) = (cos(A - B) - cos(A + B))/2</c>,
+        /// <c>cos(A)cos(B) = (cos(A - B) + cos(A + B))/2</c>,
+        /// <c>sin(A)cos(B) = (sin(A + B) + sin(A - B))/2</c>. Each application turns two factors
+        /// into a sum of two single ones, and a sine or cosine of something linear in the variable
+        /// is a rule the integrator already has — so the whole family comes out at once.
+        /// <c>sin(x)sin(2x)</c>, <c>cos(x)cos(2x)</c>, <c>cos(3x)sin(2x)</c> and
+        /// <c>sin(x)sin(2x)sin(3x)</c> had no antiderivative between them.
+        /// </para>
+        /// <para>
+        /// <b>Why this rather than a substitution.</b> These are the shapes every substitution in
+        /// the chain declines, and rightly: there is no inner function to substitute for. A
+        /// product of trigonometric functions of unequal arguments is not a function of any one of
+        /// them, which is what <see cref="SolveByHalfAngleSubstitution"/> notices when it finds an
+        /// <c>x</c> left over after rewriting — <c>sin(2x)</c> is not <c>sin(x)</c>. The identity
+        /// is the tool, not a change of variable.
+        /// </para>
+        /// <para>
+        /// <b>It terminates.</b> Each rewrite replaces two trigonometric factors with a sum whose
+        /// terms hold one each, so the number of such factors in any one product strictly
+        /// decreases, and the recursion is over strictly simpler products. Arguments equal to each
+        /// other are left alone, since <c>sin(A)^2</c> is a power rather than a product of two
+        /// arguments and wants a reduction formula instead.
+        /// </para>
+        /// <para>
+        /// <b>Nothing is assumed and no condition is owed.</b> These are identities on the whole
+        /// complex plane, not rewrites that hold on an interval: both sides are entire, so unlike
+        /// every substitution here the answer is an antiderivative everywhere the integrand is,
+        /// with no branch to pick and no interval to be inside.
+        /// </para>
+        /// https://github.com/asc-community/AngouriMath/issues/718
+        /// </remarks>
+        internal static Entity? SolveByProductToSum(Entity expr, Entity.Variable x, bool integrateByParts)
+        {
+            if (RewriteOneProduct(expr, x) is not { } rewritten)
+                return null;
+            return Integration.ComputeIndefiniteIntegral(rewritten, x, integrateByParts);
+        }
+
+        /// <summary>
+        /// The product with one pair of trigonometric factors replaced by the sum it equals, or
+        /// <see langword="null"/> where there is no such pair.
+        /// </summary>
+        private static Entity? RewriteOneProduct(Entity expr, Entity.Variable x)
+        {
+            var factors = Mulf.LinearChildren(expr).ToList();
+            if (factors.Count < 2)
+                return null;
+
+            for (var i = 0; i < factors.Count; i++)
+                for (var j = i + 1; j < factors.Count; j++)
+                {
+                    // Both arguments have to mention the variable. A sine of a constant is a
+                    // number as far as this integral is concerned, and pairing it with a real
+                    // factor would turn one term into two for nothing.
+                    var replacement = (factors[i], factors[j]) switch
+                    {
+                        (Sinf(var a), Sinf(var b)) when a != b && a.ContainsNode(x) && b.ContainsNode(x)
+                            => (MathS.Cos(a - b) - MathS.Cos(a + b)) / 2,
+                        (Cosf(var a), Cosf(var b)) when a != b && a.ContainsNode(x) && b.ContainsNode(x)
+                            => (MathS.Cos(a - b) + MathS.Cos(a + b)) / 2,
+                        (Sinf(var a), Cosf(var b)) when a != b && a.ContainsNode(x) && b.ContainsNode(x)
+                            => (MathS.Sin(a + b) + MathS.Sin(a - b)) / 2,
+                        (Cosf(var a), Sinf(var b)) when a != b && a.ContainsNode(x) && b.ContainsNode(x)
+                            => (MathS.Sin(b + a) + MathS.Sin(b - a)) / 2,
+                        _ => (Entity?)null
+                    };
+                    if (replacement is null)
+                        continue;
+
+                    var product = replacement;
+                    for (var k = 0; k < factors.Count; k++)
+                        if (k != i && k != j)
+                            product *= factors[k];
+                    return product;
+                }
+            return null;
+        }
+
+        /// <summary>
         /// A rational function of <c>e^(k x)</c>, turned into a rational function of one variable
         /// by <c>u = e^(k x)</c>.
         /// </summary>

--- a/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
@@ -393,6 +393,11 @@ namespace AngouriMath.Functions.Algebra
             // rational function, so it wants everything that answers a problem in its own terms to
             // have declined first.
             if ((answer = IndefiniteIntegralSolver.SolveByLinearRadicalSubstitution(expr, x, integrateByParts)) is { }) return answer;
+            // Product-to-sum among the rewrites rather than before them, because a product of
+            // trigonometric functions of *equal* arguments is a power and wants a different tool;
+            // this only fires where the arguments differ, which is exactly what every substitution
+            // above declines for want of an inner function to substitute for.
+            if ((answer = IndefiniteIntegralSolver.SolveByProductToSum(expr, x, integrateByParts)) is { }) return answer;
             // The exponential substitution beside the other rewrites. It is also what integrates
             // the hyperbolic functions, which are not nodes here but quotients of exponentials.
             if ((answer = IndefiniteIntegralSolver.SolveByExponentialSubstitution(expr, x, integrateByParts)) is { }) return answer;

--- a/Sources/Tests/UnitTests/Calculus/ProductToSumIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ProductToSumIntegralTest.cs
@@ -1,0 +1,111 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// Products of sines and cosines of <b>different</b> arguments, which the product-to-sum
+    /// identities turn into sums the integrator already reads.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These are the shapes every substitution in the chain declines, and rightly: a product of
+    /// trigonometric functions of unequal arguments is not a function of any one of them, so there
+    /// is nothing to substitute for. The identity is the tool rather than a change of variable.
+    /// </para>
+    /// <para>
+    /// Unlike every substitution here, the identities hold on the whole complex plane — both sides
+    /// are entire — so these answers are antiderivatives wherever the integrand is defined, with
+    /// no branch to pick and no interval to stay inside. The points below can therefore straddle
+    /// zero and go negative, which the half-angle and radical tests cannot.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class ProductToSumIntegralTest
+    {
+        private static readonly double[] Points = { 0.31, 0.77, 1.42, 2.15, -0.6 };
+
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 4,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}, "
+                + "so this asserts almost nothing");
+        }
+
+        /// <summary>Two factors, one of each of the three identities.</summary>
+        [Theory]
+        [InlineData("sin(x) * sin(2*x)")]
+        [InlineData("cos(x) * cos(2*x)")]
+        [InlineData("cos(3*x) * sin(2*x)")]
+        [InlineData("sin(2*x) * cos(5*x)")]
+        public void TwoFactorsOfDifferentArguments(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// Three factors, which needs the rewrite to apply to what the first application produced.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x) * sin(2*x) * sin(3*x)")]
+        [InlineData("cos(x) * cos(2*x) * cos(3*x)")]
+        public void ThreeFactors(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// A polynomial factor alongside, so the sum the identity produces is then integrated by
+        /// parts term by term.
+        /// </summary>
+        [Theory]
+        [InlineData("x * sin(x) * cos(2*x)")]
+        public void APolynomialFactorAlongside(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// Answered, but not by this rule, and the distinction is the point of the guard on equal
+        /// arguments.
+        /// </summary>
+        /// <remarks>
+        /// <c>sin(x)cos(x)</c> and <c>sin(x)^2</c> have one argument between them, so they are
+        /// powers rather than products of two arguments and want a different tool — they come out
+        /// as <c>sin(x)^2/2</c> and through the half-angle form respectively, both tidier than
+        /// anything this rule would build. <c>sin(2)sin(x)</c> has a constant factor, and pairing
+        /// a number with a real factor would turn one term into two for nothing.
+        /// </remarks>
+        [Theory]
+        [InlineData("sin(x) * cos(x)")]
+        [InlineData("sin(x)^2")]
+        [InlineData("sin(2) * sin(x)")]
+        public void EqualOrConstantArgumentsGoElsewhere(string integrand)
+        {
+            DifferentiatesBack(integrand);
+            var integral = integrand.ToEntity().Integrate("x").Stringize();
+            // What this rule builds always holds a sine or cosine of a sum or difference of the
+            // two arguments; none of these should have gone that way.
+            Assert.DoesNotContain("x - x", integral);
+        }
+    }
+}


### PR DESCRIPTION
Part of #718.

`sin(x)sin(2x)` had **no antiderivative**. Nor did `cos(x)cos(2x)`, `cos(3x)sin(2x)`, or `sin(x)sin(2x)sin(3x)`.

These are the shapes every substitution in the chain declines, and rightly: a product of trigonometric functions of unequal arguments is **not a function of any one of them**, so there is nothing to substitute for. `SolveByHalfAngleSubstitution` notices exactly that when it finds an `x` left over after rewriting, because `sin(2x)` is not `sin(x)`. The identity is the tool here, not a change of variable.

```
sin(A)sin(B) = (cos(A - B) - cos(A + B))/2
cos(A)cos(B) = (cos(A - B) + cos(A + B))/2
sin(A)cos(B) = (sin(A + B) + sin(A - B))/2
```

Each application turns two factors into a sum of two single ones, so the number of trigonometric factors in a product strictly decreases and this terminates. A sine or cosine of something linear is a rule the integrator already has, so the family comes out at once — including the triple products, which need the rewrite to apply again to what the first application produced.

## What it deliberately leaves alone

**Equal arguments.** `sin(x)cos(x)` and `sin(x)^2` are powers rather than products of two arguments; they want a different tool and already come out tidier without this — `sin(x)^2/2` and the half-angle form. **A constant argument**, since pairing a number with a real factor turns one term into two for nothing. Both are pinned by tests.

## Measured

Rubi's independent test suites, same corpus and flags, one machine:

| | solved | wrong | timeouts | wall clock |
|---|--:|--:|--:|--:|
| before | 863 | 0 | 12 | 650 s |
| after | **884** | **0** | 13 | 661 s |

**Twenty-one problems for eleven seconds.** Worth stating explicitly against #1244, where I measured Euler's substitutions buying 36 problems at the cost of one wrong answer, 31 new timeouts and three times the wall clock, and did not ship them. This is the same size of gain with none of that, and the reason is structural: these identities hold on the whole complex plane — both sides are entire — so there is no branch to pick and no interval to stay inside. The test points here straddle zero and go negative, which the half-angle and radical tests cannot.

## Checked

Every answer differentiated back and compared at five points, never against a printed form.

Suites: `UnitTests` 8,514 and 1,508, `FSharpWrapperUnitTests` 134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
