### PR TITLE
The inverse secant and the inverse cosecant had no antiderivative, and it is the sign that kept them out

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -357,3 +357,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/PolynomialExponentialTrigTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/InverseSecantIntegralTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IntegralPatterns.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IntegralPatterns.cs
@@ -163,6 +163,22 @@ namespace AngouriMath.Functions.Algebra
                 TreeAnalyzer.TryGetPolyLinear(arg, x, out var a, out _) =>
                     (arg * MathS.Arccotan(arg) + AntiderivativeLog(1 + arg * arg) / 2) / a,
 
+            // The other two, which were missing. They carry a `signum` where the first four do
+            // not, and it is not decoration: `d/dx arcsec(u)` is `1/(|u| sqrt(u^2 - 1))`, so the
+            // `u` that by parts multiplies it by leaves `sgn(u)/sqrt(u^2 - 1)` rather than
+            // `1/sqrt(u^2 - 1)`. The domain is `|u| >= 1`, two intervals, and the sign is what
+            // makes the answer hold on the left one as well as the right.
+            // https://github.com/asc-community/AngouriMath/issues/718
+            Entity.Arcsecantf(var arg) when
+                TreeAnalyzer.TryGetPolyLinear(arg, x, out var a, out _) =>
+                    (arg * MathS.Arcsec(arg)
+                     - MathS.Signum(arg) * AntiderivativeLog(arg + MathS.Sqrt(arg * arg - 1))) / a,
+
+            Entity.Arccosecantf(var arg) when
+                TreeAnalyzer.TryGetPolyLinear(arg, x, out var a, out _) =>
+                    (arg * MathS.Arccosec(arg)
+                     + MathS.Signum(arg) * AntiderivativeLog(arg + MathS.Sqrt(arg * arg - 1))) / a,
+
             // ∫ B^(px + q) * sin(mx + n) dx and its cosine twin. Integrating by parts
             // twice returns the integral it started from, so the usual machinery cycles
             // rather than terminating; solving that equation for the integral once gives

--- a/Sources/Tests/UnitTests/Calculus/InverseSecantIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/InverseSecantIntegralTest.cs
@@ -1,0 +1,113 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// The antiderivatives of the inverse secant and the inverse cosecant, which the table of
+    /// standard integrals had for the other four inverse trigonometric functions and not for
+    /// these two.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// They carry a <c>signum</c> where the other four do not, and it is not decoration:
+    /// <c>d/dx arcsec(u)</c> is <c>1/(|u| sqrt(u^2 - 1))</c>, so the <c>u</c> that integration by
+    /// parts multiplies it by leaves <c>sgn(u)/sqrt(u^2 - 1)</c> rather than
+    /// <c>1/sqrt(u^2 - 1)</c>. The domain is two intervals, and the sign is what makes the answer
+    /// hold on the left one as well as the right.
+    /// </para>
+    /// <para>
+    /// <b>Every case is checked on both intervals</b>, which is the only way that sign shows up:
+    /// an answer without it is right for <c>u &gt; 1</c> and wrong for <c>u &lt; -1</c>.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class InverseSecantIntegralTest
+    {
+        private static void DifferentiatesBack(string integrand, double[] points)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 4,
+                $"only {compared} of {points.Length} points were comparable for {integrand}, "
+                + "so this asserts almost nothing");
+        }
+
+        /// <summary>
+        /// Both functions, both intervals — two points where the argument is above one and two
+        /// where it is below minus one.
+        /// </summary>
+        [Theory]
+        [InlineData("asec(x)", new[] { 1.4, 2.6, 5.1, -1.9, -3.7 })]
+        [InlineData("acsc(x)", new[] { 1.4, 2.6, 5.1, -1.9, -3.7 })]
+        public void BothFunctionsOnBothIntervals(string integrand, double[] points)
+            => DifferentiatesBack(integrand, points);
+
+        /// <summary>
+        /// A linear argument, which divides the whole answer by the rate. The constant term is
+        /// there because a rule reading only the coefficient gets <c>2x + 1</c> right by accident
+        /// and <c>2x</c> wrong in the same way.
+        /// </summary>
+        [Theory]
+        [InlineData("asec(3*x)", new[] { 0.5, 1.2, 2.4, -0.6, -1.8 })]
+        [InlineData("acsc(2*x)", new[] { 0.7, 1.4, 3.1, -0.9, -2.2 })]
+        [InlineData("asec(2*x + 1)", new[] { 0.4, 1.2, 2.4, -1.5, -3.0 })]
+        [InlineData("acsc(3*x - 2)", new[] { 1.2, 2.4, 4.1, -0.5, -1.7 })]
+        public void ALinearArgument(string integrand, double[] points)
+            => DifferentiatesBack(integrand, points);
+
+        /// <summary>
+        /// The four that were already in the table, which must be untouched — the two new rows
+        /// sit directly beside them.
+        /// </summary>
+        [Theory]
+        [InlineData("arcsin(x)", new[] { 0.3, 0.5, -0.4, -0.8 })]
+        [InlineData("arccos(x)", new[] { 0.3, 0.5, -0.4, -0.8 })]
+        [InlineData("arctan(x)", new[] { 0.3, 1.5, -0.4, -2.8 })]
+        [InlineData("arccotan(x)", new[] { 0.3, 1.5, -0.4, -2.8 })]
+        [InlineData("arcsin(2*x)", new[] { 0.2, 0.4, -0.3, -0.45 })]
+        public void TheFourThatWereAlreadyThere(string integrand, double[] points)
+            => DifferentiatesBack(integrand, points);
+
+        /// <summary>
+        /// A non-linear argument is not this row's: <c>arcsec(x^2)</c> would want the chain rule
+        /// undone first, and the table reads a linear argument only.
+        /// </summary>
+        [Theory]
+        [InlineData("asec(x^2)")]
+        [InlineData("acsc(1/x)")]
+        public void ANonLinearArgumentIsDeclined(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+        }
+    }
+}


### PR DESCRIPTION
The table of standard integrals carries `arcsin`, `arccos`, `arctan` and
`arccotan`, each of them integration by parts against 1 -- a shape the by-parts
solver does not look for, since there is no product to split. The other two were
missing.

They are missing for a reason rather than by oversight. The four that are there
have a derivative that is a function of `u` alone, so by parts leaves something
the table already holds. `d/dx arcsec(u)` is `1/(|u| sqrt(u^2 - 1))`, so the `u`
that by parts multiplies it by leaves

    sgn(u)/sqrt(u^2 - 1)      rather than      1/sqrt(u^2 - 1)

and the domain is `|u| >= 1`, two intervals. Without the `signum` the answer is
right for `u > 1` and sign-reversed for `u < -1`:

    int arcsec(u) du = u arcsec(u) - sgn(u) ln|u + sqrt(u^2 - 1)|
    int arccsc(u) du = u arccsc(u) + sgn(u) ln|u + sqrt(u^2 - 1)|

That is the third time today a two-interval domain has needed the sign written
out rather than assumed -- #1277 is the same lesson for the secant substitution --
so every case in the test is checked on **both** intervals. An answer without the
sign passes a one-sided test.

## Measured

Each answer verified by differentiating back at five points, two of them below
`-1`:

    master (b7ab36f8)    arcsec, arccsc: no antiderivative
    with it              both, and with a linear argument

Rubi corpus, 463-problem sample, both arms in the foreground:

    master (b7ab36f8)   258/463, 0 wrong, 3 timeouts, 159 s
    with it             259/463, 0 wrong, 3 timeouts, 160 s

The five test suites are green.

Part of #718.


Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
