### PR TITLE
A sum is split before anything searches it, and a polynomial stops taking exponential time to integrate

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -300,3 +300,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/QuotientSpellingIntegralTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/PolynomialSumIntegralTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
@@ -343,6 +343,24 @@ namespace AngouriMath.Functions.Algebra
             // switched it off -- which is a cycle, since by parts calls back into here.
             // `x * ln(x)` went round it until the stack ran out.
             if ((answer = IndefiniteIntegralSolver.SolveAsPolynomialTerm(expr, x, integrateByParts)) is { }) return answer;
+            // An integrand *already written* as a sum is split here, before any search. Every
+            // rule below does speculative work on the whole sum first, and on a polynomial that
+            // costs everything: the terms of `1 + 2x + ... + 25x^24` integrate in under a
+            // millisecond between them, and the sum they add up to took 20 seconds.
+            //
+            //     degree               4     8     12     16     20     24
+            //     was              64ms  384ms  705ms  708ms  2.6s   20.1s
+            //     is               69ms   69ms  141ms  213ms  138ms  0.16s
+            //
+            // **Only a sum, and deliberately not a product with a sum in it.** Expanding one is a
+            // rewrite, and a rewrite this early takes answers away from the rules that give
+            // better ones: `x * (x^2 + 1)^3` is `(x^2 + 1)^4/8` by substitution and a written-out
+            // degree-8 polynomial by expanding, both right and only one worth reading. Three
+            // tests pinned exactly that and caught this when the split was put in front of the
+            // substitution wholesale. The expanding call stays where it was, below.
+            if (expr is Entity.Sumf or Entity.Minusf
+                && (answer = IndefiniteIntegralSolver.SolveBySplittingSum(expr, x, integrateByParts)) is { })
+                return answer;
             if ((answer = IndefiniteIntegralSolver.SolveLogarithmic(expr, x, integrateByParts)) is { }) return answer;
             if ((answer = IndefiniteIntegralSolver.SolveBySubstitution(expr, x, integrateByParts)) is { }) return answer;
             // After the general substitution rather than inside it, because the general one
@@ -351,19 +369,16 @@ namespace AngouriMath.Functions.Algebra
             // the substitution is no longer visible. This one rewrites rather than divides.
             if ((answer = IndefiniteIntegralSolver.SolveByTangentSubstitution(expr, x, integrateByParts)) is { }) return answer;
             if ((answer = IndefiniteIntegralSolver.SolveByPartialFractions(expr, x, integrateByParts)) is { }) return answer;
-            // Linearity comes before integration by parts, because it decomposes the problem
-            // into strictly simpler ones where by parts searches. It cannot cost an answer:
-            // splitting returns null unless *every* term integrates, so a sum that only comes
-            // out whole still falls through to by parts below.
-            //
-            // A product with a sum in it -- sin(a+f*x)^4 * (5 - 6*sin(a+f*x)^2) -- reaches
-            // this as a product, so only the expansion here finds the two terms it is. Behind
-            // by parts it never did: the search spent the whole budget first and the caller
-            // waited over 20 seconds to be told nothing, where the split answers in 0.16.
+            // Linearity again, and this time with the expansion: a product with a sum in it --
+            // sin(a+f*x)^4 * (5 - 6*sin(a+f*x)^2) -- reaches this as a product, so only the
+            // expansion finds the two terms it is. Behind by parts it never did: the search spent
+            // the whole budget first and the caller waited over 20 seconds to be told nothing,
+            // where the split answers in 0.16.
             // https://github.com/asc-community/AngouriMath/issues/779
             //
-            // Expansion is bounded by MaxExpansionTermCount, which returns null rather than
-            // building the terms, so putting it earlier cannot blow the tree up either.
+            // It cannot cost an answer: splitting returns null unless *every* term integrates, so
+            // a sum that only comes out whole still falls through to by parts below. Expansion is
+            // bounded by MaxExpansionTermCount, which returns null rather than building the terms.
             if ((answer = IndefiniteIntegralSolver.SolveBySplittingSum(expr, x, integrateByParts)) is { }) return answer;
             // The half-angle substitution goes *after* linearity, and that is not a preference.
             // It fires on anything built from sines and cosines, and it answers `cos(x) + 1` with

