### PR TITLE
Four integration gaps a symbol or a second radical was hiding, and the pinned verdict one of them falsifies

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -369,3 +369,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/HomogeneousTrigonometricTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/NestedRadicalIntegralTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/SymbolicParameterIntegralTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -73,7 +73,7 @@ namespace AngouriMath.Functions.Algebra
             // fire on one and recurse into the problem it started from. The check on the
             // quotient is the second half of that guarantee: a division that came back with
             // nothing taken out would hand the same fraction on and not terminate.
-            if (TreeAnalyzer.PolynomialLongDivision(numerator, denominator) is var (quotient, properPart)
+            if (TreeAnalyzer.PolynomialLongDivision(numerator, denominator, genericCase: true, inTermsOf: x) is var (quotient, properPart)
                 && quotient.Evaled != Entity.Number.Integer.Create(0)
                 && Integration.ComputeIndefiniteIntegral(quotient, x, integrateByParts) is { } wholePart
                 && Integration.ComputeIndefiniteIntegral(properPart, x, integrateByParts) is { } fractionPart)
@@ -1271,8 +1271,17 @@ namespace AngouriMath.Functions.Algebra
                         rateFound = rateFound is null
                             ? (multiplicity * thisRate).InnerSimplified
                             : (rateFound + multiplicity * thisRate).InnerSimplified;
-                        // The constant part of the exponent is a factor, not a rate.
-                        polynomialPart *= MathS.Pow(@base, offset * multiplicity);
+                        // The constant part of the exponent is a factor, not a rate -- and there
+                        // is none to take when the exponent has no constant part. `MathS.Pow`
+                        // leaves `b^0` written out, and a factor of `d^0` standing in front of
+                        // the polynomial is enough to stop `TryPolynomial` reading it, so
+                        // `d^x x cos(x)` was declined where `2^x x cos(x)` came out: with a
+                        // numeric base the same dead factor is folded away and with a symbolic
+                        // one it is not. `d^x cos(x)` hid it, because a polynomial part free of
+                        // the variable is never read as a polynomial at all.
+                        // https://github.com/asc-community/AngouriMath/issues/718
+                        if (offset.Evaled is not Number.Integer(0))
+                            polynomialPart *= MathS.Pow(@base, offset * multiplicity);
                         return true;
                     case Mulf(var left, var right):
                         return Read(left, multiplicity) && Read(right, multiplicity);
@@ -1520,14 +1529,22 @@ namespace AngouriMath.Functions.Algebra
                 ? MathS.Arctan(inTermsOf * MathS.Sqrt(b) / MathS.Sqrt(a))
                 : MathS.Arcsin(inTermsOf * MathS.Sqrt(-b) / MathS.Sqrt(a));
 
-            var answer = inT.Replace(node => node switch
-            {
-                Sinf(var inner) when inner == t => sine,
-                Cosf(var inner) when inner == t => cosine,
-                Tanf(var inner) when inner == t => tangent,
-                Variable v when v == t => angle,
-                _ => node
-            });
+            // **Two passes, and the order is load-bearing.** `Replace` rewrites a node's children
+            // before the node, so a single pass that also matched a bare `t` turned `tan(t)` into
+            // `tan(arccos(...))` -- the parent no longer matched once its child had been replaced.
+            // That answer is correct and cannot be evaluated: `EvalNumerical` throws on it, so a
+            // caller gets an antiderivative it can differentiate and not one it can use. The
+            // trigonometric functions of `t` go first, and only what is left of `t` becomes the
+            // angle. https://github.com/asc-community/AngouriMath/issues/718
+            var answer = inT
+                .Replace(node => node switch
+                {
+                    Sinf(var inner) when inner == t => sine,
+                    Cosf(var inner) when inner == t => cosine,
+                    Tanf(var inner) when inner == t => tangent,
+                    _ => node
+                })
+                .Replace(node => node is Variable v && v == t ? angle : node);
             if (answer.ContainsNode(t))
                 return null;
             // The reflection, once: `sign(y)^(m+1)`, which is `sign(y)` for an even power outside
@@ -2157,8 +2174,17 @@ namespace AngouriMath.Functions.Algebra
                     continue;
                 if (!@base.ContainsNode(x))
                     continue;
+                // A radical over something that is not linear is **skipped rather than refused**,
+                // and that is where the nested ones come from. `sqrt(x + sqrt(1 + x))` holds two:
+                // the inner one is over something linear and is what the substitution is for, and
+                // the outer one is over a sum holding the inner one. Declining because of the
+                // outer one refused the whole family -- and it need not, because the substitution
+                // eliminates `x` from it anyway: with `u^2 = 1 + x` the outer base is `u^2 + u - 1`
+                // and the integrand becomes `2u sqrt(u^2 + u - 1)`, which the quadratic radical
+                // rule answers. The check that no `x` survives, below, is what makes skipping safe
+                // rather than a guess. https://github.com/asc-community/AngouriMath/issues/718
                 if (!TreeAnalyzer.TryGetPolyLinear(@base, x, out var slope, out _) || slope.Evaled == 0)
-                    return null;   // a radical over something that is not linear: not this rule's
+                    continue;
                 if (radicalBase is null)
                     radicalBase = @base;
                 else if (radicalBase != @base)

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IntegralPatterns.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IntegralPatterns.cs
@@ -713,7 +713,7 @@ namespace AngouriMath.Functions.Algebra
             if (power < 2)
                 return null;
 
-            var division = TreeAnalyzer.PolynomialLongDivision(numerator, quadratic);
+            var division = TreeAnalyzer.PolynomialLongDivision(numerator, quadratic, genericCase: true, inTermsOf: x);
             if (division is null)
                 return null;
 

--- a/Sources/AngouriMath/Functions/TreeAnalyzer/LongDivision.cs
+++ b/Sources/AngouriMath/Functions/TreeAnalyzer/LongDivision.cs
@@ -113,16 +113,28 @@ namespace AngouriMath.Functions
         /// the same way it always did, and one that does not falls through to the replacement,
         /// which is the only thing that ever answered <c>sin(x)^2 / sin(x)</c>.
         /// </para>
+        /// <para>
+        /// <b><paramref name="genericCase"/> says which of two callers is asking.</b> Dividing by
+        /// the divisor's leading coefficient loses the value of the parameter that makes it zero:
+        /// <c>x / (a + b x)</c> divided out is undefined at <c>b = 0</c>, where the quotient is
+        /// <c>x / a</c> and perfectly ordinary. For the simplifier that is a rewrite which is not
+        /// an equivalence, so it is declined; for the integrator it is the answer every
+        /// neighbouring rule already gives, since <c>int 1/(a x + b) dx</c> is
+        /// <c>ln(a x + b) / a</c> and loses <c>a = 0</c> on every call. The default is the
+        /// simplifier's, and nothing about the general pass changes by adding this.
+        /// </para>
         /// </remarks>
-        internal static (Entity Divided, Entity Remainder)? PolynomialLongDivision(Entity p, Entity q)
+        internal static (Entity Divided, Entity Remainder)? PolynomialLongDivision(
+            Entity p, Entity q, bool genericCase = false, Variable? inTermsOf = null)
         {
             if (!p.Vars.Any() || !q.Vars.Any())
                 return null; // There are no variables to find polynomial as
-            return DivideOnePolynomial(p, q, replaceVars: false)
-                ?? DivideOnePolynomial(p, q, replaceVars: true);
+            return DivideOnePolynomial(p, q, replaceVars: false, genericCase, inTermsOf)
+                ?? DivideOnePolynomial(p, q, replaceVars: true, genericCase, inTermsOf);
         }
 
-        private static (Entity Divided, Entity Remainder)? DivideOnePolynomial(Entity p, Entity q, bool replaceVars)
+        private static (Entity Divided, Entity Remainder)? DivideOnePolynomial(
+            Entity p, Entity q, bool replaceVars, bool genericCase, Variable? inTermsOf)
         {
             // ---> (x^0.6 + 2x^0.3 + 1) / (x^0.3 + 1)
             var replacementInfo = GatherAllPossiblePolynomials(p + q, replaceVars);
@@ -138,8 +150,27 @@ namespace AngouriMath.Functions
             var monoinfoP = GatherAllPossiblePolynomials(p.Expand(), replaceVars: false).MonoInfo;
             var monoinfoQ = GatherAllPossiblePolynomials(q.Expand(), replaceVars: false).MonoInfo;
 
-            // First attempt to find polynoms
-            var polyvar = monoinfoP.Keys.FirstOrDefault(monoinfoQ.ContainsKey);
+            // First attempt to find polynoms.
+            //
+            // **Which variable the division is in is the caller's to say, where it knows.** The
+            // choice was whichever variable came first, and with two symbols in play that is as
+            // likely to be a parameter as the one the caller cares about: `a x^2 / (b + a x)`
+            // divides perfectly well in `a`, giving `x - b x / (b + a x)`, which is true and
+            // useless to an integrator working in `x` — and it consumes the division, so the
+            // split that would have answered is never tried. Taking the first candidate made the
+            // verdict depend on the order `Vars` happens to report, which is not a property of
+            // the division. A caller that does not care still gets the old choice.
+            //
+            // In the replaced pass the variables are gone, swapped for temporaries standing for
+            // a subtree — `sin(x)^2 / sin(x)` divides in a symbol standing for `sin(x)` — so the
+            // test there is that the subtree behind the temporary is one the caller's variable
+            // occurs in. https://github.com/asc-community/AngouriMath/issues/718
+            var candidates = monoinfoP.Keys.Where(monoinfoQ.ContainsKey);
+            var polyvar = inTermsOf is null
+                ? candidates.FirstOrDefault()
+                : candidates.FirstOrDefault(v => v == inTermsOf
+                    || (replacementInfo.RevertReplacements.TryGetValue(v, out var behind)
+                        && behind.ContainsNode(inTermsOf)));
             // cannot divide, return unchanged
             if (polyvar is null) return null;
 
@@ -160,20 +191,27 @@ namespace AngouriMath.Functions
             // for now just return polynomials unchanged
             if (maxpowP.LessThan(maxpowQ)) return null;
 
-            // The unreplaced attempt divides by the divisor's leading coefficient, so it runs
-            // only where that coefficient is a number other than zero — which is to say, where
-            // the quotient it produces is valid for every value of every symbol in it. With a
-            // symbolic leading coefficient it would not be: `x^2/(a + b x)` divided out is
-            // undefined at `b = 0`, where the integrand is `x^2/a` and perfectly ordinary, and a
-            // quotient that silently loses a value of a parameter is worse than none.
+            // The unreplaced attempt divides by the divisor's leading coefficient, so for the
+            // simplifier it runs only where that coefficient is a number other than zero — which
+            // is to say, where the quotient it produces is valid for every value of every symbol
+            // in it. With a symbolic leading coefficient it would not be: `x^2/(a + b x)` divided
+            // out is undefined at `b = 0`, where the integrand is `x^2/a` and perfectly ordinary,
+            // and a rewrite that silently loses a value of a parameter is not an equivalence.
             // `x^2/(x + a)` has leading coefficient 1 and is not that case, which is why it is
-            // answered now and was not before.
+            // answered even for the simplifier.
             //
-            // A symbolic leading coefficient is a gap here rather than a decision: what it wants
-            // is the divided form beside the degenerate one, under conditions, and this function
-            // returns a pair rather than a piecewise. Item 18 of the list below is that integral,
-            // still unticked. https://github.com/asc-community/AngouriMath/issues/180
-            if (!replaceVars && (maxvalQ.Vars.Any() || maxvalQ.Evaled == Integer.Create(0)))
+            // **The integrator asks for the generic case, and is right to.** It is not rewriting
+            // an expression into an equal one; it is naming an antiderivative, and the rest of
+            // the integrator already names the generic one. `int 1/(a x + b) dx` comes back as
+            // `ln(a x + b) / a`, `int sin(a x) dx` as `-cos(a x) / a`, `int x^n dx` as
+            // `x^(n+1)/(n+1)` — each undefined at one value of its parameter, each given anyway.
+            // The first of those divides by the very coefficient this guard was refusing to
+            // divide by, so declining here made long division the one rule in the integrator
+            // holding out for a condition none of its neighbours carry. That cost `x/(a + b x)`,
+            // `x ln(b + a x)` and every improper fraction with a symbolic coefficient, all of
+            // which come out with the coefficients made numeric.
+            // https://github.com/asc-community/AngouriMath/issues/180
+            if (!replaceVars && ((maxvalQ.Vars.Any() && !genericCase) || maxvalQ.Evaled == Integer.Create(0)))
                 return null;
 
             var result = new Dictionary<EDecimal, Entity>();

--- a/Sources/Tests/UnitTests/Calculus/ImproperFractionIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ImproperFractionIntegralTest.cs
@@ -104,32 +104,34 @@ namespace AngouriMath.Tests.Calculus
             => Assert.Equal(expected.ToEntity(), integrand.ToEntity().Integrate("x"));
 
         /// <summary>
-        /// A denominator whose <b>leading coefficient</b> is symbolic is still declined, and this
-        /// records a gap rather than a decision.
+        /// A denominator whose <b>leading coefficient</b> is symbolic is divided out too, for the
+        /// integrator — and this test recorded the opposite until it was.
         /// </summary>
         /// <remarks>
         /// <para>
-        /// Dividing out would divide by <c>b</c>, which is not decidably non-zero — and at
-        /// <c>b = 0</c> the quotient is <c>x^2/a</c>, whose antiderivative is not the limit of
-        /// the divided form. So the divided answer alone would be wrong for one value of a
-        /// parameter, which is why it is not given.
+        /// The verdict here was that dividing by <c>b</c> loses <c>b = 0</c>, where the quotient
+        /// is <c>x^2/a</c> and the divided answer is not its limit, so no answer was the honest
+        /// one. The first half is true. The second was measured against the wrong neighbours:
+        /// <c>int 1/(a x + b) dx</c> is <c>ln(a x + b)/a</c>, <c>int sin(a x) dx</c> is
+        /// <c>-cos(a x)/a</c>, <c>int x^n dx</c> is <c>x^(n+1)/(n+1)</c> — each undefined at one
+        /// value of its parameter and each given by this integrator without a condition. Long
+        /// division was the one rule holding out, and the first of those divides by the very
+        /// coefficient it refused. It now asks the division for the generic case; the simplifier,
+        /// whose rewrite has to be an equivalence, gets the old answer. The cases live in
+        /// <see cref="SymbolicParameterIntegralTest"/>.
         /// </para>
         /// <para>
-        /// <b>What is owed is the piecewise, not the decline.</b>
-        /// <see href="https://github.com/asc-community/AngouriMath/issues/180"/> lists
-        /// <c>x^2/(a + b*x)</c> as item 18 of the integrals this library should answer, and it is
-        /// still unticked — it is a target, not a settled refusal. The answer it wants is the
-        /// divided form under <c>b != 0</c> beside <c>x^3/(3a)</c> under <c>b = 0</c>, which is
-        /// how the constant-over-a-quadratic rule already reports its own degenerate branch.
-        /// Until that is built these stay unevaluated, which is the honest report.
+        /// Item 18 of <see href="https://github.com/asc-community/AngouriMath/issues/180"/> is
+        /// this integral. What it asked for is answered; the piecewise with the degenerate branch
+        /// beside it is a further step no neighbouring rule takes either.
         /// </para>
         /// </remarks>
         [Theory]
         [InlineData("x^2/(a + b*x)")]
         [InlineData("x^2/(2 + b*x)")]
         [InlineData("x^3/(a + b*x)")]
-        public void ASymbolicLeadingCoefficientIsDeclined(string integrand)
-            => Assert.Contains("integral(", integrand.ToEntity().Integrate("x").Stringize());
+        public void ASymbolicLeadingCoefficientIsDividedOut(string integrand)
+            => Assert.DoesNotContain("integral(", integrand.ToEntity().Integrate("x").Stringize());
 
         /// <summary>
         /// A symbolic coefficient that is <b>not</b> the leading one carries none of that

--- a/Sources/Tests/UnitTests/Calculus/NestedRadicalIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/NestedRadicalIntegralTest.cs
@@ -1,0 +1,148 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// A radical over a sum that holds another radical over something linear —
+    /// <c>sqrt(x + sqrt(1 + x))</c> and its family.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The linear-radical substitution was <b>refusing</b> an integrand that held a radical
+    /// over something not linear, where it need only have skipped it: with <c>u^2 = 1 + x</c>
+    /// the outer radical becomes <c>sqrt(u^2 + u - 1)</c>, free of <c>x</c>, and what is left is
+    /// a shape the quadratic-radical rule answers. The check that no <c>x</c> survives the
+    /// substitution is what made skipping safe.
+    /// </para>
+    /// <para>
+    /// Two of these are checked by <b>differences of the antiderivative against a quadrature</b>
+    /// rather than by differentiating back. Their answers come through the secant branch of the
+    /// quadratic-radical rule and carry a <c>sign</c> for the second interval, and the library
+    /// does not differentiate <c>sign</c>; a numeric check of <c>F(b) - F(a)</c> is the one this
+    /// answer admits. Simpson's rule on a smooth integrand over a short interval is accurate
+    /// well past the tolerance used.
+    /// </para>
+    /// <para>
+    /// The two-pass back-substitution this also fixes was a latent defect in the
+    /// quadratic-radical rule: <c>Replace</c> rewrites children before parents, so a bare
+    /// <c>t</c> was substituted before its enclosing <c>tan(t)</c> could match, and the answer
+    /// held <c>tan(arccos(...))</c> — correct and not evaluable.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class NestedRadicalIntegralTest
+    {
+        private static void AgreesWithQuadrature(string integrand, double from, double to)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var antiderivative = integral.Substitute("C", 0);
+            var closed = (double)(antiderivative.Substitute("x", to).EvalNumerical()
+                                  - antiderivative.Substitute("x", from).EvalNumerical()).RealPart;
+
+            var f = integrand.ToEntity();
+            const int intervals = 400;
+            var h = (to - from) / intervals;
+            var sum = 0.0;
+            for (var i = 0; i <= intervals; i++)
+            {
+                var weight = i == 0 || i == intervals ? 1 : i % 2 == 1 ? 4 : 2;
+                sum += weight * (double)f.Substitute("x", from + i * h).EvalNumerical().RealPart;
+            }
+            var numeric = sum * h / 3;
+
+            Assert.True(Math.Abs(closed - numeric) < 1e-7 * Math.Max(1, Math.Abs(numeric)),
+                $"F({to}) - F({from}) is {closed} for {integrand}, where the quadrature says {numeric}");
+        }
+
+        private static void DifferentiatesBack(string integrand, double[] points)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+            Assert.DoesNotContain("integral(", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 3,
+                $"only {compared} of {points.Length} points were comparable for {integrand}");
+        }
+
+        /// <summary>
+        /// The case this was found on, and two neighbours with a different inner slope and a
+        /// different sign on the inner radical.
+        /// </summary>
+        [Theory]
+        [InlineData("sqrt(x + sqrt(1 + x))", 0.4, 2.7)]
+        [InlineData("sqrt(x + sqrt(1 + x))", 1.1, 5.0)]
+        [InlineData("sqrt(x + sqrt(2*x + 3))", 0.5, 3.0)]
+        [InlineData("sqrt(2*x - sqrt(x + 1))", 1.0, 4.0)]
+        public void ARadicalOverASumHoldingALinearRadical(string integrand, double from, double to)
+            => AgreesWithQuadrature(integrand, from, to);
+
+        /// <summary>
+        /// The same skip lets the substitution through where the outer shape is rational after
+        /// it: the nested radical in a denominator.
+        /// </summary>
+        [Theory]
+        [InlineData("1/(x - sqrt(1 + sqrt(1 + x)))", new[] { 0.3, 0.9, 1.7 })]
+        [InlineData("sqrt(1 + x)/(x + sqrt(1 + sqrt(1 + x)))", new[] { 0.3, 1.3, 2.7 })]
+        public void ANestedRadicalInADenominator(string integrand, double[] points)
+            => DifferentiatesBack(integrand, points);
+
+        /// <summary>
+        /// What the substitution answered before, and must keep answering: one radical over a
+        /// linear base, and a radical over a radical of the variable itself.
+        /// </summary>
+        [Theory]
+        [InlineData("sqrt(1 + sqrt(x))", new[] { 0.3, 1.3, 2.7 })]
+        [InlineData("x*sqrt(1 + sqrt(x))", new[] { 0.3, 1.3, 2.7 })]
+        [InlineData("x*sqrt(1 + x)", new[] { 0.3, 1.3, 2.7 })]
+        [InlineData("1/(1 + sqrt(1 + x))", new[] { 0.3, 1.3, 2.7 })]
+        public void TheNeighboursStillAnswer(string integrand, double[] points)
+            => DifferentiatesBack(integrand, points);
+
+        /// <summary>
+        /// The answer must be one the caller can evaluate — no <c>tan(arccos(...))</c> and no
+        /// <c>t</c> left from the substitution — which is what the two-pass back-substitution is
+        /// for. Evaluating at a point is the test of that.
+        /// </summary>
+        [Theory]
+        [InlineData("sqrt(x + sqrt(1 + x))")]
+        [InlineData("x^5/sqrt(5 + x^2)")]
+        [InlineData("sqrt(x^2 - 1)")]
+        public void TheAnswerEvaluates(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x").Substitute("C", 0);
+            Assert.DoesNotContain("integral(", integral.Stringize());
+            var value = integral.Substitute("x", 2.5).EvalNumerical();
+            Assert.False(value.IsNaN, $"the antiderivative of {integrand} is NaN at x = 2.5: {integral}");
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Calculus/SymbolicParameterIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/SymbolicParameterIntegralTest.cs
@@ -1,0 +1,174 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// Integrands that came out with a numeric coefficient and were declined with a symbolic
+    /// one — three separate causes, found by probing each shape in both spellings.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every test here pins the parameters after integrating and differentiates back, so the
+    /// answer is checked as a function of <c>x</c> for one value of each parameter, which is
+    /// what an answer with a parameter in it claims for every value of it.
+    /// </para>
+    /// <para>
+    /// <b>The long division's leading coefficient.</b> The division declined a divisor whose
+    /// leading coefficient was a symbol, because the quotient loses the value that makes it
+    /// zero. That is the right decision for the simplifier, whose rewrite has to be an
+    /// equivalence, and the wrong one for the integrator, where every neighbouring rule already
+    /// gives the generic answer: <c>int 1/(a x + b) dx</c> is <c>ln(a x + b)/a</c>, undefined at
+    /// <c>a = 0</c> and given anyway. The integrator now asks for the generic case, and the
+    /// simplifier's behaviour is unchanged.
+    /// </para>
+    /// <para>
+    /// <b>The variable the division is in.</b> It was whichever came first, and for
+    /// <c>a x^2 / (b + a x)</c> that could be <c>a</c> — dividing in the parameter gives
+    /// <c>x - b x/(b + a x)</c>, true and useless, and consumes the one attempt. The integrator
+    /// now says which variable it means.
+    /// </para>
+    /// <para>
+    /// <b>A dead <c>d^0</c>.</b> The exponential-times-trigonometric reader multiplies the
+    /// polynomial part by the base to the constant part of the exponent, and with no constant
+    /// part that was <c>d^0</c> written out — which a numeric base folded away and a symbolic
+    /// one did not, and which stopped the polynomial being read.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class SymbolicParameterIntegralTest
+    {
+        private static readonly double[] Points = { 0.3, 0.9, 1.7, 2.6 };
+
+        private static void DifferentiatesBack(string integrand, params (string, double)[] pins)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+            Assert.DoesNotContain("NaN", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            Entity original = integrand.ToEntity();
+            foreach (var (name, value) in pins)
+            {
+                derivative = derivative.Substitute(name, value);
+                original = original.Substitute(name, value);
+            }
+
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 3,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}");
+        }
+
+        /// <summary>
+        /// An improper fraction whose divisor has a symbolic leading coefficient, which is the
+        /// gap <see cref="ImproperFractionIntegralTest"/> used to record as still open.
+        /// </summary>
+        [Theory]
+        [InlineData("x/(a + b*x)")]
+        [InlineData("x^2/(a + b*x)")]
+        [InlineData("x^2/(2 + b*x)")]
+        [InlineData("x^3/(a + b*x)")]
+        [InlineData("(x^2 + 1)/(a + b*x)")]
+        public void ASymbolicLeadingCoefficientIsDividedOut(string integrand)
+            => DifferentiatesBack(integrand, ("a", 1.3), ("b", 0.7));
+
+        /// <summary>
+        /// The division in the variable the integrator means, not the one that came first: the
+        /// parameter appears in the numerator too, so the division could be taken in it.
+        /// </summary>
+        [Theory]
+        [InlineData("a*x^2/(b + a*x)")]
+        [InlineData("x^2*a/(b + a*x)")]
+        [InlineData("b*x^3/(b + a*x)")]
+        public void TheDivisionIsInTheIntegrationVariable(string integrand)
+            => DifferentiatesBack(integrand, ("a", 1.3), ("b", 0.7));
+
+        /// <summary>
+        /// Integration by parts leaves exactly that improper fraction behind, so these are what
+        /// the two changes above are for.
+        /// </summary>
+        [Theory]
+        [InlineData("x*ln(b + a*x)")]
+        [InlineData("x*ln(3 + a*x)")]
+        [InlineData("x^2*ln(b + a*x)")]
+        public void ByPartsThatLeavesASymbolicImproperFraction(string integrand)
+            => DifferentiatesBack(integrand, ("a", 1.3), ("b", 0.7));
+
+        /// <summary>
+        /// A symbolic base on the exponential, with a polynomial and a trigonometric factor beside
+        /// it. <c>d^x cos(x)</c> came out and <c>d^x x cos(x)</c> did not, which is what named
+        /// the polynomial read as the place.
+        /// </summary>
+        [Theory]
+        [InlineData("d^x*x*cos(x)")]
+        [InlineData("d^x*x*sin(x)")]
+        [InlineData("d^x*x^2*cos(x)")]
+        [InlineData("d^x*x^3*cos(x)")]
+        [InlineData("d^(2*x)*x*cos(x)")]
+        [InlineData("d^x*x*cos(2*x)")]
+        public void ASymbolicExponentialBaseTimesAPolynomialAndATrigonometric(string integrand)
+            => DifferentiatesBack(integrand, ("d", 1.7));
+
+        /// <summary>
+        /// Two symbolic bases and no polynomial at all, where the dead factor was <c>a^0 b^0</c>
+        /// standing in for the polynomial. Found by the corpus rather than the probe.
+        /// </summary>
+        [Theory]
+        [InlineData("a^x/b^x")]
+        [InlineData("a^x*b^x")]
+        public void TwoSymbolicExponentialBases(string integrand)
+            => DifferentiatesBack(integrand, ("a", 1.7), ("b", 2.3));
+
+        /// <summary>
+        /// The numeric spellings, which came out before and must keep coming out the same way.
+        /// </summary>
+        [Theory]
+        [InlineData("x/(3 + 5*x)")]
+        [InlineData("x*ln(3 + 5*x)")]
+        [InlineData("3^x*x*cos(x)")]
+        [InlineData("2^x*x*cos(x)")]
+        [InlineData("x^2/(x + a)")]
+        public void TheNumericSpellingsStillAnswer(string integrand)
+            => DifferentiatesBack(integrand, ("a", 1.3));
+
+        /// <summary>
+        /// The simplifier's own long division is not what changed: a symbolic leading coefficient
+        /// is still not divided out by <c>Simplify</c>, because there the rewrite has to hold for
+        /// every value of the parameter and at <c>b = 0</c> it does not.
+        /// </summary>
+        [Theory]
+        [InlineData("x^2/(a + b*x)")]
+        [InlineData("x/(a + b*x)")]
+        public void TheSimplifierStillDoesNotDivideBySymbol(string expression)
+        {
+            var simplified = expression.ToEntity().Simplify();
+            // A quotient of the form `x/b + ...` would have to have divided by the symbol; the
+            // shape that keeps the parameter under the fraction has not.
+            Assert.DoesNotContain("/ b", simplified.Stringize());
+            Assert.DoesNotContain("/b", simplified.Stringize());
+        }
+    }
+}


