### PR TITLE
Where no substitution leaves a polynomial, the recurrences still close it

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -342,3 +342,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/RadicalQuadraticTrigTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/TrigonometricReductionTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -787,6 +787,13 @@ namespace AngouriMath.Functions.Algebra
                 (u, expansionPower, leading, insideSign, sign) =
                     (MathS.Tan(argument),
                      -(WholeOf(sinePower) + WholeOf(cosinePower)) / 2 - 1, sinePower, 1, 1);
+            // Neither substitution leaves a polynomial, and with both exponents whole there is
+            // still a closed answer -- it just holds a logarithm, which the recurrences reach and
+            // a rearranged polynomial cannot.
+            else if (IsWholeAndFitsAnInt(sinePower, out var wholeSine)
+                     && IsWholeAndFitsAnInt(cosinePower, out var wholeCosine))
+                return (factor * IntegrateSineCosineByReduction(argument, wholeSine, wholeCosine) / rate)
+                    .InnerSimplified;
             else
                 return null;
 
@@ -809,6 +816,97 @@ namespace AngouriMath.Functions.Algebra
             }
 
             return (factor * sign * total / rate).InnerSimplified;
+        }
+
+        /// <summary>
+        /// <c>int sin(t)^p cos(t)^q dt</c> for whole exponents of any sign, by the four standard
+        /// recurrences, ending on the nine integrands with both exponents in <c>{-1, 0, 1}</c>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>This is the boundary the polynomial route stops at.</b> The three substitutions in
+        /// <see cref="IntegrateAPowerOfSineTimesAPowerOfCosine"/> each leave a Laurent polynomial,
+        /// so they answer the cases where one exponent is odd and positive, or where both are even
+        /// and sum to at most <c>-2</c>. Everything else needs a <b>logarithm</b> somewhere, and
+        /// no rearrangement of a polynomial produces one: <c>sin^2 cos^(-3)</c> is
+        /// <c>x^2/sqrt(1 + x^2)</c> seen through the tangent substitution, and its antiderivative
+        /// holds an inverse hyperbolic sine.
+        /// </para>
+        /// <para>
+        /// The four recurrences, each of them one integration by parts written out:
+        /// </para>
+        /// <code>
+        ///  q down   I(p,q) =  sin^(p+1) cos^(q-1)/(p+q)   + ((q-1)/(p+q))     I(p, q-2)
+        ///  p down   I(p,q) = -sin^(p-1) cos^(q+1)/(p+q)   + ((p-1)/(p+q))     I(p-2, q)
+        ///  q up     I(p,q) = -sin^(p+1) cos^(q+1)/(q+1)   + ((p+q+2)/(q+1))   I(p, q+2)
+        ///  p up     I(p,q) =  sin^(p+1) cos^(q+1)/(p+1)   + ((p+q+2)/(p+1))   I(p+2, q)
+        /// </code>
+        /// <para>
+        /// <b>Termination is <c>|p| + |q|</c>, which every branch below lowers by two</b> until
+        /// both exponents are in <c>{-1, 0, 1}</c>. The downward pair divides by <c>p + q</c> and
+        /// the upward pair by <c>q + 1</c> and <c>p + 1</c>; the ordering is chosen so that the
+        /// branch taken never has a zero divisor. Raising is tried first for exactly that reason —
+        /// <c>q + 1</c> is zero only at <c>q = -1</c>, which is already in range, so an exponent
+        /// at most <c>-2</c> can always be raised, where <c>p + q</c> can vanish at any size.
+        /// </para>
+        /// <para>
+        /// It is <b>closed</b>: the recursion is on two integers walking towards a fixed set, and
+        /// it asks the integrator nothing.
+        /// https://github.com/asc-community/AngouriMath/issues/718
+        /// </para>
+        /// </remarks>
+        private static Entity IntegrateSineCosineByReduction(Entity argument, int sinePower, int cosinePower)
+        {
+            var sine = MathS.Sin(argument);
+            var cosine = MathS.Cos(argument);
+
+            if (sinePower >= -1 && sinePower <= 1 && cosinePower >= -1 && cosinePower <= 1)
+                return (sinePower, cosinePower) switch
+                {
+                    (0, 0) => argument,
+                    (1, 0) => -cosine,
+                    (0, 1) => sine,
+                    (1, 1) => MathS.Sqr(sine) / 2,
+                    (1, -1) => -IntegralPatterns.AntiderivativeLog(cosine),      // int tan
+                    (-1, 1) => IntegralPatterns.AntiderivativeLog(sine),         // int cot
+                    (-1, -1) => IntegralPatterns.AntiderivativeLog(MathS.Tan(argument)),
+                    // int sec and int csc, both as an inverse hyperbolic tangent. `ln|tan(t/2)|`
+                    // is the usual form of the second and is avoided deliberately: it is the one
+                    // base case whose argument is not `t` itself, and a caller substituting the
+                    // trigonometric functions back cannot express a half-angle in terms of them.
+                    // `-artanh(cos t)` is the same function and is symmetric with the first.
+                    (0, -1) => MathS.Hyperbolic.Artanh(sine),
+                    (-1, 0) => -MathS.Hyperbolic.Artanh(cosine),
+                    _ => throw new Core.Exceptions.AngouriBugException(
+                        "every pair in the base range is listed above"),
+                };
+
+            var sum = sinePower + cosinePower;
+            Entity Power(Entity of, int to) => MathS.Pow(of, Number.Integer.Create(to));
+            Entity Carried(int numerator, int denominator, int nextSine, int nextCosine)
+                => Number.Rational.Create(numerator, denominator)
+                 * IntegrateSineCosineByReduction(argument, nextSine, nextCosine);
+
+            // Raising first, because an exponent at most -2 can always be raised and lowering can
+            // be blocked by p + q being zero -- `tan(t)^2` is `sin^2 cos^(-2)`, the smallest case
+            // where it is.
+            if (cosinePower <= -2)
+                return -Power(sine, sinePower + 1) * Power(cosine, cosinePower + 1)
+                       / Number.Integer.Create(cosinePower + 1)
+                     + Carried(sum + 2, cosinePower + 1, sinePower, cosinePower + 2);
+            if (sinePower <= -2)
+                return Power(sine, sinePower + 1) * Power(cosine, cosinePower + 1)
+                       / Number.Integer.Create(sinePower + 1)
+                     + Carried(sum + 2, sinePower + 1, sinePower + 2, cosinePower);
+            // Both exponents are now at least -1, so p + q is zero only if one of them is -1 and
+            // the other 1 -- both in range, and so already answered above.
+            if (cosinePower >= 2)
+                return Power(sine, sinePower + 1) * Power(cosine, cosinePower - 1)
+                       / Number.Integer.Create(sum)
+                     + Carried(cosinePower - 1, sum, sinePower, cosinePower - 2);
+            return -Power(sine, sinePower - 1) * Power(cosine, cosinePower + 1)
+                   / Number.Integer.Create(sum)
+                 + Carried(sinePower - 1, sum, sinePower - 2, cosinePower);
         }
 
         /// <summary>
