### PR TITLE
A power whose base holds the variable is written out, so (2x + 3x^2)^3 has an antiderivative

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -312,3 +312,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/QuadraticDenominatorNaNTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/ExpandedPowerIntegralTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -753,6 +753,51 @@ namespace AngouriMath.Functions.Algebra
             return answer.Nodes.Any(node => node == MathS.NaN) ? null : answer;
         }
 
+        /// <summary>
+        /// A power whose base holds the variable, written out and integrated term by term.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>(2x + 3x^2)^3</c> had no antiderivative, and it is a polynomial. The rule for a
+        /// power integrates <c>x^n</c> and asks that the base <em>be</em> the variable, so a base
+        /// that merely contains it — any polynomial but a bare <c>x</c> — matched nothing, and
+        /// nothing else in the chain writes a power out. <c>(1 + x)^3</c> was answered only
+        /// because the linear substitution reads it.
+        /// </para>
+        /// <para>
+        /// <b>It runs last</b>, after every rule that can answer a power in its own terms.
+        /// Expanding throws away whatever structure the power had — <c>(1 + x^2)^2</c> is
+        /// answered as a power, and writing it out first would replace that answer with a longer
+        /// one saying the same thing.
+        /// </para>
+        /// <para>
+        /// <b>Only a positive whole exponent</b>, where writing it out is a finite identity. A
+        /// negative one is a quotient and belongs to partial fractions; a fractional one is a
+        /// radical and does not expand at all.
+        /// </para>
+        /// <para>
+        /// The expansion is bounded by <see cref="MathS.Settings.MaxExpansionTermCount"/> like
+        /// every other, and the rule declines where the expansion is not a sum — nothing was
+        /// written out, so handing it on would ask the same question again.
+        /// </para>
+        /// https://github.com/asc-community/AngouriMath/issues/718
+        /// </remarks>
+        internal static Entity? SolveByExpandingAPower(Entity expr, Entity.Variable x, bool integrateByParts)
+        {
+            if (expr is not Powf(var @base, Number.Integer power))
+                return null;
+            if (power.EInteger.CompareTo(EInteger.One) <= 0)
+                return null;
+            if (!@base.ContainsNode(x))
+                return null;
+
+            var written = expr.Expand();
+            if (written is not Sumf and not Minusf)
+                return null;
+
+            return Integration.ComputeIndefiniteIntegral(written, x, integrateByParts);
+        }
+
         private static int Lcm(int a, int b)
         {
             var (x, y) = (a, b);

--- a/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
@@ -405,6 +405,10 @@ namespace AngouriMath.Functions.Algebra
             // is wrong with -- it clears a parameter rather than a shape -- so everything that
             // can answer the problem as written gets to try first.
             if ((answer = IndefiniteIntegralSolver.SolveByScalingTheVariable(expr, x, integrateByParts)) is { }) return answer;
+            // After every rule that can answer a power in its own terms, because expanding one
+            // throws away whatever structure it had: (1 + x^2)^2 is answered as a power and only
+            // wants writing out if that fails.
+            if ((answer = IndefiniteIntegralSolver.SolveByExpandingAPower(expr, x, integrateByParts)) is { }) return answer;
             if (integrateByParts && (answer = IndefiniteIntegralSolver.SolveIntegratingByParts(expr, x)) is { }) return answer;
             return null;
         }

