### PR TITLE
A polynomial times an exponential times a trigonometric function, closed rather than searched for

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -354,3 +354,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/SecantSubstitutionTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/PolynomialExponentialTrigTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -1112,6 +1112,193 @@ namespace AngouriMath.Functions.Algebra
         }
 
         /// <summary>
+        /// A polynomial times an exponential times a sine or a cosine —
+        /// <c>P(x) e^(a x) cos(b x)</c> and its kin — integrated by the repeated by-parts that
+        /// this shape is the textbook case for, run out here rather than through the chain.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>e^x cos(x)</c> came out and <c>x e^x cos(x)</c> did not. The polynomial by-parts
+        /// integrates its <c>dv</c> with by-parts switched off, and <c>e^x cos(x)</c> is answered
+        /// by <b>nothing but</b> by-parts — the cyclic one, where the integral comes back a
+        /// multiple of itself. So the outer integral was declined for want of the inner one.
+        /// </para>
+        /// <para>
+        /// <b>Switching that flag on is not the fix, and this is measured.</b> It buys these
+        /// integrands and takes <c>x tan(x)^3 sec(x)^4</c> from 20 ms to <b>94 seconds</b> to
+        /// decline — one test, the whole of a 76% slowdown in the calculus suite. The cost and
+        /// the gain both arrive on the <i>second</i> round, integrating the antiderivative the
+        /// first produced, so no size measure separates them: what separates them is whether the
+        /// search succeeds, and that is only known by running it.
+        /// https://github.com/asc-community/AngouriMath/issues/1265
+        /// </para>
+        /// <para>
+        /// So the family is named instead of searched for. <c>int e^(a x)(c cos(b x) + d sin(b x))
+        /// dx</c> is closed:
+        /// </para>
+        /// <code>
+        ///     e^(ax) [ (a c - b d) cos(bx) + (b c + a d) sin(bx) ] / (a^2 + b^2)
+        /// </code>
+        /// <para>
+        /// and it stays in the same shape, so integrating <c>x^k</c> against it by parts lowers
+        /// <c>k</c> by one and leaves the same shape again. That terminates in <c>k + 1</c> steps
+        /// with no search at all, which is what makes this <b>closed</b>.
+        /// </para>
+        /// <para>
+        /// <c>a = 0</c> and <c>b = 0</c> are both admitted — a polynomial times a bare sine, or a
+        /// bare exponential — though those already came out, so what this adds is the two
+        /// together. Both zero is a polynomial and is declined, since it is the power rule's.
+        /// </para>
+        /// <para>
+        /// <b>Asked, not volunteered</b>:
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1265">#1265</a>.
+        /// </para>
+        /// https://github.com/asc-community/AngouriMath/issues/718
+        /// </remarks>
+        internal static Entity? SolveAPolynomialTimesAnExponentialAndATrigonometric(Entity expr, Entity.Variable x)
+        {
+            if (!Integration.AnsweringTheQuestionAsked)
+                return null;
+            if (!TryReadAnExponentialTimesATrigonometric(expr, x,
+                    out var polynomial, out var rate, out var frequency, out var onTheCosine, out var onTheSine))
+                return null;
+
+            // a^2 + b^2, which is zero only when both are, and then the integrand is a polynomial.
+            var scale = (MathS.Sqr(rate) + MathS.Sqr(frequency)).InnerSimplified;
+            if (scale == 0)
+                return null;
+
+            var exponential = MathS.Pow(MathS.e, rate * x);
+            var cosine = MathS.Cos(frequency * x);
+            var sine = MathS.Sin(frequency * x);
+
+            // Integrating `e^(ax)(c cos + d sin)` leaves the same shape, so one step of by parts
+            // against `P(x)` lowers its degree and leaves this loop's own state: a polynomial and
+            // the pair of coefficients. `total` collects the boundary terms.
+            Entity total = 0;
+            var carried = polynomial;
+            var c = onTheCosine;
+            var d = onTheSine;
+            for (var step = 0; ; step++)
+            {
+                if (step > MaximumByPartsSteps)
+                    return null;   // the degree should fall every round; if it has not, decline
+                // int e^(ax) cos(bx) = e^(ax)(a cos + b sin)/(a^2+b^2), and
+                // int e^(ax) sin(bx) = e^(ax)(a sin - b cos)/(a^2+b^2). Together, for
+                // `c cos + d sin`, the cosine collects `a c - b d` and the sine `b c + a d`.
+                var nextC = ((rate * c - frequency * d) / scale).InnerSimplified;
+                var nextD = ((frequency * c + rate * d) / scale).InnerSimplified;
+                var antiderivative = exponential * (nextC * cosine + nextD * sine);
+
+                total += carried * antiderivative;
+                var derivative = carried.Differentiate(x).InnerSimplified;
+                if (derivative == 0)
+                    return total.InnerSimplified;
+                // `- int P'(x) * (that) dx`, which is this loop again with the sign folded in.
+                carried = (-derivative).InnerSimplified;
+                c = nextC;
+                d = nextD;
+            }
+        }
+
+        /// <summary>
+        /// How many rounds of by parts are admitted before the rule gives up on its own
+        /// termination. The degree of the polynomial falls every round, so a polynomial this rule
+        /// accepted cannot reach it; it is a backstop against a <c>Differentiate</c> that does not
+        /// lower the degree rather than a bound on anything expected.
+        /// </summary>
+        private const int MaximumByPartsSteps = 64;
+
+        /// <summary>
+        /// Reads <paramref name="expr"/> as <c>P(x) e^(a x) (c cos(b x) + d sin(b x))</c>, where
+        /// <c>P</c> is a polynomial and <c>a</c> and <c>b</c> are free of the variable.
+        /// </summary>
+        /// <remarks>
+        /// A base other than <c>e</c> is read through: <c>2^x</c> is <c>e^(x ln 2)</c>, so
+        /// <c>2^x x cos(x)</c> is this shape and was declined for the spelling alone.
+        /// </remarks>
+        private static bool TryReadAnExponentialTimesATrigonometric(
+            Entity expr, Entity.Variable x, out Entity polynomial,
+            out Entity rate, out Entity frequency, out Entity onTheCosine, out Entity onTheSine)
+        {
+            polynomial = 1;
+            rate = 0;
+            frequency = 0;
+            onTheCosine = 1;
+            onTheSine = 0;
+
+            Entity? rateFound = null;
+            Entity? frequencyFound = null;
+            var cosines = 0;
+            var sines = 0;
+            Entity polynomialPart = 1;
+            if (!Read(expr, 1))
+                return false;
+            // At most one trigonometric factor, and it is either a sine or a cosine: a product of
+            // two is a different shape, which the product-to-sum rule takes apart first.
+            if (cosines + sines > 1 || cosines < 0 || sines < 0)
+                return false;
+            if (!MathS.TryPolynomial(polynomialPart, x, out var asPolynomial)
+                && polynomialPart.ContainsNode(x))
+                return false;
+
+            polynomial = polynomialPart.ContainsNode(x) ? asPolynomial! : polynomialPart;
+            rate = rateFound ?? 0;
+            frequency = frequencyFound ?? 0;
+            onTheCosine = sines == 1 ? 0 : 1;
+            onTheSine = sines == 1 ? 1 : 0;
+            // A bare polynomial is the power rule's, and a polynomial times a bare exponential or
+            // a bare sine already came out; what is new is the two together. Reading them all the
+            // same way costs nothing and keeps the rule one thing.
+            return rateFound is not null || frequencyFound is not null;
+
+            bool Read(Entity node, int multiplicity)
+            {
+                switch (node)
+                {
+                    case Sinf(var argument) when multiplicity == 1:
+                        sines++;
+                        return AgreesOnTheFrequency(argument);
+                    case Cosf(var argument) when multiplicity == 1:
+                        cosines++;
+                        return AgreesOnTheFrequency(argument);
+                    case Powf(var @base, var power)
+                        when !@base.ContainsNode(x) && power.ContainsNode(x) && @base != 0:
+                        // e^(ax), and any other base through its logarithm.
+                        if (!TreeAnalyzer.TryGetPolyLinear(power, x, out var slope, out var offset))
+                            return false;
+                        var thisRate = (slope * (@base == MathS.e ? 1 : MathS.Ln(@base))).InnerSimplified;
+                        rateFound = rateFound is null
+                            ? (multiplicity * thisRate).InnerSimplified
+                            : (rateFound + multiplicity * thisRate).InnerSimplified;
+                        // The constant part of the exponent is a factor, not a rate.
+                        polynomialPart *= MathS.Pow(@base, offset * multiplicity);
+                        return true;
+                    case Mulf(var left, var right):
+                        return Read(left, multiplicity) && Read(right, multiplicity);
+                    case Divf(var above, var below):
+                        return Read(above, multiplicity) && Read(below, -multiplicity);
+                    default:
+                        if (multiplicity != 1)
+                            return false;
+                        polynomialPart *= node;
+                        return true;
+                }
+            }
+
+            bool AgreesOnTheFrequency(Entity argument)
+            {
+                if (!TreeAnalyzer.TryGetPolyLinear(argument, x, out var slope, out var offset)
+                    || offset.Evaled is not Number.Integer(0))
+                    return false;   // a phase would want the angle-sum identity first
+                if (frequencyFound is not null && frequencyFound != slope)
+                    return false;
+                frequencyFound = slope;
+                return true;
+            }
+        }
+
+        /// <summary>
         /// A power of the variable times an odd half-power of a quadratic without a linear term —
         /// <c>x^m (a + b x^2)^(k/2)</c> with <c>k</c> odd — turned into a power of the sine times
         /// a power of the cosine, which

