### PR TITLE
The third trigonometric substitution, and the sign that makes its second interval right

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -351,3 +351,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/RepeatedQuadraticTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/SecantSubstitutionTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -1222,42 +1222,91 @@ namespace AngouriMath.Functions.Algebra
             => answer is null ? null : (factor * answer).InnerSimplified;
 
         /// <summary>
-        /// <c>int y^m (A + c y^2)^(k/2) dy</c> for odd <c>k</c>, written back in terms of
+        /// <c>int y^m (A + c y^2)^(k/2) dy</c>, written back in terms of
         /// <paramref name="inTermsOf"/> -- which is the variable itself where the quadratic had no
         /// linear term, and the shifted variable where it did.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>Where the answer holds.</b> Each of the three substitutions is a bijection only on
+        /// the interval where the radicand is positive, and that is where the integrand is real
+        /// in the first place: everywhere for <c>A, c &gt; 0</c>, between the two roots for
+        /// <c>c &lt; 0</c>, and outside them for <c>A &lt; 0</c>. The answer is an antiderivative
+        /// on each such interval, which is the standing caveat on a trigonometric substitution
+        /// and is not something this writes as a condition.
+        /// </para>
+        /// </remarks>
         private static Entity? IntegrateAPowerTimesARadicalQuadratic(
             Entity expr, Entity inTermsOf, int power, int half, ERational constant, ERational quadratic)
         {
-            // Both coefficients decided, and the constant one positive: that is what makes the
-            // radicand `A(1 + tan^2)` or `A(1 - sin^2)` rather than something whose sign the
-            // substitution would have to guess at. `c y^2 - A`, the signs the other way round, is
-            // the secant substitution -- a third branch whose domain is two intervals rather than
-            // one, so the answer owes a condition this does not write, and it is declined.
-            if (constant.Sign <= 0 || quadratic.IsZero)
+            // Both coefficients decided and neither zero. Their two signs pick one of the three
+            // substitutions, and there is no fourth: `A + c y^2` with both positive is
+            // `A(1 + tan^2)`, with `c` negative it is `A(1 - sin^2)`, and with `A` negative it is
+            // `|A|(sec^2 - 1)`. Both negative is a radicand that is negative everywhere, which is
+            // not this rule's business.
+            if (quadratic.IsZero || constant.IsZero
+                || (constant.Sign < 0 && quadratic.Sign < 0))
                 return null;
 
-            var a = Number.Rational.Create(constant);
+            var secant = constant.Sign < 0;
+            // **The secant branch only for a genuine radical**, and that is a correctness bound
+            // rather than a scope one. It is the one substitution whose domain is two intervals,
+            // and both of them exclude `|y| < r`. Where the power is odd the integrand excludes
+            // that interval too -- it is a square root of something negative there -- so the
+            // answer is valid wherever the integrand is. Where the power is *even* the integrand
+            // is an ordinary polynomial, real on the whole line, and an answer built from
+            // `sqrt(y^2 - r^2)` is wrong on the middle: `(2x + 3x^2)^2` came back with the sign
+            // reversed at `x = -0.5`, which is a wrong answer and not a missing condition.
+            if (secant && half % 2 == 0)
+                return null;
+            var a = Number.Rational.Create(constant.Abs());
             var b = Number.Rational.Create(quadratic);
-            var r = MathS.Sqrt(Number.Rational.Create(constant / quadratic.Abs()));
+            var r = MathS.Sqrt(Number.Rational.Create(constant.Abs() / quadratic.Abs()));
 
             var t = Variable.CreateUnique(expr, "t_trig");
-            // b > 0: y = r tan(t) leaves sin^m cos^(-m-k-2); b < 0: y = r sin(t) leaves
-            // sin^m cos^(k+1). The constant is r^(m+1) A^(k/2) either way.
-            var sinePower = ERational.FromInt32(power);
+            // The three substitutions and what each leaves, with `r = sqrt(|A/c|)`:
+            //
+            //   A > 0, c > 0   y = r tan(t)   dy = r sec^2 dt   ->  sin^m cos^(-m-k-2)
+            //   A > 0, c < 0   y = r sin(t)   dy = r cos dt     ->  sin^m cos^(k+1)
+            //   A < 0, c > 0   y = r sec(t)   dy = r sec tan dt ->  sin^(k+1) cos^(-m-k-2)
+            //
+            // and the constant outside is `r^(m+1) |A|^(k/2)` in all three.
+            var sinePower = ERational.FromInt32(secant ? half + 1 : power);
             var cosinePower = ERational.FromInt32(
-                quadratic.Sign > 0 ? -power - half - 2 : half + 1);
+                secant || quadratic.Sign > 0 ? -power - half - 2 : half + 1);
             var coefficient = MathS.Pow(r, power + 1) * MathS.Pow(a, Number.Rational.Create(half, 2));
 
             if (IntegrateAPowerOfSineTimesAPowerOfCosine(t, sinePower, cosinePower, 1, 1) is not { } inT)
                 return null;
 
             // Back in terms of the variable. Each of the three is algebraic under the
