### PR TITLE
An integrand rational in e^(k x) is a rational function under u = e^(k x), and the hyperbolic functions get antiderivatives

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -107,6 +107,37 @@ answer on the far side of a root gets a real expression where it used to get a c
 | `1/(x*(-4+x^2)^4)` | 8,472 ms | 1,878 ms |
 | `1/((1+x)^3*(2+x)^3)` | 1,343 ms | 492 ms |
 
+### The hyperbolic functions have antiderivatives, and so does anything rational in `e^(k x)`
+
+An integrand rational in `e^(k x)` becomes a rational function of one variable under
+`u = e^(k x)`, and nothing was doing that. `e^x/(1 + e^x)` was answered — its numerator happens to
+be the derivative of its denominator, which is what the general substitution looks for — and
+`1/(1 + e^x)` was not, which is the shape of the gap.
+
+**The hyperbolic functions are the visible half of it.** They are not nodes in this library:
+`tanh(x)` is built as `(e^(2x) - 1)/(e^(2x) + 1)` and `sech(x)` as `2/(e^x + e^(-x))`. So they were
+rational in an exponential all along, and none of the four had an antiderivative.
+
+| | Was | Is |
+|---|---|---|
+| `"tanh(x)".Integrate("x")`, and `coth`, `sech`, `csch` | `integral(tanh(x), x)` — left unevaluated | the antiderivative |
+| `"1/(1 + e^x)".Integrate("x")` | `integral(1 / (1 + e ^ x), x)` — left unevaluated | the antiderivative |
+| `"1/(e^x + e^(-x))".Integrate("x")` | left unevaluated | the antiderivative, `arctan(e^x)` up to the form below |
+| `"e^(3*x)/(e^x + 1)".Integrate("x")`, and every quotient whose exponentials have a common slope | left unevaluated | the antiderivative |
+
+**No previously-answered integral changes**, `e^x`, `x*e^x` and `e^x/(1 + e^x)` included: the rule
+runs after everything that answers a problem in its own terms. Every antiderivative above was
+checked by differentiating it back and comparing numerically at five points.
+
+**The answers come out in the exponential, and unfolded.** `∫sech(x) dx` is `2 arctan(e^x)` and
+prints as `4 * arctan(2 * e ^ x / 2) / 2`; `∫tanh(x) dx` is `ln(cosh(x))` and prints in `e^(2x)`.
+That is the rational integrator's own shape — it writes a logarithm as `ln((2ax + b - D)/(2ax + b + D))`
+and leaves the coefficient arithmetic standing — and it is what `1/(x*(x+1))` has always printed as
+too. A correct antiderivative in an unhelpful form, where there was none at all.
+
+`e^(x^2)` is still declined, and correctly: its exponent is not linear and it has no elementary
+antiderivative.
+
 ---
 
 ## 2.5.0 — since 2.4.0

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -291,3 +291,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/LinearRadicalSubstitutionIntegralTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/ExponentialSubstitutionIntegralTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -8,6 +8,7 @@ using HonkSharp.Fluency;
 using static AngouriMath.Entity;
 using System.Linq;
 using System.Collections.Generic;
