### PR TITLE
A power of a logarithm reaches integration by parts, and what one step leaves may be integrated by parts again

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -321,3 +321,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/DivisionByAnExponentialTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/RepeatedByPartsTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -259,13 +259,33 @@ namespace AngouriMath.Functions.Algebra
         /// https://github.com/asc-community/AngouriMath/issues/718
         /// </remarks>
         private static bool IsDifferentiatedBeforeAPolynomial(Entity factor)
-            => factor is Logf
-                or Entity.Arcsinf or Entity.Arccosf
-                or Entity.Arctanf or Entity.Arccotanf
-                or Entity.Arcsecantf or Entity.Arccosecantf;
+            => factor switch
+            {
+                Logf or Entity.Arcsinf or Entity.Arccosf
+                    or Entity.Arctanf or Entity.Arccotanf
+                    or Entity.Arcsecantf or Entity.Arccosecantf => true,
+                // And a whole power of one, which is the same function for this purpose:
+                // differentiating ln(x)^2 gives 2ln(x)/x, whose x cancels against the integrated
+                // polynomial exactly as ln(x)'s does, leaving x*ln(x) -- one step simpler, and
+                // answered by another round of parts.
+                //
+                // A positive whole exponent, because that is when differentiating lowers the
+                // power by one and the descent is finite. A negative or fractional one is a
+                // different integrand with no reason to be the factor differentiated.
+                Powf(var repeated, Number.Integer power) when power.EInteger.Sign > 0
+                    => IsDifferentiatedBeforeAPolynomial(repeated),
+                _ => false
+            };
 
         internal static Entity? SolveIntegratingByParts(Entity expr, Entity.Variable x)
         {
+            // The measure the nested call below decreases on. Read once, since every step
+            // compares against the integrand this call started from rather than against its own
+            // immediate predecessor -- what has to shrink is the distance to an answer, and a
+            // chain of steps that each shrink by nothing would otherwise be admitted one at a
+            // time.
+            var wholeSize = expr.Nodes.Count();
+
             // Standard integration by parts for polynomial × function
             static Entity? IntegrateByPartsPolynomial(Entity polynomialToDifferentiate, Entity toIntegrate, Variable x, int currentRecursion = 0)
             {
@@ -282,7 +302,7 @@ namespace AngouriMath.Functions.Algebra
             // Generalized integration by parts: tries once with v and u both being integrable
             // ∫ v·u dx = v·∫u dx - ∫(v'·∫u dx) dx
             // Only attempts if both v and u can be integrated
-            static Entity? TryIntegrateByPartsOnce(Entity v, Entity u, Variable x)
+            static Entity? TryIntegrateByPartsOnce(Entity v, Entity u, Variable x, int wholeSize)
             {
                 // Try to integrate u
                 var integralOfU = Integration.ComputeIndefiniteIntegral(u, x, false);
@@ -297,7 +317,29 @@ namespace AngouriMath.Functions.Algebra
                 // Try to integrate the remaining term: v' · ∫u dx
                 var remaining = (derivativeOfV * integralOfU).Simplify(1);
                 if (remaining is Providedf(var inner_, _)) remaining = inner_; // TODO: signularities ignored but not handled properly
-                var remainingIntegral = Integration.ComputeIndefiniteIntegral(remaining, x, false);
+                // **By parts is allowed on what is left**, and that is the whole of this change.
+                // One step of parts often leaves an integral that needs another: `x * ln(x)^2`
+                // leaves `x * ln(x)`, which is answered by parts and by nothing else, so with
+                // parts switched off here the outer integral was declined for want of the inner
+                // one. Every power of a logarithm times a polynomial was out of reach that way.
+                //
+                // It was switched off because this recursion used to run away -- `x * ln(x)`
+                // went round until the stack ran out. What stopped that was choosing the right
+                // factor to differentiate (the L-before-A of LIATE, above), and since then the
+                // integrator has grown two bounds that hold whatever the rules do: a set of
+                // integrands already on the stack, which declines a repeat immediately, and a
+                // ceiling on the depth of the descent. Those are what makes this safe now, and
+                // they are checked on every entry rather than trusted to a flag.
+                // https://github.com/asc-community/AngouriMath/issues/718
+                // ...but only where what is left is **strictly smaller** than what we started
+                // with. That is the decrease that makes the descent finite, and it is also what
+                // keeps the search from widening: `sin(x)/(x^2 + 1)^2` has no elementary
+                // antiderivative, so every solver runs to exhaustion on it, and letting parts
+                // recurse without a measure took it from about a second to 83 -- caught by
+                // `AnIntegralWithNoAnswerStillFinishesQuickly`, which exists for exactly this.
+                // A power of a logarithm does decrease: `x * ln(x)^2` leaves `x * ln(x)`.
+                var remainingIntegral = Integration.ComputeIndefiniteIntegral(
+                    remaining, x, remaining.Nodes.Count() < wholeSize);
                 if (remainingIntegral is null) return null;
 
                 return v * integralOfU - remainingIntegral;
@@ -313,9 +355,9 @@ namespace AngouriMath.Functions.Algebra
                 // Differentiating the logarithm instead turns it into 1/x, which cancels
                 // against the integrated polynomial and ends. (The L-before-A of LIATE.)
                 if (IsDifferentiatedBeforeAPolynomial(f) && MathS.TryPolynomial(g, x, out _)
-                    && TryIntegrateByPartsOnce(f, g, x) is { } logFirstF) return logFirstF;
+                    && TryIntegrateByPartsOnce(f, g, x, wholeSize) is { } logFirstF) return logFirstF;
                 if (IsDifferentiatedBeforeAPolynomial(g) && MathS.TryPolynomial(f, x, out _)
-                    && TryIntegrateByPartsOnce(g, f, x) is { } logFirstG) return logFirstG;
+                    && TryIntegrateByPartsOnce(g, f, x, wholeSize) is { } logFirstG) return logFirstG;
 
                 // Case 1: One term is polynomial - use recursive polynomial integration by parts
                 if (MathS.TryPolynomial(f, x, out var fPoly)) return IntegrateByPartsPolynomial(fPoly, g, x);
@@ -324,13 +366,13 @@ namespace AngouriMath.Functions.Algebra
                 // Case 2: Neither is polynomial - try single-step integration by parts
                 // This handles cases like ln(abs(x)) × ln(abs(x))
                 // Try both orderings: f as v, g as u OR g as v, f as u
-                if (TryIntegrateByPartsOnce(f, g, x) is { } result1) return result1;
-                if (TryIntegrateByPartsOnce(g, f, x) is { } result2) return result2;
+                if (TryIntegrateByPartsOnce(f, g, x, wholeSize) is { } result1) return result1;
+                if (TryIntegrateByPartsOnce(g, f, x, wholeSize) is { } result2) return result2;
             }
 
             // Special case for powers of integrable functions, try integration by parts on base × base
             // e.g., ln(abs(x))^2 = ln(abs(x)) × ln(abs(x))
