### PR TITLE
A power of the secant or cosecant is brought down by the recurrence, and a rule answers the question it was asked

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -324,3 +324,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/RepeatedByPartsTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/SecantPowerIntegralTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -400,6 +400,163 @@ namespace AngouriMath.Functions.Algebra
         };
 
         /// <summary>
+        /// A whole power of the secant or cosecant, brought down two at a time by the standard
+        /// reduction until the power rule for the first or the zeroth takes over.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>1/cos(x)^2</c> was answered and <c>1/cos(x)^6</c> was not. The rule for powers of
+        /// sine and cosine reads a <b>positive</b> exponent, so a negative one — which is what a
+        /// secant or cosecant is — matched nothing above the square, and the square was answered
+        /// only because it is a standard integral in its own right.
+        /// </para>
+        /// <para>
+        /// This is Rubi's rule 4.5.1.1, ported:
+        /// <code>
+        /// Int[(b*csc[c+d*x])^n] := -b*Cos[c+d*x]*(b*Csc[c+d*x])^(n-1)/(d*(n-1))
+        ///                          + b^2*(n-2)/(n-1)*Int[(b*Csc[c+d*x])^(n-2)]
+        ///     /; GtQ[n,1] &amp;&amp; IntegerQ[2*n]
+        /// </code>
+        /// which for the secant reads
+        /// <c>∫sec^n = sec^(n-2) tan/(a(n-1)) + ((n-2)/(n-1)) ∫sec^(n-2)</c>, and for the
+        /// cosecant the same with <c>-cot</c> and the sign of the first term flipped. Each step
+        /// takes two off the exponent, so it ends at <c>n = 1</c> — a standard integral here
+        /// already — or at <c>n = 0</c>, which is <c>x</c>.
+        /// </para>
+        /// <para>
+        /// <b>Read through both spellings.</b> A secant is <c>sec(u)</c>, and it is also
+        /// <c>cos(u)^(-n)</c> and <c>1/cos(u)^n</c>; all three arrive here, and answering one of
+        /// them and not the others is the defect this file has had five times over.
+        /// </para>
+        /// https://github.com/asc-community/AngouriMath/issues/718
+        /// </remarks>
+        internal static Entity? SolveBySecantPowerReduction(Entity expr, Entity.Variable x)
+        {
+            if (!TryReadReciprocalTrigonometricPower(expr, out var argument, out var power, out var isSecant))
+                return null;
+            if (power < 2)
+                return null;   // the first power and the zeroth are answered without a recursion
+            // Asked, not volunteered. Answering a power of the secant that some other rule
+            // produced on its way somewhere lets that rule's search carry on instead of
+            // stopping, and that -- rather than any work this does -- is what took
+            // `sec(x)^6*tan(x)^3` from a 637 ms decline to not returning in 400 s.
+            // https://github.com/asc-community/AngouriMath/issues/1265
+            if (!Integration.AnsweringTheQuestionAsked)
+                return null;
+            if (!TreeAnalyzer.TryGetPolyLinear(argument, x, out var rate, out _) || rate.Evaled == 0)
+                return null;
+
+            var reciprocal = isSecant ? MathS.Sec(argument) : MathS.Cosec(argument);
+            var partner = isSecant ? MathS.Tan(argument) : MathS.Cotan(argument);
+
+            // The recurrence run out here rather than through the integrator. Every step is
+            // determined -- the power comes down by two and the coefficient is (n-2)/(n-1) --
+            // so there is nothing to search for, and asking the integrator instead would put the
+            // rule's own descent behind the gate above and stop it after one step.
+            //
+            //   sec^(n-2) tan / (a(n-1))  +  ((n-2)/(n-1)) * the same at n-2
+            //  -csc^(n-2) cot / (a(n-1))  +  ((n-2)/(n-1)) * the same at n-2
+            Entity total = 0;
+            Entity carried = 1;
+            var remaining = power;
+            while (remaining >= 2)
+            {
+                var lowered = remaining - 2 == 1 ? reciprocal : MathS.Pow(reciprocal, remaining - 2);
+                var boundary = lowered * partner / (rate * Number.Integer.Create(remaining - 1));
+                if (!isSecant)
+                    boundary = -boundary;
+                total += carried * boundary;
+                carried *= Number.Rational.Create(remaining - 2, remaining - 1);
+                remaining -= 2;
+            }
+
+            // What the recurrence lands on: sec^1 and csc^1 are the standard integrals this
+            // library already carries, and sec^0 is x. Written out rather than asked for, so
+            // that the rule is closed over its own recursion.
+            var rest = remaining == 0
+                ? x
+                : isSecant
+                    ? MathS.Hyperbolic.Artanh(MathS.Sin(argument)) / rate
+                    : IntegralPatterns.AntiderivativeLog(MathS.Tan(argument / 2)) / rate;
+
+            return total + carried * rest;
+        }
+
+        /// <summary>
+        /// Reads <paramref name="expr"/> as a whole power of a secant or a cosecant, however it
+        /// is written: as the node, as a negative power of cosine or sine, or as one over a
+        /// positive power of them.
+        /// </summary>
+        private static bool TryReadReciprocalTrigonometricPower(
+            Entity expr, out Entity argument, out int power, out bool isSecant)
+        {
+            argument = 0;
+            power = 0;
+            isSecant = false;
+            switch (expr)
+            {
+                case Secantf(var secantArgument):
+                    (argument, power, isSecant) = (secantArgument, 1, true);
+                    return true;
+                case Cosecantf(var cosecantArgument):
+                    (argument, power, isSecant) = (cosecantArgument, 1, false);
+                    return true;
+                case Powf(Secantf(var raisedSecant), Number.Integer secantPower)
+                    when secantPower.EInteger.Sign > 0 && secantPower.EInteger.CanFitInInt32():
+                    (argument, power, isSecant) =
+                        (raisedSecant, secantPower.EInteger.ToInt32Checked(), true);
+                    return true;
+                case Powf(Cosecantf(var raisedCosecant), Number.Integer cosecantPower)
+                    when cosecantPower.EInteger.Sign > 0 && cosecantPower.EInteger.CanFitInInt32():
+                    (argument, power, isSecant) =
+                        (raisedCosecant, cosecantPower.EInteger.ToInt32Checked(), false);
+                    return true;
+                // cos(u)^(-n) is sec(u)^n, and sin(u)^(-n) is csc(u)^n.
+                case Powf(Cosf(var loweredCosine), Number.Integer negativeCosine)
+                    when negativeCosine.EInteger.Sign < 0 && negativeCosine.EInteger.CanFitInInt32():
+                    (argument, power, isSecant) =
+                        (loweredCosine, -negativeCosine.EInteger.ToInt32Checked(), true);
+                    return true;
+                case Powf(Sinf(var loweredSine), Number.Integer negativeSine)
+                    when negativeSine.EInteger.Sign < 0 && negativeSine.EInteger.CanFitInInt32():
+                    (argument, power, isSecant) =
+                        (loweredSine, -negativeSine.EInteger.ToInt32Checked(), false);
+                    return true;
+                // And one over a positive power, which is the same thing spelled as a quotient.
+                case Divf(var one, var below) when one == Number.Integer.One:
+                    return TryReadTrigonometricDenominator(below, ref argument, ref power, ref isSecant);
+                default:
+                    return false;
+            }
+        }
+
+        private static bool TryReadTrigonometricDenominator(
+            Entity below, ref Entity argument, ref int power, ref bool isSecant)
+        {
+            switch (below)
+            {
+                case Cosf(var cosine):
+                    (argument, power, isSecant) = (cosine, 1, true);
+                    return true;
+                case Sinf(var sine):
+                    (argument, power, isSecant) = (sine, 1, false);
+                    return true;
+                case Powf(Cosf(var cosine), Number.Integer cosinePower)
+                    when cosinePower.EInteger.Sign > 0 && cosinePower.EInteger.CanFitInInt32():
+                    (argument, power, isSecant) =
+                        (cosine, cosinePower.EInteger.ToInt32Checked(), true);
+                    return true;
+                case Powf(Sinf(var sine), Number.Integer sinePower)
+                    when sinePower.EInteger.Sign > 0 && sinePower.EInteger.CanFitInInt32():
+                    (argument, power, isSecant) =
+                        (sine, sinePower.EInteger.ToInt32Checked(), false);
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
         /// An integrand that is a function of <c>tan(x)</c> and of nothing else, integrated by
         /// the substitution <c>u = tan(x)</c>, under which <c>dx</c> is <c>du/(1 + u^2)</c>.
         /// </summary>

--- a/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
@@ -215,6 +215,29 @@ namespace AngouriMath.Functions.Algebra
         /// <summary>How deep the current descent is. Per thread, like <see cref="answered"/>.</summary>
         [System.ThreadStatic] private static int descentDepth;
 
+        /// <summary>
+        /// Whether the integrand now being solved is the one the caller asked for, rather than
+        /// one a rule produced on the way to answering something else.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// For a rule that is the right answer to a question and a distraction as an offer. A
+        /// rule which answers a sub-integral that used to come back <see langword="null"/> does
+        /// not only add its own work: it lets the search that asked stop failing and carry on,
+        /// which is where the cost turns up — on integrands the rule never fires on.
+        /// </para>
+        /// <para>
+        /// Measured on the secant power reduction: <c>sec(x)^6*tan(x)^3</c> is declined in 637 ms
+        /// without it and does not return in 400 s with it, while the rule itself fires exactly
+        /// twice and terminates both times. The work is not the rule's; the continuation is.
+        /// https://github.com/asc-community/AngouriMath/issues/1265
+        /// </para>
+        /// <para>
+        /// One is the top: the depth is incremented before the solvers run, so a rule consulted
+        /// about the caller's own integrand sees exactly one.
+        /// </para>
+        /// </remarks>
+        internal static bool AnsweringTheQuestionAsked => descentDepth == 1;
 
         /// <summary>
         /// Whether anything in the current top-level call gave up on <see cref="DeepestDescent"/>
@@ -367,6 +390,11 @@ namespace AngouriMath.Functions.Algebra
             // divides by du/dx and asks what is left, and that question loses the shape here:
             // sqrt(tan(x)) over the derivative of sqrt(tan(x)) simplifies to sin(2x), in which
             // the substitution is no longer visible. This one rewrites rather than divides.
+            // Before the tangent substitution, which would also take a power of the secant and
+            // answer it as a rational function of tan(x) -- correct, and a good deal longer than
+            // the reduction gives. Rubi's own ordering puts the reduction first for the same
+            // reason.
+            if ((answer = IndefiniteIntegralSolver.SolveBySecantPowerReduction(expr, x)) is { }) return answer;
             if ((answer = IndefiniteIntegralSolver.SolveByTangentSubstitution(expr, x, integrateByParts)) is { }) return answer;
             if ((answer = IndefiniteIntegralSolver.SolveByPartialFractions(expr, x, integrateByParts)) is { }) return answer;
             // Linearity again, and this time with the expansion: a product with a sum in it --

--- a/Sources/Tests/UnitTests/Calculus/SecantPowerIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/SecantPowerIntegralTest.cs
@@ -1,0 +1,167 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// Whole powers of the secant and the cosecant, which the downward recurrence brings to the
+    /// first power or to the zeroth.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Before this, <c>1/cos(x)^2</c> was answered and <c>1/cos(x)^6</c> was not: the rule for
+    /// powers of sine and cosine reads a positive exponent, and a secant is a negative one. The
+    /// square came out only because it is a standard integral in its own right.
+    /// </para>
+    /// <para>
+    /// <b>Three spellings, one integrand.</b> <c>sec(u)^n</c>, <c>cos(u)^(-n)</c> and
+    /// <c>1/cos(u)^n</c> all reach the integrator, and answering one and declining the others is
+    /// the defect this file's neighbours have carried repeatedly. Each case below is written out
+    /// in every spelling that parses to a different tree.
+    /// </para>
+    /// <para>
+    /// Checked by differentiating back and comparing at points, never against a printed form:
+    /// <c>∫sec(x)</c> comes out as an inverse hyperbolic tangent here rather than as
+    /// <c>ln|sec + tan|</c>, and both are right.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class SecantPowerIntegralTest
+    {
+        /// <summary>
+        /// Points inside one branch, away from the poles of both the secant and the cosecant —
+        /// which sit at multiples of <c>pi/2</c> — so that every integrand here has a value.
+        /// </summary>
+        private static readonly double[] Points = { 0.35, 0.61, 0.9, 1.15, 1.35 };
+
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 4,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}, "
+                + "so this asserts almost nothing");
+        }
+
+        /// <summary>
+        /// Even powers, which the recurrence takes down to the zeroth — so the last term is
+        /// <c>x</c> and the answer is a polynomial in the tangent.
+        /// </summary>
+        [Theory]
+        [InlineData("sec(x)^2")]
+        [InlineData("sec(x)^4")]
+        [InlineData("sec(x)^6")]
+        [InlineData("1/cos(x)^4")]
+        [InlineData("1/cos(x)^6")]
+        [InlineData("1/cos(x)^12")]
+        [InlineData("cos(x)^(-4)")]
+        [InlineData("cos(x)^(-6)")]
+        public void EvenPowersOfTheSecant(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// Odd powers, which land on the first — where the antiderivative is no longer
+        /// elementary in the tangent alone and the inverse hyperbolic tangent appears.
+        /// </summary>
+        [Theory]
+        [InlineData("sec(x)")]
+        [InlineData("sec(x)^3")]
+        [InlineData("sec(x)^5")]
+        [InlineData("1/cos(x)^3")]
+        [InlineData("1/cos(x)^5")]
+        [InlineData("cos(x)^(-3)")]
+        public void OddPowersOfTheSecant(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// The cosecant, which is the same recurrence with the cotangent in place of the tangent
+        /// and the first term the other sign. It is a separate node here, so it is separate
+        /// coverage rather than a symmetry anyone may assume.
+        /// </summary>
+        [Theory]
+        [InlineData("csc(x)^2")]
+        [InlineData("csc(x)^3")]
+        [InlineData("csc(x)^4")]
+        [InlineData("csc(x)^6")]
+        [InlineData("1/sin(x)^4")]
+        [InlineData("1/sin(x)^6")]
+        [InlineData("sin(x)^(-4)")]
+        public void PowersOfTheCosecant(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// A linear argument, which divides the whole answer by the rate. The constant term is
+        /// there because a rule that reads only the coefficient gets <c>sec(3x + 1)</c> right by
+        /// accident and <c>sec(3x)</c> wrong in the same way.
+        /// </summary>
+        [Theory]
+        [InlineData("sec(2*x)^4")]
+        [InlineData("sec(3*x + 1)^3")]
+        [InlineData("csc(2*x + 1)^4")]
+        [InlineData("1/cos(2*x)^6")]
+        public void ALinearArgument(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// The neighbouring integrands this rule must not take over. Each of these is answered
+        /// without it, and a reciprocal power that swallowed them would be a regression that no
+        /// wrong answer reveals.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x)^2")]
+        [InlineData("cos(x)^3")]
+        [InlineData("tan(x)^2")]
+        [InlineData("cot(x)^2")]
+        [InlineData("sin(x)*cos(x)")]
+        public void TheNeighboursAreUntouched(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// A power of the secant multiplied by something else is <b>not</b> this rule's, and it
+        /// must still be declined quickly rather than searched. The rule fires only on the
+        /// integrand the caller asked about, for exactly this reason:
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1265">#1265</a> — a rule
+        /// that answers a sub-integral which used to come back unanswered lets the search that
+        /// asked carry on, and the cost turns up on an integrand the rule never fires on.
+        /// </summary>
+        /// <remarks>
+        /// Bounded by the integrator's own budget rather than by a wall clock, which measures the
+        /// runner. <c>sec(x)^6*tan(x)^3</c> is declined in about a quarter of a second here and
+        /// did not return in four hundred seconds when the rule answered sub-integrals too.
+        /// </remarks>
+        [Theory]
+        [InlineData("sec(x)^6*tan(x)^3")]
+        [InlineData("cot(x)^3*csc(x)^4")]
+        public void AProductIsNotThisRules(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            // Unanswered or answered, either is a legitimate verdict; what is pinned is that the
+            // answer, if there is one, is right.
+            if (integral.Stringize().Contains("integral("))
+                return;
+            DifferentiatesBack(integrand);
+        }
+    }
+}


### PR DESCRIPTION
`1/cos(x)^2` was answered and `1/cos(x)^6` was not. The rule for powers of
sine and cosine reads a positive exponent, so a secant -- which is a negative
one -- matched nothing above the square, and the square came out only because
it is a standard integral in its own right.

Rubi's rule 4.5.1.1, ported for both functions:

    int sec^n = sec^(n-2) tan / (a(n-1)) + ((n-2)/(n-1)) int sec^(n-2)

run out here as a loop rather than through the integrator, because every step
is determined -- the power comes down by two, the coefficient is (n-2)/(n-1) --
so there is nothing to search for. It lands on the first power, a standard
integral this library already carries, or on the zeroth, which is `x`. All three
spellings a reciprocal power has here are read: `sec(u)^n`, `cos(u)^(-n)` and
`1/cos(u)^n`.

## The scope, which is the part worth reviewing

This rule was written, measured and **not shipped** two days ago, and #1265 is
the issue about why. On `sec(x)^6*tan(x)^3` -- an integrand it never answers --
master declines in 637 ms and the rule made it not return in 400 s. Instrumented,
it fired exactly twice on that input, at n = 6 and n = 4, and terminated both
times. The work was not the rule's. What changed is that two sub-integrals
stopped coming back unanswered, so the search that asked for them carried on
into ground that was always doomed.

`Integration.AnsweringTheQuestionAsked` is #1265's second proposal: the descent
depth is already tracked, and a rule can ask whether the integrand in front of
it is the one the caller asked about or one another rule produced on its way
somewhere. This reduction fires only in the first case. It is a claim about what
this kind of rule is *for* -- a closed reduction is the right answer to a
question and a distraction as an offer -- and not a size or budget heuristic;
both of those were tried on three rules and measured no better than nothing.

The property is `internal` and consulted by exactly one rule. It is put in
`Integration` rather than passed down because a rule that wants it is usually
several frames below the entry point.

## Measured

A probe of thirty shapes -- the powers, all three spellings, linear arguments,
the neighbouring integrands that must stay untouched -- each answer verified by
differentiating back and comparing at five points:

    master (2fc7b19b)   15/30 answered, 0 wrong
    with it             28/30 answered, 0 wrong

The two it does not answer are the products, and both are declined faster than
on master: `sec(x)^6*tan(x)^3` in 273 ms against 319 ms.

Rubi corpus, both arms in the foreground, 463-problem sample, five-second budget:

    master (2fc7b19b)   230/463, 0 wrong, 3 timeouts
    with it             231/463, 0 wrong, 3 timeouts

One more there, and no timeout added -- which is the number the ungated version
could not produce. The gate does cost one answer the ungated rule had,
`cot(x)^3*csc(x)^4`, which is now declined; that is the price of not volunteering,
and it is paid on an integrand where the reduction was a sub-step rather than the
question.

The five test suites are green. The new test pins every spelling separately,
since answering one and declining its synonym is the defect this file has had
five times, and pins the two products as "unanswered or right, never wrong".

Part of #1265 -- its second proposal, implemented. The issue stays open: three more parked rules (#1244 Euler, #1245 half-angle, the constant-factor firing in #1255) have the same shape and are not answered by this.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