--- a/Sources/Tests/UnitTests/Calculus/PolynomialSumIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/PolynomialSumIntegralTest.cs
@@ -1,0 +1,104 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Diagnostics;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// A long sum is split before anything searches it, so integrating a polynomial costs about
+    /// what integrating its terms costs.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Splitting a sum used to run fifth, behind the logarithm, two substitutions and partial
+    /// fractions, each of which searched the <em>whole</em> sum first. The terms of
+    /// <c>1 + 2x + ... + 25x^24</c> integrate in under a millisecond between them; the sum they
+    /// add up to took twenty seconds, and every four more degrees roughly tripled it.
+    /// </para>
+    /// <para>
+    /// <b>What this test binds is the shape of the cost, not a number of milliseconds.</b> The
+    /// wall below is minutes where the work is a fraction of a second — it cannot fire on a slow
+    /// runner, only on the growth coming back. A degree-40 polynomial on the old ordering
+    /// extrapolates to something over twenty minutes.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class PolynomialSumIntegralTest
+    {
+        private static Entity Polynomial(int degree)
+        {
+            Entity built = 1;
+            for (var power = 1; power <= degree; power++)
+                built += (power + 1) * MathS.Pow(MathS.Var("x"), power);
+            return built;
+        }
+
+        /// <summary>
+        /// Degree 40, which is far past where the old ordering stopped returning in any useful
+        /// time. The bound is deliberately enormous: this is a test about growth.
+        /// </summary>
+        [Fact]
+        public void ALongPolynomialIsIntegratedWithoutSearchingIt()
+        {
+            var integrand = Polynomial(40);
+            var watch = Stopwatch.StartNew();
+            var integral = integrand.Integrate("x");
+            watch.Stop();
+
+            Assert.DoesNotContain("integral(", integral.Stringize());
+            Assert.True(watch.Elapsed < TimeSpan.FromMinutes(2),
+                $"a degree-40 polynomial took {watch.Elapsed.TotalSeconds:0.#} s to integrate, "
+                + "which is the growth this test exists to catch rather than a slow machine");
+        }
+
+        /// <summary>
+        /// And the answer is right, at several degrees, checked by differentiating back — a
+        /// faster wrong answer would satisfy the test above on its own.
+        /// </summary>
+        [Theory]
+        [InlineData(4)]
+        [InlineData(12)]
+        [InlineData(24)]
+        [InlineData(40)]
+        public void AndTheAnswerDifferentiatesBack(int degree)
+        {
+            var integrand = Polynomial(degree);
+            var integral = integrand.Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            foreach (var at in new[] { 0.3, 0.7, 1.1 })
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = integrand.Substitute("x", at).EvalNumerical();
+                var difference = Math.Abs((double)(got - want).RealPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of the degree-{degree} polynomial is {got} "
+                    + $"at x = {at}, where the integrand is {want}");
+            }
+        }
+
+        /// <summary>
+        /// The other half of the ordering, and the reason the early split reads only a sum. A
+        /// product with a sum in it is a rewrite away from being one, and expanding it that early
+        /// takes the answer away from the substitution that gives the shorter one — these come
+        /// out as a power, not as a written-out polynomial.
+        /// </summary>
+        [Theory]
+        [InlineData("x * (x ^ 2 + 1) ^ 3", "C + (x ^ 2 + 1) ^ 4 / 8")]
+        [InlineData("x * (x ^ 2 + 1) ^ 10", "C + (x ^ 2 + 1) ^ 11 / 22")]
+        public void AProductWithASumInItKeepsItsCompactAnswer(string integrand, string expected)
+            => Assert.Equal(expected.ToEntity().Simplify(),
+                            integrand.ToEntity().Integrate("x").Simplify());
+    }
+}


### PR DESCRIPTION
The terms of `1 + 2x + ... + 25x^24` integrate in **under a millisecond between them**. The sum they
add up to took **twenty seconds**, and every four more degrees roughly tripled it.

Splitting a sum ran fifth, behind the logarithm, the general substitution, the tangent substitution
and partial fractions. Each of those does speculative work on the *whole* sum before the cheap
decisive rule gets to take it apart, so the cost of a long sum is the cost of four searches over it.

### Measured

Integrating `1 + 2x + ... + (n+1)x^n` whole, on this machine, both arms:

| degree | 4 | 8 | 12 | 16 | 20 | 24 | 28 |
|---|--:|--:|--:|--:|--:|--:|--:|
| was | 64 ms | 384 ms | 705 ms | 708 ms | 2.6 s | **20.1 s** | >60 s |
| is | 70 ms | 94 ms | 180 ms | 124 ms | 170 ms | **157 ms** | 179 ms |

Every one of them differentiates back.

### Only an integrand already written as a sum

That restriction is the whole of the care needed here, and it was not obvious.
`GatherLinearChildrenOverSumAndExpand` also *expands* a product into a sum, and expanding this early
takes answers away from the rules that give better ones:

```
x * (x^2 + 1)^3     by substitution   (x^2 + 1)^4 / 8
                    by expanding      a written-out degree-8 polynomial
```

Both are right and only one is worth reading. Putting the split in front of everything wholesale
failed three tests that pin exactly those compact forms — `TestPowerSubstitution` and
`TestHighPowerSubstitution` — which is how this was caught. The expanding call stays where it was,
after partial fractions; the early one reads a `Sumf` or `Minusf` and nothing else.

It cannot cost an answer either way: splitting returns null unless *every* term integrates, so a sum
that only comes out whole still falls through to all of them below.

### The corpus is neutral, and the number needs reading

| | solved | wrong | timeouts | wall clock |
|---|--:|--:|--:|--:|
| `2dbeedf7` (master) | 913 | 0 | 13 | 722 s |
| + this | 912 | 0 | 17 | 758 s |

That is the harness's own wobble rather than a cost, and what settles it is the list rather than the
number. Four verdicts moved. Three are the same problem reading `Unsolved` before and `Timeout`
after — one refusal spelled two ways, no answer lost. The fourth, `tanh(x)^5/sech(x)^4`, measures
**31.5 s on master and 31.0 s here** against a 5 s budget: it was recorded as solved once and timed
out once because the integrator's answer cache is process-wide and the harness restarts its worker
after a timeout, so a case this far past the budget is graded by whatever ran before it.

The corpus contains no long polynomial sums, which is why the win does not show there. It is a
plausible thing for a caller to ask.

### The test binds growth, not milliseconds

A degree-40 polynomial against a **two-minute** wall, where the work is now under a second and the
old ordering extrapolates past twenty minutes. That wall cannot fire on a slow runner, only on the
growth coming back. Correctness is asserted separately, by differentiating back at four degrees — a
faster wrong answer would satisfy a timing test on its own.

### Suites

`UnitTests` 8514 and 1529, `FSharpWrapperUnitTests` 134, `InteractiveWrapperUnitTests` 18,
`TerminalUnitTests` 41. New file `PolynomialSumIntegralTest.cs`, 7 cases.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
