### PR TITLE
A binomial denominator at its roots of unity, partial fractions over symbolic factors, and a quotient read in its third spelling

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -375,3 +375,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/SymbolicParameterIntegralTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/BinomialDenominatorIntegralTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/SymbolicFactorsPartialFractionsTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/PartialFractions.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/PartialFractions.cs
@@ -363,5 +363,255 @@ namespace AngouriMath.Functions
         /// </summary>
         private static Entity AsFraction(RationalPolynomial numerator, RationalPolynomial denominator, Variable x)
             => numerator.IsZero ? Integer.Create(0) : numerator.ToEntity(x) / denominator.ToEntity(x);
+
+        /// <summary>
+        /// <c>N/D</c> written as one fraction per factor of <paramref name="denominator"/>,
+        /// where the denominator is <b>written</b> as a product of distinct linear and quadratic
+        /// factors whose coefficients may be symbols, or <see langword="false"/> where it is not
+        /// or the decomposition cannot be settled.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The two splits above work in exact rational arithmetic and stop where the rationals
+        /// do, and a symbol is not a rational: <c>1/((x + a)(x^2 + b))</c> has factors already in
+        /// hand and each of them is a shape the integrator reads, and it was declined because
+        /// nothing here could read the factors. This is the textbook method for it -- undetermined
+        /// coefficients -- and it is the one that survives a symbol, because it solves a linear
+        /// system in the unknown numerators rather than dividing polynomials whose coefficients
+        /// have to be compared to zero.
+        /// </para>
+        /// <para>
+        /// <b>Which pivots are safe.</b> The system's entries are polynomials in the parameters,
+        /// and a row reduction has to decide whether a pivot is zero. A number is decided by
+        /// looking; a symbolic pivot is taken only when it does not simplify to zero, which is a
+        /// judgement and not a proof, and that is why <b>the decomposition is checked before it
+        /// is returned</b>: the identity <c>N = sum P_i * D/F_i</c> is evaluated at several
+        /// points with every symbol pinned, and a split that fails it is declined rather than
+        /// handed on. A wrong pivot can cost an answer here and cannot produce a wrong one.
+        /// </para>
+        /// <para>
+        /// The generic case, as everywhere in this integrator: two factors that coincide for
+        /// one value of a parameter are coprime for every other, and the answer is the one for
+        /// those. See the note on <c>PolynomialLongDivision</c>.
+        /// </para>
+        /// <para>
+        /// Distinct factors only. A repeated symbolic quadratic has no rule to land on, and a
+        /// repeated linear factor is the sibling step's, in exact arithmetic where it applies.
+        /// </para>
+        /// https://github.com/asc-community/AngouriMath/issues/718
+        /// </remarks>
+        internal static bool TrySplitOverWrittenFactors(
+            Entity numerator, Entity denominator, Variable x, [NotNullWhen(true)] out Entity? decomposition)
+        {
+            decomposition = null;
+
+            // The factors as written, each a polynomial in x of degree one or two with
+            // coefficients free of x; a factor free of x is a constant and comes out in front.
+            var factors = new List<(Entity Factor, int Degree)>();
+            Entity constant = Integer.One;
+            foreach (var part in Mulf.LinearChildren(denominator))
+            {
+                if (!part.ContainsNode(x))
+                {
+                    constant *= part;
+                    continue;
+                }
+                // A factor written as a power is a repeated factor, whatever its degree reads
+                // as: `(a + b u)^2` is a quadratic to the reader below and a repeated linear
+                // factor to the decomposition, and taking it as the former cost five seconds on
+                // `1/(a + b e^(p x))^2` for a split that nothing downstream answers.
+                if (part is Powf(_, Integer { EInteger.Sign: > 0 } repeated) && repeated != Integer.One)
+                    return false;
+                if (!TreeAnalyzer.TryGetPolynomial(part, x, out var read) || read.Count == 0)
+                    return false;
+                var degree = read.Keys.Max()!;
+                if (!degree.CanFitInInt32() || degree.ToInt32Unchecked() is not (1 or 2))
+                    return false;
+                foreach (var pair in read)
+                    if (pair.Key.Sign < 0 || pair.Value.ContainsNode(x))
+                        return false;
+                factors.Add((part.InnerSimplified, degree.ToInt32Unchecked()));
+            }
+            if (factors.Count < 2)
+                return false;
+            for (var i = 0; i < factors.Count; i++)
+                for (var j = i + 1; j < factors.Count; j++)
+                    if (factors[i].Factor == factors[j].Factor)
+                        return false;
+
+            var total = factors.Sum(f => f.Degree);
+            if (!TreeAnalyzer.TryGetPolynomial(numerator, x, out var above))
+                return false;
+            foreach (var pair in above)
+                if (pair.Key.Sign < 0 || pair.Key.CompareTo(EInteger.FromInt32(total)) >= 0 || pair.Value.ContainsNode(x))
+                    return false;
+
+            // One unknown per coefficient of each numerator P_i, of degree one less than F_i.
+            var unknowns = new List<Variable>();
+            var nameSource = numerator + denominator;
+            var numerators = new List<Entity>();
+            foreach (var (_, degree) in factors)
+            {
+                // Built without a `x^0`, which `Expand` guards with a `provided x != 0` that
+                // nothing downstream can read as a polynomial.
+                Entity? p = null;
+                for (var k = 0; k < degree; k++)
+                {
+                    var unknown = Variable.CreateUnique(nameSource, "c");
+                    nameSource += unknown;
+                    unknowns.Add(unknown);
+                    Entity term = k == 0 ? unknown : k == 1 ? unknown * x : unknown * MathS.Pow(x, k);
+                    p = p is null ? term : p + term;
+                }
+                numerators.Add(p!);
+            }
+
+            // N = sum P_i * prod_{j != i} F_j, compared coefficient by coefficient in x.
+            Entity identity = 0;
+            for (var i = 0; i < factors.Count; i++)
+            {
+                Entity cofactor = numerators[i];
+                for (var j = 0; j < factors.Count; j++)
+                    if (j != i)
+                        cofactor *= factors[j].Factor;
+                identity += cofactor;
+            }
+            if (!TreeAnalyzer.TryGetPolynomial(identity, x, out var rows))
+                return false;
+
+            var width = unknowns.Count;
+            var matrix = new Entity[total][];
+            var rhs = new Entity[total];
+            for (var power = 0; power < total; power++)
+            {
+                var row = rows.TryGetValue(EInteger.FromInt32(power), out var atPower) ? atPower : Integer.Zero;
+                matrix[power] = new Entity[width];
+                for (var column = 0; column < width; column++)
+                    matrix[power][column] = row.Differentiate(unknowns[column]).InnerSimplified;
+                rhs[power] = above.TryGetValue(EInteger.FromInt32(power), out var wanted) ? wanted : Integer.Zero;
+            }
+
+            if (!TrySolveSquare(matrix, rhs, out var values))
+                return false;
+
+            Entity sum = 0;
+            for (var i = 0; i < factors.Count; i++)
+            {
+                var p = numerators[i];
+                for (var column = 0; column < width; column++)
+                    p = p.Substitute(unknowns[column], values[column]);
+                sum += Bare(p) / factors[i].Factor;
+            }
+
+            // Checked rather than trusted, at points with every symbol pinned: a pivot that was
+            // zero without looking it would have produced a wrong decomposition, and this is
+            // what turns that into a declined one.
+            if (!HoldsAtSampledPoints(numerator / denominator, sum / constant, x))
+                return false;
+
+            decomposition = sum / constant;
+            return true;
+        }
+
+        /// <summary>
+        /// Gaussian elimination on a square system whose entries may be symbols. A pivot is a
+        /// number that is not zero where one is available in its column, and otherwise an entry
+        /// that does not simplify to zero; no such entry declines the system.
+        /// </summary>
+        private static bool TrySolveSquare(Entity[][] matrix, Entity[] rhs, [NotNullWhen(true)] out Entity[]? values)
+        {
+            values = null;
+            var size = rhs.Length;
+            if (size == 0 || matrix.Any(row => row.Length != size))
+                return false;
+
+            for (var column = 0; column < size; column++)
+            {
+                var pivot = -1;
+                for (var row = column; row < size; row++)
+                    if (matrix[row][column].Evaled is Complex { IsExact: true, IsZero: false })
+                    {
+                        pivot = row;
+                        break;
+                    }
+                if (pivot < 0)
+                    for (var row = column; row < size; row++)
+                        if (matrix[row][column] != Integer.Zero && matrix[row][column].Evaled is not Complex { IsZero: true })
+                        {
+                            pivot = row;
+                            break;
+                        }
+                if (pivot < 0)
+                    return false;
+                if (pivot != column)
+                {
+                    (matrix[pivot], matrix[column]) = (matrix[column], matrix[pivot]);
+                    (rhs[pivot], rhs[column]) = (rhs[column], rhs[pivot]);
+                }
+                for (var row = column + 1; row < size; row++)
+                {
+                    if (matrix[row][column] == Integer.Zero)
+                        continue;
+                    var factor = Bare(matrix[row][column] / matrix[column][column]);
+                    for (var k = column; k < size; k++)
+                        matrix[row][k] = Bare(matrix[row][k] - factor * matrix[column][k]);
+                    rhs[row] = Bare(rhs[row] - factor * rhs[column]);
+                }
+            }
+
+            values = new Entity[size];
+            for (var row = size - 1; row >= 0; row--)
+            {
+                var accumulated = rhs[row];
+                for (var k = row + 1; k < size; k++)
+                    accumulated -= matrix[row][k] * values[k];
+                values[row] = Bare(accumulated / matrix[row][row]);
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Simplified, and without the <c>provided pivot != 0</c> a division by a symbol
+        /// acquires on the way: that condition is the generic case this decomposition is
+        /// answering in, and left on it makes a term nothing downstream reads.
+        /// </summary>
+        private static Entity Bare(Entity e)
+            => e.InnerSimplified is Providedf(var inner, _) ? inner : e.InnerSimplified;
+
+        /// <summary>
+        /// Whether <paramref name="left"/> and <paramref name="right"/> agree, numerically, at a
+        /// few points in <paramref name="x"/> with every other symbol pinned to a fixed value.
+        /// A point where either is undefined is skipped, and at least two must compare.
+        /// </summary>
+        private static bool HoldsAtSampledPoints(Entity left, Entity right, Variable x)
+        {
+            var parameters = left.Vars.Concat(right.Vars).Where(v => v != x).Distinct().ToList();
+            var pinned = 0;
+            foreach (var parameter in parameters)
+            {
+                // Distinct values, off the integers, so that no two factors coincide by
+                // accident and a sign or a root in a coefficient stays generic.
+                var fraction = (pinned % 3) switch { 0 => "1.37", 1 => "2.71", _ => "0.83" };
+                var value = Real.Create(EDecimal.FromString(fraction).Add(EDecimal.FromInt32(pinned)));
+                left = left.Substitute(parameter, value);
+                right = right.Substitute(parameter, value);
+                pinned++;
+            }
+            var compared = 0;
+            foreach (var at in new[] { "0.29", "1.43", "3.17", "-0.61" })
+            {
+                var point = Real.Create(EDecimal.FromString(at));
+                var l = left.Substitute(x, point).EvalNumerical();
+                var r = right.Substitute(x, point).EvalNumerical();
+                if (l.IsNaN || r.IsNaN)
+                    continue;
+                var difference = (l - r).Abs().EDecimal;
+                var scale = EDecimal.Max(EDecimal.One, l.Abs().EDecimal);
+                if (difference.CompareTo(scale.Multiply(EDecimal.FromString("1e-9"))) > 0)
+                    return false;
+                compared++;
+            }
+            return compared >= 2;
+        }
     }
 }

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -118,8 +118,152 @@ namespace AngouriMath.Functions.Algebra
                 && Integration.ComputeIndefiniteIntegral(overOtherReal, x, integrateByParts) is { } realRest)
                 return realFirst + realRest;
 
