### PR TITLE
Integration by parts never looked at a quotient, and a logarithm in the middle of one was out of reach

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -336,3 +336,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/ByPartsRegroupingTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/ByPartsQuotientTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -431,11 +431,126 @@ namespace AngouriMath.Functions.Algebra
                     return regrouped;
             }
 
+            // **And once more around the factor LIATE differentiates first, wherever it sits.**
+            // The block above only runs on a product, so `arcsin(x)/(x^2*sqrt(1 - x^2))` never
+            // reached this rule at all -- its top node is a quotient. Written as the product it
+            // is, `arcsin(x) * (1/(x^2*sqrt(1 - x^2)))`, the same integrand came out. A quotient
+            // is a product with reciprocals in it, and reading it as one is the whole of this.
+            //
+            // The cut is the logarithm or inverse trigonometric factor against everything else,
+            // because that is the factor whose derivative is algebraic and cancels; taking it
+            // out of the middle of a product is the same defect as taking the polynomial out,
+            // with a different factor doing the work. `x*arcsin(x)/sqrt(1 - x^2)` needs both
+            // moves at once: read as a product, and cut at the arcsine rather than at the top.
+            //
+            // **Two bounds, and both were measured rather than added for safety.** Without them
+            // this is worth six more answers on the Rubi sample and forty per cent of its wall
+            // clock, which is what https://github.com/asc-community/AngouriMath/issues/1265 is
+            // about. With them it is worth the same six answers and three per cent.
+            //
+            // The first is scope: asked, not volunteered. The split is offered only for the
+            // caller's own integrand, never for one another rule produced on the way somewhere.
+            // A by-parts step produces quotients holding logarithms by the dozen, and each of
+            // those opening a fresh by-parts attempt is where the time went --
+            // `cos(x)^3*ln(sin(x))` is answered in 1.7 s by master and took 45 s without this,
+            // although the rule never fires on it at the top at all.
+            //
+            // The second is in the regrouping: exactly one factor to differentiate, never two.
+            if (Integration.AnsweringTheQuestionAsked
+                && TryRegroupAroundTheDifferentiatedFactor(expr) is var (differentiated, others)
+                && differentiated is not null && others is not null
+                && TrySplit(differentiated, others) is { } byLiate)
+                return byLiate;
+
             // Special case for powers of integrable functions, try integration by parts on base × base
             // e.g., ln(abs(x))^2 = ln(abs(x)) × ln(abs(x))
             if (expr is Powf(var @base, Integer(2)) && TryIntegrateByPartsOnce(@base, @base, x, wholeSize) is { } result) return result;
 
             return null;
