### PR TITLE
One integrand written two ways got one answer and one refusal, because partial fractions read only one spelling of a quotient

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -297,3 +297,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/ScaledVariableIntegralTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/QuotientSpellingIntegralTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -66,7 +66,7 @@ namespace AngouriMath.Functions.Algebra
         /// </remarks>
         internal static Entity? SolveByPartialFractions(Entity expr, Entity.Variable x, bool integrateByParts)
         {
-            if (expr is not Entity.Divf(var numerator, var denominator))
+            if (!TryReadAsQuotient(expr, out var numerator, out var denominator))
                 return null;
 
             // The helper answers null for a fraction that is already proper, so this cannot
@@ -155,6 +155,49 @@ namespace AngouriMath.Functions.Algebra
 
             return Integration.ComputeIndefiniteIntegral(numerator / variablePart, x, integrateByParts)
                 ?.Pipe(i => i / constantPart);
+        }
+
+        /// <summary>
+        /// Reads <paramref name="expr"/> as a numerator over a denominator, in either of the two
+        /// spellings a quotient has here.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>1/(1 + x^3)</c> is a <c>Divf</c> and <c>(1 + x^3)^(-1)</c> is a <c>Powf</c>, and
+        /// they are the same integrand. <see cref="SolveByPartialFractions"/> matched the first
+        /// and declined the second, so which of them was asked decided whether the integral came
+        /// back — and the second is not an exotic way to write it: it is what
+        /// <see cref="SolveAsPolynomialTerm"/> builds whenever it takes a factor out of a
+        /// quotient. That is why <c>a/(1 + x^3)</c> had no antiderivative while
+        /// <c>1/(1 + x^3)</c> and <c>a * (1/(1 + x^3))</c> both did.
+        /// </para>
+        /// <para>
+        /// <b>Only a negative whole power.</b> A positive one is not a quotient; a fractional or
+        /// symbolic exponent is not one either, and <c>(a/b)^(1/2)</c> is not <c>sqrt(a)/sqrt(b)</c>
+        /// on the branch cut. Nothing here rewrites a quotient back into a power, so this cannot
+        /// re-enter the mutual recursion <see cref="Integration.Normalized"/> records.
+        /// </para>
+        /// https://github.com/asc-community/AngouriMath/issues/718
+        /// </remarks>
+        private static bool TryReadAsQuotient(Entity expr, out Entity numerator, out Entity denominator)
+        {
+            switch (expr)
+            {
+                case Entity.Divf(var dividend, var divisor):
+                    (numerator, denominator) = (dividend, divisor);
+                    return true;
+                case Entity.Powf(var @base, Number.Integer power) when power.EInteger.Sign < 0:
+                    // Written out rather than as base^1 when the power is -1, since everything
+                    // downstream reads the denominator as a polynomial and a redundant power of
+                    // one is a shape it would have to see through.
+                    var reciprocated = -power;
+                    (numerator, denominator) = (Number.Integer.One,
+                        reciprocated == Number.Integer.One ? @base : MathS.Pow(@base, reciprocated));
+                    return true;
+                default:
+                    (numerator, denominator) = (expr, Number.Integer.One);
+                    return false;
+            }
         }
 
         internal static Entity? SolveAsPolynomialTerm(Entity expr, Entity.Variable x, bool integrateByParts = true) => expr switch

