### PR TITLE
Integration by parts cut a product where it was written rather than where the polynomial is

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -333,3 +333,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/TrigonometricPowerProductTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/ByPartsRegroupingTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -382,7 +382,7 @@ namespace AngouriMath.Functions.Algebra
                 return v * integralOfU - remainingIntegral;
             }
 
-            if (expr is Entity.Mulf(var f, var g))
+            Entity? TrySplit(Entity f, Entity g)
             {
                 // Case 0: a logarithm times a polynomial. Only one of the two orders
                 // terminates. Differentiating the polynomial, which is what Case 1 does,
@@ -405,6 +405,30 @@ namespace AngouriMath.Functions.Algebra
                 // Try both orderings: f as v, g as u OR g as v, f as u
                 if (TryIntegrateByPartsOnce(f, g, x, wholeSize) is { } result1) return result1;
                 if (TryIntegrateByPartsOnce(g, f, x, wholeSize) is { } result2) return result2;
+                return null;
+            }
+
+            if (expr is Entity.Mulf(var f, var g))
+            {
+                if (TrySplit(f, g) is { } atTheTop) return atTheTop;
+
+                // **And the same again with the factors regrouped.** The split above is the top
+                // `Mulf` node's two children, which is a fact about how the product was written
+                // rather than about the integrand: `x * cos(x) * sin(x)` parses left-associated,
+                // so the two children are `x * cos(x)` and `sin(x)` -- neither a polynomial, and
+                // none of the three cases above finds anything. `x * (cos(x) * sin(x))` is the
+                // same function with the same factors, and it came out, because there the
+                // polynomial is a child.
+                //
+                // So the factors are gathered and cut once more, polynomial on one side and the
+                // rest on the other, which is the split every one of these cases is looking for
+                // and the only one associativity can hide. Tried second, so an integrand that
+                // was answered before is answered the same way.
+                // https://github.com/asc-community/AngouriMath/issues/718
+                if (TryRegroupAroundThePolynomial(expr, x) is var (polynomialPart, restPart)
+                    && polynomialPart is not null && restPart is not null
+                    && TrySplit(polynomialPart, restPart) is { } regrouped)
+                    return regrouped;
             }
 
             // Special case for powers of integrable functions, try integration by parts on base × base
@@ -412,6 +436,38 @@ namespace AngouriMath.Functions.Algebra
             if (expr is Powf(var @base, Integer(2)) && TryIntegrateByPartsOnce(@base, @base, x, wholeSize) is { } result) return result;
 
             return null;
+        }
+
+        /// <summary>
+        /// The factors of <paramref name="expr"/> cut into the polynomial ones and the rest,
+        /// where that cut is not the one the top <c>Mulf</c> node already makes.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Both halves <see langword="null"/> when there is nothing new to offer: fewer than three
+        /// factors, or all of them polynomial, or none of them. In those cases the top node's own
+        /// split is either the same cut or the only one there is.
+        /// </para>
+        /// <para>
+        /// A factor free of the variable counts as polynomial, since it is a constant here and
+        /// belongs with the part that gets differentiated — where it survives one step and
+        /// vanishes from the recursion, rather than riding along inside an integrand.
+        /// </para>
+        /// </remarks>
+        private static (Entity? Polynomial, Entity? Remainder) TryRegroupAroundThePolynomial(Entity expr, Entity.Variable x)
+        {
+            var factors = Mulf.LinearChildren(expr).ToList();
+            if (factors.Count < 3)
+                return (null, null);
+
+            Entity? polynomial = null;
+            Entity? rest = null;
+            foreach (var factor in factors)
+                if (MathS.TryPolynomial(factor, x, out _) || !factor.ContainsNode(x))
+                    polynomial = polynomial is null ? factor : polynomial * factor;
+                else
+                    rest = rest is null ? factor : rest * factor;
+            return polynomial is null || rest is null ? (null, null) : (polynomial, rest);
         }
 
         internal static Entity? SolveLogarithmic(Entity expr, Entity.Variable x, bool integrateByParts = true) => expr switch