+        }
+
+        /// <summary>
+        /// The factors of <paramref name="expr"/> read as a product — a quotient contributing its
+        /// denominator's factors as reciprocals — cut into the one
+        /// <see cref="IsDifferentiatedBeforeAPolynomial"/> recognises and everything else.
+        /// </summary>
+        /// <remarks>
+        /// Both halves <see langword="null"/> when there is no such factor, or when it is the
+        /// whole integrand and there is nothing to put on the other side. One factor is taken,
+        /// not all of them: it is the one that gets differentiated, and differentiating a product
+        /// of two logarithms is not a step towards anything.
+        /// </remarks>
+        private static (Entity? Differentiated, Entity? Others) TryRegroupAroundTheDifferentiatedFactor(Entity expr)
+        {
+            var factors = FactorsOfTheIntegrand(expr);
+            if (factors.Count < 2)
+                return (null, null);
+
+            // Exactly one, and that is a bound rather than a tidiness. With two logarithms or
+            // inverse trigonometric factors there is no reason to differentiate one rather than
+            // the other, so the choice is a guess -- and what is left still holds the other one,
+            // so the step has not made the problem smaller. Measured on
+            // `x*arctan(x)*ln(x + sqrt(1 + x^2))/sqrt(1 + x^2)`: declined in 66 ms without this
+            // rule and in 39 s with it choosing one of the two.
+            if (factors.Count(pair => !pair.Underneath && IsDifferentiatedBeforeAPolynomial(pair.Factor)) != 1)
+                return (null, null);
+
+            Entity? differentiated = null;
+            Entity? above = null;
+            Entity? below = null;
+            foreach (var (factor, underneath) in factors)
+                if (differentiated is null && !underneath && IsDifferentiatedBeforeAPolynomial(factor))
+                    differentiated = factor;
+                else if (underneath)
+                    below = below is null ? factor : below * factor;
+                else
+                    above = above is null ? factor : above * factor;
+
+            if (differentiated is null || (above is null && below is null))
+                return (null, null);
+            // **Put the rest back together as one quotient**, numerator over denominator, rather
+            // than as a product of reciprocals. Which of the two it is decides whether the rules
+            // below read it: `1/(x^2*sqrt(1 - x^2))` is answered and
+            // `(1/x^2) * (1/sqrt(1 - x^2))` is not, and handing on the second shape means this
+            // rule reproduces, inside itself, exactly the spelling defect it exists to remove.
+            var others = below is null ? above! : above is null ? 1 / below : above / below;
+            return (differentiated, others);
+        }
+
+        /// <summary>
+        /// <paramref name="expr"/> read as a product of factors, each paired with whether it sits
+        /// under a division bar.
+        /// </summary>
+        /// <remarks>
+        /// <c>a/(b*c)</c> comes back as <c>a</c> above and <c>b</c>, <c>c</c> below — which is
+        /// what lets a rule that reasons about factors see through a quotient, where
+        /// <see cref="Mulf.LinearChildren"/> stops at it. The flag is kept rather than folded
+        /// into a reciprocal so that the caller can rebuild one quotient instead of a product of
+        /// them.
+        /// </remarks>
+        private static List<(Entity Factor, bool Underneath)> FactorsOfTheIntegrand(Entity expr)
+        {
+            var factors = new List<(Entity, bool)>();
+            Gather(expr, underneath: false);
+            return factors;
+
+            void Gather(Entity node, bool underneath)
+            {
+                switch (node)
+                {
+                    case Mulf(var left, var right):
+                        Gather(left, underneath);
+                        Gather(right, underneath);
+                        break;
+                    case Divf(var numerator, var denominator):
+                        Gather(numerator, underneath);
+                        Gather(denominator, !underneath);
+                        break;
+                    default:
+                        factors.Add((node, underneath));
+                        break;
+                }
+            }
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Calculus/ByPartsQuotientTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ByPartsQuotientTest.cs
@@ -1,0 +1,161 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// Integration by parts reads a quotient as the product it is, and cuts it at the logarithm
+    /// or inverse trigonometric factor wherever that factor sits.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>arcsin(x)/(x^2*sqrt(1 - x^2))</c> had no antiderivative and
+    /// <c>arcsin(x)*(1/(x^2*sqrt(1 - x^2)))</c> did — the same function, and the second is a
+    /// product where the first is a quotient, which by parts never looked at. The companion
+    /// defect is the split: <c>x*arcsin(x)/sqrt(1 - x^2)</c> needs the arcsine taken out of the
+    /// middle, which is the same move
+    /// <a href="https://github.com/asc-community/AngouriMath/pull/1271">#1271</a> made for a
+    /// polynomial factor.
+    /// </para>
+    /// <para>
+    /// <b>Both spellings are asserted in every case</b>, because that disagreement is the defect
+    /// and it is invisible unless the same function is asked for twice.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class ByPartsQuotientTest
+    {
+        /// <summary>
+        /// Inside <c>(0, 1)</c>, where every integrand here is real — the arcsine and
+        /// <c>sqrt(1 - x^2)</c> both want it, and so does the logarithm.
+        /// </summary>
+        private static readonly double[] Points = { 0.21, 0.35, 0.52, 0.71, 0.83 };
+
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 4,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}, "
+                + "so this asserts almost nothing");
+        }
+
+        /// <summary>
+        /// The same integrand as a quotient and as the product it is. The second of each pair
+        /// came out before this and the first did not.
+        /// </summary>
+        [Theory]
+        [InlineData("arcsin(x)/(x^2*sqrt(1 - x^2))", "arcsin(x)*(1/(x^2*sqrt(1 - x^2)))")]
+        [InlineData("x*arcsin(x)/sqrt(1 - x^2)", "arcsin(x)*(x/sqrt(1 - x^2))")]
+        [InlineData("arctan(x)/x^2", "arctan(x)*(1/x^2)")]
+        [InlineData("ln(x)/x^3", "ln(x)*(1/x^3)")]
+        public void AQuotientAndTheProductItIs(string quotient, string product)
+        {
+            DifferentiatesBack(quotient);
+            DifferentiatesBack(product);
+        }
+
+        /// <summary>
+        /// The factor to differentiate taken out of the middle of a quotient, which needs both
+        /// moves at once — read as a product, and cut somewhere other than the top node.
+        /// </summary>
+        [Theory]
+        [InlineData("x*arcsin(x)/sqrt(1 - x^2)")]
+        [InlineData("x*ln(x + sqrt(1 + x^2))/sqrt(1 + x^2)")]
+        [InlineData("x*ln(x)/x^2")]
+        public void TheFactorIsTakenOutOfTheMiddle(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// <c>ln|x|/x</c>, which a recorded verdict called unsolvable and named the logarithmic
+        /// integral for. It is not: <c>Li(x)</c> is the antiderivative of <c>1/ln(x)</c>, and
+        /// this one is <c>ln|x|^2/2</c>. What comes out is that up to a constant — on the
+        /// negative axis <c>ln(x)</c> is <c>ln|x| + i*pi</c>, so the form differs by
+        /// <c>pi^2/2</c> — and it differentiates back either side of zero.
+        /// </summary>
+        [Theory]
+        [InlineData(0.37)]
+        [InlineData(1.4)]
+        [InlineData(-0.6)]
+        [InlineData(-2.3)]
+        public void TheLogarithmOverTheVariableIsElementary(double at)
+        {
+            var integrand = "ln(abs(x))/x".ToEntity();
+            var integral = integrand.Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var got = integral.Substitute("C", 0).Differentiate("x").Substitute("x", at).EvalNumerical();
+            var want = integrand.Substitute("x", at).EvalNumerical();
+            var difference = Math.Abs((double)(got - want).RealPart)
+                           + Math.Abs((double)(got - want).ImaginaryPart);
+            Assert.True(difference / Math.Max(1.0, Math.Abs((double)want.RealPart)) < 1e-9,
+                $"d/dx of the antiderivative of ln|x|/x is {got} at x = {at}, where it is {want}");
+        }
+
+        /// <summary>
+        /// Two factors to differentiate is <b>not</b> this rule's, and the bound is what keeps it
+        /// cheap rather than what keeps it tidy: with two, there is no reason to pick one, and
+        /// what is left still holds the other, so the step has made nothing smaller.
+        /// </summary>
+        /// <remarks>
+        /// Bounded by the integrator's own budget rather than by a wall clock, which measures the
+        /// runner. Without the bound this integrand took 39 s to be declined where it takes about
+        /// sixty milliseconds; here what is pinned is only that the verdict is not a wrong answer.
+        /// </remarks>
+        [Theory]
+        [InlineData("x*arctan(x)*ln(x + sqrt(1 + x^2))/sqrt(1 + x^2)")]
+        [InlineData("ln(x)*arctan(x)/x")]
+        public void TwoFactorsToDifferentiateIsNotThisRules(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+            if (integral.Stringize().Contains("integral("))
+                return;   // unanswered is a legitimate verdict; a wrong answer is not
+            DifferentiatesBack(integrand);
+        }
+
+        /// <summary>
+        /// What must not change: the products this already answered, and a quotient with no
+        /// factor to differentiate first — which is every rational function, and the reason the
+        /// rule asks for such a factor rather than trying every quotient.
+        /// </summary>
+        [Theory]
+        [InlineData("x*ln(x)")]
+        [InlineData("x*arctan(x)")]
+        [InlineData("arcsin(x)")]
+        [InlineData("x^2*ln(x)")]
+        [InlineData("ln(x)/x^2")]
+        [InlineData("x/(x^2 + 1)")]
+        [InlineData("1/(x^2 + 1)")]
+        [InlineData("x^3/(x + 1)")]
+        [InlineData("e^x*sin(x)")]
+        public void TheNeighboursAreUntouched(string integrand) => DifferentiatesBack(integrand);
+    }
+}

