### PR TITLE
The cotangent reaches the tangent substitution, and the substituted integrand is combined into one quotient

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -422,9 +422,9 @@ namespace AngouriMath.Functions.Algebra
         /// <para>
         /// The test is the rewrite itself: replace every <c>tan(x)</c> and see whether an
         /// <c>x</c> survives. <c>tan(x) + x</c> keeps one and is declined, which is right — it is
-        /// not a function of the tangent alone. <c>cotan</c> is <b>not</b> covered, since it is
-        /// its own node rather than a reciprocal of this one, so <c>sqrt(cotan(x))</c> is still
-        /// declined.
+        /// not a function of the tangent alone. <b>The cotangent is covered</b>, by writing it as
+        /// <c>1/tan</c> on the way in: it is the same function the other way up, and declining it
+        /// for having its own node meant <c>tan(x)^2</c> was answered and <c>cot(x)^2</c> was not.
         /// </para>
         /// <para>
         /// <b>No condition is owed by the substitution</b>, but the answer inherits the
@@ -434,6 +434,19 @@ namespace AngouriMath.Functions.Algebra
         /// </remarks>
         internal static Entity? SolveByTangentSubstitution(Entity expr, Entity.Variable x, bool integrateByParts)
         {
+            // The cotangent first, because it is the tangent written the other way up and this
+            // rule used to decline it for no better reason than the node being a different one.
+            // `tan(x)^2` was answered and `cot(x)^2` was not, though the second is `1/tan(x)^2`.
+            //
+            // cot(u) = 1/tan(u) wherever either is defined: both are cos(u)/sin(u), and the
+            // points where the quotient is written differently -- tan undefined at odd multiples
+            // of pi/2, where cot is zero -- are removable in the same way for both, so this
+            // neither widens nor narrows the domain of an integrand built from them.
+            expr = expr.Replace(node =>
+                node is Cotanf(var cotangentArgument)
+                    ? 1 / MathS.Tan(cotangentArgument)
+                    : node);
+
             var tangent = MathS.Tan(x);
             if (!expr.ContainsNode(tangent))
                 return null;
@@ -443,7 +456,17 @@ namespace AngouriMath.Functions.Algebra
             if (inU.ContainsNode(x))
                 return null;
 
-            var integrand = (inU / (1 + MathS.Sqr(uSub))).InnerSimplified;
+            // Combined into one quotient, not merely inner-simplified. Writing the cotangent as
+            // 1/tan puts a quotient inside a quotient -- cot(x)^2 arrives as (1/u)^2/(1 + u^2) --
+            // and `InnerSimplified` leaves that nesting standing. Everything downstream wants a
+            // single Divf of two polynomials, and it is the difference between an answer and
+            // none: `1/(u^2*(1 + u^2))` is integrated and `(1/u)^2/(1 + u^2)`, which is the same
+            // expression, is not. The half-angle and exponential substitutions comb their
+            // integrands for the same reason.
+            var integrand = Functions.SingleQuotient
+                .Combine(inU / (1 + MathS.Sqr(uSub))).Simplify();
+            if (integrand is Providedf(var withoutCondition, _))
+                integrand = withoutCondition;
             return Integration.ComputeIndefiniteIntegral(integrand, uSub, integrateByParts) is { } result
                 ? result.Substitute(uSub, tangent)
                 : null;

--- a/Sources/Tests/UnitTests/Calculus/TangentSubstitutionIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/TangentSubstitutionIntegralTest.cs
@@ -119,21 +119,43 @@ namespace AngouriMath.Tests.Calculus
         /// </summary>
         /// <remarks>
         /// <list type="bullet">
-        /// <item><c>sqrt(cotan(x))</c> — <c>cotan</c> is its own node rather than a reciprocal of
-        /// the tangent, so the rewrite finds nothing to replace and this never starts.</item>
-        /// <item><c>1/(1 + tan(x)^2)</c> becomes <c>1/(1 + u^2)^2</c>, a repeated irreducible
-        /// quadratic, which the partial fraction step declines because there is no rule for a
-        /// numerator over one.</item>
+        /// <item><c>sqrt(cotan(x))</c> — the cotangent is written as <c>1/tan</c> on the way in
+        /// now, so this does start; what stops it is the fractional power, which leaves a
+        /// radical in <c>u</c> rather than a rational function.</item>
         /// </list>
         /// <c>tan(x)^2</c> and <c>tan(x)^3</c> were on this list, for becoming improper rational
-        /// functions that nothing divided out. They are answered above now that the rational
-        /// integrator divides first, which is why a list like this is worth keeping as tests
-        /// rather than as prose: it fails when the boundary moves.
+        /// functions that nothing divided out; they are answered above now that the rational
+        /// integrator divides first. <c>1/(1 + tan(x)^2)</c> was on it too, for becoming
+        /// <c>1/(1 + u^2)^2</c> — and it is answered now that the substituted integrand is
+        /// combined into a single quotient rather than merely inner-simplified. That is twice
+        /// this list has moved, which is why it is worth keeping as tests rather than as prose:
+        /// it fails when the boundary moves.
         /// </remarks>
         [Theory]
         [InlineData("sqrt(cotan(x))")]
-        [InlineData("1/(1 + tan(x)^2)")]
         public void WhatIsStillDeclined(string integrand)
             => Assert.Contains("integral(", integrand.ToEntity().Integrate("x").Stringize());
+
+        /// <summary>
+        /// <c>1/(1 + tan(x)^2)</c> is <c>cos(x)^2</c>, and it used to be declined for becoming
+        /// <c>1/(1 + u^2)^2</c> under the substitution. Asserted as a value, since what it comes
+        /// out as says nothing about whether it is an antiderivative.
+        /// </summary>
+        [Fact]
+        public void ARepeatedQuadraticFromTheSubstitutionIsAnswered()
+        {
+            var integrand = "1/(1 + tan(x)^2)".ToEntity();
+            var integral = integrand.Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            foreach (var at in new[] { 0.35, 0.9, 2.4 })
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = integrand.Substitute("x", at).EvalNumerical();
+                Assert.True(System.Math.Abs((double)(got - want).RealPart) < 1e-9,
+                    $"d/dx of the antiderivative is {got} at x = {at}, where the integrand is {want}");
+            }
+        }
     }
 }


