### PR TITLE
The scratch-pool lock is the guard's API rather than a convention, because one caller had skipped it

### DIFF
--- a/Sources/AngouriMath/Core/Entity/Omni/Entity.Matrix.cs
+++ b/Sources/AngouriMath/Core/Entity/Omni/Entity.Matrix.cs
@@ -304,8 +304,8 @@ namespace AngouriMath
                     // GenericTensor's Laplace determinant writes into a process-wide scratch
                     // matrix, so two threads here silently corrupt each other's minors. See
                     // Functions.GenTensorGuard.
-                    lock (Functions.GenTensorGuard.ScratchPool)
-                        return @this.InnerMatrix.DeterminantLaplace().InnerSimplified;
+                    return Functions.GenTensorGuard
+                        .DeterminantLaplace(@this.InnerMatrix).InnerSimplified;
                 },
                 this
                 );
@@ -323,8 +323,7 @@ namespace AngouriMath
                     return null;
                 // Inverting goes through the adjugate, which takes its minors in the same
                 // process-wide scratch matrix the determinant does. See Functions.GenTensorGuard.
-                lock (Functions.GenTensorGuard.ScratchPool)
-                    cp.InvertMatrix();
+                Functions.GenTensorGuard.InvertMatrix(cp);
                 return ToMatrix(new Matrix(cp).InnerSimplified);
             }, this);
             private LazyPropertyA<Matrix?> inverse;
@@ -498,10 +497,7 @@ namespace AngouriMath
                             return null;
                         // The adjugate takes every minor in one process-wide scratch matrix.
                         // See Functions.GenTensorGuard.
-                        Entity innerSimplified;
-                        lock (Functions.GenTensorGuard.ScratchPool)
-                            innerSimplified = new Matrix(@this.InnerMatrix.Adjoint()).InnerSimplified;
-                        return ToMatrix(innerSimplified);
+                        return ToMatrix(Functions.GenTensorGuard.Adjoint(@this.InnerMatrix));
                     },
                     this);
             private LazyPropertyA<Matrix?> adjugate;

--- a/Sources/AngouriMath/Functions/GenTensorGuard.cs
+++ b/Sources/AngouriMath/Functions/GenTensorGuard.cs
@@ -47,7 +47,47 @@ namespace AngouriMath.Functions
         /// goes through the adjugate. <c>DeterminantGaussianSafeDivision</c> and
         /// <c>MatrixMultiply</c> do not touch the pool and are deliberately not covered.
         /// </summary>
-        [ConstantField] internal static readonly object ScratchPool = new object();
+        /// <remarks>
+        /// It is private, and the three operations below are the whole surface, because mutual
+        /// exclusion here is not a property any one caller can hold up: a single call that skips
+        /// the lock corrupts every call that takes it, and reads corrupted minors back. Exposing
+        /// the lock lets a caller reach GenericTensor without it; exposing only the operations
+        /// does not.
+        /// </remarks>
+        [ConstantField] private static readonly object ScratchPool = new object();
+
+        /// <summary>Laplace expansion, serialised on <see cref="ScratchPool"/>.</summary>
+        internal static Entity DeterminantLaplace(GenTensor matrix)
+        {
+            lock (ScratchPool)
+                return matrix.DeterminantLaplace();
+        }
+
+        /// <summary>
+        /// The adjugate, serialised on <see cref="ScratchPool"/>, and returned already read out
+        /// of the tensor rather than as one.
+        /// </summary>
+        /// <remarks>
+        /// Reading it out is what the lock has to cover, and returning a <c>GenTensor</c> would
+        /// put that read on the far side of the lock: <c>Entity.Matrix</c>'s constructor copies,
+        /// so the copy is where the elements are actually touched, and nothing here documents
+        /// whether the adjugate is a fresh tensor or the pool's own.
+        /// </remarks>
+        internal static Entity Adjoint(GenTensor matrix)
+        {
+            lock (ScratchPool)
+                return new Entity.Matrix(matrix.Adjoint()).InnerSimplified;
+        }
+
+        /// <summary>
+        /// Inversion in place, serialised on <see cref="ScratchPool"/> -- it goes through the
+        /// adjugate, so it takes its minors in the same pool.
+        /// </summary>
+        internal static void InvertMatrix(GenTensor matrix)
+        {
+            lock (ScratchPool)
+                matrix.InvertMatrix();
+        }
 
         [ConstantField] private static readonly Lazy<bool> piecewiseCache =
             new Lazy<bool>(WarmPiecewiseCache, LazyThreadSafetyMode.ExecutionAndPublication);