--- a/Sources/Tests/UnitTests/Calculus/IntegrationTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/IntegrationTest.cs
@@ -204,7 +204,11 @@ namespace AngouriMath.Tests.Calculus
         [InlineData("ln(abs(3x - 1))", "(3 * x - 1) / 3 * (ln(abs(3 * x - 1)) - 1) + C")] // Direct pattern with linear arg
         [InlineData("ln(abs(x + 5))", "(x + 5) * (ln(abs(x + 5)) - 1) + C")] // Direct pattern with linear arg
         [InlineData("ln(abs(2x + 4))", "(2 * x + 4) / 2 * (ln(abs(2 * x + 4)) - 1) + C")] // Direct pattern with linear arg
-        [InlineData("ln(abs(x)) / x", "integral(ln(abs(x)) / x, x)")] // Unsolvable - logarithmic integral Li(x), not expressible in elementary functions
+        // Elementary, and the note that used to sit here said it was not: it named Li(x), which
+        // is the antiderivative of 1/ln(x) and a different integrand. This one is ln|x|^2/2. The
+        // form below is that up to a constant -- with ln(x) = ln|x| + i*pi on the negative axis
+        // it is ln|x|^2/2 + pi^2/2, and differentiating it gives back ln|x|/x either side of zero.
+        [InlineData("ln(abs(x)) / x", "ln(abs(x)) * ln(x) - ln(x) ^ 2 / 2 + C")]
         [InlineData("ln(abs(x)) * ln(abs(x))", "ln(abs(x)) * x * (ln(abs(x)) - 1) - (x * (ln(abs(x)) - 1) + -x) + C")]
         [InlineData("x * ln(abs(x^2))", "x ^ 2 * (ln(abs(x ^ 2)) - 1) / 2 + C")] // Solvable via u-substitution
         [InlineData("ln(abs(sin(x))) * cos(x)", "sin(x) * (ln(abs(sin(x))) - 1) + C")] // Solvable via u-substitution