-            if (expr is Powf(var @base, Integer(2)) && TryIntegrateByPartsOnce(@base, @base, x) is { } result) return result;
+            if (expr is Powf(var @base, Integer(2)) && TryIntegrateByPartsOnce(@base, @base, x, wholeSize) is { } result) return result;
 
             return null;
         }

--- a/Sources/Tests/UnitTests/Calculus/RepeatedByPartsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/RepeatedByPartsTest.cs
@@ -1,0 +1,119 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using System.Diagnostics;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// A whole power of a logarithm times a polynomial, which needs integration by parts twice.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>x * ln(x)</c> was answered and <c>x * ln(x)^2</c> was not, and it took two changes
+    /// together — either alone leaves it declined.
+    /// </para>
+    /// <para>
+    /// The rule choosing which factor to differentiate named the logarithm node and not a power
+    /// of one, so <c>ln(x)^2</c> was not recognised as the factor to differentiate. And the
+    /// remaining integral after one step was computed with parts switched off, so even once it
+    /// was recognised, the <c>x * ln(x)</c> that one step leaves behind could not be answered —
+    /// it is answered by parts and by nothing else.
+    /// </para>
+    /// <para>
+    /// <b>The second change is why the timing test below is here.</b> Parts was switched off for
+    /// the remainder because the recursion used to run away. It is allowed again only where the
+    /// remainder is strictly smaller than the integrand the call started from, which is a
+    /// decrease that makes the descent finite; without that measure
+    /// <c>sin(x)/(x^2 + 1)^2</c> — which has no elementary antiderivative and so runs every
+    /// solver to exhaustion — went from about a second to 83.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class RepeatedByPartsTest
+    {
+        private static readonly double[] Points = { 0.13, 0.37, 0.61, 0.82, 1.4 };
+
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            var written = integral.Stringize();
+            Assert.DoesNotContain("integral(", written);
+            Assert.DoesNotContain("NaN", written);
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 3,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}");
+        }
+
+        /// <summary>A squared logarithm times a polynomial, which one step of parts reduces.</summary>
+        [Theory]
+        [InlineData("x * ln(x) ^ 2")]
+        public void ASquaredLogarithmTimesAPolynomial(string integrand)
+            => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// What was already answered by one step and must go on being answered — including the
+        /// bare logarithm case, whose choice of factor this reuses.
+        /// </summary>
+        [Theory]
+        [InlineData("x * ln(x)")]
+        [InlineData("x ^ 2 * ln(x)")]
+        [InlineData("ln(x)")]
+        [InlineData("ln(x) ^ 2")]
+        [InlineData("x * atan(x)")]
+        [InlineData("atan(x)")]
+        [InlineData("x * e ^ x")]
+        [InlineData("x * sin(x)")]
+        [InlineData("e ^ x * sin(x)")]
+        public void WhatWasAlreadyAnswered(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// The measure that bounds the recursion, asserted where it is load-bearing.
+        /// <c>sin(x)/(x^2 + 1)^2</c> has no elementary antiderivative, so every solver runs to
+        /// exhaustion on it and it pays the full cost of the search.
+        /// </summary>
+        /// <remarks>
+        /// The bound is a wall that cannot fire on a slow runner — the work is about a second —
+        /// and it is a guard against the growth coming back rather than a benchmark.
+        /// <c>IntegralAnswerCacheTest</c> asserts the same integrand for a different reason; this
+        /// one is about the recursion rather than the answer cache, and both should keep failing
+        /// independently if either regresses.
+        /// </remarks>
+        [Fact]
+        public void AnUnanswerableIntegralDoesNotPayForTheRecursion()
+        {
+            var watch = Stopwatch.StartNew();
+            var answer = "sin(x) / (x ^ 2 + 1) ^ 2".ToEntity().Integrate("x");
+            watch.Stop();
+
+            Assert.Contains("integral(", answer.Stringize());
+            Assert.True(watch.Elapsed < TimeSpan.FromSeconds(30),
+                $"took {watch.Elapsed.TotalSeconds:F1}s; without the decrease measure on the "
+                + "remaining integrand it was 83s");
+        }
+    }
+}


