### PR TITLE
A symbolic parameter no longer stops a rational integrand being integrated, and 16 more Rubi integrals come out

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -138,6 +138,40 @@ too. A correct antiderivative in an unhelpful form, where there was none at all.
 `e^(x^2)` is still declined, and correctly: its exponent is not linear and it has no elementary
 antiderivative.
 
+### A symbolic parameter no longer stops a rational integrand being integrated
+
+`1/(8 + x^3)` and `1/(16 - x^4)` are answered at once. `1/(a^3 + x^3)` and `1/(a^4 - x^4)` were not,
+and the parameter is the whole difference: the rational rules read a denominator as a polynomial
+**over the rationals**, so `a^3` is not a coefficient they can work with.
+
+Two things were in the way, and both are fixed here.
+
+**A constant factor inside the denominator stayed there.** `a * (1/(1 + x^3))` was taken apart and
+`1/(a*(1 + x^3))` — the same number — was not, because the branches that take a factor out of a
+quotient each want the whole of one side free of the variable.
+
+**And the integrand is scaled by its parameter**, `x = c t`, which puts integer coefficients back;
+the parameter comes out as a constant factor and the answer is read at `t = x/c`. Homogeneity is
+checked rather than assumed, so an integrand the scale does not separate is declined.
+
+| | Was | Is |
+|---|---|---|
+| `"1/(a^3 + x^3)".Integrate("x")`, and `1/(a^4 - x^4)`, `x^2/(a^4 + x^4)` | left unevaluated | the antiderivative |
+| `"1/(x^3*(a^3 + x^3))".Integrate("x")`, and the family `1/(x^k (a^n ± x^n))` | left unevaluated | the antiderivative |
+| `"1/(a*(1 + x^3))".Integrate("x")`, and every constant factor inside a denominator | left unevaluated | the antiderivative |
+
+Every one of them was checked by differentiating it back with the parameter pinned and comparing at
+five points. **No previously-answered integral changes**: the scaling runs last of the rewrites,
+because unlike the others it fires on an integrand nothing is wrong with.
+
+`x/((a^2 + x^2)*(b^2 + x^2))` is still declined, and deliberately — two parameters means scaling by
+one leaves the other, and the sub-problem could then be scaled again without end.
+
+**Where the answer is not defined.** `c = 0` is not a scaling, and what this produces —
+`a^(-2) G(x/a)` for `1/(a^3 + x^3)` — has no value there. That is the honest report for a
+substitution that does not exist rather than a wrong answer, and the integrand at `a = 0` is a
+different function (`1/x^3`), answered on its own if asked that way.
+
 ---
 
 ## 2.5.0 — since 2.4.0

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -294,3 +294,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/ExponentialSubstitutionIntegralTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/ScaledVariableIntegralTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -121,6 +121,42 @@ namespace AngouriMath.Functions.Algebra
             return null;
         }
 