### PR DESCRIPTION
`arcsin(x)/(x^2*sqrt(1 - x^2))` had no antiderivative.
`arcsin(x)*(1/(x^2*sqrt(1 - x^2)))` did. Same function.

#1271 fixed one face of this -- by parts cut a product at the top `Mulf` node, so
where the polynomial sat decided whether it was found. The other face is that a
**quotient is not a `Mulf` at all**, so an integrand whose top node is a division
never reached the rule, however plainly it was a product. And the factor that
wants differentiating is not always a polynomial: for an arcsine or a logarithm
over something algebraic it is the arcsine, and taking it out of the middle is
the same move #1271 made for a polynomial with a different factor doing the work.

`x*arcsin(x)/sqrt(1 - x^2)` needs both at once: read the quotient as a product,
and cut at the arcsine rather than at the top.

## What it is

The factors are gathered through both `Mulf` and `Divf`, each paired with whether
it sits under the bar, and cut into the one factor LIATE differentiates first and
everything else -- rebuilt as **one quotient**, numerator over denominator, not as
a product of reciprocals. That last part is not cosmetic: `1/(x^2*sqrt(1 - x^2))`
is answered and `(1/x^2) * (1/sqrt(1 - x^2))` is not, so handing on the second
shape would have this rule reproduce, inside itself, the spelling defect it exists
to remove. It cost one measurement to find and the fix is one line.

## Two bounds, both measured rather than added for safety

Without them the rule is worth six answers and **forty per cent of the corpus wall
clock** -- which is https://github.com/asc-community/AngouriMath/issues/1265,
arriving for the sixth time. With them it is worth the same six answers and three
per cent. Each removed one of the two costs, and the arms are separated:

**Scope.** Asked, not volunteered -- `AnsweringTheQuestionAsked` from #1266. A
by-parts step produces quotients holding logarithms by the dozen, and each of them
opening a fresh by-parts attempt is where the time went:

    cos(x)^3*ln(sin(x))      master 1.7 s answered   ungated 45 s   gated 1.5 s

The rule never fires on that integrand at the top at all. The cost was entirely in
the sub-integrals, which is the shape #1265 describes.

**Exactly one factor to differentiate, never two.** With two logarithms or inverse
trigonometric factors there is no reason to pick one, and what is left still holds
the other, so the step has made nothing smaller:

    x*arctan(x)*ln(x + sqrt(1 + x^2))/sqrt(1 + x^2)
        master 66 ms declined   without the bound 39 s   with it 60 ms

## A recorded verdict, and its reason, both wrong

`ln(abs(x))/x` was pinned as unevaluated with the note *"Unsolvable - logarithmic
integral Li(x), not expressible in elementary functions"*. `Li(x)` is the
antiderivative of `1/ln(x)`, a different integrand. This one is `ln|x|^2/2`.

It now comes out as `ln|x|*ln(x) - ln(x)^2/2`, which is that up to a constant --
on the negative axis `ln(x)` is `ln|x| + i*pi`, so the form is `ln|x|^2/2 + pi^2/2`
-- and it differentiates back to `ln|x|/x` at every sample point either side of
zero, checked at seven of them. The test records the answer and the correction.

## Measured

Twenty shapes, each quotient beside the product it is, verified by differentiating
back and comparing at five points:

    master (3818d2e7)   10/20 answered, 0 wrong
    with it             16/20 answered, 0 wrong

Rubi corpus, 463-problem sample, both arms in the foreground:

    master (3818d2e7)   236/463, 0 wrong, 3 timeouts, 152 s
    with it             242/463, 0 wrong, 3 timeouts, 158 s

Six more answers, no timeout added, and the wall clock inside the noise. The five
test suites are green.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