### PR DESCRIPTION
`x/(a + b*x)` had no antiderivative. `x/(3 + 5*x)` did. Nine shapes from the
Rubi sample were like that -- answered with a number in the coefficient, declined
with a symbol -- and probing each in both spellings found three separate causes.
A fourth gap, the nested radical `sqrt(x + sqrt(1 + x))`, is one word.

## The long division's leading coefficient

The division declined a divisor whose leading coefficient was a symbol, because
the quotient loses the value that makes it zero: `x/(a + b x)` divided out is
undefined at `b = 0`. #1269 wrote that guard and its test pinned the decline as
"the honest report".

It was measured against the wrong neighbours. Every rule beside it gives the
generic answer:

    int 1/(a x + b) dx   =  ln(a x + b) / a       undefined at a = 0
    int sin(a x) dx      =  -cos(a x) / a         undefined at a = 0
    int x^n dx           =  x^(n+1) / (n+1)       undefined at n = -1
    int (a x + b)^7 dx   =  (a x + b)^8 / (8 a)   undefined at a = 0

The first of those divides by the very coefficient the guard refused to divide
by. Long division was the one rule in the integrator holding out for a condition
none of its neighbours carry.

The guard is right for the simplifier, whose rewrite has to be an equivalence,
and `PolynomialLongDivision` serves both. So it takes a `genericCase` flag: the
integrator's two call sites pass it, the simplifier's rule set does not, and
`Simplify` on `x/(a + b*x)` is unchanged. Item 18 of #180 is this integral, and
it is answered; the piecewise with the degenerate branch beside it is a further
step no neighbouring rule takes either.