+        /// <summary>
+        /// <c>N/(c g(x))</c> integrated as <c>(1/c) * N/g(x)</c>, where <c>c</c> is whatever part
+        /// of the denominator is free of the variable.
+        /// </summary>
+        /// <remarks>
+        /// The constant is a constant wherever it stands, and the two branches above take it out
+        /// only when it is the *whole* of one side — so <c>a * (1/(1 + x^3))</c> was answered and
+        /// <c>1/(a*(1 + x^3))</c>, the same number, was not. Everything downstream reads the
+        /// denominator as a polynomial over the rationals, and a symbolic factor stops it being
+        /// one, so leaving the factor in place is not a neutral choice.
+        ///
+        /// It terminates because the denominator handed on has strictly fewer factors, and
+        /// declines at once where there is no constant factor to take.
+        /// https://github.com/asc-community/AngouriMath/issues/718
+        /// </remarks>
+        private static Entity? TakeConstantFactorOutOfDenominator(
+            Entity numerator, Entity denominator, Entity.Variable x, bool integrateByParts)
+        {
+            Entity constantPart = Number.Integer.One;
+            Entity variablePart = Number.Integer.One;
+            foreach (var factor in Entity.Mulf.LinearChildren(denominator))
+                if (factor.ContainsNode(x))
+                    variablePart *= factor;
+                else
+                    constantPart *= factor;
+
+            // Only where the denominator genuinely mixes the two. A denominator that is entirely
+            // constant, or entirely in the variable, is one of the branches below's to answer,
+            // and taking this one would hand on `N/1` and go round again.
+            if (constantPart == Number.Integer.One || variablePart == Number.Integer.One)
+                return null;
+
+            return Integration.ComputeIndefiniteIntegral(numerator / variablePart, x, integrateByParts)
+                ?.Pipe(i => i / constantPart);
+        }
+
         internal static Entity? SolveAsPolynomialTerm(Entity expr, Entity.Variable x, bool integrateByParts = true) => expr switch
         {
             Entity.Mulf(var m1, var m2) =>
@@ -131,6 +167,13 @@ namespace AngouriMath.Functions.Algebra
                 null,
 
             Entity.Divf(var div, var over) =>
+                // A denominator that is partly constant is split first, and the order matters.
+                // The branch below turns `c/g(x)` into `c * g(x)^(-1)`, and a power is a shape
+                // the rational rules do not read -- so `1/(a*(1 + x^3))` went that way and was
+                // declined, although `a * (1/(1 + x^3))`, the same number, is taken apart by the
+                // Mulf case above. Taking the constant out is both cheaper and more decisive.
+                TakeConstantFactorOutOfDenominator(div, over, x, integrateByParts) is { } withoutIt ?
+                    withoutIt :
                 !div.ContainsNode(x) ?
                     over is Entity.Powf(var @base, var power) ?
                         Integration.ComputeIndefiniteIntegral(MathS.Pow(@base, -power), x, integrateByParts)?.Pipe(i => div * i) :
@@ -492,6 +535,94 @@ namespace AngouriMath.Functions.Algebra
                 return null;
 
             var answer = result.Substitute(u, MathS.Pow(MathS.e, Number.Integer.Create(k) * x));
+            return answer.Nodes.Any(node => node == MathS.NaN) ? null : answer;
+        }
+
+        /// <summary>
+        /// An integrand carrying one symbolic parameter, scaled by it — <c>x = c t</c> — so that
+        /// what is left to integrate has the variable alone in it.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>1/(a^3 + x^3)</c> had no antiderivative, and neither did <c>1/(a^4 - x^4)</c>,
+        /// <c>1/(a^5 + x^5)</c> or any of the family <c>1/(x^k (a^n ± x^n))</c> — while
+        /// <c>1/(8 + x^3)</c> and <c>1/(16 - x^4)</c> are answered at once. The parameter is the
+        /// whole difference: the rational rules read a denominator as a polynomial <b>over the
+        /// rationals</b>, and <c>a^3</c> is not a rational coefficient, so the factoring that
+        /// answers <c>x^3 + 8</c> has nothing to work with on <c>x^3 + a^3</c>.
+        /// </para>
+        /// <para>
+        /// <b>Scaling puts the parameter where it does no harm.</b> With <c>x = c t</c> and
+        /// <c>dx = c dt</c>, a homogeneous integrand becomes <c>c^k</c> times a function of
+        /// <c>t</c> alone: <c>1/(a^3 + x^3)</c> becomes <c>a^(-2) / (1 + t^3)</c>, whose
+        /// denominator has integer coefficients again. The parameter comes back out as a constant
+        /// factor and the answer is read at <c>t = x/c</c>.
+        /// </para>
+        /// <para>
+        /// <b>Homogeneity is checked rather than assumed</b>, and it is what makes this
+        /// terminate. The scaled integrand has to be exactly <c>c^k h(t)</c> for a whole
+        /// <c>k</c>, which is verified by dividing it out; only <c>h</c> is handed on, so the
+        /// sub-problem has one variable and cannot be scaled again. Without that check the rule
+        /// would hand on something still carrying <c>c</c> and scale it once more at every level.
+        /// </para>
+        /// <para>
+        /// <b>What it is not defined at.</b> <c>c = 0</c> is not a scaling, and the answer this
+        /// produces is undefined there rather than wrong — <c>a^(-2) G(x/a)</c> has no value at
+        /// <c>a = 0</c>, which is the honest report for a substitution that does not exist. The
+        /// integrand itself is a different function there (<c>1/(a^3 + x^3)</c> is <c>1/x^3</c>),
+        /// and is answered on its own if asked that way.
+        /// </para>
+        /// https://github.com/asc-community/AngouriMath/issues/718
+        /// </remarks>
+        internal static Entity? SolveByScalingTheVariable(Entity expr, Entity.Variable x, bool integrateByParts)
+        {
+            // One parameter, and it is the scale. Two would each need their own and neither
+            // clears the other; none means there is nothing in the way to begin with.
+            Entity.Variable? scale = null;
+            foreach (var variable in expr.Vars)
+            {
+                if (variable == x)
+                    continue;
+                if (scale is not null)
+                    return null;
+                scale = variable;
+            }
+            if (scale is null)
+                return null;
+
+            // dx = c dt.
+            var t = Variable.CreateUnique(expr, "u_scale");
+            var scaled = (expr.Substitute(x, scale * t) * scale).Simplify();
+            if (scaled.ContainsNode(x))
+                return null;
+
+            // c^k h(t), with h read off at c = 1 and k found by dividing it out. A scaled
+            // integrand that is not of that shape is not homogeneous and is declined.
+            // The integrand with the scale set to one is the candidate h(t), and what is left
+            // over when the scaled integrand is divided by it is the candidate factor. Read off
+            // rather than searched for: if the two do separate, the quotient *is* the factor.
+            var withoutScale = scaled.Substitute(scale, Number.Integer.One).Simplify();
+            if (withoutScale.ContainsNode(scale) || withoutScale == Number.Integer.Zero)
+                return null;
+
+            var factor = (scaled / withoutScale).Simplify();
+            // Collapsing the quotient attaches the condition that the denominator it cleared is
+            // non-zero. That denominator is the integrand's own, so the condition says where the
+            // integrand is defined and nothing about this rewrite; it is dropped for the same
+            // reason the other rewrites drop theirs.
+            if (factor is Providedf(var withoutCondition, _))
+                factor = withoutCondition;
+
+            // The whole of the homogeneity check. If the scale did not separate, what is left
+            // still mentions t, and handing that on would carry the parameter into the
+            // sub-problem -- which could then be scaled again, at every level, without end.
+            if (factor.ContainsNode(t) || factor.ContainsNode(x))
+                return null;
+
+            if (Integration.ComputeIndefiniteIntegral(withoutScale, t, integrateByParts) is not { } result)
+                return null;
+
+            var answer = (factor * result).Substitute(t, x / scale);
             return answer.Nodes.Any(node => node == MathS.NaN) ? null : answer;
         }
 