-            // substitution, so no inverse trigonometric function appears -- and the closed core
-            // never leaves a bare `t` behind, which the check at the end confirms rather than
-            // assumes.
-            var radical = MathS.Sqrt((a + b * MathS.Sqr(inTermsOf)).InnerSimplified);
-            var (sine, cosine, tangent) = quadratic.Sign > 0
+            // substitution, so the answer stays algebraic except where the recursion bottoms out
+            // on `int 1 dt` -- which is where the inverse function below enters.
+            //
+            // Under the secant substitution `tan(t)^2` is `y^2/r^2 - 1`, which is the radicand
+            // over `|A|`, so the radical the integrand came in with is what goes back in.
+            var radicand = ((secant ? -a : a) + b * MathS.Sqr(inTermsOf)).InnerSimplified;
+            var radical = MathS.Sqrt(radicand);
+            // **The secant branch is written for the right interval and reflected onto the left.**
+            // It is the one substitution whose domain is two intervals, and the two are not the
+            // same calculation: `(a tan(t)^2)^(k/2)` is `a^(k/2) |tan(t)|^k`, and `tan(t)` is
+            // negative for `t` in `(pi/2, pi)`, which is where `y < -r` lands. Writing `tan(t)^k`
+            // there is wrong by a sign for odd `k`, and the sign it is wrong by depends on the
+            // power outside the radical as well, so patching the three replacements one at a time
+            // does not converge -- measured, and it does not.
+            //
+            // What is true without cases: the integrand `y^m (b y^2 - a)^(k/2)` is even or odd
+            // under `y -> -y` according to `m`, so an antiderivative `F` valid for `y > r` gives
+            // the whole answer as `sign(y)^(m+1) F(|y|)`. So everything below is written in
+            // `|y|`, where the substitution's own interval is the principal one and every sign is
+            // positive, and the reflection is applied once at the end.
+            var absolute = MathS.Abs(inTermsOf);
+            var (sine, cosine, tangent) =
+                secant
+                ? (radical / (absolute * MathS.Sqrt(b)),
+                   r / absolute,
+                   radical / MathS.Sqrt(a))
+                : quadratic.Sign > 0
                 ? (inTermsOf * MathS.Sqrt(b) / radical,
                    MathS.Sqrt(a) / radical,
                    inTermsOf * MathS.Sqrt(b) / MathS.Sqrt(a))
@@ -1268,7 +1317,9 @@ namespace AngouriMath.Functions.Algebra
             // `t` itself appears whenever the reduction bottoms out on `int 1 dt`, and that is
             // where an inverse trigonometric function enters an answer that is otherwise
             // algebraic -- `int sqrt(1 - x^2)/x^2 dx` holds an arcsine for exactly this reason.
-            var angle = quadratic.Sign > 0
+            var angle = secant
+                ? MathS.Arccos(r / absolute)
+                : quadratic.Sign > 0
                 ? MathS.Arctan(inTermsOf * MathS.Sqrt(b) / MathS.Sqrt(a))
                 : MathS.Arcsin(inTermsOf * MathS.Sqrt(-b) / MathS.Sqrt(a));
 
@@ -1280,7 +1331,14 @@ namespace AngouriMath.Functions.Algebra
                 Variable v when v == t => angle,
                 _ => node
             });
