### PR TITLE
NaN was returned as the antiderivative of 1/(a x^2), which has one

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -172,6 +172,31 @@ one leaves the other, and the sub-problem could then be scaled again without end
 substitution that does not exist rather than a wrong answer, and the integrand at `a = 0` is a
 different function (`1/x^3`), answered on its own if asked that way.
 
+### `NaN` was returned as the antiderivative of something that has one
+
+**A wrong answer, not a missing one.** `1/(a*x^2)` came back as `NaN + C`, and `NaN` is this
+library's way of saying the thing does not exist. It does exist: it is `-1/(a x)`.
+
+| | Was | Is |
+|---|---|---|
+| `"1/(a*x^2)".Integrate("x")` | `NaN + C` | the antiderivative, `-1/(a x)` up to form |
+| `"1/((a + b)*x^2)".Integrate("x")`, and every symbolic constant times `x^2` | `NaN + C` | the antiderivative |
+| `"1/(a*x^2 + b*x^2)".Integrate("x")`, and the same collected differently | `NaN + C` | the antiderivative |
+
+The rule for a constant over a quadratic answers with a piecewise over the discriminant, and one of
+its branches is for `a = 0`, where the denominator is linear. With `b` and `c` both zero that branch
+computes `k/0`. A **numeric** `a` makes the branch decidably false and it is dropped before the
+`NaN` can spread, which is why `1/(2*x^2)` was always right; a symbolic `a` leaves it standing, and
+one `NaN` case takes the whole piecewise with it.
+
+The branch is now left out entirely when the denominator has neither a linear nor a constant term,
+because there it asks about an expression that does not exist — with `a`, `b` and `c` all zero the
+denominator is identically zero and there is no integrand to integrate. What is left is the
+zero-discriminant arm, which gives the right answer.
+
+Each of these was checked by differentiating it back with the parameters pinned and comparing at
+four points. Nothing that already had an antiderivative changes.
+
 ---
 
 ## 2.5.0 — since 2.4.0

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -306,3 +306,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/BiquadraticFactorIntegralTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/QuadraticDenominatorNaNTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IntegralPatterns.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IntegralPatterns.cs
@@ -510,10 +510,20 @@ namespace AngouriMath.Functions.Algebra
             // the whole piecewise with it. That is only ever reached when a is symbolic, since
             // a numeric a makes this arm decidably unreachable and it is dropped before the
             // NaN can propagate -- so k/(a x^2 + c) answered NaN while k/(2 x^2 + c) did not.
+            // And where c is zero as well, that constant is k/0: with a, b and c all zero the
+            // denominator is identically zero and there is no integrand to have an
+            // antiderivative. So the branch is not merely unreachable, it is asking about an
+            // expression that does not exist, and the piecewise leaves it out rather than
+            // carrying a NaN that swallows the cases that do exist. `1/(a*x^2)` came back as
+            // `NaN + C` -- an assertion that it has no antiderivative -- where it is `-1/(a x)`,
+            // read off the perfect-square arm below, which is exactly what a zero discriminant
+            // gives here. https://github.com/asc-community/AngouriMath/issues/718
+            var denominatorVanishesWithoutA = TreeAnalyzer.IsZero(b) && TreeAnalyzer.IsZero(c);
             var linearCase = TreeAnalyzer.IsZero(b)
                 ? numerator * x / c
                 : numerator * AntiderivativeLog(b * x + c) / b;
-            
+
+
             // For true quadratics (a ≠ 0), discriminant Δ = 4ac - b^2 determines the form
             var discriminant = 4 * a * c - b * b;
             
@@ -534,12 +544,13 @@ namespace AngouriMath.Functions.Algebra
             var lnCase = numerator * AntiderivativeLog((twoAxPlusB - sqrtNegDiscriminant) / (twoAxPlusB + sqrtNegDiscriminant)) / sqrtNegDiscriminant;
             
             // Return as piecewise based on a and discriminant