+            // The two splits above stop where exact rational arithmetic does, and a symbol is
+            // not a rational. A denominator *written* as a product of distinct linear and
+            // quadratic factors -- `(x + a)(x^2 + b)` -- is decomposed by undetermined
+            // coefficients, checked, and each piece is a shape the rules below read.
+            if (Functions.PartialFractions.TrySplitOverWrittenFactors(numerator, denominator, x, out var overWrittenFactors)
+                && Integration.ComputeIndefiniteIntegral(overWrittenFactors, x, integrateByParts) is { } termByTerm)
+                return termByTerm;
+
+            // Last, because everything above answers in exact arithmetic where it can: a
+            // binomial denominator the splits above could not take apart -- `x^3 + 2`, `x^5 + 1`,
+            // `a x^3 - b` -- decomposed at its roots of unity in closed form.
+            if (IntegrateAPolynomialOverABinomial(numerator, denominator, x) is { } atTheRootsOfUnity)
+                return atTheRootsOfUnity;
+
             return null;
         }
+
+        /// <summary>
+        /// A polynomial over a binomial <c>a x^n + b</c>, <c>n >= 3</c>, decomposed at the
+        /// <c>n</c>-th roots of <c>-b/a</c> and integrated term by term in closed form.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>1/(x^3 + 1)</c> had an antiderivative and <c>1/(x^3 + 2)</c> did not: the first
+        /// factors over the rationals and the coprime split takes it apart, the second does not
+        /// and nothing further was tried. The same for <c>1/(x^5 + 1)</c>, <c>1/(x^6 + 2)</c> and
+        /// every <c>1/(a x^n + b)</c> with a symbol in it, which no split over the rationals can
+        /// reach at all. Rubi's test suite has these by the dozen.
+        /// </para>
+        /// <para>
+        /// <b>The decomposition is a formula, not a computation.</b> Writing the denominator as
+        /// <c>a (x^n - c)</c> with <c>c = -b/a</c> and <c>rho^n = c</c>, the roots are
+        /// <c>rho e^(i theta_k)</c> and the residue of <c>x^m/(x^n - c)</c> at one of them is
+        /// <c>rho^(m+1-n) e^(i (m+1-n) theta_k) / n</c>. A root on the real line gives
+        /// <c>rho^(m+1-n) cos((m+1-n) theta) / n</c> over <c>x - rho cos(theta)</c>; a conjugate
+        /// pair gives, over <c>x^2 - 2 rho cos(theta) x + rho^2</c>,
+        /// </para>
+        /// <code>
+        ///     (2 rho^(m+1-n) / n) (cos((m+1-n) theta) x - rho cos((m-n) theta))
+        /// </code>
+        /// <para>
+        /// and each of those is a logarithm plus an arctangent, written out here rather than
+        /// handed back to the integrator: the quadratic is <c>(x - h)^2 + k^2</c> with
+        /// <c>h = rho cos(theta)</c> and <c>k = rho sin(theta)</c>, and
+        /// <c>int (P x + Q) / ((x - h)^2 + k^2) dx</c> is
+        /// <c>(P/2) ln((x - h)^2 + k^2) + ((Q + P h)/k) arctan((x - h)/k)</c>. Handing the pieces
+        /// back would have the quadratic rule decide the sign of a discriminant that is
+        /// <c>-4 rho^2 sin^2(theta)</c> and cannot be read as negative once <c>rho</c> is a
+        /// symbol, and answer with a piecewise for what is one branch.
+        /// </para>
+        /// <para>
+        /// <b>Which roots, by the sign of <c>c</c>.</b> For <c>c &gt; 0</c> the real
+        /// <c>rho = c^(1/n)</c> puts the roots at <c>2 pi k / n</c>; for <c>c &lt; 0</c> it is
+        /// <c>rho = (-c)^(1/n)</c> and they sit at <c>pi (2k + 1) / n</c>, so that every
+        /// <c>rho</c> and every angle is real and the answer is real on the real line. A symbol
+        /// has no sign to read, and takes the first form with <c>rho = c^(1/n)</c>: the
+        /// factorisation <c>x^n - c = prod (x - rho zeta_k)</c> is an identity for any
+        /// <c>rho</c> with <c>rho^n = c</c>, so the antiderivative is correct for every
+        /// <c>c</c> and happens to be written through a complex <c>rho</c> where <c>c</c> is
+        /// negative -- which is what Rubi's own answer for <c>1/(a + b x^3)</c> does with its
+        /// <c>(a/b)^(1/3)</c>, and is the generic case this integrator gives elsewhere.
+        /// </para>
+        /// <para>
+        /// After every split over the rationals, so that a denominator which factors exactly
+        /// keeps the exact answer it had. A proper fraction only; an improper one has been
+        /// divided out above.
+        /// </para>
+        /// https://github.com/asc-community/AngouriMath/issues/718
+        /// </remarks>
+        private static Entity? IntegrateAPolynomialOverABinomial(Entity numerator, Entity denominator, Entity.Variable x)
+        {
+            if (!TreeAnalyzer.TryGetPolynomial(denominator, x, out var below) || below.Count != 2
+                || !below.TryGetValue(EInteger.Zero, out var b))
+                return null;
+            var degree = below.Keys.First(power => !power.IsZero);
+            if (!degree.CanFitInInt32() || degree.ToInt32Unchecked() is var n && (n < 3 || n > MaximumBinomialDegree))
+                return null;
+            var a = below[degree];
+            if (a.ContainsNode(x) || b.ContainsNode(x)
+                || a.Evaled is Number.Complex { IsZero: true } || b.Evaled is Number.Complex { IsZero: true })
+                return null;
+            if (!TreeAnalyzer.TryGetPolynomial(numerator, x, out var above))
+                return null;
+            foreach (var term in above)
+                if (term.Key.Sign < 0 || term.Key.CompareTo(degree) >= 0 || term.Value.ContainsNode(x))
+                    return null;
+
+            // a x^n + b = a (x^n - c). The roots are rho e^(i pi t), for t = (2k + offset)/n.
+            var c = (-b / a).InnerSimplified;
+            var offset = 0;
+            Entity rho;
+            // A symbol has no sign to read, but it has a spelling: `x^3 + a` arrives as
+            // `c = -a`, and taking `rho = a^(1/3)` with the roots at the odd multiples is the
+            // real answer for the sign the integrand was evidently written for, where
+            // `(-a)^(1/3)` would be a complex one for it. Either is correct; this one is the
+            // one a reader expects.
+            if (c.Evaled is Number.Real { IsFinite: true } sign && sign < 0
+                || c is Mulf(var leading, _) && leading.Evaled is Number.Real { IsFinite: true } negative && negative < 0)
+            {
+                rho = MathS.Pow(-c, Number.Rational.Create(1, n));
+                offset = 1;
+            }
+            else
+                rho = MathS.Pow(c, Number.Rational.Create(1, n));
+            rho = rho.InnerSimplified;
+
+            Entity total = 0;
+            for (var k = 0; k < n; k++)
+            {
+                var twiceKPlusOffset = 2 * k + offset;
+                // Past pi the roots are the conjugates of the ones before it, and each pair is
+                // taken once, at its representative below pi.
+                if (twiceKPlusOffset > n)
+                    break;
+                var theta = MathS.pi * Number.Rational.Create(twiceKPlusOffset, n);
+                foreach (var term in above)
+                {
+                    var m = term.Key.ToInt32Unchecked();
+                    var coefficient = term.Value;
+                    // rho^(m+1-n) / n, the modulus of the residue at every root.
+                    var modulus = (coefficient * MathS.Pow(rho, m + 1 - n) / n).InnerSimplified;
+                    if (twiceKPlusOffset == 0)
+                        total += modulus * IntegralPatterns.AntiderivativeLog(x - rho);
+                    else if (twiceKPlusOffset == n)
+                        total += modulus * ((m + 1 - n) % 2 == 0 ? 1 : -1) * IntegralPatterns.AntiderivativeLog(x + rho);
+                    else
+                    {
+                        var p = (2 * modulus * MathS.Cos((m + 1 - n) * theta)).InnerSimplified;
+                        var q = (-2 * modulus * rho * MathS.Cos((m - n) * theta)).InnerSimplified;
+                        var h = (rho * MathS.Cos(theta)).InnerSimplified;
+                        var kappa = (rho * MathS.Sin(theta)).InnerSimplified;
+                        var quadratic = MathS.Sqr(x) - 2 * h * x + MathS.Sqr(rho);
+                        total += p / 2 * MathS.Ln(quadratic) + (q + p * h) / kappa * MathS.Arctan((x - h) / kappa);
+                    }
+                }
+            }
+            return (total / a).InnerSimplified;
+        }
+
+        /// <summary>
+        /// The largest binomial degree <see cref="IntegrateAPolynomialOverABinomial"/> takes on.
+        /// Every root past the first two is a logarithm and an arctangent, so the answer's size
+        /// is linear in the degree; the cap keeps a stray <c>x^1000 + 1</c> from being answered
+        /// with five hundred of each. Rubi's suite goes to twelve.
+        /// </summary>
+        private const int MaximumBinomialDegree = 24;
 
         /// <summary>
         /// <c>N/(c g(x))</c> integrated as <c>(1/c) * N/g(x)</c>, where <c>c</c> is whatever part