### PR DESCRIPTION
`x * ln(x)` had an antiderivative and `x * ln(x)^2` did not.

It took **two changes together** — either alone leaves it declined, which is why they are one commit.

### The factor to differentiate was named as a node, not as a power of one

The rule picks the logarithm to differentiate rather than the polynomial — the L-before-A of LIATE,
whose reason is already in the comment there — and the condition read `factor is Logf`. `ln(x)^2` is
a `Powf`, so it was not recognised, and the polynomial was differentiated instead: the order that
does not terminate.

### And the integral left over after one step had parts switched off

```csharp
var remainingIntegral = Integration.ComputeIndefiniteIntegral(remaining, x, false);
```

One step on `x * ln(x)^2` leaves `x * ln(x)`, which is answered by parts and by nothing else. So
even with the factor chosen correctly, the remainder could not be integrated.

That flag was switched off because the recursion used to run away. It is allowed again **only where
the remainder is strictly smaller than the integrand the call started from** — compared against the
whole rather than against the previous step, so a chain that shrinks by nothing is not admitted one
step at a time.

### The measure is load-bearing, and I have the number for leaving it out

Without it, `sin(x)/(x^2 + 1)^2` — no elementary antiderivative, so every solver runs to exhaustion
— went from about a second to **83 seconds**, and `AnIntegralWithNoAnswerStillFinishesQuickly`
failed. That test exists for exactly this, and it caught it. With the measure, that integrand is
unchanged and the test passes.

It costs one answer the unguarded version found: `x^3 * ln(x)^2` comes out without the measure and
not with it. One answer against 80× is the right way round — and a rule able to bound what it
*spends* rather than what it *looks at* would keep both, which is the same conclusion as #1255 and
#1244.

### Measured

Both arms in the foreground, same 463-problem sample and flags:

| | solved | wrong | timeouts |
|---|--:|--:|--:|
| `7c0963a9` (master) | 227 | 0 | 3 |
| + this | **228** | **0** | 3 |

### Suites

`UnitTests` 8514 and 1671, `FSharpWrapperUnitTests` 134, `InteractiveWrapperUnitTests` 18,
`TerminalUnitTests` 41. New file `RepeatedByPartsTest.cs`, 11 cases — including its own timing
guard on the recursion, separate from the answer-cache one, so that either regressing fails
independently.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
