### PR TITLE
An exponent read as written rather than as a number made the power rule answer NaN

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -197,6 +197,36 @@ zero-discriminant arm, which gives the right answer.
 Each of these was checked by differentiating it back with the parameters pinned and comparing at
 four points. Nothing that already had an antiderivative changes.
 
+### `NaN` again, from an exponent that was read as written rather than as a number
+
+**A wrong answer, and a second one of the same kind.** `(a^2 + 2abx^2 + b^2x^4)^3/x^7` came back as
+`NaN + C` while `(a + bx^2)^6/x^7` — the same integrand with its base not written out — was
+answered. Unrelated to the entry above: that one was the quadratic rule's `a = 0` branch, and this
+reproduces with it fixed.
+
+| | Was | Is |
+|---|---|---|
+| `"(a^2 + 2*a*b*x^2 + b^2*x^4)^3/x^7".Integrate("x")` | `NaN + C` | the antiderivative |
+| `"(a^2 + 2*a*b*x^2 + b^2*x^4)^3/x^9".Integrate("x")` | `NaN + C` | the antiderivative |
+| `"(a^2 + 2*a*b*x + b^2*x^2)^3/x^7".Integrate("x")`, the same shape in one variable | `NaN + C` | the antiderivative |
+
+The power rule recognised the exponent `-1` — the one case where the antiderivative is a logarithm
+rather than a power — only when it was spelled as the integer. It also returned `x^(p + 1)/(p + 1)`
+with that sum left standing, and repeated integration by parts hands an antiderivative back in as
+an integrand, so a later round arrived carrying `x^(-3 + 1 + 1)`. That is `x^(-1)` and wants the
+logarithm; read as written it is not `-1`, so the power rule applied and produced
+`x^(-3 + 1 + 1 + 1)/(-3 + 1 + 1 + 1)`, which is `x^0/0`. The rule was feeding itself the one input
+it could not read.
+
+The exponent is now normalised both when it is read and when it is written back out. A **symbolic**
+exponent is unaffected: `int x^n dx` is still `x^(n+1)/(n+1)`, since whether an undecidable `n` is
+`-1` is not something this decides — what changed is an exponent that *is* decidable and was being
+read as though it were not.
+
+Each of these was checked by differentiating it back with the parameters pinned and comparing at
+four points. The Rubi sample is unchanged at 231 of 463 with no wrong answers, so nothing that
+already had an antiderivative moves.
+
 ---
 
 ## 2.5.0 — since 2.4.0

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -327,3 +327,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/SecantPowerIntegralTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/ExpandedSquareNaNTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -227,9 +227,7 @@ namespace AngouriMath.Functions.Algebra
 
             Entity.Powf(var @base, var power) =>
                 !power.ContainsNode(x) && @base == x ?
-                    power == -1 ?
-                        IntegralPatterns.AntiderivativeLog(@base) :
-                        MathS.Pow(x, power + 1) / (power + 1) :
+                    IntegrateAPowerOfTheVariable(@base, power, x) :
                     null,
 
             Entity.Variable v =>
@@ -237,6 +235,45 @@ namespace AngouriMath.Functions.Algebra
 
             _ => null
         };
+
+        /// <summary>
+        /// <c>x^p</c> for a <paramref name="power"/> that does not hold the variable: the power
+        /// rule, or the logarithm where the power rule would divide by zero.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>The exponent is normalised before it is read.</b> <c>x^(-3 + 1 + 1)</c> is
+        /// <c>x^(-1)</c>, but the sum is not the integer, so comparing the written form against
+        /// <c>-1</c> missed the logarithmic case and applied the power rule to it — producing
+        /// <c>x^(-3 + 1 + 1 + 1)/(-3 + 1 + 1 + 1)</c>, which is <c>x^0/0</c>, which is
+        /// <c>NaN</c>. That is a claim that no antiderivative exists where one plainly does, and
+        /// it reached the caller: <c>(a^2 + 2abx^2 + b^2x^4)^3/x^7</c> came back <c>NaN + C</c>
+        /// while the same integrand written <c>(a + bx^2)^6/x^7</c> was answered.
+        /// https://github.com/asc-community/AngouriMath/issues/1258
+        /// </para>
+        /// <para>
+        /// <b>And normalised again on the way out</b>, which is the other half and the half that
+        /// explains where such an exponent comes from. This rule used to return <c>p + 1</c>
+        /// standing as a sum, so an answer handed back in as an integrand — which is exactly what
+        /// repeated integration by parts does — accumulated one <c>+ 1</c> per round until a
+        /// round landed on <c>-1</c> spelled as a sum. The rule was feeding itself the one input
+        /// it could not read.
+        /// </para>
+        /// <para>
+        /// A <b>symbolic</b> exponent is left to the power rule as before. <c>int x^n dx</c> is
+        /// <c>x^(n+1)/(n+1)</c> for every <c>n</c> but <c>-1</c>, and this does not decide
+        /// whether an undecidable <c>n</c> is that one; what it fixes is an exponent that
+        /// <em>is</em> decidable and was read as though it were not.
+        /// </para>
+        /// </remarks>
+        private static Entity IntegrateAPowerOfTheVariable(Entity @base, Entity power, Entity.Variable x)
+        {
+            var exponent = power.InnerSimplified;
+            if (exponent == -1)
+                return IntegralPatterns.AntiderivativeLog(@base);
+            var raised = (exponent + 1).InnerSimplified;
+            return MathS.Pow(x, raised) / raised;
+        }
 
         /// <summary>
         /// Whether <paramref name="factor"/> is one of the functions integration by parts

