### PR TITLE
An inverse trigonometric function is differentiated before a polynomial, which is the I of LIATE

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -315,3 +315,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/ExpandedPowerIntegralTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/InverseTrigByPartsTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -238,6 +238,32 @@ namespace AngouriMath.Functions.Algebra
             _ => null
         };
 
+        /// <summary>
+        /// Whether <paramref name="factor"/> is one of the functions integration by parts
+        /// differentiates rather than integrates when the other factor is a polynomial.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is the <b>L</b> and the <b>I</b> of LIATE, which both come before <b>A</b>. The
+        /// rule below implemented only the L, and the reason it gives for the logarithm is the
+        /// same one that holds for an inverse trigonometric function: differentiating it turns it
+        /// into something algebraic that cancels against the integrated polynomial and ends,
+        /// where integrating it puts the original integral back in front of us.
+        /// </para>
+        /// <para>
+        /// <c>x * atan(x)</c> is the case: differentiating <c>atan</c> gives <c>1/(1 + x^2)</c>
+        /// and what is left is <c>x^2/(2(1 + x^2))</c>, which is answered; integrating it first
+        /// gives an antiderivative holding <c>x*atan(x)</c> again, which is where the search went
+        /// instead and why it was left unevaluated.
+        /// </para>
+        /// https://github.com/asc-community/AngouriMath/issues/718
+        /// </remarks>
+        private static bool IsDifferentiatedBeforeAPolynomial(Entity factor)
+            => factor is Logf
+                or Entity.Arcsinf or Entity.Arccosf
+                or Entity.Arctanf or Entity.Arccotanf
+                or Entity.Arcsecantf or Entity.Arccosecantf;
+
         internal static Entity? SolveIntegratingByParts(Entity expr, Entity.Variable x)
         {
             // Standard integration by parts for polynomial × function
@@ -286,9 +312,9 @@ namespace AngouriMath.Functions.Algebra
                 // that is how integral(x * ln(x), x) recursed until the stack ran out.
                 // Differentiating the logarithm instead turns it into 1/x, which cancels
                 // against the integrated polynomial and ends. (The L-before-A of LIATE.)
-                if (f is Logf && MathS.TryPolynomial(g, x, out _)
+                if (IsDifferentiatedBeforeAPolynomial(f) && MathS.TryPolynomial(g, x, out _)
                     && TryIntegrateByPartsOnce(f, g, x) is { } logFirstF) return logFirstF;
-                if (g is Logf && MathS.TryPolynomial(f, x, out _)
+                if (IsDifferentiatedBeforeAPolynomial(g) && MathS.TryPolynomial(f, x, out _)
                     && TryIntegrateByPartsOnce(g, f, x) is { } logFirstG) return logFirstG;
 
                 // Case 1: One term is polynomial - use recursive polynomial integration by parts

--- a/Sources/Tests/UnitTests/Calculus/InverseTrigByPartsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/InverseTrigByPartsTest.cs
@@ -1,0 +1,118 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// An inverse trigonometric function times a polynomial is integrated by parts with the
+    /// inverse function differentiated — the <b>I</b> of LIATE, which comes before <b>A</b>.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The rule already made this choice for a logarithm and for nothing else, so
+    /// <c>x * ln(x)</c> was answered and <c>x * atan(x)</c> was not. Its stated reason holds for
+    /// both: differentiating turns the function into something algebraic that cancels against the
+    /// integrated polynomial and ends, where integrating it puts the original integral back in
+    /// front of us.
+    /// </para>
+    /// <para>
+    /// <b>Where it stops, and why.</b> <c>atan</c> and <c>acot</c> differentiate to rational
+    /// functions, so what is left is rational and answered. <c>asin</c> and <c>acos</c>
+    /// differentiate to <c>1/sqrt(1 - x^2)</c>, so what is left is a radical integrand and is a
+    /// different gap — the choice of which factor to differentiate is right for those too, and it
+    /// is the remainder that is not read.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class InverseTrigByPartsTest
+    {
+        /// <summary>Inside the unit interval, where every inverse function here is real.</summary>
+        private static readonly double[] Points = { 0.13, 0.37, 0.61, 0.82 };
+
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            var written = integral.Stringize();
+            Assert.DoesNotContain("integral(", written);
+            Assert.DoesNotContain("NaN", written);
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 3,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}");
+        }
+
+        /// <summary>
+        /// The arctangent and arccotangent, whose derivatives are rational, so the remaining
+        /// integral is one the rational rules read. None of these had an antiderivative.
+        /// </summary>
+        [Theory]
+        [InlineData("x * atan(x)")]
+        [InlineData("x ^ 3 * atan(x)")]
+        [InlineData("x * acot(x)")]
+        public void AnArctangentTimesAPolynomial(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// The logarithm, which made this choice already and must go on making it, and the bare
+        /// inverse functions, which are answered by their own rules rather than by this one.
+        /// </summary>
+        [Theory]
+        [InlineData("x * ln(x)")]
+        [InlineData("x ^ 2 * ln(x)")]
+        [InlineData("ln(x)")]
+        [InlineData("atan(x)")]
+        [InlineData("asin(x)")]
+        [InlineData("acos(x)")]
+        public void WhatWasAlreadyAnswered(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// Unrelated products by parts, which must be unaffected: the polynomial is the factor to
+        /// differentiate in each of these, and it still is.
+        /// </summary>
+        [Theory]
+        [InlineData("x * e ^ x")]
+        [InlineData("x * sin(x)")]
+        [InlineData("e ^ x * sin(x)")]
+        public void OrdinaryProductsAreUnaffected(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// Still declined, and recorded rather than assumed. <c>asin</c> and <c>acos</c>
+        /// differentiate to <c>1/sqrt(1 - x^2)</c>, so what is left over is a radical integrand
+        /// this library does not read — a different gap from which factor to differentiate.
+        /// Should something later answer them, these move rather than being deleted.
+        /// </summary>
+        [Theory]
+        [InlineData("x * asin(x)")]
+        [InlineData("x ^ 2 * acos(x)")]
+        public void AnArcsineLeavesARadicalAndIsDeclined(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            // What must never happen is a wrong answer, so where one does appear it is checked.
+            if (!integral.Stringize().Contains("integral("))
+                DifferentiatesBack(integrand);
+        }
+    }
+}


### PR DESCRIPTION
`x * ln(x)` had an antiderivative and `x * atan(x)` did not.

Integration by parts has to choose which factor to differentiate, and the rule already made that
choice for a logarithm, with this reason in its own comment:

> Only one of the two orders terminates. Differentiating the polynomial […] leaves the logarithm to
> be integrated, and the antiderivative of `ln(x)` holds an `x*ln(x)` that puts the original
> integral back in front of us — that is how `integral(x * ln(x), x)` recursed until the stack ran
> out. Differentiating the logarithm instead turns it into `1/x`, which cancels against the
> integrated polynomial and ends. **(The L-before-A of LIATE.)**

Every word of that holds for an inverse trigonometric function, and LIATE puts the **I** before the
**A** for exactly the same reason. The condition simply named `Logf` and nothing else.

So `x * atan(x)` went the other way round: integrating `atan` gives an antiderivative that holds
`x*atan(x)` again, and the search never came back. Differentiating it instead gives `1/(1 + x^2)`,
and what is left is `x^2/(2(1 + x^2))` — rational, and answered.

### Measured

Both arms in the foreground on this machine, same 463-problem sample and flags:

| | solved | wrong | timeouts |
|---|--:|--:|--:|
| `36ca3bc6` (master) | 222 | 0 | 3 |
| + this | **225** | **0** | 3 |

Three verdicts moved, all three answers that were not there — `x * atan(x)`, `x^2 * atan(x)`,
`x * acot(x)`. Nothing regressed. Each verified by differentiating back at four points inside the
unit interval.

### Where it stops, and why that is the remainder rather than the choice

`atan` and `acot` differentiate to rational functions, so what is left is rational. `asin` and
`acos` differentiate to `1/sqrt(1 - x^2)`, so what is left is a **radical** integrand this library
does not read — `x * asin(x)` is still declined, and the choice of factor is right for it too. It is
in the tests as a decline so that it moves rather than being deleted when the radical gap closes.

The named condition covers all six inverse trigonometric nodes rather than the four with
integration rules, since it states which factor to differentiate and that does not depend on what
else happens to be integrable.

### A note on the sample size

463 of 1774, because a full pass does not fit the foreground time limit and background runs on this
machine are being killed by a memory supervisor firing on transient blips — with 13 GB free and the
harness itself using about 600 MB. Both arms were run identically so the comparison holds, but the
absolute number is not comparable to the full-corpus figures in the other PRs.

### Suites

`UnitTests` 8514 and 1628, `FSharpWrapperUnitTests` 134, `InteractiveWrapperUnitTests` 18,
`TerminalUnitTests` 41. New file `InverseTrigByPartsTest.cs`, 14 cases.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