## The variable the division is in

With that guard lifted, `a x^2/(b + a x)` still declined while `x^2/(b + a x)`
came out. The division chose its variable as *whichever came first*, and with
`a` in the numerator too that could be `a` -- dividing in the parameter gives
`x - b x/(b + a x)`, true and useless, and it consumes the one attempt. The
integrator now passes `inTermsOf: x`; a caller that does not say keeps the old
choice. In the replaced pass the variable is behind a temporary, so the test
there is that the subtree it stands for mentions the caller's variable.

`x ln(b + a x)` is what this was for: by parts leaves exactly that fraction.

## A dead `d^0`

`d^x cos(x)` came out and `d^x x cos(x)` did not, which named the polynomial
read as the place. The exponential-times-trigonometric reader multiplies the
polynomial part by the base to the constant part of the exponent, and with no
constant part that was `MathS.Pow(d, 0)` written out -- folded away for a
numeric base, left standing for a symbolic one, and enough to stop
`TryPolynomial`. Nothing is multiplied in when there is nothing to multiply.
The corpus then found `a^x/b^x` answered too: `a^0 b^0` had been standing in for
the polynomial there.

## The nested radical

`SolveByLinearRadicalSubstitution` **refused** an integrand holding a radical
over something not linear. `sqrt(x + sqrt(1 + x))` holds two: the inner one is
what the substitution is for, and the outer one is over a sum containing it.
With `u^2 = 1 + x` the outer radical is `sqrt(u^2 + u - 1)`, free of `x`, and
the integrand is `2u sqrt(u^2 + u - 1)`, which the quadratic-radical rule
answers. `return null` is now `continue`; the check that no `x` survives the
substitution is what makes skipping safe.