-            return answer.ContainsNode(t) ? null : (coefficient * answer).InnerSimplified;
+            if (answer.ContainsNode(t))
+                return null;
+            // The reflection, once: `sign(y)^(m+1)`, which is `sign(y)` for an even power outside
+            // the radical and nothing for an odd one. A factor constant on each interval changes
+            // an antiderivative by a constant there and nothing else.
+            if (secant && power % 2 == 0)
+                answer *= MathS.Signum(inTermsOf);
+            return (coefficient * answer).InnerSimplified;
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Calculus/RootOverSquareIntegralsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/RootOverSquareIntegralsTest.cs
@@ -68,14 +68,28 @@ namespace AngouriMath.Tests.Calculus
             AssertIsAntiderivative(integrand, points);
 
         /// <summary>
-        /// Outside the family the formula does not apply and nothing is claimed: a power of
-        /// x other than the square, and a radicand whose constant term is zero, which the
-        /// formula would divide by.
+        /// Outside the family <b>this</b> formula does not apply, and nothing is claimed by it:
+        /// a power of x other than the square, and a radicand whose constant term is zero, which
+        /// the formula would divide by.
         /// </summary>
+        /// <remarks>
+        /// Whether anything <em>else</em> answers them is not this rule's business and is not
+        /// asserted here. <c>1/(x^3 sqrt(x^2 - 1))</c> was pinned as unevaluated and is now
+        /// answered by the trigonometric substitution — an improvement rather than a change to
+        /// this rule, so what is pinned is that the answer, if there is one, is right. The second
+        /// is still unevaluated: a negative power of the variable beside a quadratic with a
+        /// linear term is outside that rule too.
+        /// </remarks>
         [Theory]
-        [InlineData("1 / (x ^ 3 * sqrt(x ^ 2 - 1))")]
-        [InlineData("1 / (x ^ 2 * sqrt(x ^ 2 + x + 1))")]
-        public void OutsideTheFamilyNothingIsClaimed(string integrand) =>
-            Assert.Contains("integral(", integrand.ToEntity().Integrate("x").Stringize());
+        [InlineData("1 / (x ^ 3 * sqrt(x ^ 2 - 1))", new[] { 1.4, 2.6, 5.1, -1.9, -3.7 })]
+        [InlineData("1 / (x ^ 2 * sqrt(x ^ 2 + x + 1))", new[] { 0.4, 1.6, 3.2 })]
+        public void OutsideTheFamilyThisFormulaClaimsNothing(string integrand, double[] points)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+            if (integral.Stringize().Contains("integral("))
+                return;
+            AssertIsAntiderivative(integrand, points);
+        }
     }
 }