@@ -172,6 +316,17 @@ namespace AngouriMath.Functions.Algebra
         /// <c>1/(1 + x^3)</c> and <c>a * (1/(1 + x^3))</c> both did.
         /// </para>
         /// <para>
+        /// <b>And the third spelling, a product with a negative power in it.</b>
+        /// <c>3 u (4 - u^3)^(-1)</c> is what <c>Simplify</c> makes of <c>3u/(4 - u^3)</c>, and it
+        /// is neither a <c>Divf</c> nor a bare <c>Powf</c>, so it was declined here -- and then
+        /// taken by integration by parts with <c>v' = (4 - u^3)^(-1)</c>, which integrates to a
+        /// hundred-node sum of logarithms and arctangents that the search then spent thirty
+        /// seconds failing to integrate against <c>3u</c>. Read as the quotient it is, the same
+        /// integrand is answered in a fifth of a second. The factors are gathered and one quotient
+        /// rebuilt from them, which is what makes the verdict independent of how the product
+        /// happens to be associated.
+        /// </para>
+        /// <para>
         /// <b>Only a negative whole power.</b> A positive one is not a quotient; a fractional or
         /// symbolic exponent is not one either, and <c>(a/b)^(1/2)</c> is not <c>sqrt(a)/sqrt(b)</c>
         /// on the branch cut. Nothing here rewrites a quotient back into a power, so this cannot