+using PeterO.Numbers;
 
 namespace AngouriMath.Functions.Algebra
 {
@@ -389,6 +390,109 @@ namespace AngouriMath.Functions.Algebra
             return Integration.ComputeIndefiniteIntegral(integrand, u, integrateByParts) is { } result
                 ? result.Substitute(u, MathS.Pow(radicalBase, Number.Rational.Create(1, q)))
                 : null;
+        }
+
+        /// <summary>
+        /// A rational function of <c>e^(k x)</c>, turned into a rational function of one variable
+        /// by <c>u = e^(k x)</c>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// With <c>u = e^(k x)</c> we have <c>dx = du/(k u)</c>, and every exponential in the
+        /// integrand becomes a whole power of <c>u</c>, so a quotient built from them is a
+        /// quotient of polynomials — which the rational integrator answers.
+        /// </para>
+        /// <para>
+        /// <b>What was missing.</b> <c>1/(1 + e^x)</c> had no antiderivative, and neither did
+        /// <c>1/(e^x + e^(-x))</c>. <c>e^x/(1 + e^x)</c> did, which is the shape of the gap: the
+        /// general substitution answers an exponential integrand only when the numerator happens
+        /// to be the derivative of something in it, and declines the rest for want of anything to
+        /// substitute for.
+        /// </para>
+        /// <para>
+        /// <b>It is also how the hyperbolic functions get integrated</b>, since they are not nodes
+        /// here — <c>tanh(x)</c> is built as <c>(e^(2x) - 1)/(e^(2x) + 1)</c> and <c>sech(x)</c>
+        /// as <c>2/(e^x + e^(-x))</c>, so both are rational functions of an exponential, and
+        /// <c>tanh</c>, <c>coth</c>, <c>sech</c> and <c>csch</c> had no antiderivative at all.
+        /// </para>
+        /// <para>
+        /// The answers come out in the exponential rather than as <c>ln(cosh(x))</c> or
+        /// <c>2 arctan(e^x)</c>, and unfolded — the rational integrator writes a logarithm as
+        /// <c>ln((2ax + b - D)/(2ax + b + D))</c> and leaves the arithmetic in the coefficients
+        /// standing. That is its shape on plain rational integrands too, not something this
+        /// rewrite introduces; <c>1/(x(x+1))</c> comes out as
+        /// <c>ln((2x + 1 - 1)/(2x + 1 + 1))</c> with nothing exponential in sight.
+        /// </para>
+        /// <para>
+        /// <b>One <c>k</c> for the whole integrand.</b> The exponents are read as linear in the
+        /// variable and their slopes taken together by greatest common divisor, so <c>e^x</c>
+        /// beside <c>e^(2x)</c> gives <c>u</c> and <c>u^2</c> under one substitution. A slope that
+        /// is not a whole number, or an exponent that is not linear — <c>e^(x^2)</c>, whose
+        /// integral is not elementary at all — is declined.
+        /// </para>
+        /// <para>
+        /// <b>No condition is owed.</b> <c>e^(k x)</c> is positive for every real <c>x</c> and
+        /// never zero, so the substitution is invertible on the whole line and introduces no
+        /// interval of its own; <c>u</c> is a genuine change of variable rather than a branch.
+        /// </para>
+        /// https://github.com/asc-community/AngouriMath/issues/718
+        /// </remarks>
+        internal static Entity? SolveByExponentialSubstitution(Entity expr, Entity.Variable x, bool integrateByParts)
+        {
+            var slopes = new List<EInteger>();
+            var offsets = new Dictionary<Entity, (EInteger Slope, Entity Offset)>();
+            foreach (var node in expr.Nodes)
+            {
+                if (node is not Powf(var @base, var exponent) || @base != MathS.e)
+                    continue;
+                if (!exponent.ContainsNode(x))
+                    continue;
+                if (!TreeAnalyzer.TryGetPolyLinear(exponent, x, out var slope, out var offset))
+                    return null;   // not linear in x, so not a power of one exponential
+                if (slope.Evaled is not Number.Integer whole || whole.EInteger.IsZero)
+                    return null;
+                slopes.Add(whole.EInteger);
+                offsets[node] = (whole.EInteger, offset);
+            }
+            if (slopes.Count == 0)
+                return null;
+
+            var k = slopes[0].Abs();
+            foreach (var slope in slopes)
+                k = k.Gcd(slope.Abs());
+            if (k.IsZero)
+                return null;
+
+            var u = Variable.CreateUnique(expr, "u_exp");
+
+            // e^(k_i x + m_i) is e^(m_i) times u^(k_i/k), and k_i/k is a whole number by
+            // construction. Built directly rather than by substituting x and simplifying, for the
+            // same reason as the radical substitutions: (u^(1/k))^(k_i) is not something the
+            // simplifier will reduce, and is right not to.
+            var rewritten = expr.Replace(node =>
+                offsets.TryGetValue(node, out var found)
+                    ? MathS.Pow(MathS.e, found.Offset)
+                      * MathS.Pow(u, Number.Integer.Create(found.Slope / k))
+                    : node);
+
+            if (rewritten.ContainsNode(x))
+                return null;
+
+            // dx = du/(k u). Combined into one quotient and then simplified, in that order, and
+            // the order decides four of these. Combine does not cancel, so 1/(e^x + e^(-x)) leaves
+            // u/(u(u^2 + 1)) -- which the rational integrator declines although it answers
+            // 1/(u^2 + 1) at once. Simplifying first instead leaves the nesting for Combine to
+            // flatten and the common factor never meets a cancellation.
+            var integrand = Functions.SingleQuotient.Combine(
+                rewritten / (Number.Integer.Create(k) * u)).Simplify();
+            if (integrand is Providedf(var inner, _))
+                integrand = inner;
+
+            if (Integration.ComputeIndefiniteIntegral(integrand, u, integrateByParts) is not { } result)
+                return null;
+
+            var answer = result.Substitute(u, MathS.Pow(MathS.e, Number.Integer.Create(k) * x));
+            return answer.Nodes.Any(node => node == MathS.NaN) ? null : answer;
         }
 
         private static int Lcm(int a, int b)