--- a/Sources/Tests/UnitTests/Calculus/ByPartsRegroupingTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ByPartsRegroupingTest.cs
@@ -1,0 +1,135 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// Integration by parts cuts a product into the polynomial factors and the rest, rather than
+    /// at whichever node the product happens to have been built around.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>x*cos(x)*sin(x)</c> had no antiderivative and <c>x*(cos(x)*sin(x))</c> did. They are the
+    /// same function: multiplication is associative, and the only difference is that the first
+    /// parses left-associated, so the top node's two children are <c>x*cos(x)</c> and
+    /// <c>sin(x)</c> — neither a polynomial, which is what every one of the by-parts cases is
+    /// looking for.
+    /// </para>
+    /// <para>
+    /// <b>Both spellings are asserted in every case below</b>, and that is the point of the test:
+    /// the defect is invisible unless the same function is asked for twice.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class ByPartsRegroupingTest
+    {
+        private static readonly double[] Points = { 0.35, 0.61, 0.9, 1.15, 1.35 };
+
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 4,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}, "
+                + "so this asserts almost nothing");
+        }
+
+        /// <summary>
+        /// A polynomial times two trigonometric factors, written flat and written grouped. The
+        /// second of each pair came out before this and the first did not.
+        /// </summary>
+        [Theory]
+        [InlineData("x*cos(x)*sin(x)", "x*(cos(x)*sin(x))")]
+        [InlineData("x*sin(x)*cos(x)^2", "x*(sin(x)*cos(x)^2)")]
+        [InlineData("x^2*sin(x)*cos(x)", "x^2*(sin(x)*cos(x))")]
+        [InlineData("x*sin(x)^3*cos(x)^2", "x*(sin(x)^3*cos(x)^2)")]
+        public void TheSameProductWrittenTwoWays(string flat, string grouped)
+        {
+            DifferentiatesBack(flat);
+            DifferentiatesBack(grouped);
+        }
+
+        /// <summary>
+        /// Associativity is not the only spelling that moved the split — the order of the factors
+        /// decides it too, since <c>cos(x)*sin(x)*x</c> puts the polynomial where the top node can
+        /// see it and <c>x*cos(x)*sin(x)</c> does not. All four orders of the same three factors.
+        /// </summary>
+        [Theory]
+        [InlineData("x*cos(x)*sin(x)")]
+        [InlineData("cos(x)*x*sin(x)")]
+        [InlineData("cos(x)*sin(x)*x")]
+        [InlineData("sin(x)*x*cos(x)")]
+        public void EveryOrderOfTheSameThreeFactors(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// More than one polynomial factor, which the regrouping gathers onto one side rather than
+        /// leaving scattered, and a constant among them — a factor free of the variable belongs
+        /// with the part that is differentiated, where it survives one step and then vanishes.
+        /// </summary>
+        [Theory]
+        [InlineData("x*x*sin(x)*cos(x)")]
+        [InlineData("2*x*sin(x)*cos(x)")]
+        [InlineData("x*(x + 1)*sin(x)*cos(x)")]
+        public void SeveralPolynomialFactors(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// What the regrouping must not change: a two-factor product, where the top node's split
+        /// is the only one there is, and a product with no polynomial factor at all. These were
+        /// answered before and are answered the same way.
+        /// </summary>
+        [Theory]
+        [InlineData("x*sin(x)")]
+        [InlineData("x*ln(x)")]
+        [InlineData("x*e^x")]
+        [InlineData("x^2*sin(x)")]
+        [InlineData("sin(x)*cos(x)")]
+        [InlineData("e^x*sin(x)")]
+        [InlineData("x*arctan(x)")]
+        public void TheTwoFactorCasesAreUnchanged(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// A product of three factors with nothing polynomial in it, which the regrouping declines
+        /// to cut because there is no polynomial side to cut towards. Unanswered is a legitimate
+        /// verdict here; a wrong answer is not.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x)*cos(x)*e^x")]
+        [InlineData("ln(x)*sin(x)*cos(x)")]
+        public void NoPolynomialFactorToCutTowards(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+            if (integral.Stringize().Contains("integral("))
+                return;
+            DifferentiatesBack(integrand);
+        }
+    }
+}


### PR DESCRIPTION
`x*cos(x)*sin(x)` had no antiderivative. `x*(cos(x)*sin(x))` did. They are the same
function.

Multiplication is associative and the parser is not: the first parses
left-associated, so the top `Mulf` node's two children are `x*cos(x)` and
`sin(x)`. By parts reads exactly those two children, and every one of its three
cases is looking for a polynomial factor -- neither of those is one, so all three
declined. Put the same three factors in a different order and it came out again:
`cos(x)*sin(x)*x` works, because there the polynomial is where the top node can
see it.

    x*cos(x)*sin(x)        no antiderivative
    x*(cos(x)*sin(x))      answered
    cos(x)*sin(x)*x        answered
    cos(x)*x*sin(x)        no antiderivative

## What it is

The factors are gathered with `Mulf.LinearChildren` and cut once more, polynomial
on one side and the rest on the other. That is the split all three cases are
looking for and the only one associativity can hide.

Tried **second**, after the top node's own split, so an integrand that was
answered before is answered by the same route and the same way. Offered only when
there are at least three factors and both sides would be non-empty -- with two
factors the top node's split is already the only cut there is.

A factor free of the variable goes with the polynomial side, since it is a
constant here and belongs with the part that is differentiated, where it survives
one step and then leaves the recursion rather than riding along inside an
integrand.

## Measured

    master (51075a21)    9/16 answered, 0 wrong
    with it             12/16 answered, 0 wrong

on a probe that writes each product in both spellings, verified by differentiating
back at five points. `x*e^x*sin(x)` is still declined in **both** spellings, which
is a different gap and not this one -- the point of the probe is that the two
spellings now agree everywhere.

Rubi corpus, 463-problem sample, both arms in the foreground:

    master (51075a21)   235/463, 0 wrong, 3 timeouts, 151 s
    with it             236/463, 0 wrong, 3 timeouts, 152 s

The wall clock does not move, which matters more here than the extra answer: this
widens the by-parts search by one split per product, and the search running longer
on integrands it will never answer is what #1265 is about. The two tests that
exist for that -- `AnIntegralWithNoAnswerStillFinishesQuickly` and
`DecliningStaysCheap` -- pass, and the five suites are green.

The new test asserts **both spellings in every case**, because the defect is
invisible unless the same function is asked for twice, and covers all four orders
of the same three factors, several polynomial factors at once, the two-factor
products that must not change, and a three-factor product with nothing polynomial
in it for the regrouping to decline.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