--- a/Sources/Tests/UnitTests/Calculus/SecantSubstitutionTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/SecantSubstitutionTest.cs
@@ -1,0 +1,146 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// The third trigonometric substitution: <c>b x^2 - a</c>, where <c>x = r sec(t)</c>.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <a href="https://github.com/asc-community/AngouriMath/pull/1273">#1273</a> shipped the
+    /// tangent and sine substitutions and left this one out, because its domain is two intervals
+    /// rather than one. That is the whole of what this adds, and the whole of what makes it
+    /// delicate: <c>(a tan(t)^2)^(k/2)</c> is <c>a^(k/2) |tan(t)|^k</c>, and <c>tan(t)</c> is
+    /// negative on the left one.
+    /// </para>
+    /// <para>
+    /// <b>Every case here is checked on both intervals</b>, which is the point. Patching the
+    /// three back-substitutions with an absolute value and a signum gets the right interval right
+    /// and the left one wrong in a way that varies with the power outside the radical — measured,
+    /// eight of thirteen shapes still reversed. What is true without cases is that the integrand
+    /// is even or odd under <c>x -> -x</c> according to that power, so an antiderivative valid
+    /// for <c>x &gt; r</c> gives the whole answer as <c>sign(x)^(m+1) F(|x|)</c>.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class SecantSubstitutionTest
+    {
+        private static void DifferentiatesBack(string integrand, double[] points)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 4,
+                $"only {compared} of {points.Length} points were comparable for {integrand}, "
+                + "so this asserts almost nothing");
+        }
+
+        /// <summary>
+        /// The radicand positive on both sides of the gap, and the points chosen on both — two
+        /// above <c>r</c> and two below <c>-r</c>. An answer that is right only to the right of
+        /// the gap passes a one-sided test and is wrong.
+        /// </summary>
+        [Theory]
+        [InlineData("sqrt(x^2 - 1)", new[] { 1.7, 3.1, -1.9, -4.2 })]
+        [InlineData("x^2/sqrt(x^2 - 1)", new[] { 1.7, 3.1, -1.9, -4.2 })]
+        [InlineData("x^3*sqrt(x^2 - 1)", new[] { 1.7, 3.1, -1.9, -4.2 })]
+        [InlineData("1/(x^2 - 1)^(3/2)", new[] { 1.7, 3.1, -1.9, -4.2 })]
+        [InlineData("1/(x^2*sqrt(x^2 - 1))", new[] { 1.7, 3.1, -1.9, -4.2 })]
+        [InlineData("1/(x^3*sqrt(x^2 - 1))", new[] { 1.7, 3.1, -1.9, -4.2 })]
+        [InlineData("sqrt(9*x^2 - 1)/x^2", new[] { 0.9, 2.3, -1.1, -3.4 })]
+        [InlineData("1/(x^3*sqrt(x^2 - 16))", new[] { 5.1, 9.3, -6.2, -11.0 })]
+        [InlineData("(x^2 - 10)^(5/2)/x", new[] { 4.1, 7.3, -5.2, -9.0 })]
+        [InlineData("sqrt(x^2 - 4)/x", new[] { 2.7, 5.1, -3.3, -6.2 })]
+        public void BothIntervals(string integrand, double[] points)
+            => DifferentiatesBack(integrand, points);
+
+        /// <summary>
+        /// With a linear term as well, so the square is completed first and the shifted constant
+        /// is what comes out negative. The gap is then not around zero, and the points are chosen
+        /// either side of where it actually is.
+        /// </summary>
+        [Theory]
+        [InlineData("sqrt(x^2 - 2*x)", new[] { 2.7, 5.1, -1.3, -4.2 })]
+        [InlineData("x/sqrt(x^2 - 2*x)", new[] { 2.7, 5.1, -1.3, -4.2 })]
+        [InlineData("1/sqrt(x^2 - 4*x + 3)", new[] { 3.4, 6.1, -0.7, -3.2 })]
+        public void AShiftedQuadratic(string integrand, double[] points)
+            => DifferentiatesBack(integrand, points);
+
+        /// <summary>
+        /// A <b>whole</b> power of such a quadratic must not take this route, and this is a
+        /// correctness bound rather than a matter of taste.
+        /// </summary>
+        /// <remarks>
+        /// Where the power outside is a half the integrand is a square root of something negative
+        /// between the roots, so it is undefined exactly where the substitution is. Where the
+        /// power is whole the integrand is an ordinary polynomial, real on the whole line, and an
+        /// answer built from <c>sqrt(x^2 - r^2)</c> is wrong in the middle: <c>(2x + 3x^2)^2</c>
+        /// came back with the sign reversed at <c>x = -0.5</c> before this was bounded, which is
+        /// a wrong answer and not a missing condition. These are pinned at points <b>inside</b>
+        /// the interval the substitution cannot see.
+        /// </remarks>
+        [Theory]
+        [InlineData("(2*x + 3*x^2)^2", new[] { -0.5, -0.2, 0.3, 1.0 })]
+        [InlineData("(2*x + 3*x^2)^3", new[] { -0.5, -0.2, 0.3, 1.0 })]
+        [InlineData("(x^2 - 1)^2", new[] { -0.5, -0.2, 0.3, 0.8 })]
+        [InlineData("(x^2 - 4)^3", new[] { -1.5, -0.2, 0.3, 1.8 })]
+        public void AWholePowerIsNotThisSubstitutions(string integrand, double[] points)
+            => DifferentiatesBack(integrand, points);
+
+        /// <summary>
+        /// The other two substitutions, which must be unaffected — the branch is chosen by the
+        /// two signs and there is no fourth case, so getting a third one wrong would show here.
+        /// </summary>
+        [Theory]
+        [InlineData("1/(1 + x^2)^(3/2)", new[] { 0.3, 1.6, -0.4, -2.2 })]
+        [InlineData("x^5/sqrt(5 + x^2)", new[] { 0.3, 1.6, -0.4, -2.2 })]
+        [InlineData("x^2/sqrt(1 + x^2)", new[] { 0.3, 1.6, -0.4, -2.2 })]
+        [InlineData("sqrt(1 - x^2)/x^2", new[] { 0.3, 0.5, -0.4, -0.8 })]
+        [InlineData("1/(1 - x^2)^(3/2)", new[] { 0.3, 0.5, -0.4, -0.8 })]
+        [InlineData("x/sqrt(1 + x + x^2)", new[] { 0.3, 1.6, -0.4, -2.2 })]
+        [InlineData("1/(x*(1 + x^2)^2)", new[] { 0.3, 1.6, -0.4, -2.2 })]
+        public void TheOtherTwoSubstitutionsAreUnaffected(string integrand, double[] points)
+            => DifferentiatesBack(integrand, points);
+
+        /// <summary>
+        /// A radicand negative everywhere has no real integrand to integrate and is declined —
+        /// there is no fourth substitution and none is invented.
+        /// </summary>
+        [Theory]
+        [InlineData("sqrt(-1 - x^2)")]
+        [InlineData("1/sqrt(-4 - 9*x^2)")]
+        public void ARadicandNegativeEverywhereIsDeclined(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+        }
+    }
+}


