### PR TITLE
Scope was wrong for one of the five rules it was put on, and it cost ten answers

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -360,3 +360,6 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/InverseSecantIntegralTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/RadicalBelowTheTopTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -1322,42 +1322,52 @@ namespace AngouriMath.Functions.Algebra
         /// routes is closed and the other is a search.
         /// </para>
         /// <para>
-        /// <b>Two substitutions, chosen by the sign of the quadratic's leading coefficient.</b>
-        /// With <c>r = sqrt(|a/b|)</c>:
+        /// <b>Three substitutions, chosen by the two signs.</b> With <c>r = sqrt(|a/b|)</c>:
         /// </para>
         /// <list type="bullet">
         /// <item><description>
-        /// <c>b &gt; 0</c>: <c>x = r tan(t)</c>, under which <c>a + b x^2 = a sec(t)^2</c> and
-        /// <c>dx = r sec(t)^2 dt</c>, leaving <c>sin(t)^m cos(t)^(-m-k-2)</c>.
+        /// <c>a &gt; 0, b &gt; 0</c>: <c>x = r tan(t)</c>, under which <c>a + b x^2 = a sec(t)^2</c>
+        /// and <c>dx = r sec(t)^2 dt</c>, leaving <c>sin(t)^m cos(t)^(-m-k-2)</c>.
         /// </description></item>
         /// <item><description>
-        /// <c>b &lt; 0</c>: <c>x = r sin(t)</c>, under which <c>a + b x^2 = a cos(t)^2</c> and
-        /// <c>dx = r cos(t) dt</c>, leaving <c>sin(t)^m cos(t)^(k+1)</c>.
+        /// <c>a &gt; 0, b &lt; 0</c>: <c>x = r sin(t)</c>, under which <c>a + b x^2 = a cos(t)^2</c>
+        /// and <c>dx = r cos(t) dt</c>, leaving <c>sin(t)^m cos(t)^(k+1)</c>.
+        /// </description></item>
+        /// <item><description>
+        /// <c>a &lt; 0, b &gt; 0</c>: <c>x = r sec(t)</c>, added in
+        /// <a href="https://github.com/asc-community/AngouriMath/pull/1277">#1277</a>. Its domain
+        /// is two intervals rather than one, and the sign that makes the second one right is
+        /// written out in <see cref="IntegrateAPowerTimesARadicalQuadratic"/>.
         /// </description></item>
         /// </list>
         /// <para>
-        /// Both need <c>a</c> and <c>b</c> of known sign with <c>a</c> positive, so that the
-        /// radicand is the one the substitution assumes it is. <c>b x^2 - a</c> with both signs
-        /// the other way is the secant substitution and a third branch; it is left out rather
-        /// than guessed at, because its domain is two intervals rather than one and the answer
-        /// owes a condition this does not yet write.
+        /// Both signs negative is a radicand negative everywhere, with no real integrand to
+        /// integrate, and there is no fourth case.
         /// </para>
         /// <para>
         /// <b>Coming back.</b> The answer arrives in <c>sin(t)</c>, <c>cos(t)</c> and
-        /// <c>tan(t)</c>, each of which is algebraic in <c>x</c> under the substitution — no
-        /// <c>arctan</c> appears, because the closed core never leaves a bare <c>t</c> behind.
+        /// <c>tan(t)</c>, each of which is algebraic in <c>x</c> under the substitution, and in
+        /// <c>t</c> itself wherever the recursion bottoms out on <c>int 1 dt</c> — which is where
+        /// an <c>arcsin</c> or an <c>arctan</c> enters an otherwise algebraic answer.
         /// </para>
         /// <para>