--- a/Sources/Tests/UnitTests/Algebra/Polynomials/FractionFreeDeterminantTest.cs
+++ b/Sources/Tests/UnitTests/Algebra/Polynomials/FractionFreeDeterminantTest.cs
@@ -148,7 +148,13 @@ namespace AngouriMath.Tests.Algebra.Polynomials
                 if (ByElimination(matrix) is not { } byElimination)
                     continue;
                 compared++;
-                var byLaplace = matrix.InnerMatrix.DeterminantLaplace().InnerSimplified;
+                // Through the guard rather than straight to GenericTensor, whose Laplace
+                // expansion takes its minors in a process-wide scratch matrix. xUnit runs test
+                // classes in parallel and MatrixConcurrencyTest expands forty matrices across
+                // every core, so an unguarded call here reads that test's minors and reports the
+                // determinant of an integer matrix as containing sin(a).
+                var byLaplace = GenTensorGuard.DeterminantLaplace(matrix.InnerMatrix)
+                    .InnerSimplified;
                 if ((byElimination - byLaplace).Simplify() != 0)
                     disagreements.Add($"{matrix.Stringize()}: "
                         + $"{byElimination.Stringize()} vs {byLaplace.Stringize()}");


### PR DESCRIPTION
`FractionFreeDeterminantTest.EliminationAgreesWithLaplaceWhereverBothApply` fails on `master`
whenever it happens to run beside `MatrixConcurrencyTest`, and it fails in the way #1219 was
filed for — the determinant of a matrix whose entries are integers and `a`, `b`, `c` comes back
containing `sin(a)`, which is an entry of the *other* test's matrices:

```
[[-4, 3, -1], [-2, a, 0], [1, a, 3]]:
  -9 * a + 18   vs   (-4) * (a * 3 + -sin(a) * 2 * sin(a)) + 18 + -((-2) * a + -a)
```

Thirteen of the three hundred generated matrices disagreed. Reproducing it needs nothing but the
two classes together, since xUnit runs test classes in parallel:

```
dotnet test Sources/Tests/UnitTests/UnitTests.csproj -c Release \
  --filter "FullyQualifiedName~MatrixConcurrencyTest|FullyQualifiedName~FractionFreeDeterminantTest"
```

`Failed: 1` on `master`. Each class on its own passes, which is why this has not been noticed.

### Why the #1230 guard did not cover it

It covers all three of the library's callers. This one is in the test tree: it reaches
`DeterminantLaplace` directly, because comparing Laplace against the elimination is the whole
point of the test and `Determinant` would answer by elimination. One unguarded caller is enough
to break every guarded one — it writes into the shared scratch matrix while they are reading it,
and reads their minors back.

### What this changes

Locking in the test would fix this instance. Instead the lock object becomes `private` and the
three pool operations — `DeterminantLaplace`, `Adjoint`, `InvertMatrix` — become the guard's whole
surface, so a caller can no longer reach GenericTensor without the lock. The library's three call
sites lose their `lock` statements and gain a method call; the test calls the same method.

`Adjoint` returns the `Entity` rather than the tensor deliberately. The lock has to cover reading
the elements out of the tensor, and `Entity.Matrix`'s constructor is where they are read, so a
`GenTensor`-returning signature would put that read on the far side of the lock. That is the
bracket the previous code had, kept.

No public API moves, and no answer changes on a single thread.

### Measured

Three runs of the failing command with this change: `Failed: 0` each time.

| suite | |
|---|---|
| `UnitTests` (`!~Calculus`) | 8514 passed |
| `UnitTests` (`~Calculus`) | 1508 passed |
| `FSharpWrapperUnitTests` | 134 passed |
| `InteractiveWrapperUnitTests` | 18 passed |
| `TerminalUnitTests` | 41 passed |

`AotSmokeTest` was left to CI — this change adds no reflection or generic instantiation, and
`CPPWrapperUnitTests` is a `.bat`.

Part of #1219, which was closed by #1230 and turns out to have had one caller left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