@@ -956,11 +1054,19 @@ namespace AngouriMath.Functions.Algebra
                    radical / MathS.Sqrt(a),
                    inTermsOf * MathS.Sqrt(-b) / radical);
 
+            // `t` itself appears whenever the reduction bottoms out on `int 1 dt`, and that is
+            // where an inverse trigonometric function enters an answer that is otherwise
+            // algebraic -- `int sqrt(1 - x^2)/x^2 dx` holds an arcsine for exactly this reason.
+            var angle = quadratic.Sign > 0
+                ? MathS.Arctan(inTermsOf * MathS.Sqrt(b) / MathS.Sqrt(a))
+                : MathS.Arcsin(inTermsOf * MathS.Sqrt(-b) / MathS.Sqrt(a));
+
             var answer = inT.Replace(node => node switch
             {
                 Sinf(var inner) when inner == t => sine,
                 Cosf(var inner) when inner == t => cosine,
                 Tanf(var inner) when inner == t => tangent,
+                Variable v when v == t => angle,
                 _ => node
             });
             return answer.ContainsNode(t) ? null : (coefficient * answer).InnerSimplified;

--- a/Sources/Tests/UnitTests/Calculus/TrigonometricReductionTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/TrigonometricReductionTest.cs
@@ -1,0 +1,178 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// <c>sin^p cos^q</c> where no substitution leaves a polynomial, answered by the four standard
+    /// recurrences instead — and, through the quadratic radical rule, every integrand that reaches
+    /// that shape.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <a href="https://github.com/asc-community/AngouriMath/pull/1268">#1268</a> answers
+    /// <c>sin^p cos^q</c> by substituting and integrating a polynomial term by term, which covers
+    /// the cases where one exponent is odd and positive or both are even and sum to at most
+    /// <c>-2</c>. The rest need a <b>logarithm</b>, and no rearrangement of a polynomial produces
+    /// one: <c>sec(x)^3</c>, <c>tan(x)^2 sec(x)</c> and <c>cos(x)^2/sin(x)^3</c> were all declined.
+    /// </para>
+    /// <para>
+    /// <a href="https://github.com/asc-community/AngouriMath/pull/1273">#1273</a> sends a square
+    /// root of a quadratic through the same shape, so the same gap was there in algebraic clothes:
+    /// <c>x^2/sqrt(1 + x^2)</c> is <c>sin^2 cos^(-3)</c> under the tangent substitution, and
+    /// <c>sqrt(1 - x^2)/x^2</c> is <c>sin^(-2) cos^2</c> under the sine one.
+    /// </para>
+    /// <para>
+    /// Checked by differentiating back and comparing at points. These answers hold an inverse
+    /// hyperbolic tangent where a textbook writes <c>ln|sec + tan|</c>, and an arcsine or arctangent
+    /// wherever the recursion bottoms out on <c>int 1 dt</c> — all of them right, and none of them
+    /// comparable by shape.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class TrigonometricReductionTest
+    {
+        /// <summary>
+        /// Inside <c>(0, 1)</c>, away from the poles of all six trigonometric functions and inside
+        /// the interval where <c>sqrt(1 - x^2)</c> is real.
+        /// </summary>
+        private static readonly double[] Points = { 0.21, 0.35, 0.52, 0.71, 0.83 };
+
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 4,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}, "
+                + "so this asserts almost nothing");
+        }
+
+        /// <summary>
+        /// The trigonometric shapes, each of them a mixed parity or a negative exponent that no
+        /// substitution turns into a polynomial.
+        /// </summary>
+        [Theory]
+        [InlineData("sec(x)^3")]
+        [InlineData("csc(x)^3")]
+        [InlineData("tan(x)^2*sec(x)")]
+        [InlineData("cot(x)^2*csc(x)")]
+        [InlineData("sin(x)^2/cos(x)^3")]
+        [InlineData("cos(x)^2/sin(x)^3")]
+        [InlineData("1/(sin(x)^2*cos(x)^3)")]
+        [InlineData("sin(x)^2*cos(x)^2")]
+        [InlineData("sin(x)^4/cos(x)^2")]
+        public void WhereNoSubstitutionLeavesAPolynomial(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// The same gap in algebraic clothes, through the quadratic radical rule. These are the
+        /// classic radicals of a quadratic, and each answer holds the inverse function the
+        /// recursion's last step produces.
+        /// </summary>
+        [Theory]
+        [InlineData("x^2/sqrt(1 + x^2)")]
+        [InlineData("x^2/sqrt(1 - x^2)")]
+        [InlineData("sqrt(1 + x^2)")]
+        [InlineData("sqrt(1 - x^2)")]
+        [InlineData("sqrt(1 - x^2)/x^2")]
+        [InlineData("x^2*sqrt(1 + x^2)")]
+        [InlineData("1/(x*sqrt(1 + x^2))")]
+        [InlineData("1/(x^3*sqrt(1 + x^2))")]
+        public void ARadicalOfAQuadraticThroughTheSameShape(string integrand)
+            => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// With a linear term in the quadratic as well, where the shift and the recursion compose:
+        /// these need completing the square <b>and</b> a step that bottoms out on an inverse
+        /// function.
+        /// </summary>
+        [Theory]
+        [InlineData("x/sqrt(1 + x + x^2)")]
+        [InlineData("x^2/(1 + x + x^2)^(3/2)")]
+        [InlineData("x/sqrt(5 + 4*x - x^2)")]
+        [InlineData("1/sqrt(1 + x + x^2)")]
+        public void AShiftedQuadraticAsWell(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// Every base case of the recursion, reached directly. Two of them are the cosecant and
+        /// the secant, and the cosecant is written as <c>-artanh(cos)</c> rather than the usual
+        /// <c>ln|tan(t/2)|</c> — the same function, and the only form a caller substituting the
+        /// trigonometric functions back can express, since a half-angle is not one of them.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x)")]
+        [InlineData("cos(x)")]
+        [InlineData("sin(x)*cos(x)")]
+        [InlineData("tan(x)")]
+        [InlineData("cot(x)")]
+        [InlineData("1/(sin(x)*cos(x))")]
+        [InlineData("sec(x)")]
+        [InlineData("csc(x)")]
+        public void EveryBaseCase(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// What must not move: the shapes the polynomial route already answered, which reach it
+        /// first and must keep the shorter answer it gives.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x)^3*cos(x)^2")]
+        [InlineData("tan(x)^3*sec(x)^4")]
+        [InlineData("cot(x)^3*csc(x)^4")]
+        [InlineData("sec(x)^4")]
+        [InlineData("csc(x)^6")]
+        [InlineData("tan(x)^2")]
+        [InlineData("sin(x)^2")]
+        [InlineData("cos(x)^6")]
+        [InlineData("1/(1 + x^2)^(3/2)")]
+        [InlineData("x^5/sqrt(5 + x^2)")]
+        [InlineData("x*sin(x)")]
+        [InlineData("1/(1 + x^2)")]
+        [InlineData("sqrt(x)")]
+        public void TheNeighboursAreUntouched(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// A fractional exponent is still outside this: the recursion walks two <b>whole</b>
+        /// exponents towards a fixed set, and there is no such walk from a half. The polynomial
+        /// route still takes what it can there, so these must be answered or declined, never wrong.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x)^(1/2)*cos(x)^(1/2)")]
+        [InlineData("sqrt(tan(x))")]
+        [InlineData("sin(x)^(1/2)")]
+        public void AFractionalExponentIsNotThisRules(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+            if (integral.Stringize().Contains("integral("))
+                return;
+            DifferentiatesBack(integrand);
+        }
+    }
+}


### PR DESCRIPTION
`sec(x)^3`, `x^2/sqrt(1 + x^2)`, `sqrt(1 - x^2)` and `sqrt(1 - x^2)/x^2` had no
antiderivative. They are one integrand in four spellings: `sin^p cos^q` where no
substitution leaves a polynomial.

#1268 answers `sin^p cos^q` by substituting and integrating a polynomial term by
term, which covers an odd positive exponent or both even summing to at most -2.
The rest need a **logarithm**, and no rearrangement of a polynomial produces one.
#1273 then sends a square root of a quadratic through the same shape, so the same
gap was there in algebraic clothes: `x^2/sqrt(1 + x^2)` is `sin^2 cos^(-3)` under
the tangent substitution, and `sqrt(1 - x^2)/x^2` is `sin^(-2) cos^2` under the
sine one.

## The four recurrences

Each is one integration by parts written out:

    q down   I(p,q) =  sin^(p+1) cos^(q-1)/(p+q)  + ((q-1)/(p+q))    I(p, q-2)
    p down   I(p,q) = -sin^(p-1) cos^(q+1)/(p+q)  + ((p-1)/(p+q))    I(p-2, q)
    q up     I(p,q) = -sin^(p+1) cos^(q+1)/(q+1)  + ((p+q+2)/(q+1))  I(p, q+2)
    p up     I(p,q) =  sin^(p+1) cos^(q+1)/(p+1)  + ((p+q+2)/(p+1))  I(p+2, q)

`|p| + |q|` falls by two on every branch until both exponents are in `{-1, 0, 1}`,
where the nine base cases are written out. It is **closed**: two integers walking
towards a fixed set, asking the integrator nothing.

The ordering is not a preference. The downward pair divides by `p + q`, which can
vanish at any size -- `tan(x)^2` is `sin^2 cos^(-2)`, the smallest case where it
does -- and the upward pair divides by `q + 1` and `p + 1`, which vanish only at
`-1`, already in range. So raising is tried first, and the branch taken never has
a zero divisor.

## Two things the shape of the answer forced

**`int csc` is written `-artanh(cos t)`, not `ln|tan(t/2)|`.** They are the same
function, and it is the one base case whose argument is not `t` itself. A caller
substituting the trigonometric functions back cannot express a half-angle in terms
of them, so the usual form left a `t` behind and the whole answer was declined.
Found by `1/(x*sqrt(1 + x^2))` coming back unevaluated when every step of its
recursion had succeeded.

**A bare `t` is where an inverse function enters.** The recursion bottoms out on
`int 1 dt` whenever both exponents reach zero, and that `t` is `arctan` or
`arcsin` of the substituted variable. `int sqrt(1 - x^2)/x^2 dx` holds an arcsine
for exactly this reason, and without substituting the angle itself the rule
declined every integrand whose recursion passed through `I(0, 0)`.

## Measured

Twenty-eight shapes -- the trigonometric ones, the algebraic ones that reach the
same form through #1273, the shifted quadratics, the base cases reached directly,
and everything that must not move -- each answer verified by differentiating back
and comparing at five points:

    master (2c512fa6)   18/28 answered, 0 wrong
    with it             28/28 answered, 0 wrong

Rubi corpus, 463-problem sample, both arms in the foreground:

    master (2c512fa6)   242/463, 0 wrong, 3 timeouts, 158 s
    with it             254/463, 0 wrong, 3 timeouts, 159 s

**Twelve more**, no timeout added, and the wall clock unmoved -- which is what a
closed rule looks like, and the reason for going to some trouble to keep it one.
The five test suites are green.

A fractional exponent is still outside this: the recursion walks two whole
exponents, and there is no such walk from a half. The polynomial route takes what
it can there, and the test pins those as answered-or-declined, never wrong.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