-        /// <b>Asked, not volunteered</b>, like the rule it hands to:
-        /// <a href="https://github.com/asc-community/AngouriMath/issues/1265">#1265</a>.
+        /// <b>Volunteered, and deliberately so</b> — this is the one rule of the five that is not
+        /// scoped to <see cref="Integration.AnsweringTheQuestionAsked"/>. Scope is right for a
+        /// rule whose answers only ever let some other search carry on into ground that was
+        /// doomed, which is what
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1265">#1265</a> is about.
+        /// It is wrong for this one, because the sub-integrals it answers are the ones integration
+        /// by parts asks for and then uses: <c>int x arcsin(x) dx</c> leaves
+        /// <c>int x^2/sqrt(1 - x^2) dx</c>, which is squarely this rule's and was refused for
+        /// sitting one level down. Ungating it is worth <b>ten</b> more of the Rubi sample and
+        /// measures free — same wall clock, same timeouts, and the same 28.8 s over a probe of
+        /// integrands that are declined either way.
         /// </para>
         /// https://github.com/asc-community/AngouriMath/issues/718
         /// </remarks>
         internal static Entity? SolveARadicalOfAQuadraticAsTrigonometric(
             Entity expr, Entity.Variable x, bool aWholePowerCounts = false)
         {
-            if (!Integration.AnsweringTheQuestionAsked)
-                return null;
             if (!TryReadAPowerTimesARadicalQuadratic(expr, x, out var power, out var half,
                     out var constant, out var middle, out var quadratic, out var factor))
                 return null;

--- a/Sources/Tests/UnitTests/Calculus/RadicalBelowTheTopTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/RadicalBelowTheTopTest.cs
@@ -1,0 +1,124 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// Integrands whose radical of a quadratic appears only <b>below the top</b> — after a step of
+    /// integration by parts, not in what the caller wrote.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/1265">#1265</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>int x arcsin(x) dx</c> leaves <c>int x^2/sqrt(1 - x^2) dx</c>, which is squarely the
+    /// quadratic radical rule's and was refused for sitting one level down: that rule was scoped
+    /// to the integrand the caller asked about, as the other four closed rules are.
+    /// </para>
+    /// <para>
+    /// <b>Scope is right for a rule whose answers only let some other search carry on into ground
+    /// that was doomed, and wrong for one whose answers are used.</b> These are the second kind —
+    /// by parts asks for the sub-integral and then uses it. Ungating measured free: ten more of
+    /// the Rubi sample, the same wall clock, the same timeouts, and the same 28.8 s over a probe
+    /// of integrands declined either way.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class RadicalBelowTheTopTest
+    {
+        private static void DifferentiatesBack(string integrand, double[] points)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 3,
+                $"only {compared} of {points.Length} points were comparable for {integrand}, "
+                + "so this asserts almost nothing");
+        }
+
+        /// <summary>
+        /// A polynomial times an inverse trigonometric function. By parts differentiates the
+        /// inverse function into something algebraic, and what is left is a power of the variable
+        /// over a radical of a quadratic.
+        /// </summary>
+        [Theory]
+        [InlineData("x*arcsin(x)", new[] { 0.3, 0.5, -0.4, -0.8 })]
+        [InlineData("x^2*arcsin(x)", new[] { 0.3, 0.5, -0.4, -0.8 })]
+        [InlineData("x*arccos(x)", new[] { 0.3, 0.5, -0.4, -0.8 })]
+        [InlineData("x^3*arcsin(x)", new[] { 0.3, 0.5, -0.4, -0.8 })]
+        public void APolynomialTimesAnInverseFunction(string integrand, double[] points)
+            => DifferentiatesBack(integrand, points);
+
+        /// <summary>
+        /// The same with a negative power, and with the radical already in the integrand — the
+        /// sub-integral is still a level down, which is what was refused.
+        /// </summary>
+        [Theory]
+        [InlineData("arcsin(x)/x^2", new[] { 0.3, 0.5, 0.7, 0.85 })]
+        [InlineData("x*arctan(x)/sqrt(1 + x^2)", new[] { 0.3, 1.5, -0.4, -2.8 })]
+        [InlineData("x*arcsin(x)/sqrt(1 - x^2)", new[] { 0.3, 0.5, 0.7, 0.85 })]
+        public void ANegativePowerAndARadicalAlreadyThere(string integrand, double[] points)
+            => DifferentiatesBack(integrand, points);
+
+        /// <summary>
+        /// What the rule answered at the top before and must keep answering — the ungating is not
+        /// meant to change any of these.
+        /// </summary>
+        [Theory]
+        [InlineData("1/(1 + x^2)^(3/2)", new[] { 0.3, 1.6, -0.4, -2.2 })]
+        [InlineData("x^5/sqrt(5 + x^2)", new[] { 0.3, 1.6, -0.4, -2.2 })]
+        [InlineData("x^2/sqrt(1 + x^2)", new[] { 0.3, 1.6, -0.4, -2.2 })]
+        [InlineData("sqrt(1 - x^2)/x^2", new[] { 0.3, 0.5, 0.7, 0.85 })]
+        [InlineData("sqrt(x^2 - 1)", new[] { 1.7, 3.1, -1.9, -4.2 })]
+        [InlineData("x/sqrt(1 + x + x^2)", new[] { 0.3, 1.6, -0.4, -2.2 })]
+        [InlineData("1/(x*(1 + x^2)^2)", new[] { 0.3, 1.6, -0.4, -2.2 })]
+        public void WhatItAnsweredAtTheTopBefore(string integrand, double[] points)
+            => DifferentiatesBack(integrand, points);
+
+        /// <summary>
+        /// And the integrands that are declined either way, which must stay <b>cheaply</b>
+        /// declined — that is the whole risk the scope was guarding against, and the measurement
+        /// says it does not arise for this rule.
+        /// </summary>
+        /// <remarks>
+        /// Bounded by the integrator's own budget rather than by a wall clock, which measures the
+        /// runner. Over a fourteen-integrand probe these total 28.8 s with the rule scoped and
+        /// 28.8 s without it.
+        /// </remarks>
+        [Theory]
+        [InlineData("x*tan(x)^3*sec(x)^4")]
+        [InlineData("1/((4 + x^2)*sqrt(1 + 4*x^2))")]
+        [InlineData("(1 + x^4)/((1 + x + x^2)*sqrt(2 + x + x^2))")]
+        [InlineData("x*sqrt(1 + x^3)*ln(x)")]
+        public void WhatIsDeclinedEitherWay(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+        }
+    }
+}