--- a/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
@@ -378,6 +378,9 @@ namespace AngouriMath.Functions.Algebra
             // rational function, so it wants everything that answers a problem in its own terms to
             // have declined first.
             if ((answer = IndefiniteIntegralSolver.SolveByLinearRadicalSubstitution(expr, x, integrateByParts)) is { }) return answer;
+            // The exponential substitution beside the other rewrites. It is also what integrates
+            // the hyperbolic functions, which are not nodes here but quotients of exponentials.
+            if ((answer = IndefiniteIntegralSolver.SolveByExponentialSubstitution(expr, x, integrateByParts)) is { }) return answer;
             if (integrateByParts && (answer = IndefiniteIntegralSolver.SolveIntegratingByParts(expr, x)) is { }) return answer;
             return null;
         }

--- a/Sources/Tests/UnitTests/Calculus/ExponentialSubstitutionIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ExponentialSubstitutionIntegralTest.cs
@@ -1,0 +1,130 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// Integrands that are rational in <c>e^(k x)</c>, which <c>u = e^(k x)</c> turns into
+    /// rational functions of one variable.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The hyperbolic functions are here because they are not nodes in this library —
+    /// <c>tanh(x)</c> is built as a quotient of exponentials — so this is the rule that
+    /// integrates them, and none of the four had an antiderivative before it.
+    /// </para>
+    /// <para>
+    /// Checked by differentiating back and comparing at points, never against a printed form.
+    /// These come out in the exponential rather than as <c>ln(cosh(x))</c> or
+    /// <c>2 arctan(e^x)</c>, and comparing shapes would fail on answers that are correct.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class ExponentialSubstitutionIntegralTest
+    {
+        /// <summary>
+        /// Real points either side of zero. Every integrand here is defined on the whole real
+        /// line except the two with a zero at <c>x = 0</c>, which is not among these.
+        /// </summary>
+        private static readonly double[] Points = { -0.5, 0.23, 0.61, 1.05, 1.7 };
+
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 4,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}, "
+                + "so this asserts almost nothing");
+        }
+
+        /// <summary>
+        /// The four hyperbolic functions that had no antiderivative at all, and the two spellings
+        /// of the secant, since one is a helper over the other and only one of them is what the
+        /// parser produces.
+        /// </summary>
+        [Theory]
+        [InlineData("tanh(x)")]
+        [InlineData("coth(x)")]
+        [InlineData("sech(x)")]
+        [InlineData("csch(x)")]
+        [InlineData("1/cosh(x)")]
+        [InlineData("tanh(x)^2")]
+        public void TheHyperbolicFunctions(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// Quotients written in the exponential directly. <c>e^x/(1 + e^x)</c> was already
+        /// answered — its numerator is the derivative of its denominator, which is what the
+        /// general substitution looks for — and is here so that the rule cannot break it.
+        /// </summary>
+        [Theory]
+        [InlineData("1/(1 + e^x)")]
+        [InlineData("1/(1 - e^x)")]
+        [InlineData("1/(e^x - 1)")]
+        [InlineData("1/(e^x + e^(-x))")]
+        [InlineData("e^x/(1 + e^x)")]
+        [InlineData("e^x/(1 + e^(2*x))")]
+        public void AQuotientOfExponentials(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// Slopes that differ, taken together by their greatest common divisor so that one
+        /// substitution serves the whole integrand.
+        /// </summary>
+        [Theory]
+        [InlineData("1/(1 + e^(2*x))")]
+        [InlineData("e^(2*x)/(1 + e^x)")]
+        [InlineData("e^(3*x)/(e^x + 1)")]
+        [InlineData("1/(e^(2*x) - e^(4*x))")]
+        public void SlopesTakenTogether(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// What the rule must not disturb: exponentials the other rules already answer, and which
+        /// are not rational in <c>e^(k x)</c> at all.
+        /// </summary>
+        [Theory]
+        [InlineData("e^x")]
+        [InlineData("x*e^x")]
+        [InlineData("e^(2*x)")]
+        public void WhatWasAlreadyAnswered(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// Declined, so the boundary is recorded rather than assumed. <c>e^(x^2)</c> has no
+        /// elementary antiderivative at all, and its exponent is not linear, which is the check
+        /// that stops it — a rewrite would leave an <c>x</c> standing beside the new variable.
+        /// Should it later be answered by something else, this moves rather than being deleted.
+        /// </summary>
+        [Theory]
+        [InlineData("e^(x^2)")]
+        [InlineData("e^(1/x)")]
+        public void WhatIsNotRationalInOneExponentialIsDeclined(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("u_exp", integral.Stringize());
+        }
+    }
+}


### PR DESCRIPTION
`tanh(x)`, `coth(x)`, `sech(x)` and `csch(x)` had no antiderivative. Neither did `1/(1 + e^x)` or
`1/(e^x + e^(-x))`, while `e^x/(1 + e^x)` did — which is the shape of the gap. The general
substitution answers an exponential integrand only when the numerator happens to be the derivative
of something in it, and declines the rest for want of anything to substitute for.

With `u = e^(k x)` we have `dx = du/(k u)`, and every exponential in the integrand becomes a whole
power of `u`, so a quotient built from them is a quotient of polynomials — which the rational
integrator already answers. The exponents are read as linear in the variable and their slopes taken
together by greatest common divisor, so `e^x` beside `e^(2x)` is one substitution giving `u` and
`u^2`.

**The hyperbolic functions come out of this** because they are not nodes in this library: `tanh(x)`
is built as `(e^(2x) - 1)/(e^(2x) + 1)` and `sech(x)` as `2/(e^x + e^(-x))`. They were rational in
an exponential all along and nothing was reading them that way.

### Measured on Rubi's independent test suites

Same corpus and flags, both arms on this machine, back to back:

| | solved | wrong | timeouts | wall clock |
|---|--:|--:|--:|--:|
| `35bb061b` (master) | 863 | 0 | 12 | 649 s |
| + this rule | **913** | **0** | 13 | 722 s |

**Fifty more answers and no wrong ones**, for about 11% more wall clock — the corpus spends the
extra time on integrands the rule reads and hands to the rational integrator. One more timeout,
and it was unevaluated before too.

The baseline arm was re-measured now rather than quoted from #1245's table, since comparing wall
clocks across separate runs on one machine is not a measurement. It came back at 863 either way.

### Two details are load-bearing

**The quotient is combined and then simplified, in that order,** and the order decides four of
these. `SingleQuotient.Combine` does not cancel, so `1/(e^x + e^(-x))` leaves `u/(u(u^2 + 1))` —
which the rational integrator declines although it answers `1/(u^2 + 1)` at once. Simplifying first
instead leaves the nesting for `Combine` to flatten and the common factor never meets a
cancellation. That one swap took the probe set from 11 of 15 to 19 of 20.

**Nothing is owed as a condition.** `e^(k x)` is positive for every real `x` and never zero, so the
substitution is invertible on the whole line and introduces no interval of its own — `u` is a
genuine change of variable rather than a branch. This is unlike the half-angle substitution, whose
answers hold between the poles of `tan(x/2)`.

### Where it sits, and what it declines

After everything that decomposes the problem into pieces the ordinary rules know, for the same
reason the half-angle and radical substitutions are there: it rewrites the integrand into a rational
function, so anything that answers a problem in its own terms gets first refusal. `e^x`, `x*e^x` and
`e^x/(1 + e^x)` are all still answered by what answered them before, and are in the tests so that
this cannot change.

`e^(x^2)` is declined — its exponent is not linear, and it has no elementary antiderivative at all.
So is `e^(1/x)`.

### On the shape of the answers

They come out in the exponential and unfolded: `∫sech(x) dx` is `2 arctan(e^x)` and prints as
`4 * arctan(2 * e ^ x / 2) / 2`. That is the rational integrator's own shape rather than something
this rewrite introduces — it writes a logarithm as `ln((2ax + b - D)/(2ax + b + D))` and leaves the
coefficient arithmetic standing, so `1/(x*(x+1))` has always printed as `ln((2x + 1 - 1)/(2x + 1 + 1))`
with nothing exponential in sight. A correct antiderivative in an unhelpful form, where there was
none at all. Tidying that is the rational integrator's own piece of work.

Every antiderivative was checked by differentiating it back and comparing numerically at five
points, never against a printed form.

### Suites

`UnitTests` 8514 and 1529, `FSharpWrapperUnitTests` 134, `InteractiveWrapperUnitTests` 18,
`TerminalUnitTests` 41. New file `ExponentialSubstitutionIntegralTest.cs`, 21 cases.

`BREAKING-CHANGES.md` carries an entry, since "left unevaluated → the antiderivative" is the class
the 2.5.0 section already records. #1243 and #1245 add the same class of change without one; worth
a decision on whether those want entries too.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