--- a/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
@@ -394,6 +394,11 @@ namespace AngouriMath.Functions.Algebra
             // answer it as a rational function of tan(x) -- correct, and a good deal longer than
             // the reduction gives. Rubi's own ordering puts the reduction first for the same
             // reason.
+            // A polynomial times an exponential times a sine or a cosine, which repeated by parts
+            // closes in as many rounds as the polynomial has degree. Before the trigonometric
+            // rules, because none of them reads the exponential and all of them would have to
+            // decline it.
+            if ((answer = IndefiniteIntegralSolver.SolveAPolynomialTimesAnExponentialAndATrigonometric(expr, x)) is { }) return answer;
             if ((answer = IndefiniteIntegralSolver.SolveBySecantPowerReduction(expr, x)) is { }) return answer;
             // And beside it: a power of the sine times a power of the cosine, which is every
             // product of the six trigonometric functions once tangents and secants are read as

--- a/Sources/Tests/UnitTests/Calculus/IntegrationTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/IntegrationTest.cs
@@ -361,7 +361,13 @@ namespace AngouriMath.Tests.Calculus
         }
 
         [Theory]
-        [InlineData("e^x * x^2", "e ^ x * (x ^ 2 - 2 * (x - 1)) + C")] // Polynomial times exponential (should use recursive polynomial IBP)
+        // The polynomial coefficient now comes out written out rather than factored --
+        // `x^2 - 2x + 2` where this used to say `x^2 - 2(x - 1)`, which is the same polynomial.
+        // The rule that answers it is the closed one for a polynomial times an exponential times
+        // a trigonometric function, and it collects its coefficients as a sum. Their difference
+        // simplifies to exactly 0; `EqualTo(...).Simplify()` does not settle it either way, which
+        // is why the form is pinned here at all.
+        [InlineData("e^x * x^2", "e ^ x * (x ^ 2 + (-2) * x + 2) + C")] // Polynomial times exponential (should use recursive polynomial IBP)
         [InlineData("x^3 * sin(x)", "-cos(x) * x ^ 3 + 6 * cos(x) * x + (-6) * sin(x) + 3 * sin(x) * x ^ 2 + C")] // Polynomial times trig (should use recursive polynomial IBP)
         // [InlineData("x * ln(abs(x)) ^ 2", "x ^ 2 / 2 * (ln(abs(x)) ^ 2 - ln(abs(x)) - ln(abs(x))) + x ^ 2 + C")] // TODO: ln(abs(x)) ^ 2 needs integration by parts
         public void TestPolynomialIntegrationByParts(string initial, string expected)