--- a/Sources/Tests/UnitTests/Calculus/ExpandedSquareNaNTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ExpandedSquareNaNTest.cs
@@ -1,0 +1,128 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// The power rule reads its exponent normalised, so a monomial does not depend on how its
+    /// exponent happens to be written.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/1258">#1258</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>(a^2 + 2abx^2 + b^2x^4)^3/x^7</c> came back <c>NaN + C</c> while
+    /// <c>(a + bx^2)^6/x^7</c> — the same integrand with its base not written out — was answered.
+    /// <c>NaN</c> is <b>this does not exist</b>, not <b>I could not settle it</b>, so that was a
+    /// wrong answer rather than a gap.
+    /// </para>
+    /// <para>
+    /// The exponent <c>-1</c> was recognised only when it was spelled as the integer. Repeated
+    /// integration by parts feeds an antiderivative back in as an integrand, and the power rule
+    /// returned <c>x^(p + 1)/(p + 1)</c> with the sum left standing — so a round accumulated
+    /// <c>x^(-3 + 1 + 1)</c>, which is <c>x^(-1)</c> and wanted a logarithm, was not recognised
+    /// as one, and became <c>x^(-3 + 1 + 1 + 1)/(-3 + 1 + 1 + 1)</c>: <c>x^0/0</c>.
+    /// </para>
+    /// <para>
+    /// The trigger is internal, so these are pinned through the integrals that expose it rather
+    /// than by handing the rule an exponent no parser produces — <c>x^(-3 + 1 + 1)</c> is folded
+    /// to <c>x^(-1)</c> before it ever reaches the integrator, and asserting on it would pin
+    /// nothing.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class ExpandedSquareNaNTest
+    {
+        private static readonly double[] Points = { 0.41, 0.77, 1.3, 2.2 };
+
+        /// <summary>
+        /// Every parameter is pinned before the comparison, since these integrands carry two or
+        /// three of them and an antiderivative holding a parameter cannot be evaluated.
+        /// </summary>
+        private static Entity Pin(Entity expr) => expr
+            .Substitute("a", 2).Substitute("b", 3)
+            .Substitute("c", 2).Substitute("d", 3).Substitute("e", 5);
+
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var derivative = Pin(integral.Substitute("C", 0).Differentiate("x"));
+            var original = Pin(integrand.ToEntity());
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 3,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}, "
+                + "so this asserts almost nothing");
+        }
+
+        /// <summary>
+        /// The reported pair, and the two neighbours that decide it is the perfect square rather
+        /// than the shape: a quartic with independent coefficients was always answered, and so
+        /// was the unexpanded base.
+        /// </summary>
+        [Theory]
+        [InlineData("(a^2 + 2*a*b*x^2 + b^2*x^4)^3/x^7")]
+        [InlineData("(a + b*x^2)^6/x^7")]
+        [InlineData("(c + d*x^2 + e*x^4)^3/x^7")]
+        [InlineData("(1 + 2*x^2 + x^4)^3/x^7")]
+        public void TheReportedPair(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// The denominator decides how many rounds the accumulation runs for, so the boundary is
+        /// pinned either side: <c>/x^5</c> was answered and <c>/x^7</c> was not.
+        /// </summary>
+        [Theory]
+        [InlineData("(a^2 + 2*a*b*x^2 + b^2*x^4)^3/x^3")]
+        [InlineData("(a^2 + 2*a*b*x^2 + b^2*x^4)^3/x^5")]
+        [InlineData("(a^2 + 2*a*b*x^2 + b^2*x^4)^3/x^7")]
+        [InlineData("(a^2 + 2*a*b*x^2 + b^2*x^4)^3/x^9")]
+        [InlineData("(a^2 + 2*a*b*x^2 + b^2*x^4)^4/x^7")]
+        public void EveryDepthOfTheAccumulation(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// The same shape in one variable, which is the linear rather than the biquadratic
+        /// perfect square and reaches the power rule by the same route.
+        /// </summary>
+        [Theory]
+        [InlineData("(1 + 2*x + x^2)^3/x^7")]
+        [InlineData("(1 + x)^6/x^7")]
+        [InlineData("(a^2 + 2*a*b*x + b^2*x^2)^3/x^7")]
+        public void TheSameShapeInOneVariable(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// The power rule itself, which the fix changes and must still answer: the logarithmic
+        /// case, the ordinary one, and a negative exponent.
+        /// </summary>
+        [Theory]
+        [InlineData("1/x")]
+        [InlineData("x^(-1)")]
+        [InlineData("x^2")]
+        [InlineData("x^(-2)")]
+        [InlineData("x^(-7)")]
+        [InlineData("x^(1/2)")]
+        public void ThePowerRuleIsUnchanged(string integrand) => DifferentiatesBack(integrand);
+    }
+}


### PR DESCRIPTION
`(a^2 + 2*a*b*x^2 + b^2*x^4)^3/x^7` came back as `NaN + C`, while `(a + b*x^2)^6/x^7`
-- the same integrand with its base not written out -- was answered. NaN is this
library's way of saying the thing does not exist; it exists. That is a wrong
answer, not a gap.

Not the defect fixed in #1257: that was the quadratic rule's `a = 0` branch, and
this reproduces with that fix in place.

## What it was

The power rule recognises `-1` -- the one exponent whose antiderivative is a
logarithm rather than a power -- by comparing the exponent against the integer.
It also returned `x^(p + 1)/(p + 1)` with the sum left standing rather than
folded.

Those two together are a loop. Repeated integration by parts hands an
antiderivative back in as an integrand, so a later round arrives carrying an
exponent this rule wrote:

    x^(-3)              ->  x^(-3 + 1)/(-3 + 1)
    x^(-3 + 1)          ->  x^(-3 + 1 + 1)/(-3 + 1 + 1)
    x^(-3 + 1 + 1)      ->  it is -1, and wants ln(x)
                            read as written it is a Sumf, not the integer,
                            so the power rule applies:
                            x^(-3 + 1 + 1 + 1)/(-3 + 1 + 1 + 1)  =  x^0/0

The rule was feeding itself the one input it could not read. Traced by printing
which solver answered each sub-integral, which showed the exponent growing a
`+ 1` per round and the logarithmic case being missed on the round it landed on.

## What it is

The exponent is normalised once, and used for both the test and the answer:

    var exponent = power.InnerSimplified;
    if (exponent == -1) return AntiderivativeLog(@base);
    var raised = (exponent + 1).InnerSimplified;
    return MathS.Pow(x, raised) / raised;

Both halves are load-bearing. Normalising on the way in is the fix; normalising
on the way out is what stops the unreadable spelling being produced at all, and
it is this rule that produces it.

A **symbolic** exponent is untouched. `int x^n dx` is still `x^(n+1)/(n+1)`,
because whether an undecidable `n` is `-1` is not something this decides. What
changed is an exponent that *is* decidable and was being read as though it were
not -- the same "one expression, two spellings, two verdicts" shape this file
has now had six times.

## Measured

Every case verified by differentiating back with the parameters pinned and
comparing at four points:

    (a^2 + 2*a*b*x^2 + b^2*x^4)^3/x^7    NaN + C  ->  the antiderivative
    (a^2 + 2*a*b*x^2 + b^2*x^4)^3/x^9    NaN + C  ->  the antiderivative
    (a^2 + 2*a*b*x   + b^2*x^2)^3/x^7    NaN + C  ->  the antiderivative

Rubi corpus, 463-problem sample, both arms in the foreground:

    master (0513a13f)   231/463, 0 wrong, 3 timeouts, 152 s
    with it             231/463, 0 wrong, 3 timeouts, 152 s

Unchanged, which is what a fix to a wrong answer on a shape the sample does not
carry should look like. The five test suites are green.

The new test pins the reported pair, the neighbours that show it is the perfect
square and not the shape, every depth of the accumulation either side of the
boundary (`/x^5` was answered, `/x^7` was not), and the power rule's own cases.
It asserts through the integrals rather than by handing the rule an exponent no

Closes #1258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
