### PR TITLE
A power of the sine times a power of the cosine, which is every product of the six trigonometric functions

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -330,3 +330,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/ExpandedSquareNaNTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/TrigonometricPowerProductTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -520,6 +520,169 @@ namespace AngouriMath.Functions.Algebra
         }
 
         /// <summary>
+        /// An integrand that is a power of the sine times a power of the cosine, of one common
+        /// argument linear in the variable, turned into a polynomial by whichever of
+        /// <c>u = cos</c>, <c>u = sin</c> and <c>u = tan</c> the two exponents admit.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Everything built from the six trigonometric functions is a <c>sin^p cos^q</c></b>,
+        /// and reading it that way is what makes one rule out of a family Rubi spreads over
+        /// several sections: <c>tan^m sec^n</c> is <c>sin^m cos^(-m-n)</c>, <c>cot^m csc^n</c> is
+        /// <c>cos^m sin^(-m-n)</c>, a power of the secant alone is <c>cos^(-n)</c>. The exponents
+        /// are integers of either sign, so the same three cases below cover all of them.
+        /// </para>
+        /// <para>
+        /// <b>Which substitution, and why exactly these three.</b> Each one has to leave a
+        /// <i>Laurent polynomial</i> — a sum of powers of <c>u</c>, integrated term by term —
+        /// because that is what makes the rule closed. It asks the integrator nothing.
+        /// </para>
+        /// <list type="bullet">
+        /// <item><description>
+        /// <c>p</c> odd and at least one: <c>u = cos</c>, <c>du = -sin dx</c>, so one sine goes
+        /// into <c>du</c> and <c>sin^(p-1)</c> is <c>(1 - u^2)^((p-1)/2)</c>. Leaves
+        /// <c>-(1 - u^2)^((p-1)/2) u^q</c>, and <c>q</c> may be anything.
+        /// </description></item>
+        /// <item><description>
+        /// <c>q</c> odd and at least one: <c>u = sin</c>, the mirror of it.
+        /// </description></item>
+        /// <item><description>
+        /// both even and <c>p + q</c> at most <c>-2</c>: <c>u = tan</c>, under which
+        /// <c>cos^2 = 1/(1 + u^2)</c> and <c>dx = du/(1 + u^2)</c>, leaving
+        /// <c>u^p (1 + u^2)^(-(p+q)/2 - 1)</c> — a polynomial exactly when <c>p + q</c> is at
+        /// most <c>-2</c>, which is the condition. <c>tan^2 sec^4</c> is this case and neither
+        /// of the others.
+        /// </description></item>
+        /// </list>
+        /// <para>
+        /// <b>What is deliberately left out</b>: both exponents even with <c>p + q</c> at least
+        /// zero, where the tangent substitution leaves a negative power of <c>1 + u^2</c> rather
+        /// than a polynomial. Those are the ordinary <c>sin^2 cos^4</c> shapes, which the
+        /// power-reduction rules already answer, so the boundary costs nothing. A power of the
+        /// secant or cosecant alone reaches <see cref="SolveBySecantPowerReduction"/> first,
+        /// which gives a shorter answer for it.
+        /// </para>
+        /// <para>
+        /// <b>Asked, not volunteered</b>, for the reason in
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1265">#1265</a>: a rule
+        /// that answers a sub-integral which used to come back unanswered lets the search that
+        /// asked for it carry on, and that cost lands on integrands the rule never fires on.
+        /// </para>
+        /// https://github.com/asc-community/AngouriMath/issues/718
+        /// </remarks>
+        internal static Entity? SolveByTrigonometricPowerSubstitution(Entity expr, Entity.Variable x)
+        {
+            if (!Integration.AnsweringTheQuestionAsked)
+                return null;
+            if (!TryReadSineCosinePowers(expr, out var argument, out var sinePower, out var cosinePower, out var factor))
+                return null;
+            if (!TreeAnalyzer.TryGetPolyLinear(argument, x, out var rate, out _) || rate.Evaled == 0)
+                return null;
+
+            // What is left after the substitution: u^leading times (1 + insideSign*u^2) raised to
+            // expansionPower, all times sign -- which is what the substitution's own derivative
+            // contributes, negative for the cosine and positive for the sine and the tangent.
+            Entity u;
+            int expansionPower, leading, insideSign, sign;
+            if (sinePower % 2 != 0 && sinePower >= 1)
+                (u, expansionPower, leading, insideSign, sign) =
+                    (MathS.Cos(argument), (sinePower - 1) / 2, cosinePower, -1, -1);
+            else if (cosinePower % 2 != 0 && cosinePower >= 1)
+                (u, expansionPower, leading, insideSign, sign) =
+                    (MathS.Sin(argument), (cosinePower - 1) / 2, sinePower, -1, 1);
+            else if (sinePower % 2 == 0 && cosinePower % 2 == 0 && sinePower + cosinePower <= -2)
+                (u, expansionPower, leading, insideSign, sign) =
+                    (MathS.Tan(argument), -(sinePower + cosinePower) / 2 - 1, sinePower, 1, 1);
+            else
+                return null;
+
+            // The binomial expansion, each term integrated by the power rule -- or by the
+            // logarithm at the one exponent where the power rule would divide by zero, which is
+            // reachable here whenever `leading` is negative and odd.
+            Entity total = 0;
+            var coefficient = EInteger.One;
+            for (var i = 0; i <= expansionPower; i++)
+            {
+                var exponent = leading + 2 * i;
+                var term = exponent == -1
+                    ? IntegralPatterns.AntiderivativeLog(u)
+                    : MathS.Pow(u, Number.Integer.Create(exponent + 1)) / Number.Integer.Create(exponent + 1);
+                var alternating = insideSign < 0 && i % 2 != 0 ? -1 : 1;
+                total += Number.Integer.Create(coefficient) * alternating * term;
+                // The next binomial coefficient from this one: C(k, i+1) = C(k, i) * (k-i)/(i+1).
+                coefficient = coefficient * (expansionPower - i) / (i + 1);
+            }
+
+            return (factor * sign * total / rate).InnerSimplified;
+        }
+
+        /// <summary>
+        /// Reads <paramref name="expr"/> as a rational multiple of <c>sin(u)^p cos(u)^q</c> over
+        /// one common argument, however the six trigonometric functions spell it.
+        /// </summary>
+        /// <remarks>
+        /// A tangent contributes <c>(+1, -1)</c>, a secant <c>(0, -1)</c>, a cosecant
+        /// <c>(-1, 0)</c> and a cotangent <c>(-1, +1)</c>, so a product of any of them over one
+        /// argument is a pair of integers. Anything else in the product — a second argument, a
+        /// non-integer power, a function of the variable that is not one of the six — makes the
+        /// whole read fail, because a rule that guesses at the part it did not recognise answers
+        /// a question it was not asked.
+        /// </remarks>
+        private static bool TryReadSineCosinePowers(
+            Entity expr, out Entity argument, out int sinePower, out int cosinePower, out Entity factor)
+        {
+            Entity? common = null;
+            var sine = 0;
+            var cosine = 0;
+            Entity constant = 1;
+            var read = Read(expr, 1);
+            argument = common ?? 0;
+            sinePower = sine;
+            cosinePower = cosine;
+            factor = constant;
+            return read && common is not null && (sine != 0 || cosine != 0);
+
+            bool Agrees(Entity candidate)
+            {
+                if (common is null)
+                {
+                    common = candidate;
+                    return true;
+                }
+                return common == candidate;
+            }
+
+            bool Read(Entity node, int multiplicity)
+            {
+                switch (node)
+                {
+                    case Sinf(var a): sine += multiplicity; return Agrees(a);
+                    case Cosf(var a): cosine += multiplicity; return Agrees(a);
+                    case Tanf(var a): sine += multiplicity; cosine -= multiplicity; return Agrees(a);
+                    case Cotanf(var a): sine -= multiplicity; cosine += multiplicity; return Agrees(a);
+                    case Secantf(var a): cosine -= multiplicity; return Agrees(a);
+                    case Cosecantf(var a): sine -= multiplicity; return Agrees(a);
+                    case Mulf(var left, var right):
+                        return Read(left, multiplicity) && Read(right, multiplicity);
+                    case Divf(var above, var below):
+                        return Read(above, multiplicity) && Read(below, -multiplicity);
+                    case Powf(var @base, Number.Integer power) when power.EInteger.CanFitInInt32():
+                        return Read(@base, multiplicity * power.EInteger.ToInt32Checked());
+                    // A rational factor rides along; anything else is declined rather than
+                    // carried, since carrying it would claim the rest of the product is
+                    // trigonometric when it has not been read.
+                    case Number.Rational rational:
+                        constant = multiplicity > 0
+                            ? constant * MathS.Pow(rational, multiplicity)
+                            : constant / MathS.Pow(rational, -multiplicity);
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+        }
+
+        /// <summary>
         /// Reads <paramref name="expr"/> as a whole power of a secant or a cosecant, however it
         /// is written: as the node, as a negative power of cosine or sine, or as one over a
         /// positive power of them.

--- a/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
@@ -395,6 +395,11 @@ namespace AngouriMath.Functions.Algebra
             // the reduction gives. Rubi's own ordering puts the reduction first for the same
             // reason.
             if ((answer = IndefiniteIntegralSolver.SolveBySecantPowerReduction(expr, x)) is { }) return answer;
+            // And beside it: a power of the sine times a power of the cosine, which is every
+            // product of the six trigonometric functions once tangents and secants are read as
+            // the pair of exponents they are. After the reduction, because a power of the secant
+            // alone is both rules' and the reduction's answer for it is shorter.
+            if ((answer = IndefiniteIntegralSolver.SolveByTrigonometricPowerSubstitution(expr, x)) is { }) return answer;
             if ((answer = IndefiniteIntegralSolver.SolveByTangentSubstitution(expr, x, integrateByParts)) is { }) return answer;
             if ((answer = IndefiniteIntegralSolver.SolveByPartialFractions(expr, x, integrateByParts)) is { }) return answer;
             // Linearity again, and this time with the expansion: a product with a sum in it --

--- a/Sources/Tests/UnitTests/Calculus/TrigonometricPowerProductTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/TrigonometricPowerProductTest.cs
@@ -1,0 +1,190 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// A power of the sine times a power of the cosine — which is every product of the six
+    /// trigonometric functions, once a tangent and a secant are read as the pair of exponents
+    /// they are.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>tan(x)^m sec(x)^n</c> is <c>sin^m cos^(-m-n)</c> and <c>cot(x)^m csc(x)^n</c> is
+    /// <c>cos^m sin^(-m-n)</c>, so the whole family is one rule and one test. Each of these was
+    /// declined before it, including <c>sec(x)^6 tan(x)^3</c>, which is the integrand
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/1265">#1265</a> was written
+    /// about.
+    /// </para>
+    /// <para>
+    /// Checked by differentiating back and comparing at points, never against a printed form: the
+    /// substitution decides whether an answer comes out in the cosine, the sine or the tangent,
+    /// and all three are right.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class TrigonometricPowerProductTest
+    {
+        /// <summary>
+        /// Inside one branch and away from the poles of all six functions, which sit at multiples
+        /// of <c>pi/2</c>.
+        /// </summary>
+        private static readonly double[] Points = { 0.35, 0.61, 0.9, 1.15, 1.35 };
+
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 4,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}, "
+                + "so this asserts almost nothing");
+        }
+
+        /// <summary>
+        /// <c>tan^m sec^n</c>. An odd <c>m</c> goes by <c>u = cos</c> and an even one with
+        /// <c>n</c> even by <c>u = tan</c>, so both branches are covered here rather than only
+        /// the textbook case.
+        /// </summary>
+        [Theory]
+        [InlineData("tan(x)^3*sec(x)^4")]
+        [InlineData("tan(x)^2*sec(x)^4")]
+        [InlineData("tan(x)*sec(x)^3")]
+        [InlineData("tan(x)^5*sec(x)^2")]
+        [InlineData("tan(x)^3*sec(x)^5")]
+        [InlineData("sec(x)^6*tan(x)^3")]
+        [InlineData("sec(x)^4*tan(x)^2")]
+        public void TheTangentTimesTheSecant(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// <c>cot^m csc^n</c>, which is a separate set of nodes here and so separate coverage
+        /// rather than a symmetry anyone may assume.
+        /// </summary>
+        [Theory]
+        [InlineData("cot(x)^3*csc(x)^4")]
+        [InlineData("cot(x)^2*csc(x)^4")]
+        [InlineData("csc(x)^3*cot(x)")]
+        [InlineData("cot(x)^5*csc(x)^2")]
+        public void TheCotangentTimesTheCosecant(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// The same integrands spelled in the sine and the cosine, including as quotients. One
+        /// expression written two ways has to get one verdict, which is the defect this file's
+        /// neighbours have carried repeatedly.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x)^2/cos(x)^4")]
+        [InlineData("sin(x)^3/cos(x)^5")]
+        [InlineData("sin(x)^3/cos(x)^7")]
+        [InlineData("cos(x)^3/sin(x)^7")]
+        [InlineData("sin(x)/cos(x)^3")]
+        [InlineData("1/(sin(x)^2*cos(x)^2)")]
+        [InlineData("1/(sin(x)*cos(x))")]
+        public void TheSameThingInSineAndCosine(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// Positive powers of both, where the answer is a polynomial in whichever of the two the
+        /// odd exponent picks out.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x)^3*cos(x)^2")]
+        [InlineData("sin(x)^5*cos(x)^4")]
+        [InlineData("sin(x)^3*cos(x)^3")]
+        [InlineData("sin(x)^3")]
+        [InlineData("cos(x)^5")]
+        public void PositivePowersOfBoth(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// A linear argument, which divides the whole answer by the rate. The constant term is
+        /// there because a rule reading only the coefficient gets <c>3x + 1</c> right by accident
+        /// and <c>3x</c> wrong in the same way.
+        /// </summary>
+        [Theory]
+        [InlineData("tan(2*x)^3*sec(2*x)^4")]
+        [InlineData("cot(3*x + 1)^3*csc(3*x + 1)^4")]
+        [InlineData("sin(2*x)^3*cos(2*x)^2")]
+        public void ALinearArgument(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// The neighbours, each answered without this rule and each a chance for it to take an
+        /// integrand it should leave alone. Both exponents even and non-negative is deliberately
+        /// outside it — the tangent substitution leaves a negative power of <c>1 + u^2</c> there
+        /// rather than a polynomial — and the power reductions answer those.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x)^2*cos(x)^4")]
+        [InlineData("sin(x)^4*cos(x)^2")]
+        [InlineData("sin(x)^2")]
+        [InlineData("cos(x)^6")]
+        [InlineData("sec(x)^4")]
+        [InlineData("csc(x)^6")]
+        [InlineData("sec(x)^3")]
+        [InlineData("tan(x)^2")]
+        [InlineData("cot(x)^4")]
+        [InlineData("sin(x)*cos(2*x)")]
+        [InlineData("x*sin(x)")]
+        public void TheNeighboursAreUntouched(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// Integrands the read must refuse: two different arguments, a non-integer power, and a
+        /// factor that is not trigonometric at all. A rule that guessed at the part it did not
+        /// recognise would answer a question it was not asked, so these must come back unanswered
+        /// or answered by something else — never wrong.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x)^3*cos(2*x)^2")]
+        [InlineData("sin(x)^(1/2)*cos(x)^3")]
+        [InlineData("x*tan(x)^3*sec(x)^4")]
+        [InlineData("a*sin(x)^3*cos(x)^2")]
+        public void WhatTheReadRefuses(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+            if (integral.Stringize().Contains("integral("))
+                return;   // unanswered is a legitimate verdict; a wrong answer is not
+            // Answered by some other rule, which is fine — but it has to be right.
+            var derivative = integral.Substitute("C", 0).Differentiate("x").Substitute("a", 3);
+            var original = integrand.ToEntity().Substitute("a", 3);
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
`tan(x)^3*sec(x)^4`, `cot(x)^3*csc(x)^4`, `sin(x)^2/cos(x)^4` and `sec(x)^6*tan(x)^3`
had no antiderivative between them. They are all one thing: `tan^m sec^n` is
`sin^m cos^(-m-n)`, `cot^m csc^n` is `cos^m sin^(-m-n)`, a power of the secant
alone is `cos^(-n)`. Read as a pair of integer exponents, the family Rubi spreads
over several sections is one rule.

## The three cases, and why exactly three

Each substitution has to leave a *Laurent polynomial* -- a sum of powers of `u`,
integrated term by term -- because that is what makes the rule closed: it asks
the integrator nothing and cannot recurse.

    p odd, p >= 1        u = cos   ->  -(1 - u^2)^((p-1)/2) * u^q        q anything
    q odd, q >= 1        u = sin   ->   u^p * (1 - u^2)^((q-1)/2)        p anything
    both even, p+q <= -2 u = tan   ->   u^p * (1 + u^2)^(-(p+q)/2 - 1)

The third is the one a textbook treatment usually omits and it is not optional:
`tan^2 sec^4` is `sin^2 cos^(-6)`, both exponents even, and neither of the first
two applies. The bound `p + q <= -2` is exactly where the exponent of `1 + u^2`
stops being negative.

Deliberately left out: both even with `p + q >= 0`, the ordinary `sin^2 cos^4`
shapes, where the tangent substitution leaves a negative power of `1 + u^2`
rather than a polynomial. The power reductions already answer those, so the
boundary costs nothing. A power of the secant or cosecant alone reaches the
reduction from #1266 first, which gives a shorter answer for it.

The read refuses anything it has not recognised -- a second argument, a
non-integer power, a factor that is not one of the six -- rather than carrying
it, because a rule that guesses at the part it did not read answers a question
it was not asked. A rational factor rides along.

## Scope

Gated on `AnsweringTheQuestionAsked`, the mechanism #1266 added for #1265.
Measured both ways on the corpus: **identical**, 235 solved and 3 timeouts either
way. Uncapped, on integrands where the rule can only fire below the top, ungating
costs a little and gains nothing:

                                       gated    ungated
    x*tan(x)^3*sec(x)^4                 25 ms    454 ms
    ln(x)*tan(x)^3*sec(x)^4             20 ms    676 ms

So the gate is kept -- it costs nothing measurable and it closes a failure mode a
five-second budget hides as one more timeout, which is how the same shape was
missed on the secant reduction until a targeted probe found it.

## Measured

A probe of 37 shapes -- both products, every spelling, linear arguments, the
neighbours that must stay untouched, and four the read must refuse -- each answer
verified by differentiating back and comparing at five points:

    master (877755c7)   24/37 answered, 0 wrong
    with it             36/37 answered, 0 wrong

The one left is `sin(x)^(1/2)`, which is not this rule's and is declined on both.

Rubi corpus, 463-problem sample, both arms in the foreground:

    master (877755c7)   231/463, 0 wrong, 3 timeouts, 152 s
    with it             235/463, 0 wrong, 3 timeouts, 150 s

Four more, no timeout added, and the wall clock unmoved. Among the four is
`sec(x)^6*tan(x)^3` -- the integrand #1265 was written about, which used to take
637 ms to decline and 400 s to fail to -- now answered in 83 ms. And
`cot(x)^3*csc(x)^4`, the one answer the scope in #1266 gave up, comes back.

The five test suites are green.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