### PR DESCRIPTION
`sqrt(9*x^2 - 1)/x^2`, `1/(x^3*sqrt(x^2 - 16))` and `(x^2 - 10)^(5/2)/x` had no
antiderivative. #1273 shipped the tangent and sine substitutions and left this one
out, saying its domain is two intervals rather than one and that the answer owed a
condition it did not write. That was the right call at the time and the condition
turns out not to be what it needs.

    A > 0, c > 0   y = r tan(t)   ->  sin^m cos^(-m-k-2)     one interval, all of R
    A > 0, c < 0   y = r sin(t)   ->  sin^m cos^(k+1)        one interval, between the roots
    A < 0, c > 0   y = r sec(t)   ->  sin^(k+1) cos^(-m-k-2) two intervals, outside them

There is no fourth: both coefficients negative is a radicand negative everywhere,
which has no real integrand to integrate, and it is declined.

## The sign, which took two attempts

`(a tan(t)^2)^(k/2)` is `a^(k/2) |tan(t)|^k`, and `tan(t)` is negative for `t` in
`(pi/2, pi)` -- which is where `y < -r` lands. Writing `tan(t)^k` there is wrong by
a sign for odd `k`.

The first attempt patched the three back-substitutions, putting an absolute value
on `sin(t)` and a signum on `tan(t)`. That got `y > r` right and left **eight of
thirteen** shapes still sign-reversed on the other side, because the sign it is
wrong by depends on the power outside the radical as well and the three
replacements do not compose into it.

What is true without cases: the integrand `y^m (b y^2 - a)^(k/2)` is even or odd
under `y -> -y` according to `m`, so an antiderivative `F` valid for `y > r` gives
the whole answer as `sign(y)^(m+1) F(|y|)`. So everything is written in `|y|`,
where the substitution's own interval is the principal one and every sign is
positive, and the reflection is applied once at the end. Thirteen of thirteen.

## A whole power is not this substitution's, and that is correctness

`(2*x + 3*x^2)^2` completes the square to a negative constant, so it reaches the
secant branch -- and it is a **polynomial**, real on the whole line, where the
substitution is defined only outside `|y| > r`. It came back with the sign reversed
at `x = -0.5`. That is a wrong answer, not a missing condition, and the branch now
takes only an odd half-power, where the integrand is a square root of something
negative in the middle and so is undefined exactly where the substitution is.

Caught by `ExpandedPowerIntegralTest`, which exists for that shape and fired.

## Measured

Every case checked on **both** intervals -- two points above `r` and two below
`-r`. An answer right only to the right of the gap passes a one-sided test, which
is how the first attempt looked correct.

    master (5070a363)   5/13 answered, 0 wrong
    with it            13/13 answered, 0 wrong

Rubi corpus, 463-problem sample, both arms in the foreground:

    master (5070a363)   255/463, 0 wrong, 3 timeouts, 158 s
    with it             257/463, 0 wrong, 3 timeouts, 158 s

Two more, no timeout added, wall clock unmoved. The five test suites are green.

`RootOverSquareIntegralsTest` pinned `1/(x^3*sqrt(x^2 - 1))` as unevaluated and it
is now answered. That test is about its own formula rather than about the
integrand, so it now says so and checks the answer instead of its absence -- the
second case it pins is still unevaluated, since a negative power of the variable
beside a quadratic with a linear term is outside this rule too.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