@@ -193,6 +348,31 @@ namespace AngouriMath.Functions.Algebra
                     var reciprocated = -power;
                     (numerator, denominator) = (Number.Integer.One,
                         reciprocated == Number.Integer.One ? @base : MathS.Pow(@base, reciprocated));
+                    return true;
+                case Entity.Mulf:
+                    Entity above = Number.Integer.One;
+                    Entity below = Number.Integer.One;
+                    foreach (var factor in Entity.Mulf.LinearChildren(expr))
+                        switch (factor)
+                        {
+                            case Entity.Powf(var @base, Number.Integer power) when power.EInteger.Sign < 0:
+                                var positive = -power;
+                                below *= positive == Number.Integer.One ? @base : MathS.Pow(@base, positive);
+                                break;
+                            case Entity.Divf(var dividend, var divisor):
+                                above *= dividend;
+                                below *= divisor;
+                                break;
+                            default:
+                                above *= factor;
+                                break;
+                        }
+                    if (below == Number.Integer.One)
+                    {
+                        (numerator, denominator) = (expr, Number.Integer.One);
+                        return false;
+                    }
+                    (numerator, denominator) = (above, below);
                     return true;
                 default:
                     (numerator, denominator) = (expr, Number.Integer.One);

--- a/Sources/Tests/UnitTests/Calculus/BinomialDenominatorIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/BinomialDenominatorIntegralTest.cs
@@ -1,0 +1,146 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// A polynomial over a binomial <c>a x^n + b</c>, <c>n >= 3</c>, decomposed at the
+    /// <c>n</c>-th roots of <c>-b/a</c> in closed form.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>1/(x^3 + 1)</c> came out and <c>1/(x^3 + 2)</c> did not: the first factors over the
+    /// rationals, the second does not, and nothing further was tried. The rule writes the
+    /// residue at each root and pairs the conjugates, so every term is a logarithm and an
+    /// arctangent and the answer is real wherever the sign of <c>-b/a</c> can be read.
+    /// </para>
+    /// <para>
+    /// Every answer is differentiated back and compared to the integrand at sampled points;
+    /// where a parameter is present it is pinned first. The exact cases — <c>x^3 + 1</c>,
+    /// <c>x^4 + 1</c>, <c>x^6 + 1</c> — are here to show they still take the split over the
+    /// rationals in front of this rule and keep the answer they had.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class BinomialDenominatorIntegralTest
+    {
+        private static readonly double[] Points = { 0.31, 0.77, 1.43, 2.19, -0.58 };
+
+        private static void DifferentiatesBack(string integrand, params (string, double)[] pins)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+            Assert.DoesNotContain("NaN", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            Entity original = integrand.ToEntity();
+            foreach (var (name, value) in pins)
+            {
+                derivative = derivative.Substitute(name, value);
+                original = original.Substitute(name, value);
+            }
+
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 4,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}");
+        }
+
+        /// <summary>
+        /// The denominators that do not factor over the rationals, at each degree from three
+        /// to six, with both signs of the constant.
+        /// </summary>
+        [Theory]
+        [InlineData("1/(x^3 + 2)")]
+        [InlineData("1/(x^3 - 2)")]
+        [InlineData("1/(5*x^3 - 3)")]
+        [InlineData("1/(x^4 + 3)")]
+        [InlineData("1/(x^5 + 1)")]
+        [InlineData("1/(x^5 + 32)")]
+        [InlineData("1/(x^5 - 7)")]
+        [InlineData("1/(x^6 + 2)")]
+        [InlineData("1/(2 + x^6)")]
+        public void AConstantOverABinomial(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// A polynomial numerator, monomial by monomial: the residue carries the power, and the
+        /// terms for each are summed.
+        /// </summary>
+        [Theory]
+        [InlineData("x/(x^3 + 2)")]
+        [InlineData("x^2/(x^5 + 1)")]
+        [InlineData("(x^3 + x)/(x^5 + 1)")]
+        [InlineData("(1 + 2*x + 3*x^2)/(x^4 + 5)")]
+        [InlineData("x^7/(1 + x^12)")]
+        public void APolynomialOverABinomial(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// A symbol in the binomial. <c>x^3 + a</c> takes <c>rho = a^(1/3)</c> with the roots at
+        /// the odd multiples, which is the real answer for <c>a &gt; 0</c>; <c>a x^3 - b</c> takes
+        /// <c>(b/a)^(1/3)</c>, the real answer for <c>b/a &gt; 0</c>. Pinned to those.
+        /// </summary>
+        [Theory]
+        [InlineData("1/(x^3 + a)")]
+        [InlineData("1/(a*x^3 - b)")]
+        [InlineData("1/(x^5 + a^5)")]
+        [InlineData("1/(x^4 + a)")]
+        [InlineData("x/(a*x^3 + b)")]
+        public void ASymbolicBinomial(string integrand)
+            => DifferentiatesBack(integrand, ("a", 1.7), ("b", 2.3));
+
+        /// <summary>
+        /// What factors over the rationals keeps the exact answer it had: the split in front of
+        /// this rule takes it, and no root of unity appears.
+        /// </summary>
+        [Theory]
+        [InlineData("1/(x^3 + 1)", "sqrt(3)")]
+        [InlineData("1/(x^6 + 1)", "sqrt(3)")]
+        [InlineData("1/(x^4 + 1)", "sqrt(2)")]
+        public void AnExactFactorisationIsStillTakenFirst(string integrand, string expectedRadical)
+        {
+            var integral = integrand.ToEntity().Integrate("x").Stringize();
+            Assert.DoesNotContain("integral(", integral);
+            Assert.DoesNotContain("cos(", integral);
+            Assert.Contains(expectedRadical, integral);
+            DifferentiatesBack(integrand);
+        }
+
+        /// <summary>
+        /// What is not this shape and must stay declined by it rather than mis-answered: a
+        /// trinomial, a repeated binomial, a degree below three, and an improper fraction —
+        /// the last of which the division in front takes, so it is answered and not by this.
+        /// </summary>
+        [Theory]
+        [InlineData("1/(x^3 + x + 1)")]
+        [InlineData("1/(x^3 + 2)^2")]
+        public void OutsideTheShapeNothingIsClaimed(string integrand)
+            => Assert.Contains("integral(", integrand.ToEntity().Integrate("x").Stringize());
+
+        [Theory]
+        [InlineData("x^4/(x^3 + 2)")]
+        [InlineData("x^5/(x^3 - 2)")]
+        public void AnImproperFractionIsDividedOutFirst(string integrand) => DifferentiatesBack(integrand);
+    }
+}