### PR DESCRIPTION
`tan(x)^2` had an antiderivative and `cot(x)^2` did not. Two spellings of one idea, and it took two fixes of the same kind.

### The cotangent is the tangent the other way up

The rule required a literal `tan(x)` node, and its own doc comment recorded the consequence:

> `cotan` is **not** covered, since it is its own node rather than a reciprocal of this one

Writing `cot(u)` as `1/tan(u)` on the way in is an identity — both are `cos(u)/sin(u)`, and the points where the spellings differ are removable the same way for both — so the domain neither widens nor narrows.

### And the substituted integrand was inner-simplified rather than combined

That alone left `cot(x)^2` declined even once it reached the rule. It arrives as `(1/u)^2/(1 + u^2)`, and:

```
1/(u^2*(1 + u^2))   →  integrated
(1/u)^2/(1 + u^2)   →  not
```

Same expression; they even simplify to the same thing. `SingleQuotient.Combine` puts it into the single `Divf` of two polynomials everything downstream wants — which the half-angle and exponential substitutions already do, for exactly this reason.

### Newly answered

Each verified by differentiating back at five points:

| |
|---|
| `cot(x)^2`, `cot(x)^3`, `cot(x)^4`, `cot(2*x)^2` |
| `1/cot(x)`, `cot(x)/(1 + cot(x))`, `cot(x)^2*tan(x)` |

### A pinned decline moved, and rightly

`1/(1 + tan(x)^2)` was on this substitution's list of what it cannot answer, for becoming `1/(1 + u^2)^2`. It is `cos(x)^2`, and it is answered now — agreeing with `cos(x)^2`'s own antiderivative to a hundred digits. That list has moved **twice** now, which is the argument for keeping it as tests rather than prose.

`sqrt(cotan(x))` stays on it, for a new reason: the rewrite now applies, and what stops it is the fractional power leaving a radical rather than a rational function.

### Measured

Both arms in the foreground, same 463-problem sample and flags:

| | solved | wrong | timeouts |
|---|--:|--:|--:|
| `4e639e6c` (master) | 228 | 0 | 3 |
| + this | **230** | **0** | 3 |

`cot(x)^2` and `cot(x)^4`; nothing regressed.

### Suites

`UnitTests` 8514 and 1671, `FSharpWrapperUnitTests` 134, `InteractiveWrapperUnitTests` 18, `TerminalUnitTests` 41.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura