### PR TITLE
A variable replacement made polynomial division fail whenever the expression had two variables

### DIFF
--- a/Sources/AngouriMath/Functions/TreeAnalyzer/LongDivision.cs
+++ b/Sources/AngouriMath/Functions/TreeAnalyzer/LongDivision.cs
@@ -88,13 +88,44 @@ namespace AngouriMath.Functions
         /// Divides one polynomial over another one:
         /// <a href="https://en.wikipedia.org/wiki/Polynomial_long_division"/>
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>As written first, and only then with the variables replaced.</b> The replacement
+        /// exists for a base that is not a variable — <c>sin(x)^2 / sin(x)</c>, where the thing
+        /// the division is in is <c>sin(x)</c> — and it works by swapping each variable's
+        /// smallest enclosing subtree for a fresh symbol. With one variable that is harmless,
+        /// because nothing in the pair contains the whole expression. With <b>two</b> it is
+        /// destructive: for <c>x / (a + b x)</c> the smallest subtree holding <c>a</c> is
+        /// <c>a + b x</c>, so the divisor is replaced wholesale by one opaque symbol, the
+        /// dividend keeps its <c>x</c>, and the two no longer share a variable to divide in.
+        /// The division then reports that it cannot be done.
+        /// </para>
+        /// <para>
+        /// What that cost: <c>int x/(a + b x) dx</c> was unanswered while
+        /// <c>int x/(2 + 3 x) dx</c> came out, and the same for every improper fraction with a
+        /// symbolic coefficient — including the one <c>int x ln(b + a x) dx</c> is left with
+        /// after integration by parts. A numeric coefficient hid the defect, which is the usual
+        /// way this one hides.
+        /// https://github.com/asc-community/AngouriMath/issues/718
+        /// </para>
+        /// <para>
+        /// Trying the unreplaced form first keeps both: a pair that divides as written divides
+        /// the same way it always did, and one that does not falls through to the replacement,
+        /// which is the only thing that ever answered <c>sin(x)^2 / sin(x)</c>.
+        /// </para>
+        /// </remarks>
         internal static (Entity Divided, Entity Remainder)? PolynomialLongDivision(Entity p, Entity q)
         {
             if (!p.Vars.Any() || !q.Vars.Any())
                 return null; // There are no variables to find polynomial as
+            return DivideOnePolynomial(p, q, replaceVars: false)
+                ?? DivideOnePolynomial(p, q, replaceVars: true);
+        }
 
+        private static (Entity Divided, Entity Remainder)? DivideOnePolynomial(Entity p, Entity q, bool replaceVars)
+        {
             // ---> (x^0.6 + 2x^0.3 + 1) / (x^0.3 + 1)
-            var replacementInfo = GatherAllPossiblePolynomials(p + q, replaceVars: true);
+            var replacementInfo = GatherAllPossiblePolynomials(p + q, replaceVars);
 
             var originalP = p;
             var originalQ = q;
@@ -128,6 +159,22 @@ namespace AngouriMath.Functions
             // TODO: add case where all powers are non-positive
             // for now just return polynomials unchanged
             if (maxpowP.LessThan(maxpowQ)) return null;
+
+            // The unreplaced attempt divides by the divisor's leading coefficient, so it runs
+            // only where that coefficient is a number other than zero — which is to say, where
+            // the quotient it produces is valid for every value of every symbol in it. With a
+            // symbolic leading coefficient it would not be: `x^2/(a + b x)` divided out is
+            // undefined at `b = 0`, where the integrand is `x^2/a` and perfectly ordinary, and a
+            // quotient that silently loses a value of a parameter is worse than none.
+            // `x^2/(x + a)` has leading coefficient 1 and is not that case, which is why it is
+            // answered now and was not before.
+            //
+            // A symbolic leading coefficient is a gap here rather than a decision: what it wants
+            // is the divided form beside the degenerate one, under conditions, and this function
+            // returns a pair rather than a piecewise. Item 18 of the list below is that integral,
+            // still unticked. https://github.com/asc-community/AngouriMath/issues/180
+            if (!replaceVars && (maxvalQ.Vars.Any() || maxvalQ.Evaled == Integer.Create(0)))
+                return null;
 
             var result = new Dictionary<EDecimal, Entity>();
             // possibly very long process

--- a/Sources/Tests/UnitTests/Calculus/ImproperFractionIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ImproperFractionIntegralTest.cs
@@ -104,15 +104,96 @@ namespace AngouriMath.Tests.Calculus
             => Assert.Equal(expected.ToEntity(), integrand.ToEntity().Integrate("x"));
 
         /// <summary>
-        /// A denominator whose leading coefficient is symbolic is still declined. The division
-        /// would have to divide by <c>b</c>, which is not decidably non-zero — and at <c>b = 0</c>
-        /// the quotient is <c>x^2/a</c>, whose antiderivative is not the limit of the divided
-        /// form. <see href="https://github.com/asc-community/AngouriMath/issues/180"/> item 18.
+        /// A denominator whose <b>leading coefficient</b> is symbolic is still declined, and this
+        /// records a gap rather than a decision.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Dividing out would divide by <c>b</c>, which is not decidably non-zero — and at
+        /// <c>b = 0</c> the quotient is <c>x^2/a</c>, whose antiderivative is not the limit of
+        /// the divided form. So the divided answer alone would be wrong for one value of a
+        /// parameter, which is why it is not given.
+        /// </para>
+        /// <para>
+        /// <b>What is owed is the piecewise, not the decline.</b>
+        /// <see href="https://github.com/asc-community/AngouriMath/issues/180"/> lists
+        /// <c>x^2/(a + b*x)</c> as item 18 of the integrals this library should answer, and it is
+        /// still unticked — it is a target, not a settled refusal. The answer it wants is the
+        /// divided form under <c>b != 0</c> beside <c>x^3/(3a)</c> under <c>b = 0</c>, which is
+        /// how the constant-over-a-quadratic rule already reports its own degenerate branch.
+        /// Until that is built these stay unevaluated, which is the honest report.
+        /// </para>
+        /// </remarks>
         [Theory]
         [InlineData("x^2/(a + b*x)")]
-        [InlineData("x^2/(x + a)")]
+        [InlineData("x^2/(2 + b*x)")]
+        [InlineData("x^3/(a + b*x)")]
         public void ASymbolicLeadingCoefficientIsDeclined(string integrand)
             => Assert.Contains("integral(", integrand.ToEntity().Integrate("x").Stringize());
+
+        /// <summary>
+        /// A symbolic coefficient that is <b>not</b> the leading one carries none of that
+        /// argument, and these are answered.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>x^2/(x + a)</c> was on the list above, and it did not belong there: its leading
+        /// coefficient is <c>1</c>, nothing is divided by a symbol, and the quotient
+        /// <c>x - a + a^2/(x + a)</c> holds for every <c>a</c>. It was declined for an unrelated
+        /// reason — the division replaced each variable by its smallest enclosing subtree, which
+        /// for <c>a</c> is the whole denominator, so the divisor became one opaque symbol and no
+        /// longer shared a variable with the dividend.
+        /// </para>
+        /// <para>
+        /// Recorded here rather than deleted, because the reason written against the old verdict
+        /// was true of one of its two cases and not of the other, and the difference is exactly
+        /// what decides whether a quotient like this may be given.
+        /// </para>
+        /// </remarks>
+        [Theory]
+        [InlineData("x^2/(x + a)", new[] { 0.3, 1.7, 5.0 })]
+        [InlineData("x^2/(a + x)", new[] { 0.3, 1.7, 5.0 })]
+        [InlineData("x^3/(x + a)", new[] { 0.3, 1.7, 5.0 })]
+        [InlineData("x^4/(x + a)", new[] { 0.3, 1.7, 5.0 })]
+        [InlineData("(x^2 + 1)/(x + a)", new[] { 0.3, 1.7, 5.0 })]
+        [InlineData("x^3/(x^2 + a)", new[] { 0.3, 1.7, 5.0 })]
+        [InlineData("x*ln(a + x)", new[] { 0.3, 1.7, 5.0 })]
+        [InlineData("x^2*ln(a + x)", new[] { 0.3, 1.7, 5.0 })]
+        public void ASymbolicCoefficientThatIsNotTheLeadingOne(string integrand, double[] points)
+        {
+            var pinned = integrand.ToEntity().Substitute("a", 2);
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+            Assert.DoesNotContain("NaN", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x").Substitute("a", 2);
+            var compared = 0;
+            foreach (var at in points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = pinned.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 3,
+                $"only {compared} of {points.Length} points were comparable for {integrand}");
+        }
+
+        /// <summary>
+        /// What the division has always been able to do and must keep doing: a base that is not a
+        /// variable, which only the variable replacement reaches.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x)^2/sin(x)", new[] { 0.3, 0.9, 1.3 })]
+        [InlineData("x^(6/10)/x^(3/10)", new[] { 0.3, 1.7, 5.0 })]
+        public void ABaseThatIsNotAVariable(string integrand, double[] points)
+            => DifferentiatesBack(integrand, points);
     }
 }