That exposed a latent defect in the quadratic-radical rule's back-substitution
(#1273, #1277): `Replace` rewrites children before parents, so a bare `t` was
substituted before its enclosing `tan(t)` could match, and the answer held
`tan(arccos(...))` -- correct, and `EvalNumerical` throws on it. Two passes now,
the trigonometric functions of `t` first.

## Measured

Every answer differentiated back, or -- for the secant-branch answers that carry
a `sign`, which the library does not differentiate -- checked as `F(b) - F(a)`
against Simpson's rule.

Rubi corpus, 463-problem sample, this branch against the master it was cut from
(6294e7a7, without #1282 which is still open):

    master      271/463, 0 wrong, 3 timeouts, 169 s
    with it     278/463, 0 wrong, 3 timeouts, 173 s

Seven more answered and nothing lost: `x/(a+b*x)`, `x*ln(b+a*x)`, `a^x/b^x`,
`d^x*x*cos(x)`, `d^x*x^3*cos(x)` (Hearn); `1/(x-sqrt(1+sqrt(1+x)))`,
`sqrt(1+x)/(x+sqrt(1+sqrt(1+x)))` (Bondarenko). An eighth,
`x/(x+sqrt(1-sqrt(1+x)))`, now answers and is complex at every real sample
point, which the harness reports as unverifiable rather than solved.

`ImproperFractionIntegralTest.ASymbolicLeadingCoefficientIsDeclined` recorded
the gap and is now `...IsDividedOut`, with the reasoning that changed written
against it. The five test suites are green. One `.editorconfig` conflict round is expected once #1282 lands; nothing else in the two branches overlaps.

Part of #718. Part of #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