--- a/Sources/Tests/UnitTests/Calculus/PowerSubstitutionIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/PowerSubstitutionIntegralTest.cs
@@ -93,22 +93,36 @@ namespace AngouriMath.Tests.Calculus
         // Becomes 2u^2/(1 + u^2), which is improper; answered once the rational integrator
         // divides an improper fraction out before decomposing it.
         [InlineData("sqrt(x)/(x + 1)")]
+        // Becomes 2u^2/(1 + u^8), a binomial denominator, decomposed at its roots of unity.
+        [InlineData("sqrt(x)/(1 + x^4)")]
         public void AFractionalPowerIsAlsoASubstitution(string integrand)
             => DifferentiatesBack(integrand);
 
         /// <summary>
-        /// Where a fractional substitution reaches and the rest of the chain does not, recorded
-        /// so the boundary is visible. <c>sqrt(x)/(1 + x^4)</c> becomes <c>2u^2/(1 + u^8)</c>,
-        /// whose denominator is neither factorable over the rationals nor a biquadratic.
+        /// Where a fractional substitution reaches and the rest of the chain does not, as a
+        /// note rather than a pin: <c>sqrt(x)/(1 + x + x^4)</c> becomes
+        /// <c>2u^2/(1 + u^2 + u^8)</c>, whose denominator is irreducible over the rationals,
+        /// not a biquadratic and not a binomial. Its antiderivative is a sum over the eight
+        /// roots of <c>w^8 + w^2 + 1</c> of <c>w ln(sqrt(x) - w)/(4 w^6 + 1)</c>, which this
+        /// library has no node to write, and that is
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1285">#1285</a> rather
+        /// than a verdict to record here — a test that pins the decline would have to be
+        /// falsified to close the issue.
         /// </summary>
         /// <remarks>