--- a/Sources/Tests/UnitTests/Calculus/QuotientSpellingIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/QuotientSpellingIntegralTest.cs
@@ -1,0 +1,131 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// One integrand written two ways gets one answer. A quotient is either a <c>Divf</c> or a
+    /// negative whole <c>Powf</c>, and partial fractions used to read only the first.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The second spelling is not an exotic way to write it — it is what the integrator builds
+    /// for itself. Taking a constant factor out of <c>a/(1 + x^3)</c> leaves
+    /// <c>(1 + x^3)^(-1)</c>, so <c>a/(1 + x^3)</c> had no antiderivative while
+    /// <c>1/(1 + x^3)</c> and <c>a * (1/(1 + x^3))</c> both did.
+    /// </para>
+    /// <para>
+    /// Checked by differentiating back with the parameter pinned to a value and comparing at
+    /// points, since the answers are logarithms and arctangents whose printed form says nothing
+    /// about whether they differentiate back.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class QuotientSpellingIntegralTest
+    {
+        private static readonly double[] Points = { -0.5, 0.23, 0.61, 1.05, 1.7 };
+
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            // A parameter is pinned to a value only for the numeric comparison; the
+            // antiderivative itself was found symbolically.
+            var derivative = integral.Substitute("C", 0).Differentiate("x")
+                .Substitute("a", 1.7).Substitute("b", 0.9);
+            var original = integrand.ToEntity().Substitute("a", 1.7).Substitute("b", 0.9);
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 4,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}, "
+                + "so this asserts almost nothing");
+        }
+
+        /// <summary>
+        /// The reciprocal written as a power, which is the shape the integrator hands itself.
+        /// </summary>
+        [Theory]
+        [InlineData("(1 + x^3)^(-1)")]
+        [InlineData("(1 + x^4)^(-1)")]
+        [InlineData("(x^4 + 3*x^2 + 2)^(-1)")]
+        [InlineData("(x^2 - 1)^(-2)")]
+        public void AReciprocalWrittenAsAPower(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// A constant factor over a denominator partial fractions has to take apart. These are
+        /// the ones the two spellings actually cost: the factor comes out, and what is left is
+        /// the power spelling.
+        /// </summary>
+        [Theory]
+        [InlineData("a/(1 + x^3)")]
+        [InlineData("b/(1 + x^4)")]
+        [InlineData("a/(x^4 + 3*x^2 + 2)")]
+        [InlineData("a/(x^2 - 1)")]
+        [InlineData("a/((1 + x)^3*(2 + x)^3)")]
+        public void AConstantFactorOverAFactorableDenominator(string integrand)
+            => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// The three spellings of one integrand agree, which is the property this is about
+        /// rather than any particular antiderivative.
+        /// </summary>
+        [Fact]
+        public void TheSpellingsAgree()
+        {
+            var points = new[] { 0.23, 0.61, 1.7 };
+            foreach (var written in new[] { "1/(1 + x^3)", "(1 + x^3)^(-1)" })
+            {
+                var integral = written.ToEntity().Integrate("x").Substitute("C", 0);
+                var reference = "1/(1 + x^3)".ToEntity().Integrate("x").Substitute("C", 0);
+                foreach (var at in points)
+                {
+                    var got = integral.Substitute("x", at).EvalNumerical();
+                    var want = reference.Substitute("x", at).EvalNumerical();
+                    Assert.True(Math.Abs((double)(got - want).RealPart) < 1e-9,
+                        $"{written} integrates to {got} at x = {at}, where 1/(1 + x^3) gives {want}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// What is still declined, so the boundary is recorded rather than assumed. A positive
+        /// or fractional power is not a quotient, and a constant factor inside the denominator
+        /// is a different gap — the denominator is then not a polynomial over the rationals.
+        /// Should either later be answered, these move rather than being deleted.
+        /// </summary>
+        [Theory]
+        [InlineData("(1 + x^3)^2")]
+        [InlineData("(1 + x^3)^(1/2)")]
+        [InlineData("1/(a*(1 + x^3))")]
+        public void WhatIsStillDeclined(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            // Either answered by something else entirely or left alone — what must not happen is
+            // a wrong answer, so this asserts the value rather than the verdict where there is one.
+            if (!integral.Stringize().Contains("integral("))
+                DifferentiatesBack(integrand);
+        }
+    }
+}


### PR DESCRIPTION
`a/(1 + x^3)` had no antiderivative. `1/(1 + x^3)` had one, and so did `a * (1/(1 + x^3))` — the
same integral, the same constant factor, written differently.

### Why

A quotient has two spellings here, `Divf(1, g)` and `Powf(g, -1)`. `SolveByPartialFractions` opened
with

```csharp
if (expr is not Entity.Divf(var numerator, var denominator))
    return null;
```

and the second spelling is not an exotic way to write it — it is what `SolveAsPolynomialTerm` builds
every time it takes a factor out of a quotient:

```csharp
ComputeIndefiniteIntegral(MathS.Pow(over, -1), x, integrateByParts)?.Pipe(i => div * i)
```

So `a/(1 + x^3)` had its `a` correctly pulled out, and the remaining `(1 + x^3)^(-1)` was then handed
to the one rule that knew how to split it, in the one shape that rule could not see. Typed in by hand
`(1 + x^3)^(-1)` *is* answered, because `Entity.Integrate` simplifies its input into a `Divf` before
the chain runs — so which of the two shapes reached the rule decided the verdict.

Traced on the two, at the point where the integrand reaches the solvers:

```
a/(1 + x^3)        d=1  a / (1 + x ^ 3)         → partial fractions declines the symbolic numerator
                   d=2  (1 + x ^ 3) ^ (-1)      → declined for being a Powf.  no answer
(1 + x^3)^(-1)     d=1  1 / (1 + x ^ 3)         → split into 1/3/(x + 1) and (2/3 - x/3)/(x^2 - x + 1)
```

### What this changes

Reading both spellings, and nothing else. Only a **negative whole** power counts: a positive one is
not a quotient, and a fractional or symbolic exponent is not one either, since `(a/b)^(1/2)` is not
`sqrt(a)/sqrt(b)` on the branch cut. Nothing here rewrites a quotient back into a power, so it cannot
re-enter the mutual recursion between the two spellings that `Integration.Normalized` already records
in its doc comment.

Newly answered, each verified by differentiating back at five points with the parameter pinned:

| |
|---|
| `a/(1 + x^3)`, `b/(1 + x^4)` |
| `a/(x^4 + 3*x^2 + 2)`, `a/(x^2 - 1)` |
| `a/((1 + x)^3*(2 + x)^3)` |

### It moves the Rubi corpus not at all

Worth stating plainly rather than leaving to be found:

| | solved | wrong | timeouts |
|---|--:|--:|--:|
| `35bb061b` | 863 | 0 | 12 |
| + this fix | 863 | 0 | 13 |

Both arms on the commit they share. Rubi's suites write their integrands with numeric coefficients,
so the shape this fixes does not occur in them — one problem moved from unevaluated to timeout and
nothing else changed. **The case for this is not coverage**: it is that one integrand gave two
different verdicts according to how it was spelled.

If you would rather not carry a change with no corpus movement behind it, say so and I will close it
— but the inconsistency is real and the fix is four lines of matching.

### Still declined

`1/(a*(1 + x^3))`, a constant factor *inside* the denominator. Different gap — the denominator is
then not a polynomial over the rationals — and it is recorded in the test as declined rather than
left to be assumed, so that it moves rather than being deleted if something later answers it.

### Suites

`UnitTests` 8514 and 1542, `FSharpWrapperUnitTests` 134, `InteractiveWrapperUnitTests` 18,
`TerminalUnitTests` 41. New file `QuotientSpellingIntegralTest.cs`, 13 cases.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