### PR DESCRIPTION
`int x arcsin(x) dx` was unanswered. By parts differentiates the arcsine into
something algebraic and leaves `int x^2/sqrt(1 - x^2) dx`, which is squarely what
#1273 answers -- and it was refused, for sitting one level down.

#1266 added `AnsweringTheQuestionAsked` and four rules since have been written
against it. The reason is real and measured: a rule that answers a sub-integral
which used to come back unanswered lets the search that asked carry on into ground
that was always doomed, and the cost lands on integrands the rule never fires on.
`sec(x)^6*tan(x)^3` went from a 637 ms decline to not returning in 400 s that way.

**But that is a property of what the caller does with the answer, not of the
rule.** Where the sub-integral is one the caller *uses* -- by parts asks for
`int x^2/sqrt(1 - x^2)` and then builds its answer out of it -- the scope refuses
the one thing that would have finished the job.

## Measured, one gate at a time

Each of the five ungated on its own, same build, Rubi sample of 463, foreground:

| ungated | solved | timeouts | wall clock |
|---|--:|--:|--:|
| (all scoped, master) | 258 | 3 | 159 s |
| `SolveBySecantPowerReduction` | 258 | 3 | 160 s |
| `SolveByTrigonometricPowerSubstitution` | 258 | 3 | 159 s |
| `SolveABinomialDifferential` + `SolveAPolynomialTimesAnExponentialAndATrigonometric` | 259 | 3 | 158 s |
| **`SolveARadicalOfAQuadraticAsTrigonometric`** | **268** | 3 | 161 s |

One of the five, and only one. So the scope stays on the other four and comes off
this one, rather than a policy being changed for all of them on the strength of a
single measurement.

And it measures free. A probe of fourteen integrands that are declined either way
-- including `x tan(x)^3 sec(x)^4`, `1/(1 + sin(x)^3)` and
`(1 + x^4)/((1 + x + x^2) sqrt(2 + x + x^2))` -- totals **28.8 s scoped and 28.8 s
not**. The five test suites are green and the calculus suite is unmoved at 1m20.

    master (0e56e5cc)   259/463, 0 wrong, 3 timeouts, 159 s
    with it             269/463, 0 wrong, 3 timeouts, 159 s

(The one-gate-at-a-time table above was taken against `b7ab36f8`, one commit
earlier, where the same arm read 258 and 268. #1279 landed the two inverse-secant
integrals in between and moves both by one.)

## What else this PR does

The rule's own summary said there were two substitutions and that the secant one
was "left out rather than guessed at". #1277 added it, and updated the helper's
documentation without updating this one. It now names all three, says what decides
between them, and says there is no fourth.

## The general statement, for the next rule

Scope answers **a rule whose answers are only ever a distraction**: something the
surrounding search would have stopped on, and now does not. It is the wrong
instrument for **a rule whose answers are what the caller was asking for**. The
four it remains on are power reductions and substitutions that answer an integrand
in its own terms; the one it comes off is the one integration by parts routinely
needs a level down. That is a question worth asking of each new rule rather than a
default to copy.

Part of #718. Part of #1265.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura

Part of #718. Part of #1265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