--- a/Sources/Tests/UnitTests/Calculus/PolynomialExponentialTrigTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/PolynomialExponentialTrigTest.cs
@@ -1,0 +1,150 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// A polynomial times an exponential times a sine or a cosine, closed by the repeated by
+    /// parts this shape is the textbook case for.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>e^x cos(x)</c> came out and <c>x e^x cos(x)</c> did not: the polynomial by-parts
+    /// integrates its <c>dv</c> with by-parts switched off, and <c>e^x cos(x)</c> is answered by
+    /// nothing but by-parts — the cyclic one. Switching that flag on buys these and takes
+    /// <c>x tan(x)^3 sec(x)^4</c> from 20 ms to 94 seconds to decline, so the family is named
+    /// rather than searched for.
+    /// </para>
+    /// <para>
+    /// Checked by differentiating back and comparing at points, never against a printed form.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class PolynomialExponentialTrigTest
+    {
+        private static readonly double[] Points = { -1.3, -0.4, 0.7, 1.5, 2.2 };
+
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 4,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}, "
+                + "so this asserts almost nothing");
+        }
+
+        /// <summary>All three factors at once, which is what was declined.</summary>
+        [Theory]
+        [InlineData("x*e^x*cos(x)")]
+        [InlineData("x*e^x*sin(x)")]
+        [InlineData("x^2*e^x*cos(x)")]
+        [InlineData("x^3*e^x*cos(x)")]
+        [InlineData("(x^2 + 1)*e^x*sin(x)")]
+        [InlineData("x*e^(2*x)*sin(3*x)")]
+        [InlineData("x*e^(-x)*cos(2*x)")]
+        public void AllThreeFactors(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// A base other than <c>e</c>, which is the same shape written differently:
+        /// <c>2^x</c> is <c>e^(x ln 2)</c>, and these were declined for the spelling alone.
+        /// </summary>
+        [Theory]
+        [InlineData("2^x*x*cos(x)")]
+        [InlineData("3^x*x^2*sin(x)")]
+        [InlineData("2^(3*x)*x*sin(x)")]
+        public void ABaseOtherThanE(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// The degenerate corners of the same formula — no polynomial, no exponential, no
+        /// trigonometric factor. Each already came out, and each now comes out through this rule
+        /// as well, so the signs have to be right at <c>a = 0</c> and <c>b = 0</c> too. That is
+        /// not a formality: the first version of the formula had the sign of the <c>b</c> terms
+        /// reversed, which is invisible on <c>e^x cos(x)</c> and wrong on <c>x^2 sin(x)</c>.
+        /// </summary>
+        [Theory]
+        [InlineData("e^x*cos(x)")]
+        [InlineData("e^(2*x)*sin(3*x)")]
+        [InlineData("x*e^x")]
+        [InlineData("x^2*e^x")]
+        [InlineData("x*sin(x)")]
+        [InlineData("x^2*sin(x)")]
+        [InlineData("x^2*cos(x)")]
+        [InlineData("x^3*sin(x)")]
+        [InlineData("2^x*x")]
+        [InlineData("e^x")]
+        [InlineData("sin(x)")]
+        [InlineData("cos(3*x)")]
+        public void TheDegenerateCorners(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// What the read must refuse: a bare polynomial, which is the power rule's; a phase in
+        /// the trigonometric argument, which wants the angle-sum identity first; two
+        /// trigonometric factors, which the product-to-sum rule takes apart; and a factor that is
+        /// neither polynomial nor exponential nor trigonometric.
+        /// </summary>
+        [Theory]
+        [InlineData("x^2")]
+        [InlineData("e^x*cos(x + 1)")]
+        [InlineData("x*sin(x)*cos(2*x)")]
+        [InlineData("x*ln(x)*e^x")]
+        [InlineData("x*e^(x^2)*cos(x)")]
+        public void WhatTheReadRefuses(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+            if (integral.Stringize().Contains("integral("))
+                return;   // unanswered is a legitimate verdict; a wrong answer is not
+            DifferentiatesBack(integrand);
+        }
+
+        /// <summary>
+        /// The integrand the closed form exists to avoid opening a search on. It is declined
+        /// either way; what is pinned is that it is declined <em>cheaply</em>, which the closed
+        /// rule keeps and switching the by-parts flag on did not.
+        /// </summary>
+        /// <remarks>
+        /// Bounded by the integrator's own budget rather than by a wall clock, which measures the
+        /// runner: `x tan(x)^3 sec(x)^4` took 94 seconds with the flag on and takes about thirty
+        /// milliseconds here.
+        /// </remarks>
+        [Theory]
+        [InlineData("x*tan(x)^3*sec(x)^4")]
+        [InlineData("x*cot(x)^3*csc(x)^4")]
+        public void TheSearchThisAvoidsOpening(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+            if (integral.Stringize().Contains("integral("))
+                return;
+            DifferentiatesBack(integrand);
+        }
+    }
+}


### PR DESCRIPTION
`e^x*cos(x)` came out and `x*e^x*cos(x)` did not. So did `x^2*e^x*cos(x)`,
`(x^2 + 1)*e^x*sin(x)`, `2^x*x*cos(x)` and everything else in the family a
textbook teaches repeated by parts with.

The cause is one flag. `IntegrateByPartsPolynomial` integrates its `dv` with
by-parts **switched off**, and `e^x*cos(x)` is answered by nothing but by parts --
the cyclic one, where the integral comes back a multiple of itself. So the outer
integral was declined for want of the inner one.

## Switching the flag on is not the fix, and that is measured

It buys exactly these integrands, and it takes

    x*tan(x)^3*sec(x)^4     20 ms  ->  94 seconds, to decline

which is one test and the whole of a 76% slowdown in the calculus suite (1m20 to
2m21, both arms twice). Found by diffing the per-test durations of the two arms:
1,994 of the 1,995 tests were within noise and one was 0.02 s against 94.45 s.
That is https://github.com/asc-community/AngouriMath/issues/1265 for the fifth
time today.

Two bounds were tried against it and neither works. **Scope** does not, because
the tests -- and users -- call `Integrate` at the top, so the gate is always open.
**A size measure** does not, because the cost and the gain both arrive on the
*second* round, integrating the antiderivative the first produced: what separates
them is whether the search succeeds, which is only known by running it.

## So the family is named

`int e^(ax)(c cos(bx) + d sin(bx)) dx` is closed,

    e^(ax) [ (a c - b d) cos(bx) + (b c + a d) sin(bx) ] / (a^2 + b^2)

and it stays in the same shape, so integrating `x^k` against it by parts lowers
`k` by one and leaves the same shape again. That terminates in `k + 1` steps with
no search at all. `x*tan(x)^3*sec(x)^4` is declined in 30 ms, as before.

A base other than `e` is read through -- `2^x` is `e^(x ln 2)` -- so `2^x x cos(x)`
was declined for the spelling alone. `a = 0` and `b = 0` are admitted, which
matters more than it looks: the first version of the formula had the sign of the
`b` terms reversed, and that is invisible on `e^x cos(x)` and wrong on
`x^2 sin(x)`. Every test differentiates back, which is what caught it.

## Measured

Twenty-three shapes -- all three factors, other bases, every degenerate corner,
the neighbours, and the integrand the closed form exists to avoid opening a search
on -- each answer verified by differentiating back at five points:

    master (62c033cc)   13/23 answered, 0 wrong, 2033 ms for the probe
    with it             22/23 answered, 0 wrong,  415 ms

The one left is `x*tan(x)^3*sec(x)^4`, declined on both.

Rubi corpus, 463-problem sample, both arms in the foreground:

    master (62c033cc)   257/463, 0 wrong, 3 timeouts, 158 s
    with it             258/463, 0 wrong, 3 timeouts, 159 s

The five test suites are green and the calculus suite is unmoved at 1m23.

One pinned form changed: `int e^x x^2 dx` now comes out as `e^x(x^2 - 2x + 2)`
where the test said `e^x(x^2 - 2(x - 1))`. The same polynomial, and their
difference simplifies to exactly 0 -- `EqualTo(...).Simplify()` does not settle it
either way, which is why the form is pinned there at all. The test now carries the
new form and says why.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