--- a/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
@@ -381,6 +381,10 @@ namespace AngouriMath.Functions.Algebra
             // The exponential substitution beside the other rewrites. It is also what integrates
             // the hyperbolic functions, which are not nodes here but quotients of exponentials.
             if ((answer = IndefiniteIntegralSolver.SolveByExponentialSubstitution(expr, x, integrateByParts)) is { }) return answer;
+            // Last of the rewrites, because it is the only one that fires on an integrand nothing
+            // is wrong with -- it clears a parameter rather than a shape -- so everything that
+            // can answer the problem as written gets to try first.
+            if ((answer = IndefiniteIntegralSolver.SolveByScalingTheVariable(expr, x, integrateByParts)) is { }) return answer;
             if (integrateByParts && (answer = IndefiniteIntegralSolver.SolveIntegratingByParts(expr, x)) is { }) return answer;
             return null;
         }

--- a/Sources/Tests/UnitTests/Calculus/ScaledVariableIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ScaledVariableIntegralTest.cs
@@ -1,0 +1,147 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// Integrands carrying one symbolic parameter, which <c>x = c t</c> scales away.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>1/(8 + x^3)</c> is answered at once and <c>1/(a^3 + x^3)</c> was not, which is the whole
+    /// shape of the gap: the rational rules read a denominator as a polynomial <b>over the
+    /// rationals</b>, and <c>a^3</c> is not a rational coefficient. Scaling by the parameter puts
+    /// integer coefficients back and the parameter comes out as a constant factor.
+    /// </para>
+    /// <para>
+    /// The parameter is pinned to a value for the numeric comparison only; every antiderivative
+    /// here was found symbolically, in <c>a</c>.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class ScaledVariableIntegralTest
+    {
+        /// <summary>
+        /// Away from zero on both sides, since several of these have a pole at the origin.
+        /// </summary>
+        private static readonly double[] Points = { -0.5, 0.23, 0.61, 1.05, 2.3 };
+
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x")
+                .Substitute("a", 1.7).Substitute("b", 0.9);
+            var original = integrand.ToEntity().Substitute("a", 1.7).Substitute("b", 0.9);
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 4,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}, "
+                + "so this asserts almost nothing");
+        }
+
+        /// <summary>A sum or difference of like powers, with the parameter in one of them.</summary>
+        [Theory]
+        [InlineData("1/(a^3 + x^3)")]
+        [InlineData("x/(a^3 + x^3)")]
+        [InlineData("1/(a^4 - x^4)")]
+        [InlineData("x^2/(a^4 + x^4)")]
+        public void ASumOfLikePowers(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// The same over a power of the variable, which is where the family runs long in Rubi's
+        /// suites — each of these was unevaluated.
+        /// </summary>
+        [Theory]
+        [InlineData("1/(x*(a^3 + x^3))")]
+        [InlineData("1/(x^2*(a^3 + x^3))")]
+        [InlineData("1/(x^3*(a^3 + x^3))")]
+        [InlineData("1/(x^4*(a^3 + x^3))")]
+        [InlineData("1/(x^5*(a^3 + x^3))")]
+        [InlineData("1/(x*(a^4 - x^4))")]
+        [InlineData("1/(x^2*(a^4 - x^4))")]
+        [InlineData("1/(x^3*(a^4 - x^4))")]
+        [InlineData("1/(x^4*(a^4 - x^4))")]
+        public void OverAPowerOfTheVariable(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// A constant factor inside the denominator, which the two branches taking a factor out
+        /// of a quotient both missed because neither side was wholly free of the variable.
+        /// </summary>
+        [Theory]
+        [InlineData("1/(a*(1 + x^3))")]
+        [InlineData("1/(a^2*(1 + x^3))")]
+        [InlineData("1/(2*a*(1 + x^4))")]
+        [InlineData("x/(a*(1 + x^3))")]
+        [InlineData("1/(a*(1 + x^2))")]
+        public void AConstantFactorInsideTheDenominator(string integrand)
+            => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// What was already answered and has to stay answered. The scaling rule fires on
+        /// integrands nothing is wrong with, so it runs last and these prove it does not get in
+        /// front of anything.
+        /// </summary>
+        [Theory]
+        [InlineData("a*sin(x)")]
+        [InlineData("a*x^2")]
+        [InlineData("a/x")]
+        [InlineData("sin(a*x)")]
+        [InlineData("x*e^(a*x)")]
+        [InlineData("1/(1 + x^3)")]
+        public void WhatWasAlreadyAnswered(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// Two parameters is a decline, and deliberately: scaling by one leaves the other, so the
+        /// sub-problem would still carry a parameter and could be scaled again without end. The
+        /// homogeneity check is what stops it, and this is the case that exercises the check
+        /// rather than the substitution.
+        /// </summary>
+        [Theory]
+        [InlineData("x/((a^2 + x^2)*(b^2 + x^2))")]
+        [InlineData("x^2/((a^2 + x^2)*(b^2 + x^2))")]
+        public void TwoParametersAreDeclined(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("u_scale", integral.Stringize());
+        }
+
+        /// <summary>
+        /// An integrand that is not homogeneous in the parameter, so the scale does not separate.
+        /// Declined for the same reason, and this is the case where the substitution applies
+        /// cleanly and the check still has to refuse it.
+        /// </summary>
+        [Theory]
+        [InlineData("1/(a + x^3)")]
+        [InlineData("1/(a^2 + x^3)")]
+        public void AnInhomogeneousParameterIsDeclined(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            // Whatever it answers must not be built on a substitution that does not hold.
+            if (!integral.Stringize().Contains("integral("))
+                DifferentiatesBack(integrand);
+        }
+    }
+}


### PR DESCRIPTION
`1/(8 + x^3)` and `1/(16 - x^4)` are answered at once. `1/(a^3 + x^3)` and `1/(a^4 - x^4)` were not.

The parameter is the whole difference. The rational rules read a denominator as a polynomial **over
the rationals** — `TryGetRationalCoefficients` is the gate — so `a^3` is not a coefficient they can
work with, and the factoring that answers `x^3 + 8` has nothing to hold on to for `x^3 + a^3`.

Measured rather than assumed, on `master`:

```
ok   1/(8 + x^3)        ok   1/(16 - x^4)
NO   1/(a^3 + x^3)      NO   1/(a^4 - x^4)
```

### Two things were in the way

**A constant factor inside the denominator stayed there.** The two branches that take a factor out
of a quotient each want the whole of one side free of the variable, so `a * (1/(1 + x^3))` was taken
apart and `1/(a*(1 + x^3))`, the same number, was not. Taking the constant out now happens *first*,
before the branch that turns `c/g(x)` into `c * g(x)^(-1)` — a power being a shape the rational
rules do not read, that ordering is what decides these.

**And the integrand is scaled by its parameter.** With `x = c t` and `dx = c dt` a homogeneous
integrand becomes a constant times a function of `t` alone: `1/(a^3 + x^3)` becomes
`a^(-2)/(1 + t^3)`, whose denominator has integer coefficients again. The answer is read at
`t = x/c`.

### Homogeneity is checked, and the check is what makes it terminate

The scaled integrand has to divide into a factor free of `t` times a function of `t`, and only the
second is handed on — so the sub-problem has one variable and cannot be scaled again. Without that,
the rule would hand on something still carrying `c` and scale it once more at every level.

`x/((a^2 + x^2)*(b^2 + x^2))` is declined for exactly that reason: scaling by one parameter leaves
the other. It is in the tests as a decline, so the check is exercised rather than assumed.

### Measured on Rubi's independent test suites

Same corpus and flags, both arms on this machine:

| | solved | wrong | timeouts | wall clock |
|---|--:|--:|--:|--:|
| `2dbeedf7` (master) | 913 | 0 | 13 | 722 s |
| + this | **929** | **0** | 16 | 794 s |

Sixteen more answers and no wrong ones, for about 10% more wall clock. Newly answered includes the
whole `1/(x^k (a^n ± x^n))` family, which is where this runs long in Timofeev's set. Each was also
checked by differentiating it back with the parameter pinned and comparing at five points.

### Where the answer is not defined

`c = 0` is not a scaling, and `a^(-2) G(x/a)` has no value there. That is the honest report for a
substitution that does not exist rather than a wrong answer — and `1/(a^3 + x^3)` at `a = 0` is a
different function, `1/x^3`, which is answered on its own if asked that way. Recorded in
`BREAKING-CHANGES.md` rather than left to be discovered.

### Ordering

It runs **last** of the rewrites, because unlike the others it fires on an integrand nothing is
wrong with — it clears a parameter rather than a shape. `a*sin(x)`, `a*x^2`, `a/x`, `sin(a*x)`,
`x*e^(a*x)` and `1/(1 + x^3)` are all in the tests to hold that: they were answered before and are
answered by the same rules now.

### Suites

`UnitTests` 8514 and 1557, `FSharpWrapperUnitTests` 134, `InteractiveWrapperUnitTests` 18,
`TerminalUnitTests` 41. New file `ScaledVariableIntegralTest.cs`, 28 cases.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