### PR DESCRIPTION
`int x^2/(x + 1) dx` came out and `int x^2/(x + a) dx` did not. Nothing about the
second is harder: its quotient is `x - a + a^2/(x + a)`, every piece of which has
been integrable throughout, and nothing is divided by a symbol.

## What it was

`PolynomialLongDivision` begins by replacing each variable with a fresh symbol
standing for that variable's **smallest enclosing subtree**. That is there for a
base which is not a variable -- `sin(x)^2 / sin(x)`, where the thing the division
is in is `sin(x)` -- and with one variable it is harmless, because nothing in the
pair contains the whole expression.

With two variables it is destructive. For `x / (a + b*x)` the smallest subtree
holding `a` is `a + b*x`, so the replacement map is

    x + a + b*x  =>  %1      a + b*x  =>  %2      b*x  =>  %3

and the divisor is rewritten wholesale to the single opaque symbol `%2` while the
dividend keeps its `x`. The two no longer share a variable to divide in, and the
division reports that it cannot be done. Traced by printing the replacement map
and the monomial keys of each side.

A numeric coefficient hides it: `x + 3 + 2*x` has one variable, so no replacement
matches either side and the division runs. That is why `x^2/(x + 1)` worked and
`x^2/(x + a)` did not -- and why it took a Rubi corpus row rather than a test to
notice.

## What it is

The pair is divided **as written** first, and only then with the variables
replaced. A pair that divided before divides the same way; one that did not falls
through to the replacement, which is still the only thing that answers
`sin(x)^2 / sin(x)`.

The unreplaced attempt is guarded on the divisor's **leading coefficient being a
number other than zero** -- which is to say, on the quotient being valid for every
value of every symbol in it. `x^2/(a + b*x)` is not that case: divided out it is
undefined at `b = 0`, where the integrand is `x^2/a` and perfectly ordinary, and a
quotient that silently loses a value of a parameter is worse than none. That case
stays declined.

**And that is a gap, not a decision.** #180 lists `x^2/(a + b*x)` as item 18 of
the integrals this library should answer and it is still unticked -- a target, not
a settled refusal. What it wants is the divided form under `b != 0` beside
`x^3/(3a)` under `b = 0`, which is how the constant-over-a-quadratic rule already
reports its own degenerate branch. Producing that is a piecewise where this
function returns a pair, so it belongs above the division rather than in it, and
is left for its own change. The test comment now says so; it previously read as
though #180 had decided to decline.

## A recorded verdict that was right about one of its two cases

That test pinned both `x^2/(a + b*x)` and `x^2/(x + a)` as declined, under one
reason: "the division would have to divide by `b`, which is not decidably
non-zero". True of the first. The second has leading coefficient **1** and divides
by nothing symbolic; it was on the list because of the defect above, and the
reason written against it was a rationalisation of an accident.

The test now separates them: the symbolic-leading-coefficient cases stay pinned as
declined and gain two more, and the second case moves to a new theory that checks
the answer by differentiating it back. The old reason is kept, attached to the
half it is true of, with a note saying why the other half moved -- because the
distinction is exactly what decides whether a quotient like this may be given.

## Measured

Thirteen shapes with a symbolic coefficient that is not the leading one, each
verified by differentiating back with `a` pinned and comparing at points:

    master (877755c7)    4/13 answered, 0 wrong
    with it             13/13 answered, 0 wrong

Newly answered: `x^2/(x + a)`, `x^3/(x + a)`, `x^4/(x + a)`, `(x^2 + 1)/(x + a)`,
`x^3/(x^2 + a)`, `x*ln(a + x)`, `x^2*ln(a + x)`, and their spellings the other way
round.

Rubi corpus, 463-problem sample, both arms in the foreground:

    master (877755c7)   231/463, 0 wrong, 3 timeouts, 152 s
    with it             231/463, 0 wrong, 3 timeouts, 154 s

Unchanged, which is what a fix on a shape the sample does not carry should look
like -- the sample's parameters sit in the leading position.

`Simplify` uses this division too, through its own `PolynomialLongDivision` rule
set, and its answers do not move: it ranks the compact form above the divided one
and `x^2/(x + a)` still prints as itself. The five test suites are green.

Part of #718. Part of #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