-        /// <c>sqrt(x)/(x + 1)</c> was here too, for becoming an improper fraction that nothing
-        /// divided out. It is answered above now that the rational integrator divides first.
+        /// <c>sqrt(x)/(x + 1)</c> and <c>sqrt(x)/(1 + x^4)</c> were pinned here in turn, for an
+        /// improper fraction nothing divided out and for a binomial nothing decomposed, and each
+        /// moved up into the theory above when its rule arrived.
         /// </remarks>
-        [Theory]
-        [InlineData("sqrt(x)/(1 + x^4)")]
-        public void WhereTheChainStops(string integrand)
-            => Assert.Contains("integral(", integrand.ToEntity().Integrate("x").Stringize());
+        [Fact]
+        public void WhereTheChainStopsIsAnIssueNotAPin()
+        {
+            var integral = "sqrt(x)/(1 + x + x^4)".ToEntity().Integrate("x");
+            // Either answer is acceptable here: unevaluated today, and a correct antiderivative
+            // once #1285 gives it a form. What is not acceptable is a wrong one.
+            if (!integral.Stringize().Contains("integral("))
+                DifferentiatesBack("sqrt(x)/(1 + x + x^4)");
+        }
 
         /// <summary>
         /// The shape the issue is about: an odd power over an even one, where the substitution is