--- a/Sources/Tests/UnitTests/Calculus/ExpandedPowerIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ExpandedPowerIntegralTest.cs
@@ -1,0 +1,109 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// A power whose base holds the variable, written out and integrated term by term.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>(2x + 3x^2)^3</c> had no antiderivative, and it is a polynomial. The rule for a power
+    /// asks that the base <em>be</em> the variable, so a base that merely contains it matched
+    /// nothing, and nothing else in the chain writes a power out. <c>(1 + x)^3</c> was answered
+    /// only because the linear substitution happens to read it.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class ExpandedPowerIntegralTest
+    {
+        private static readonly double[] Points = { -0.5, 0.23, 0.61, 1.05, 2.3 };
+
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x").Substitute("a", 1.7);
+            var original = integrand.ToEntity().Substitute("a", 1.7);
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 4,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}, "
+                + "so this asserts almost nothing");
+        }
+
+        /// <summary>
+        /// A base that is not a bare variable and not linear either, so nothing upstream reads
+        /// it. Each of these is a polynomial and each was left unevaluated.
+        /// </summary>
+        [Theory]
+        [InlineData("(2*x + 3*x^2)^3")]
+        [InlineData("(2*x + 3*x^2)^2")]
+        [InlineData("(1 - 2*x - 2*x^2)^3")]
+        [InlineData("(x^2 + x)^4")]
+        [InlineData("(1 + x^3)^2")]
+        public void APolynomialBaseRaisedToAWholePower(string integrand)
+            => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// What was already answered, and by what. These reach the power rule or the linear
+        /// substitution first, and the expansion runs after both — so they are answered by the
+        /// same rules as before rather than written out.
+        /// </summary>
+        [Theory]
+        [InlineData("(1 + x)^3")]
+        [InlineData("(x + 1)^10")]
+        [InlineData("(1 + x^2)^2")]
+        [InlineData("sin(x)^2")]
+        public void WhatWasAlreadyAnswered(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// Exponents this must not touch. A negative one is a quotient and belongs to partial
+        /// fractions; a fractional one is a radical and does not expand at all. Both are
+        /// answered, and by something else.
+        /// </summary>
+        [Theory]
+        [InlineData("(1 + x^2)^(-1)")]
+        [InlineData("(1 + x^3)^(-1)")]
+        [InlineData("(1 + x^2)^(1/2)")]
+        [InlineData("sqrt(1 + x)")]
+        public void ANegativeOrFractionalExponentIsNotExpanded(string integrand)
+            => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// Still declined, so the boundary is recorded. The power is the numerator of a quotient
+        /// rather than the whole integrand, and this rule reads only the whole. Should something
+        /// later answer it, this moves rather than being deleted.
+        /// </summary>
+        [Theory]
+        [InlineData("(a - b*x^2)^3/x^7")]
+        public void APowerInsideAQuotientIsNotReached(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            if (!integral.Stringize().Contains("integral("))
+                DifferentiatesBack(integrand);
+        }
+    }
+}


### PR DESCRIPTION
`(2*x + 3*x^2)^3` had no antiderivative, and it is a polynomial.

The rule for a power integrates `x^n` and asks that the base **be** the variable, so a base that
merely contains it — any polynomial but a bare `x` — matched nothing, and nothing else in the chain
writes a power out. `(1 + x)^3` was answered only because the linear substitution happens to read
it.

### Newly answered

Each verified by differentiating back at sample points:

| |
|---|
| `(2x + 3x^2)^3`, `(2x + 3x^2)^2` |
| `(1 - 2x - 2x^2)^3`, `(x^2 + x)^4`, `(1 + x^3)^2` |

### Where it runs, and what it declines

**Last**, after every rule that can answer a power in its own terms. Expanding throws away whatever
structure the power had: `(1 + x^2)^2` is answered as a power, and writing it out first would
replace that answer with a longer one saying the same thing.

**Only a positive whole exponent**, where writing it out is a finite identity. A negative one is a
quotient and belongs to partial fractions; a fractional one is a radical and does not expand at all.
`(1 + x^2)^(-1)`, `(1 + x^3)^(-1)`, `(1 + x^2)^(1/2)` and `sqrt(1 + x)` are all in the tests, still
answered by what answered them before.

### This waited on #1250

Worth saying why, since it is the interesting part. Written against the old ordering, this rule
turned `(1 + x + x^2)^20` from an **instant refusal into over 370 seconds**. Expanding is instant
and produces 237 nodes; integrating the sum that came out was exponential in its length, because
splitting a sum ran behind four searches that each worked the whole sum first.

That is exactly what #1250 fixed. With it in place the same integrand is **1,003 ms** and correct:

```
(1+x+x^2)^10     729 ms   peak 78 MB   verified
(1+x+x^2)^14   1,094 ms   peak 84 MB   verified
(1+x+x^2)^20   1,003 ms   peak 98 MB   verified
```

Held back until the cause was gone, rather than shipped behind a size bound invented to hide it.

### No corpus figure, and the reason is the machine

`intbench` cannot complete a run here at present. **Master alone**, on the same family and flags,
now dies within seconds where the same command finished in 778 s earlier today, with 13 GB free.

I had read an earlier correlation the other way — runs carrying this rule died where others
completed — and a matched baseline does not support it. The one input its last run stopped at,
`(1-2*x)^3/((2+3*x)^8*(3+5*x)^2)`, exceeds 400 s on master too, so that hang is pre-existing and
not this rule's.

So the evidence here is the shapes above, the growth table, and the suites — not a corpus delta. If
you would rather have one before merging, it needs a machine that can finish a run.

### Suites

`UnitTests` 8514 and 1615, `FSharpWrapperUnitTests` 134, `InteractiveWrapperUnitTests` 18,
`TerminalUnitTests` 41. New file `ExpandedPowerIntegralTest.cs`, 14 cases.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