-            return MathS.Piecewise([
-                new Entity.Providedf(linearCase, a.EqualTo(0)),
-                new Entity.Providedf(arctanCase, discriminant > 0),
-                new Entity.Providedf(perfectSquareCase, discriminant.EqualTo(0)),
-                new Entity.Providedf(lnCase, discriminant < 0)
-            ]).InnerSimplified;
+            var cases = new List<Entity.Providedf>();
+            if (!denominatorVanishesWithoutA)
+                cases.Add(new Entity.Providedf(linearCase, a.EqualTo(0)));
+            cases.Add(new Entity.Providedf(arctanCase, discriminant > 0));
+            cases.Add(new Entity.Providedf(perfectSquareCase, discriminant.EqualTo(0)));
+            cases.Add(new Entity.Providedf(lnCase, discriminant < 0));
+            return MathS.Piecewise(cases).InnerSimplified;
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Calculus/QuadraticDenominatorNaNTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/QuadraticDenominatorNaNTest.cs
@@ -1,0 +1,94 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// A denominator that is a symbolic multiple of <c>x^2</c> has an antiderivative, and the
+    /// integrator used to answer <c>NaN</c> — which says the opposite.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>1/(a*x^2)</c> came back as <c>NaN + C</c>, where it is <c>-1/(a x)</c>. The rule for a
+    /// constant over a quadratic returns a piecewise over the discriminant with a branch for
+    /// <c>a = 0</c>, and with <c>b</c> and <c>c</c> both zero that branch computes <c>k/0</c>. A
+    /// symbolic <c>a</c> makes it undecidable, so the branch stays, and one <c>NaN</c> case takes
+    /// the whole piecewise with it.
+    /// </para>
+    /// <para>
+    /// <b>Unevaluated and <c>NaN</c> are different answers.</b> The first says the library could
+    /// not settle it; the second says the antiderivative does not exist. These exist, so
+    /// <c>NaN</c> was a wrong answer rather than a missing one — which is why this is asserted
+    /// as a value and not merely as "not <c>NaN</c>".
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class QuadraticDenominatorNaNTest
+    {
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            var written = integral.Stringize();
+            Assert.DoesNotContain("integral(", written);
+            Assert.DoesNotContain("NaN", written);
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x")
+                .Substitute("a", 1.3).Substitute("b", 0.7).Substitute("c", 2.1);
+            var original = integrand.ToEntity()
+                .Substitute("a", 1.3).Substitute("b", 0.7).Substitute("c", 2.1);
+            var compared = 0;
+            foreach (var at in new[] { 0.4, 0.9, 1.6, -0.7 })
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 3,
+                $"only {compared} points were comparable for {integrand}");
+        }
+
+        /// <summary>
+        /// The denominator is a symbolic constant times <c>x^2</c>, however that constant is
+        /// written — one symbol, a sum of them, or the sum the terms collect into.
+        /// </summary>
+        [Theory]
+        [InlineData("1/(a*x^2)")]
+        [InlineData("1/((a + b)*x^2)")]
+        [InlineData("1/(a*x^2 + b*x^2)")]
+        [InlineData("1/(a*x^2 + b*x^2 + c*x^2)")]
+        public void ASymbolicMultipleOfXSquared(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// The neighbours, which were right and have to stay right. A numeric coefficient never
+        /// reached the bad branch — the <c>a = 0</c> case is decidably false and dropped — and a
+        /// denominator with a linear or constant term takes a different arm of the piecewise.
+        /// </summary>
+        [Theory]
+        [InlineData("1/x^2")]
+        [InlineData("1/(2*x^2)")]
+        [InlineData("1/(a*x^2 + b*x)")]
+        [InlineData("1/(a*x^2 + b)")]
+        [InlineData("1/(a*x + b*x)")]
+        [InlineData("1/(x^2 + 1)")]
+        [InlineData("1/(x^2 - 1)")]
+        [InlineData("1/(2*x^2 + 3*x + 1)")]
+        [InlineData("1/(a*x^2 + b*x + c)")]
+        public void TheNeighbouringShapes(string integrand) => DifferentiatesBack(integrand);
+    }
+}


### PR DESCRIPTION
`1/(a*x^2)` came back as `NaN + C`.

That is **a wrong answer, not a missing one**. Unevaluated says the library could not settle it;
`NaN` says the antiderivative does not exist. This one exists — it is `-1/(a x)`.

```
1/x^2         →  ok
1/(2*x^2)     →  ok
1/(a*x^2)     →  NaN + C
```

### Where it comes from

The rule for a constant over a quadratic answers with a piecewise over the discriminant, and one
branch covers `a = 0`, where the denominator is linear rather than quadratic. That branch already
carried a guard for `b = 0`, added for this same class of bug, whose comment reads:

> Where the denominator has no x term the integrand is the constant `k/c` and its antiderivative is
> `kx/c`; writing the logarithm there divides by zero, and a `Providedf` carrying `NaN` takes the
> whole piecewise with it.

One case short. With `b` **and** `c` both zero, `numerator * x / c` divides by zero in its turn. A
numeric `a` makes the branch decidably false and it is dropped before the `NaN` can spread — which
is why `1/(2*x^2)` was always right. A symbolic `a` leaves the branch standing, and one `NaN` case
takes the piecewise with it.

### The fix

Where the denominator has neither a linear nor a constant term, the branch is left out entirely
rather than guarded with another value. It is not merely unreachable: with `a`, `b` and `c` all
zero the denominator is identically zero, so the branch is asking about an expression that does not
exist. What remains is the zero-discriminant arm, and for `k/(a x^2)` that is `-2k/(2 a x)` — right.

### How it was found

By running `intbench` over Rubi's **algebraic** family, which this session had not measured before.
It grades by differentiating back, and reported three wrong answers on master. Two were this. The
third, `x^24*(a*x+b*x^38)^12`, differs in the sixteenth significant digit and is a tolerance
artefact rather than a defect.

**Pre-existing** — present at `35bb061b`, before any of this session's merges.

### Newly right

Each verified by differentiating back at four points with the parameters pinned:

| |
|---|
| `1/(a*x^2)`, `1/((a + b)*x^2)` |
| `1/(a*x^2 + b*x^2)`, `1/(a*x^2 + b*x^2 + c*x^2)` |

The neighbours are in the tests too — `1/(2*x^2)`, `1/(a*x^2 + b*x)`, `1/(a*x^2 + b)`,
`1/(a*x^2 + b*x + c)` — since they were right and the change must keep them so.

Recorded in `BREAKING-CHANGES.md`: it changes an answer, even though the old one was `NaN`.

### Suites

`UnitTests` 8514 and 1604, `FSharpWrapperUnitTests` 134, `InteractiveWrapperUnitTests` 18,
`TerminalUnitTests` 41. New file `QuadraticDenominatorNaNTest.cs`, 13 cases.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