--- a/Sources/Tests/UnitTests/Calculus/SymbolicFactorsPartialFractionsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/SymbolicFactorsPartialFractionsTest.cs
@@ -1,0 +1,131 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// Partial fractions over a denominator <b>written</b> as a product of distinct linear and
+    /// quadratic factors whose coefficients are symbols, by undetermined coefficients.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>1/((x + 3)(x^2 + 5))</c> came out and <c>1/((x + a)(x^2 + b))</c> did not: the split
+    /// over the rationals cannot read a symbol, and no other split existed. The factors were
+    /// already in hand and each is a shape the integrator answers on its own.
+    /// </para>
+    /// <para>
+    /// The decomposition solves a linear system whose entries are the parameters, and a
+    /// symbolic pivot is a judgement rather than a proof — so the identity is checked at
+    /// sampled points with the symbols pinned before anything is returned, and these tests
+    /// check the antiderivative the same way. Where a piece lands on the quadratic rule with an
+    /// undecidable discriminant the answer is a piecewise, which is correct and is what the
+    /// differentiate-back check sees through numerically.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class SymbolicFactorsPartialFractionsTest
+    {
+        private static readonly double[] Points = { 0.31, 0.77, 1.43, 2.19 };
+
+        private static void DifferentiatesBack(string integrand, string variable, params (string, double)[] pins)
+        {
+            var integral = integrand.ToEntity().Integrate(variable);
+            Assert.DoesNotContain("integral(", integral.Stringize());
+            Assert.DoesNotContain("NaN", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate(variable);
+            Entity original = integrand.ToEntity();
+            foreach (var (name, value) in pins)
+            {
+                derivative = derivative.Substitute(name, value);
+                original = original.Substitute(name, value);
+            }
+
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute(variable, at).EvalNumerical();
+                var want = original.Substitute(variable, at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/d{variable} of the antiderivative of {integrand} is {got} at {variable} = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 3,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}");
+        }
+
+        /// <summary>
+        /// A linear factor beside a quadratic one, and two quadratics, with a symbol in each.
+        /// </summary>
+        [Theory]
+        [InlineData("1/((x + a)*(x^2 + b))")]
+        [InlineData("1/((x^2 + a)*(x + 1))")]
+        [InlineData("1/((a + x^2)*(b + x^2))")]
+        [InlineData("1/((x^2 + 4)*(x^2 + b))")]
+        [InlineData("x/((a^2 + x^2)*(b^2 + x^2))")]
+        [InlineData("(x + 1)/((x + a)*(x^2 + b))")]
+        [InlineData("x^2/((x + a)*(x^2 + b))")]
+        public void DistinctSymbolicFactors(string integrand)
+            => DifferentiatesBack(integrand, "x", ("a", 1.7), ("b", 2.3));
+
+        /// <summary>
+        /// Three factors, so the system is larger than one pair and the elimination has to
+        /// pivot past a symbol.
+        /// </summary>
+        [Theory]
+        [InlineData("1/((x + a)*(x + b)*(x^2 + 1))")]
+        [InlineData("x/((x + a)*(x^2 + b)*(x^2 + 2))")]
+        public void ThreeFactors(string integrand)
+            => DifferentiatesBack(integrand, "x", ("a", 1.7), ("b", 2.3));
+
+        /// <summary>
+        /// A parameter that multiplies the variable, and a factor with a constant in front of
+        /// the product — Moses's <c>-B (A^2 + B^2) / ((1 + w^2)(B^2 - A^2 w^2))</c> from the
+        /// Rubi suite, integrated in <c>w</c>.
+        /// </summary>
+        [Theory]
+        [InlineData("1/((1 + w^2)*(B^2 - A^2*w^2))")]
+        [InlineData("-B*(A^2 + B^2)/((1 + w^2)*(B^2 - A^2*w^2))")]
+        public void AParameterOnTheVariable(string integrand)
+            => DifferentiatesBack(integrand, "w", ("A", 0.6), ("B", 1.9));
+
+        /// <summary>
+        /// The numeric spellings, which the split over the rationals still takes first and
+        /// which keep their exact answers.
+        /// </summary>
+        [Theory]
+        [InlineData("1/((x + 3)*(x^2 + 5))")]
+        [InlineData("1/((3 + x^2)*(5 + x^2))")]
+        public void TheNumericSpellingsStillAnswer(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x").Stringize();
+            Assert.DoesNotContain("piecewise", integral);
+            DifferentiatesBack(integrand, "x");
+        }
+
+        /// <summary>
+        /// A repeated factor is not this rule's — there is nothing for a symbolic repeated
+        /// quadratic to land on — and a denominator not written as a product is left to the
+        /// other splits.
+        /// </summary>
+        [Theory]
+        [InlineData("1/((x^2 + a)^2*(x + 1))")]
+        public void ARepeatedSymbolicQuadraticIsDeclined(string integrand)
+            => Assert.Contains("integral(", integrand.ToEntity().Integrate("x").Stringize());
+    }
+}


### PR DESCRIPTION
`1/(x^3 + 1)` had an antiderivative and `1/(x^3 + 2)` did not. `1/((x + 3)(x^2 + 5))`
did and `1/((x + a)(x^2 + b))` did not. Both splits the integrator has work in exact
rational arithmetic and stop where the rationals do; nothing was tried past that.

## A polynomial over `a x^n + b`, in closed form

Writing the denominator as `a (x^n - c)` with `rho^n = c`, the residue of
`x^m/(x^n - c)` at the root `rho e^(i theta)` is `rho^(m+1-n) e^(i(m+1-n)theta)/n`,
and pairing each root with its conjugate gives, over `x^2 - 2 rho cos(theta) x + rho^2`,

    (2 rho^(m+1-n)/n) (cos((m+1-n) theta) x - rho cos((m-n) theta))

which is one logarithm and one arctangent, written out directly: handing the pieces
back would have the quadratic rule decide the sign of `-4 rho^2 sin^2(theta)`, which it
cannot once `rho` is a symbol, and answer a piecewise for what is one branch.

For `c > 0` the roots sit at `2 pi k/n`; for `c < 0`, at `pi(2k+1)/n` with
`rho = (-c)^(1/n)`, so the answer is real on the real line whenever the sign can be
read. A symbol has no sign but has a spelling: `x^3 + a` arrives as `c = -a` and takes
`rho = a^(1/3)`, the real answer for the sign it was evidently written for. Either
choice is correct for every `c` -- the factorisation is an identity in `rho` -- and this
is the one Rubi's own `(a/b)^(1/3)` makes. After every split over the rationals, so
`x^3 + 1`, `x^4 + 1` and `x^6 + 1` keep the exact answers they had.

## Partial fractions over factors that are written down

A denominator written as a product of distinct linear and quadratic factors with
symbols in them is decomposed by undetermined coefficients: one unknown per numerator
coefficient, the identity `N = sum P_i * D/F_i` compared power by power, and the
linear system solved by a row reduction whose pivots are numbers where a column has
one and symbols that do not simplify to zero otherwise. A symbolic pivot is a
judgement rather than a proof, so **the decomposition is checked at sampled points
with every symbol pinned before it is returned**, and one that fails is declined. A
wrong pivot can cost an answer here and cannot produce one.

`InnerSimplified` attaches `provided pivot != 0` to every division by a symbol on the
way, and left in place that made a term nothing downstream reads; it is the generic
case this whole decomposition is answering in, and it is stripped.

## The third spelling of a quotient

Found by the corpus, as a new timeout: `(a + b x)/((3 - x^2)(1 + x^2)^(1/3))` went from
a fast decline to five seconds spent. Under `u = (1 + x^2)^(1/3)` its `x` term is
`3u/(4 - u^3)`, which `Simplify` writes as `3 u (4 - u^3)^(-1)` -- a product, which
`TryReadAsQuotient` did not read. Integration by parts then took it with
`v' = (4 - u^3)^(-1)`, the new rule answered that with a hundred-node sum of logarithms
and arctangents, and the search spent thirty seconds failing to integrate `3u` against
it. Read as the quotient it is, the same integrand is answered in a second, and
`x/((3 - x^2)(1 + x^2)^(1/3))` comes out. The factors of a product are gathered and
one quotient rebuilt, so the verdict no longer depends on how the product is
associated.

## Measured

Every answer differentiated back, with parameters pinned.

Rubi corpus, 463-problem sample, against #1283's branch it was cut from (both rebased
on master with #1282, both timed on the same afternoon):

    #1283       281/463, 0 wrong, 0 timeouts, 93 s
    with this   290/463, 0 wrong, 0 timeouts, 95 s

Nine more, nothing lost: `1/(-b + a x^3)`, `1/(2 + x^6)`, `x^7/(1 + x^12)` (twice, Hearn
and Moses), `1/(a^5 + x^5)`, `x/((a^2 + x^2)(b^2 + x^2))`, Moses's
`-B(A^2 + B^2)/((1 + w^2)(B^2 - A^2 w^2))`, and two the reading of a quotient reached on
its own: Stewart's `1/(-1/x^(1/3) + sqrt(x))` and Welz's `x^2/((1 - x^3)^(1/3)(1 + x^3))`.
Per problem, the five largest time increases are five of those nine -- an answer costs
what a decline did not -- and the sum over the sample is 92 s to 94 s.

`PowerSubstitutionIntegralTest.WhereTheChainStops` pinned `sqrt(x)/(1 + x^4)` as the
boundary, for becoming `2u^2/(1 + u^8)`; that is a binomial now, and the boundary is
recorded one step further on.

The five test suites are green.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
