### PR TITLE
Mixed trigonometric arguments unified, a half-power of 1 + sin closed, a power of an inverse tangent by parts, and a symbolic repeated linear factor

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -381,3 +381,12 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/SymbolicFactorsPartialFractionsTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/MixedTrigonometricArgumentsTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/HalfPowerOfOnePlusASineTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/InverseTangentPowerByPartsTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/PartialFractions.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/PartialFractions.cs
@@ -395,8 +395,8 @@ namespace AngouriMath.Functions
         /// those. See the note on <c>PolynomialLongDivision</c>.
         /// </para>
         /// <para>
-        /// Distinct factors only. A repeated symbolic quadratic has no rule to land on, and a
-        /// repeated linear factor is the sibling step's, in exact arithmetic where it applies.
+        /// Distinct factors, where a repeated linear one counts as a single block over its whole
+        /// power. A repeated symbolic quadratic has no rule to land on and is declined.
         /// </para>
         /// https://github.com/asc-community/AngouriMath/issues/718
         /// </remarks>
@@ -419,18 +419,30 @@ namespace AngouriMath.Functions
                 // A factor written as a power is a repeated factor, whatever its degree reads
                 // as: `(a + b u)^2` is a quadratic to the reader below and a repeated linear
                 // factor to the decomposition, and taking it as the former cost five seconds on
-                // `1/(a + b e^(p x))^2` for a split that nothing downstream answers.
-                if (part is Powf(_, Integer { EInteger.Sign: > 0 } repeated) && repeated != Integer.One)
-                    return false;
-                if (!TreeAnalyzer.TryGetPolynomial(part, x, out var read) || read.Count == 0)
+                // `1/(a + b e^(p x))^2` for a split that nothing downstream answers. A repeated
+                // **linear** factor is taken as one block, `P/(a + b u)^k` with `P` of degree
+                // `k - 1`, which is the shape the rule for a numerator over a power of a linear
+                // reads; a repeated quadratic has no such rule and is declined.
+                var toRead = part;
+                var multiplicity = 1;
+                if (part is Powf(var repeatedBase, Integer { EInteger.Sign: > 0 } repeated) && repeated != Integer.One)
+                {
+                    if (!repeated.EInteger.CanFitInInt32())
+                        return false;
+                    toRead = repeatedBase;
+                    multiplicity = repeated.EInteger.ToInt32Unchecked();
+                }
+                if (!TreeAnalyzer.TryGetPolynomial(toRead, x, out var read) || read.Count == 0)
                     return false;
                 var degree = read.Keys.Max()!;
                 if (!degree.CanFitInInt32() || degree.ToInt32Unchecked() is not (1 or 2))
                     return false;
+                if (multiplicity > 1 && degree.ToInt32Unchecked() != 1)
+                    return false;
                 foreach (var pair in read)
                     if (pair.Key.Sign < 0 || pair.Value.ContainsNode(x))
                         return false;
-                factors.Add((part.InnerSimplified, degree.ToInt32Unchecked()));
+                factors.Add((part.InnerSimplified, degree.ToInt32Unchecked() * multiplicity));
             }
             if (factors.Count < 2)
                 return false;

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -119,9 +119,14 @@ namespace AngouriMath.Functions.Algebra
                 return realFirst + realRest;
 
             // The two splits above stop where exact rational arithmetic does, and a symbol is
-            // not a rational. A denominator *written* as a product of distinct linear and
-            // quadratic factors -- `(x + a)(x^2 + b)` -- is decomposed by undetermined
-            // coefficients, checked, and each piece is a shape the rules below read.
+            // not a rational. A polynomial over a power of a linear with a symbol in it --
+            // `(c + d x)/(a + b x)^2` -- is one substitution from a sum of powers.
+            if (IntegrateAPolynomialOverAPowerOfALinear(numerator, denominator, x) is { } overALinearPower)
+                return overALinearPower;
+
+            // And a denominator *written* as a product of distinct linear and quadratic
+            // factors -- `(x + a)(x^2 + b)` -- is decomposed by undetermined coefficients,
+            // checked, and each piece is a shape the rules here read.
             if (Functions.PartialFractions.TrySplitOverWrittenFactors(numerator, denominator, x, out var overWrittenFactors)
                 && Integration.ComputeIndefiniteIntegral(overWrittenFactors, x, integrateByParts) is { } termByTerm)
                 return termByTerm;
@@ -133,6 +138,59 @@ namespace AngouriMath.Functions.Algebra
                 return atTheRootsOfUnity;
 
             return null;
+        }
+
+        /// <summary>
+        /// A polynomial over a power of a linear, <c>P(x)/(a + b x)^k</c> with <c>k >= 2</c>,
+        /// under <c>t = a + b x</c>: <c>P((t - a)/b) t^(-k) / b</c> is a sum of powers of
+        /// <c>t</c>, each a power rule or a logarithm.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>(c + d x)/(3 + 5 x)^2</c> came out and <c>(c + d x)/(a + b x)^2</c> did not: the
+        /// first has a rational root to split at, the second has none, and no other rule read
+        /// the shape. <c>1/(a + b x)^2</c> was answered by the quadratic rule, as a piecewise on
+        /// a discriminant that is identically zero. This is what the symbolic partial-fraction
+        /// split hands on for a repeated linear factor, and it was declined there for want of
+        /// this.
+        /// </para>
+        /// <para>
+        /// After the splits over the rationals, so that a numeric coefficient keeps the answer
+        /// it had. <c>b</c> is divided by, in the generic case as everywhere here; a decidably
+        /// zero <c>b</c> is not a linear at all and is declined.
+        /// </para>
+        /// https://github.com/asc-community/AngouriMath/issues/718
+        /// </remarks>
+        private static Entity? IntegrateAPolynomialOverAPowerOfALinear(Entity numerator, Entity denominator, Entity.Variable x)
+        {
+            if (denominator is not Powf(var linear, Number.Integer exponent)
+                || !exponent.EInteger.CanFitInInt32() || exponent.EInteger.ToInt32Unchecked() is var k && k < 2)
+                return null;
+            if (!TreeAnalyzer.TryGetPolyLinear(linear, x, out var b, out var a)
+                || b.Evaled is Number.Complex { IsZero: true })
+                return null;
+            if (!TreeAnalyzer.TryGetPolynomial(numerator, x, out var above))
+                return null;
+            foreach (var term in above)
+                if (term.Key.Sign < 0 || term.Value.ContainsNode(x))
+                    return null;
+
+            var t = Variable.CreateUnique(numerator + denominator, "t");
+            var inT = numerator.Substitute(x, (t - a) / b).Expand();
+            if (!TreeAnalyzer.TryGetPolynomial(inT, t, out var powersOfT))
+                return null;
+
+            Entity total = 0;
+            foreach (var term in powersOfT)
+            {
+                if (!term.Key.CanFitInInt32())
+                    return null;
+                var power = term.Key.ToInt32Unchecked() - k;
+                total += power == -1
+                    ? term.Value * IntegralPatterns.AntiderivativeLog(t)
+                    : term.Value * MathS.Pow(t, power + 1) / (power + 1);
+            }
+            return (total / b).Substitute(t, linear).InnerSimplified;
         }
 
         /// <summary>
@@ -502,6 +560,17 @@ namespace AngouriMath.Functions.Algebra
             // chain of steps that each shrink by nothing would otherwise be admitted one at a
             // time.
             var wholeSize = expr.Nodes.Count();
+            // And the second component of that measure: the highest power of a logarithm or
+            // inverse trigonometric factor in the integrand. `x*arctan(x)^2` leaves
+            // `x^2*arctan(x)/(1 + x^2)` after one step, which has more nodes and needs one more
+            // round of parts to finish, so on node count alone it was declined; on the power it
+            // is one step smaller, 2 to 1, and that is the descent the step made. Ordered with
+            // the power first: a step that lowers it may grow the expression, and a step that
+            // keeps it must shrink the expression, so the pair is well-founded and the runaway
+            // the node count was put in for is still stopped by it -- an integrand with no such
+            // factor has power zero on both sides and is measured by nodes alone as before.
+            // https://github.com/asc-community/AngouriMath/issues/718
+            var wholePower = HighestDifferentiatedPower(expr);
 
             // Standard integration by parts for polynomial × function
             static Entity? IntegrateByPartsPolynomial(Entity polynomialToDifferentiate, Entity toIntegrate, Variable x, int currentRecursion = 0)
@@ -519,7 +588,7 @@ namespace AngouriMath.Functions.Algebra
             // Generalized integration by parts: tries once with v and u both being integrable
             // ∫ v·u dx = v·∫u dx - ∫(v'·∫u dx) dx
             // Only attempts if both v and u can be integrated
-            static Entity? TryIntegrateByPartsOnce(Entity v, Entity u, Variable x, int wholeSize)
+            static Entity? TryIntegrateByPartsOnce(Entity v, Entity u, Variable x, int wholeSize, int wholePower)
             {
                 // Try to integrate u
                 var integralOfU = Integration.ComputeIndefiniteIntegral(u, x, false);
@@ -555,8 +624,31 @@ namespace AngouriMath.Functions.Algebra
                 // recurse without a measure took it from about a second to 83 -- caught by
                 // `AnIntegralWithNoAnswerStillFinishesQuickly`, which exists for exactly this.
                 // A power of a logarithm does decrease: `x * ln(x)^2` leaves `x * ln(x)`.
-                var remainingIntegral = Integration.ComputeIndefiniteIntegral(
-                    remaining, x, remaining.Nodes.Count() < wholeSize);
+                // The power admits a larger remainder only while a factor is left for the next
+                // round to differentiate. Once it has fallen to zero the remainder is whatever
+                // the derivative and the integral made together -- for `asec(x)^2` times a
+                // radical, a hundred-node radical expression -- and a by-parts search on that
+                // is the runaway the node bound exists for: measured at thirty seconds for a
+                // decline, where the node bound alone declined it in one.
+                var remainingPower = HighestDifferentiatedPower(remaining);
+                var partsOnTheRemainder = remaining.Nodes.Count() < wholeSize
+                    || (remainingPower >= 1 && remainingPower < wholePower);
+                // Spelled as the product its own next step reads, where there is one. `Simplify`
+                // writes `2 arctan(x)/(1 + x^2) * x^2/2` as `arctan(x) x^2/(x^2 + 1)`, a
+                // quotient, and this rule runs on a product. `x*arctan(x)^2` is answered by
+                // exactly this and by nothing else.
+                //
+                // Only where what is left beside the factor is **rational** in the variable,
+                // which is where the next round is a division and a table lookup. With a
+                // radical there instead -- `asec(x)^2` times `(x^2 - 1)^(3/2)/x^5` -- the
+                // re-spelled remainder handed a by-parts search a hundred-node radical
+                // expression at every level below, and a one-second decline became thirty.
+                if (partsOnTheRemainder
+                    && TryRegroupAroundTheDifferentiatedFactor(remaining) is var (next, rest)
+                    && next is not null && rest is not null
+                    && IsRationalIn(rest, x))
+                    remaining = next * rest;
+                var remainingIntegral = Integration.ComputeIndefiniteIntegral(remaining, x, partsOnTheRemainder);
                 if (remainingIntegral is null) return null;
 
                 return v * integralOfU - remainingIntegral;
@@ -572,9 +664,9 @@ namespace AngouriMath.Functions.Algebra
                 // Differentiating the logarithm instead turns it into 1/x, which cancels
                 // against the integrated polynomial and ends. (The L-before-A of LIATE.)
                 if (IsDifferentiatedBeforeAPolynomial(f) && MathS.TryPolynomial(g, x, out _)
-                    && TryIntegrateByPartsOnce(f, g, x, wholeSize) is { } logFirstF) return logFirstF;
+                    && TryIntegrateByPartsOnce(f, g, x, wholeSize, wholePower) is { } logFirstF) return logFirstF;
                 if (IsDifferentiatedBeforeAPolynomial(g) && MathS.TryPolynomial(f, x, out _)
-                    && TryIntegrateByPartsOnce(g, f, x, wholeSize) is { } logFirstG) return logFirstG;
+                    && TryIntegrateByPartsOnce(g, f, x, wholeSize, wholePower) is { } logFirstG) return logFirstG;
 
                 // Case 1: One term is polynomial - use recursive polynomial integration by parts
                 if (MathS.TryPolynomial(f, x, out var fPoly)) return IntegrateByPartsPolynomial(fPoly, g, x);
@@ -583,8 +675,8 @@ namespace AngouriMath.Functions.Algebra
                 // Case 2: Neither is polynomial - try single-step integration by parts
                 // This handles cases like ln(abs(x)) × ln(abs(x))
                 // Try both orderings: f as v, g as u OR g as v, f as u
-                if (TryIntegrateByPartsOnce(f, g, x, wholeSize) is { } result1) return result1;
-                if (TryIntegrateByPartsOnce(g, f, x, wholeSize) is { } result2) return result2;
+                if (TryIntegrateByPartsOnce(f, g, x, wholeSize, wholePower) is { } result1) return result1;
+                if (TryIntegrateByPartsOnce(g, f, x, wholeSize, wholePower) is { } result2) return result2;
                 return null;
             }
 
@@ -644,9 +736,41 @@ namespace AngouriMath.Functions.Algebra
 
             // Special case for powers of integrable functions, try integration by parts on base × base
             // e.g., ln(abs(x))^2 = ln(abs(x)) × ln(abs(x))
-            if (expr is Powf(var @base, Integer(2)) && TryIntegrateByPartsOnce(@base, @base, x, wholeSize) is { } result) return result;
+            if (expr is Powf(var @base, Integer(2)) && TryIntegrateByPartsOnce(@base, @base, x, wholeSize, wholePower) is { } result) return result;
 
             return null;
+        }
+
+        /// <summary>
+        /// Whether <paramref name="expr"/> is a quotient of polynomials in <paramref name="x"/>,
+        /// read in either spelling a quotient has here.
+        /// </summary>
+        private static bool IsRationalIn(Entity expr, Entity.Variable x)
+        {
+            if (!TryReadAsQuotient(expr, out var above, out var below))
+                return TreeAnalyzer.TryGetPolynomial(expr, x, out _);
+            return TreeAnalyzer.TryGetPolynomial(above, x, out _) && TreeAnalyzer.TryGetPolynomial(below, x, out _);
+        }
+
+        /// <summary>
+        /// The highest power of a factor <see cref="IsDifferentiatedBeforeAPolynomial"/>
+        /// recognises among the factors of <paramref name="expr"/>, or zero where there is none:
+        /// the first component of the measure integration by parts descends on.
+        /// </summary>
+        private static int HighestDifferentiatedPower(Entity expr)
+        {
+            var highest = 0;
+            foreach (var (factor, underneath) in FactorsOfTheIntegrand(expr))
+            {
+                if (underneath || !IsDifferentiatedBeforeAPolynomial(factor))
+                    continue;
+                var power = factor is Powf(_, Number.Integer exponent) && exponent.EInteger.CanFitInInt32()
+                    ? exponent.EInteger.ToInt32Unchecked()
+                    : 1;
+                if (power > highest)
+                    highest = power;
+            }
+            return highest;
         }
 
         /// <summary>
@@ -786,6 +910,94 @@ namespace AngouriMath.Functions.Algebra
 
             _ => null
         };
+
+        /// <summary>
+        /// <c>(a + b sin(c x + d))^n</c> or the same with a cosine, for <c>a^2 = b^2</c> and
+        /// <c>n</c> a positive half-integer, in closed form.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>sqrt(1 + sin(x))</c> had no antiderivative. It is <c>-2 cos(x)/sqrt(1 + sin(x))</c>:
+        /// differentiating that gives <c>(2 sin (1 + sin) + cos^2)/(1 + sin)^(3/2)</c>, and with
+        /// <c>cos^2 = 1 - sin^2 = (1 - sin)(1 + sin)</c> the numerator is <c>(1 + sin)^2</c>. That
+        /// cancellation is what <c>a^2 = b^2</c> buys, and it is the whole of the rule.
+        /// </para>
+        /// <para>
+        /// Above the base case, one step of by parts lowers <c>n</c> by one:
+        /// </para>
+        /// <code>
+        ///     int (a + b sin)^n = -b cos (a + b sin)^(n-1)/(c n) + (a (2n - 1)/n) int (a + b sin)^(n-1)
+        /// </code>
+        /// <para>
+        /// which is checked by differentiating the first term and using <c>b^2 cos^2 =
+        /// (a - b sin)(a + b sin)</c>. Applied until <c>n</c> is <c>1/2</c>, so
+        /// <c>(1 - sin(2x/3))^(5/2)</c> is two steps and a base. A cosine is the same rule
+        /// with <c>sin</c> replaced by <c>-cos</c> in the first term, since <c>d cos = -sin</c>.
+        /// </para>
+        /// <para>
+        /// <b>No condition is owed.</b> <c>a + b sin</c> is never negative when <c>a^2 = b^2</c>,
+        /// so its square root is real wherever the integrand is, and the base-case answer is a
+        /// single antiderivative across the zeros of <c>1 + sin</c>: both it and the integrand
+        /// vanish there. <c>a^2 = b^2</c> is required decidably, so a symbolic <c>a</c> beside a
+        /// numeric <c>b</c> is not this shape. Rubi's rule for the same case is the source.
+        /// </para>
+        /// https://github.com/asc-community/AngouriMath/issues/718
+        /// </remarks>
+        internal static Entity? SolveAHalfPowerOfOnePlusASine(Entity expr, Entity.Variable x)
+        {
+            if (expr is not Powf(var @base, Number.Rational exponent) || exponent is Number.Integer
+                || !exponent.ERational.Denominator.Equals(EInteger.FromInt32(2)) || exponent.ERational.Sign <= 0)
+                return null;
+            // a + b f(u), for f a sine or cosine of something linear in x, read off the sum.
+            Entity a = 0;
+            Entity? b = null;
+            Entity? argument = null;
+            var isSine = false;
+            foreach (var term in Sumf.LinearChildren(@base))
+            {
+                if (!term.ContainsNode(x))
+                {
+                    a += term;
+                    continue;
+                }
+                Entity coefficient = 1;
+                Entity? function = null;
+                foreach (var factor in Mulf.LinearChildren(term))
+                    if (!factor.ContainsNode(x))
+                        coefficient *= factor;
+                    else if (function is null && factor is Sinf or Cosf)
+                        function = factor;
+                    else
+                        return null;
+                if (function is null || b is not null)
+                    return null;
+                b = coefficient;
+                isSine = function is Sinf;
+                argument = function.DirectChildren.First();
+            }
+            if (b is null || argument is null)
+                return null;
+            if (!TreeAnalyzer.TryGetPolyLinear(argument, x, out var rate, out _)
+                || rate.Evaled is Number.Complex { IsZero: true })
+                return null;
+            // a^2 = b^2, decided rather than assumed.
+            if ((MathS.Sqr(a) - MathS.Sqr(b)).Evaled is not Number.Complex { IsZero: true })
+                return null;
+
+            var n = exponent.ERational;
+            // The direction of the first by-parts term: b cos for a sine, -b sin for a cosine.
+            var complement = isSine ? MathS.Cos(argument) : -MathS.Sin(argument);
+            Entity Step(ERational power)
+            {
+                var previous = Number.Rational.Create(power.Subtract(ERational.One));
+                var current = Number.Rational.Create(power);
+                if (power.CompareTo(ERational.Create(1, 2)) == 0)
+                    return -2 * b * complement / (rate * MathS.Sqrt(@base));
+                return -b * complement * MathS.Pow(@base, previous) / (rate * current)
+                    + a * (2 * current - 1) / current * Step(power.Subtract(ERational.One));
+            }
+            return Step(n).InnerSimplified;
+        }
 
         /// <summary>
         /// A whole power of the secant or cosecant, brought down two at a time by the standard
@@ -2413,6 +2625,381 @@ namespace AngouriMath.Functions.Algebra
             return Integration.ComputeIndefiniteIntegral(integrand, u, integrateByParts) is { } result
                 ? result.Substitute(u, MathS.Pow(radicalBase, Number.Rational.Create(1, q)))
                 : null;
+        }
+
+        /// <summary>
+        /// An integrand whose trigonometric functions have <b>different multiples</b> of one
+        /// argument — <c>sin(x)/cos(2x)</c>, <c>cos(x)/(sin(x) tan(x/2))</c> — rewritten so that
+        /// every one of them is of the same argument, and handed on.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Every trigonometric rule here reads one argument: a quotient of homogeneous
+        /// polynomials in <c>sin(u)</c> and <c>cos(u)</c>, a function of <c>tan(u)</c>, the
+        /// half-angle substitution in <c>u</c>. An integrand with <c>x</c> and <c>2x</c> in it
+        /// is none of those and every one of them declined it — while the same integrand with
+        /// <c>cos(2x)</c> written as <c>1 - 2 sin(x)^2</c> came out. Nothing was missing but the
+        /// rewriting. Product-to-sum, beside this, goes the other way, and fires on a product of
+        /// two different arguments; this fires on anything else built from them.
+        /// </para>
+        /// <para>
+        /// The common argument is <c>g x</c> with <c>g</c> the greatest common divisor of the
+        /// slopes, so <c>x</c> and <c>x/2</c> share <c>x/2</c> and <c>2x</c> and <c>3x</c> share
+        /// <c>x</c>. Each function of <c>n g x</c> is then a polynomial in <c>sin(g x)</c> and
+        /// <c>cos(g x)</c> through the Chebyshev recurrences, <c>cos(n t) = T_n(cos t)</c> and
+        /// <c>sin(n t) = sin(t) U_(n-1)(cos t)</c>, which are identities and owe no condition;
+        /// a tangent, secant or cosecant is the quotient of those it stands for. Slopes are
+        /// rational and the multiples are capped, since a function of <c>50x</c> beside one of
+        /// <c>x</c> is a degree-fifty polynomial nobody wants.
+        /// </para>
+        /// <para>
+        /// It terminates: what it hands on has one argument, on which this rule declines.
+        /// </para>
+        /// https://github.com/asc-community/AngouriMath/issues/718
+        /// </remarks>
+        internal static Entity? SolveByUnifyingTrigonometricArguments(Entity expr, Entity.Variable x, bool integrateByParts)
+        {
+            // Rational in the trigonometric functions, and no more: a radical of one, or a
+            // fractional power, is a different integrand, and the expanded polynomial under it
+            // is one no rule reads. `sqrt(cos(x) sin(x)^3)` beside `sin(2x)` and
+            // `(2 - 3 sin(x)^2)^(3/5) sin(4x)` were each five seconds spent to decline once the
+            // rewriting let them through; each declined in a tenth of that before.
+            //
+            // And bounded in the degree the rewriting produces: a power of a sum holding a
+            // function of `3x`, raised to the fifth, is a polynomial of degree fifteen in the
+            // sine and cosine, and `1/(cos(x) + cos(3x))^5` went the same way for it.
+            var slopes = new List<Number.Rational>();
+            foreach (var node in expr.Nodes)
+            {
+                if (!node.ContainsNode(x))
+                    continue;
+                switch (node)
+                {
+                    case Variable or Sumf or Minusf or Mulf or Divf:
+                    case Sinf or Cosf or Tanf or Cotanf or Secantf or Cosecantf:
+                    case Powf(_, Number.Integer):
+                        break;
+                    default:
+                        return null;
+                }
+                if (TrigonometricArgument(node) is not { } argument || !argument.ContainsNode(x))
+                    continue;
+                if (!TreeAnalyzer.TryGetPolyLinear(argument, x, out var slope, out var offset)
+                    || offset.Evaled is not Number.Integer { IsZero: true }
+                    || slope.Evaled is not Number.Rational rational || rational.IsZero)
+                    return null;
+                slopes.Add(rational);
+            }
+            if (slopes.Count < 2)
+                return null;
+
+            // g = gcd of the numerators over the lcm of the denominators, so that every slope is
+            // a whole multiple of it; nothing to do when they are all the same multiple.
+            var numerators = EInteger.Zero;
+            var denominators = EInteger.One;
+            foreach (var slope in slopes)
+            {
+                numerators = numerators.Gcd(slope.ERational.Numerator.Abs());
+                denominators = denominators.Multiply(slope.ERational.Denominator)
+                    .Divide(denominators.Gcd(slope.ERational.Denominator));
+            }
+            var common = ERational.Create(numerators, denominators);
+            var multiples = new HashSet<int>();
+            foreach (var slope in slopes)
+            {
+                // Reduced before its numerator is read: `Divide` leaves `2/2` as it is.
+                var multiple = slope.ERational.Divide(common).ToLowestTerms();
+                if (!multiple.IsInteger() || !multiple.Numerator.Abs().CanFitInInt32())
+                    return null;
+                var n = multiple.Numerator.Abs().ToInt32Unchecked();
+                if (n > MaximumUnifiedMultiple)
+                    return null;
+                multiples.Add(n);
+            }
+            if (multiples.Count < 2)
+                return null;
+            if (ExpandedDegree(expr, x, common) > MaximumUnifiedDegree)
+                return null;
+
+            var theta = (Number.Rational.Create(common) * x).InnerSimplified;
+
+            // Up before down. With only the argument and its double present, an integrand that
+            // is even in the smaller one is a function of the doubled one alone, at half the
+            // degree the other direction gives; that is tried first and the rest falls through.
+            if (multiples.Count == 2 && multiples.Contains(1) && multiples.Contains(2)
+                && TryRaiseToTheDoubledArgument(expr, x, theta) is { } raised)
+            {
+                var (raisedNumerator, raisedDenominator) = Functions.SingleQuotient.Of(raised.InnerSimplified);
+                if (Integration.ComputeIndefiniteIntegral(
+                        CancelCommonFactors(raisedNumerator, raisedDenominator), x, integrateByParts: false) is { } fromAbove)
+                    return fromAbove;
+            }
+
+            var sine = MathS.Sin(theta);
+            var cosine = MathS.Cos(theta);
+            var rewritten = expr.Replace(node =>
+            {
+                if (TrigonometricArgument(node) is not { } argument || !argument.ContainsNode(x)
+                    || !TreeAnalyzer.TryGetPolyLinear(argument, x, out var slope, out _)
+                    || slope.Evaled is not Number.Rational rational)
+                    return node;
+                var multiple = rational.ERational.Divide(common).ToLowestTerms();
+                var n = multiple.Numerator.Abs().ToInt32Unchecked();
+                var negative = multiple.Numerator.Sign < 0;
+                var (sin, cos) = SineAndCosineOfAMultiple(n, sine, cosine);
+                if (negative)
+                    sin = -sin;
+                return node switch
+                {
+                    Sinf => sin,
+                    Cosf => cos,
+                    Tanf => sin / cos,
+                    Cotanf => cos / sin,
+                    Secantf => 1 / cos,
+                    Cosecantf => 1 / sin,
+                    _ => node
+                };
+            });
+            // As one quotient with the common factors cancelled, before it is handed on. The
+            // rewriting leaves a quotient of quotients with a factor to cancel -- `tan(x)/tan(2x)`
+            // becomes `(s/c) / (2sc/(2c^2 - 1))` -- and on that shape, or on the single quotient
+            // with the `s` still in it, the search ran for twenty-five seconds to decline what is
+            // `1 - 1/(2c^2)` and answered in a quarter of one. `Simplify` is not the tool: it
+            // folds `2sc` back into `sin(2x)` and hands this rule its own input.
+            var (numerator, denominator) = Functions.SingleQuotient.Of(rewritten.InnerSimplified);
+            var cancelled = CancelCommonFactors(numerator, denominator);
+            return Integration.ComputeIndefiniteIntegral(cancelled, x, integrateByParts: false);
+        }
+
+        /// <summary>
+        /// <paramref name="expr"/>, whose trigonometric functions are of <paramref name="theta"/>
+        /// and of <c>2 theta</c>, rewritten in <c>sin(2 theta)</c> and <c>cos(2 theta)</c> alone
+        /// — or <see langword="null"/> where it is not even in <paramref name="theta"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>sin^2 = (1 - C)/2</c>, <c>cos^2 = (1 + C)/2</c> and <c>sin cos = S/2</c>, with
+        /// <c>S</c> and <c>C</c> the sine and cosine of the doubled argument; so a monomial
+        /// <c>sin^p cos^q</c> is a rational function of <c>S</c> and <c>C</c> exactly when
+        /// <c>p + q</c> is even, negative powers included, and an expression built from such
+        /// monomials by sums, products and quotients is one too. Going up to the doubled argument
+        /// where that holds gives polynomials of half the degree the other direction does:
+        /// <c>sec(2t)/(1 + sec(t)^2 + 3 tan(t))</c> is answered in a third of a second written in
+        /// <c>2t</c> and declined after five written in <c>t</c>.
+        /// </para>
+        /// </remarks>
+        private static Entity? TryRaiseToTheDoubledArgument(Entity expr, Entity.Variable x, Entity theta)
+        {
+            var sine = MathS.Sin(theta);
+            var cosine = MathS.Cos(theta);
+            var doubledSine = MathS.Sin((2 * theta).InnerSimplified);
+            var doubledCosine = MathS.Cos((2 * theta).InnerSimplified);
+
+            // A monomial sin^p cos^q of the small argument, as a function of the doubled one:
+            // (sin cos)^k times an even power of whichever is left, with k the smaller of the two
+            // exponents so that the leftover power is p - q or q - p, even by the parity check.
+            Entity? Monomial(int p, int q)
+            {
+                if ((p + q) % 2 != 0)
+                    return null;
+                // Either exponent will do for k, since p - q is even; the one that leaves the
+                // smaller exponents behind gives the tidier form -- sec^2 as 2/(1 + C) rather
+                // than as 2(1 - C)/S^2.
+                static int Size(int k, int p, int q) => System.Math.Abs(k) + System.Math.Abs(p - k) + System.Math.Abs(q - k);
+                var k = Size(p, p, q) <= Size(q, p, q) ? p : q;
+                Entity result = k == 0 ? Number.Integer.One : MathS.Pow(doubledSine / 2, k);
+                if (p != k)
+                    result *= MathS.Pow((1 - doubledCosine) / 2, (p - k) / 2);
+                if (q != k)
+                    result *= MathS.Pow((1 + doubledCosine) / 2, (q - k) / 2);
+                return result;
+            }
+
+            Entity? Raise(Entity node)
+            {
+                if (!node.ContainsNode(x))
+                    return node;
+                switch (node)
+                {
+                    case Sumf(var a, var b):
+                        return Raise(a) is { } summandA && Raise(b) is { } summandB ? summandA + summandB : null;
+                    case Minusf(var a, var b):
+                        return Raise(a) is { } ma && Raise(b) is { } mb ? ma - mb : null;
+                    case Divf(var a, var b):
+                        return Raise(a) is { } da && Raise(b) is { } db ? da / db : null;
+                    case Mulf:
+                    {
+                        // The sine and cosine powers of the small argument gathered across the
+                        // product, so that sin * cos pairs off; every other factor on its own.
+                        int p = 0, q = 0;
+                        Entity rest = Number.Integer.One;
+                        foreach (var factor in Mulf.LinearChildren(node))
+                        {
+                            var (@base, power) = factor is Powf(var pb, Number.Integer pe) && pe.EInteger.CanFitInInt32()
+                                ? (pb, pe.EInteger.ToInt32Unchecked())
+                                : (factor, 1);
+                            if (@base == sine) p += power;
+                            else if (@base == cosine) q += power;
+                            else if (@base is Tanf(var ta) && ta == theta) { p += power; q -= power; }
+                            else if (@base is Cotanf(var ca) && ca == theta) { p -= power; q += power; }
+                            else if (@base is Secantf(var sa) && sa == theta) q -= power;
+                            else if (@base is Cosecantf(var csa) && csa == theta) p -= power;
+                            else if (Raise(factor) is { } raised) rest *= raised;
+                            else return null;
+                        }
+                        return Monomial(p, q) is { } monomial ? rest * monomial : null;
+                    }
+                    case Powf(var @base, Number.Integer exponent) when exponent.EInteger.CanFitInInt32():
+                    {
+                        var n = exponent.EInteger.ToInt32Unchecked();
+                        if (@base == sine) return Monomial(n, 0);
+                        if (@base == cosine) return Monomial(0, n);
+                        if (@base is Tanf(var ta) && ta == theta) return Monomial(n, -n);
+                        if (@base is Cotanf(var ca) && ca == theta) return Monomial(-n, n);
+                        if (@base is Secantf(var sa) && sa == theta) return Monomial(0, -n);
+                        if (@base is Cosecantf(var csa) && csa == theta) return Monomial(-n, 0);
+                        return Raise(@base) is { } rb ? MathS.Pow(rb, exponent) : null;
+                    }
+                    case Sinf(var a) when a == theta: return null;
+                    case Cosf(var a) when a == theta: return null;
+                    case Tanf(var a) when a == theta: return Monomial(1, -1);
+                    case Cotanf(var a) when a == theta: return Monomial(-1, 1);
+                    case Secantf(var a) when a == theta: return null;
+                    case Cosecantf(var a) when a == theta: return null;
+                    // Of the doubled argument, everything in its sine and cosine, which is what
+                    // the rules below read.
+                    case Tanf(var a) when a == doubledSine.DirectChildren.First(): return doubledSine / doubledCosine;
+                    case Cotanf(var a) when a == doubledSine.DirectChildren.First(): return doubledCosine / doubledSine;
+                    case Secantf(var a) when a == doubledSine.DirectChildren.First(): return 1 / doubledCosine;
+                    case Cosecantf(var a) when a == doubledSine.DirectChildren.First(): return 1 / doubledSine;
+                    default:
+                        // A function of the doubled argument, or anything else, stays as it is;
+                        // a bare sine or cosine of the small argument is odd and was declined above.
+                        return node.DirectChildren.Any(child => child.ContainsNode(x) && Raise(child) is null) ? null : node;
+                }
+            }
+
+            return Raise(expr);
+        }
+
+        /// <summary>
+        /// <paramref name="numerator"/> over <paramref name="denominator"/> with every factor
+        /// that appears in both, to a whole power, divided out by the smaller of the two powers.
+        /// Factors are compared as written, which is what a rewriting that built both sides from
+        /// the same pieces needs and no more.
+        /// </summary>
+        private static Entity CancelCommonFactors(Entity numerator, Entity denominator)
+        {
+            static Dictionary<Entity, int> Powers(Entity side)
+            {
+                var powers = new Dictionary<Entity, int>();
+                foreach (var factor in Mulf.LinearChildren(side))
+                {
+                    var (@base, power) = factor is Powf(var b, Number.Integer e) && e.EInteger.CanFitInInt32()
+                        ? (b, e.EInteger.ToInt32Unchecked())
+                        : (factor, 1);
+                    powers[@base] = powers.TryGetValue(@base, out var already) ? already + power : power;
+                }
+                return powers;
+            }
+            static Entity Rebuild(Dictionary<Entity, int> powers)
+            {
+                Entity built = Number.Integer.One;
+                foreach (var pair in powers)
+                {
+                    if (pair.Value == 0)
+                        continue;
+                    var factor = pair.Value == 1 ? pair.Key : MathS.Pow(pair.Key, pair.Value);
+                    built = built == Number.Integer.One ? factor : built * factor;
+                }
+                return built;
+            }
+
+            var above = Powers(numerator);
+            var below = Powers(denominator);
+            foreach (var pair in above.ToList())
+                if (below.TryGetValue(pair.Key, out var underneath) && pair.Value > 0 && underneath > 0)
+                {
+                    var shared = System.Math.Min(pair.Value, underneath);
+                    above[pair.Key] = pair.Value - shared;
+                    below[pair.Key] = underneath - shared;
+                }
+            var top = Rebuild(above);
+            var bottom = Rebuild(below);
+            return bottom == Number.Integer.One ? top : top / bottom;
+        }
+
+        /// <summary>
+        /// The largest multiple <see cref="SolveByUnifyingTrigonometricArguments"/> expands;
+        /// past it the Chebyshev polynomials are longer than any answer they lead to.
+        /// </summary>
+        private const int MaximumUnifiedMultiple = 6;
+
+        /// <summary>
+        /// The largest degree, in the sine and cosine of the common argument, that the rewriting
+        /// is allowed to produce anywhere in the integrand.
+        /// </summary>
+        private const int MaximumUnifiedDegree = 8;
+
+        /// <summary>
+        /// An upper bound on the degree in <c>sin(g x)</c> and <c>cos(g x)</c> that rewriting
+        /// <paramref name="expr"/> to the common slope <paramref name="common"/> produces: a
+        /// function of <c>n g x</c> is degree <c>n</c>, a product adds, a power multiplies, a sum
+        /// or quotient takes the larger side.
+        /// </summary>
+        private static int ExpandedDegree(Entity expr, Entity.Variable x, ERational common)
+        {
+            if (!expr.ContainsNode(x))
+                return 0;
+            switch (expr)
+            {
+                case Sumf or Minusf or Divf:
+                    return expr.DirectChildren.Max(child => ExpandedDegree(child, x, common));
+                case Mulf:
+                    return expr.DirectChildren.Sum(child => ExpandedDegree(child, x, common));
+                case Powf(var @base, Number.Integer power) when power.EInteger.CanFitInInt32():
+                    return ExpandedDegree(@base, x, common) * System.Math.Abs(power.EInteger.ToInt32Unchecked());
+                default:
+                    if (TrigonometricArgument(expr) is { } argument
+                        && TreeAnalyzer.TryGetPolyLinear(argument, x, out var slope, out _)
+                        && slope.Evaled is Number.Rational rational)
+                    {
+                        var multiple = rational.ERational.Divide(common).ToLowestTerms();
+                        return multiple.Numerator.Abs().CanFitInInt32() ? multiple.Numerator.Abs().ToInt32Unchecked() : int.MaxValue / 4;
+                    }
+                    return 1;
+            }
+        }
+
+        private static Entity? TrigonometricArgument(Entity node) => node switch
+        {
+            Sinf(var a) => a,
+            Cosf(var a) => a,
+            Tanf(var a) => a,
+            Cotanf(var a) => a,
+            Secantf(var a) => a,
+            Cosecantf(var a) => a,
+            _ => null
+        };
+
+        /// <summary>
+        /// <c>sin(n t)</c> and <c>cos(n t)</c> as polynomials in <paramref name="sine"/> and
+        /// <paramref name="cosine"/>, by the Chebyshev recurrences.
+        /// </summary>
+        private static (Entity Sine, Entity Cosine) SineAndCosineOfAMultiple(int n, Entity sine, Entity cosine)
+        {
+            // T_0 = 1, T_1 = c, T_(k+1) = 2c T_k - T_(k-1); U_0 = 1, U_1 = 2c, likewise.
+            Entity tPrevious = 1, tCurrent = cosine;
+            Entity uPrevious = 1, uCurrent = 2 * cosine;
+            if (n == 0)
+                return (0, 1);
+            for (var k = 1; k < n; k++)
+            {
+                (tPrevious, tCurrent) = (tCurrent, (2 * cosine * tCurrent - tPrevious).InnerSimplified);
+                (uPrevious, uCurrent) = (uCurrent, (2 * cosine * uCurrent - uPrevious).InnerSimplified);
+            }
+            // sin(n t) = sin(t) U_(n-1)(cos t): after the loop uPrevious is U_(n-1).
+            return ((sine * uPrevious).InnerSimplified, tCurrent);
         }
 
         /// <summary>

--- a/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
@@ -399,6 +399,10 @@ namespace AngouriMath.Functions.Algebra
             // rules, because none of them reads the exponential and all of them would have to
             // decline it.
             if ((answer = IndefiniteIntegralSolver.SolveAPolynomialTimesAnExponentialAndATrigonometric(expr, x)) is { }) return answer;
+            // A half-integer power of `1 + sin` or `1 - cos` and their kin, closed by one
+            // cancellation that `a^2 = b^2` allows. Before the reductions, which do not read a
+            // fractional power at all.
+            if ((answer = IndefiniteIntegralSolver.SolveAHalfPowerOfOnePlusASine(expr, x)) is { }) return answer;
             if ((answer = IndefiniteIntegralSolver.SolveBySecantPowerReduction(expr, x)) is { }) return answer;
             // And beside it: a power of the sine times a power of the cosine, which is every
             // product of the six trigonometric functions once tangents and secants are read as
@@ -462,6 +466,10 @@ namespace AngouriMath.Functions.Algebra
             // this only fires where the arguments differ, which is exactly what every substitution
             // above declines for want of an inner function to substitute for.
             if ((answer = IndefiniteIntegralSolver.SolveByProductToSum(expr, x, integrateByParts)) is { }) return answer;
+            // And the other way round: not a product of two arguments but anything else built
+            // from different multiples of one -- `sin(x)/cos(2x)`, `cos(x)/(sin(x) tan(x/2))` --
+            // rewritten to the one argument every trigonometric rule above reads.
+            if ((answer = IndefiniteIntegralSolver.SolveByUnifyingTrigonometricArguments(expr, x, integrateByParts)) is { }) return answer;
             // The exponential substitution beside the other rewrites. It is also what integrates
             // the hyperbolic functions, which are not nodes here but quotients of exponentials.
             if ((answer = IndefiniteIntegralSolver.SolveByExponentialSubstitution(expr, x, integrateByParts)) is { }) return answer;

--- a/Sources/Tests/UnitTests/Calculus/ExpandedPowerIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ExpandedPowerIntegralTest.cs
@@ -93,17 +93,27 @@ namespace AngouriMath.Tests.Calculus
             => DifferentiatesBack(integrand);
 
         /// <summary>
-        /// Still declined, so the boundary is recorded. The power is the numerator of a quotient
-        /// rather than the whole integrand, and this rule reads only the whole. Should something
-        /// later answer it, this moves rather than being deleted.
+        /// A power inside a quotient is not this rule's — it reads only the whole integrand —
+        /// and it is answered all the same, by the rule for a polynomial over a power of a
+        /// linear, which expands the numerator under <c>t = x</c>. Recorded here as declined
+        /// until that rule existed; the boundary moved and this moved with it.
         /// </summary>
         [Theory]
         [InlineData("(a - b*x^2)^3/x^7")]
-        public void APowerInsideAQuotientIsNotReached(string integrand)
+        public void APowerInsideAQuotientIsAnotherRules(string integrand)
         {
             var integral = integrand.ToEntity().Integrate("x");
-            if (!integral.Stringize().Contains("integral("))
-                DifferentiatesBack(integrand);
+            Assert.DoesNotContain("integral(", integral.Stringize());
+            var derivative = integral.Substitute("C", 0).Differentiate("x").Substitute("a", 1.3).Substitute("b", 0.7);
+            var original = integrand.ToEntity().Substitute("a", 1.3).Substitute("b", 0.7);
+            foreach (var at in new[] { 0.4, 1.1, 2.3 })
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                var difference = Math.Abs((double)(got - want).RealPart) + Math.Abs((double)(got - want).ImaginaryPart);
+                Assert.True(difference / Math.Max(1.0, Math.Abs((double)want.RealPart)) < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, where the integrand is {want}");
+            }
         }
     }
 }

--- a/Sources/Tests/UnitTests/Calculus/HalfPowerOfOnePlusASineTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/HalfPowerOfOnePlusASineTest.cs
@@ -1,0 +1,92 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// <c>(a + b sin(c x + d))^n</c> and the cosine, for <c>a^2 = b^2</c> and <c>n</c> a positive
+    /// half-integer, closed by the reduction Rubi uses for the same case.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <c>sqrt(1 + sin(x))</c> had no antiderivative and is <c>-2 cos(x)/sqrt(1 + sin(x))</c>;
+    /// the cancellation <c>cos^2 = (1 - sin)(1 + sin)</c> that checks it is what <c>a^2 = b^2</c>
+    /// buys. Each answer here is differentiated back. The sample points avoid the zeros of
+    /// <c>1 + sin</c>, where the integrand is zero and the comparison says nothing.
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class HalfPowerOfOnePlusASineTest
+    {
+        private static readonly double[] Points = { 0.3, 0.9, 1.7, 2.6, -0.4 };
+
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+            Assert.DoesNotContain("NaN", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 4,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}");
+        }
+
+        /// <summary>
+        /// The base case and the reduction above it, for the sine and the cosine, both signs,
+        /// a rate, an offset and a common factor. The second is Rubi's (Timofeev).
+        /// </summary>
+        [Theory]
+        [InlineData("(1 + sin(x))^(1/2)")]
+        [InlineData("(1 - sin(2/3*x))^(5/2)")]
+        [InlineData("(1 + sin(x))^(3/2)")]
+        [InlineData("(1 + cos(x))^(1/2)")]
+        [InlineData("(1 - cos(3*x))^(3/2)")]
+        [InlineData("(2 + 2*sin(x))^(1/2)")]
+        [InlineData("(3 - 3*cos(x + 1))^(3/2)")]
+        public void AHalfPowerWithEqualSquares(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// The base case's exact form, so that a later change to the reduction is visible.
+        /// </summary>
+        [Fact]
+        public void TheBaseCaseIsTheClosedForm()
+        {
+            var integral = "(1 + sin(x))^(1/2)".ToEntity().Integrate("x");
+            Assert.Equal("(-2) * cos(x) / sqrt(1 + sin(x)) + C", integral.Stringize());
+        }
+
+        /// <summary>
+        /// <c>a^2 != b^2</c> is an elliptic integral, and a whole power is another rule's; both
+        /// are declined here and the whole power is answered elsewhere.
+        /// </summary>
+        [Fact]
+        public void UnequalSquaresAreDeclined()
+            => Assert.Contains("integral(", "(1 + 2*sin(x))^(1/2)".ToEntity().Integrate("x").Stringize());
+
+        [Fact]
+        public void AWholePowerIsAnotherRules() => DifferentiatesBack("(1 + sin(x))^2");
+    }
+}

--- a/Sources/Tests/UnitTests/Calculus/InverseTangentPowerByPartsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/InverseTangentPowerByPartsTest.cs
@@ -1,0 +1,106 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// A power of an inverse tangent times a rational function, by two rounds of parts: the
+    /// descent measure of integration by parts now counts the power of the factor it
+    /// differentiates as well as the size of what is left.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>x arctan(x)^2</c> leaves <c>x^2 arctan(x)/(1 + x^2)</c> after one step, which has more
+    /// nodes and needs one more step to finish; on nodes alone the second step was refused. The
+    /// power fell from two to one, and that is the descent the step made. The measure is the
+    /// pair, power first, and a remainder with no such factor left is still measured by nodes
+    /// alone — which is what keeps <c>asec(x)^2</c> times a radical from opening a search on a
+    /// hundred-node remainder, measured at thirty seconds when it did.
+    /// </para>
+    /// <para>
+    /// The remainder is also re-spelled as a product cut at the factor, where what is beside it
+    /// is rational, since <c>Simplify</c> writes it as a quotient and by parts runs on a product.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class InverseTangentPowerByPartsTest
+    {
+        private static readonly double[] Points = { 0.3, 0.9, 1.7, 2.6 };
+
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+            Assert.DoesNotContain("NaN", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 3,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}");
+        }
+
+        /// <summary>
+        /// Apostol's <c>x arctan(x)^2</c> and Timofeev's <c>arctan(x)^2/x^3</c>, with the
+        /// logarithm's square beside them, which came out before and must keep coming out.
+        /// </summary>
+        [Theory]
+        [InlineData("x*atan(x)^2")]
+        [InlineData("atan(x)^2/x^3")]
+        [InlineData("x^3*atan(x)^2")]
+        [InlineData("x*ln(x)^2")]
+        [InlineData("x*ln(x)^3")]
+        [InlineData("x^2*ln(x)^2")]
+        public void APowerOfTheFactorTimesARationalFunction(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// <c>arctan(x)^2/x^2</c> leaves <c>arctan(x)/(x (1 + x^2))</c>, which has no elementary
+        /// antiderivative, and the descent has to stop there rather than search: bounded by the
+        /// clock, since the measure is what keeps a decline quick.
+        /// </summary>
+        [Fact]
+        public void ANonElementaryRemainderIsDeclinedQuickly()
+        {
+            var watch = System.Diagnostics.Stopwatch.StartNew();
+            var integral = "atan(x)^2/x^2".ToEntity().Integrate("x");
+            Assert.Contains("integral(", integral.Stringize());
+            Assert.True(watch.Elapsed < TimeSpan.FromSeconds(20), $"declined in {watch.Elapsed}");
+        }
+
+        /// <summary>
+        /// A radical beside the power is not re-spelled: the remainder is a hundred-node radical
+        /// expression that a by-parts search took thirty seconds to decline, and is declined in
+        /// about one without the re-spelling.
+        /// </summary>
+        [Fact]
+        public void ARadicalRemainderIsNotSearched()
+        {
+            var watch = System.Diagnostics.Stopwatch.StartNew();
+            _ = "(x^2 - 1)^(3/2)*asec(x)^2/x^5".ToEntity().Integrate("x");
+            Assert.True(watch.Elapsed < TimeSpan.FromSeconds(20), $"took {watch.Elapsed}");
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Calculus/MixedTrigonometricArgumentsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/MixedTrigonometricArgumentsTest.cs
@@ -1,0 +1,109 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// An integrand whose trigonometric functions have different multiples of one argument —
+    /// <c>sin(x)/cos(2x)</c>, <c>cos(x)/(sin(x) tan(x/2))</c> — rewritten to one argument and
+    /// handed on.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every trigonometric rule reads one argument, so an integrand with <c>x</c> and <c>2x</c>
+    /// in it was declined by all of them, while the same integrand with <c>cos(2x)</c> written
+    /// as <c>1 - 2 sin(x)^2</c> came out. The rewriting goes down to the greatest common
+    /// divisor of the slopes through the Chebyshev recurrences, or — when only an argument and
+    /// its double are present and the integrand is even in the smaller — up to the double,
+    /// which gives polynomials of half the degree.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class MixedTrigonometricArgumentsTest
+    {
+        private static readonly double[] Points = { 0.3, 0.7, 1.1, 2.3 };
+
+        private static void DifferentiatesBack(string integrand, string variable = "x")
+        {
+            var integral = integrand.ToEntity().Integrate(variable);
+            Assert.DoesNotContain("integral(", integral.Stringize());
+            Assert.DoesNotContain("NaN", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate(variable);
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute(variable, at).EvalNumerical();
+                var want = original.Substitute(variable, at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/d{variable} of the antiderivative of {integrand} is {got} at {variable} = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 3,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}");
+        }
+
+        /// <summary>
+        /// The argument and its double, written down to the argument. The first three are
+        /// Rubi's (Timofeev, Stewart, and — with the half angle — Hearn).
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x)/cos(2*x)")]
+        [InlineData("(cos(x) + sin(x))/sin(2*x)")]
+        [InlineData("cos(x)/(sin(x)*tan(x/2))")]
+        [InlineData("sin(x/2)/(1 + cos(x))")]
+        [InlineData("1/(sin(x) + sin(2*x))")]
+        [InlineData("sin(3*x)/sin(x)")]
+        [InlineData("sin(2*x)/(1 + cos(x)^2)")]
+        public void DifferentMultiplesOfOneArgument(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// Even in the smaller argument, so written up to the double: <c>tan(x)/tan(2x)</c> is
+        /// <c>1 - 1/(2 cos(x)^2)</c> that way, and Moses's <c>sec(2t)/(1 + sec(t)^2 + 3 tan(t))</c>
+        /// is a rational function of <c>sin(2t)</c> and <c>cos(2t)</c> that the half-angle
+        /// substitution answers, where the other direction declined after five seconds.
+        /// </summary>
+        [Theory]
+        [InlineData("tan(x)/tan(2*x)", "x")]
+        [InlineData("cos(2*x)/cos(x)^2", "x")]
+        [InlineData("sec(2*t)/(1 + sec(t)^2 + 3*tan(t))", "t")]
+        public void EvenInTheSmallerArgument(string integrand, string variable) => DifferentiatesBack(integrand, variable);
+
+        /// <summary>
+        /// A product of two arguments is product-to-sum's and keeps the answer it had, in sines
+        /// and cosines of sums rather than in powers.
+        /// </summary>
+        [Fact]
+        public void AProductIsStillProductToSums()
+        {
+            var integral = "sin(x)*sin(2*x)".ToEntity().Integrate("x").Stringize();
+            Assert.Contains("sin(x + 2 * x)", integral);
+            DifferentiatesBack("sin(x)*sin(2*x)");
+        }
+
+        /// <summary>
+        /// One argument throughout is not this rule's, and an offset in one of the arguments is
+        /// not read; both are declined by it and answered or not by the rest as before.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x)/cos(x)^2")]
+        [InlineData("sin(x)*cos(x)")]
+        public void OneArgumentIsLeftToTheOthers(string integrand) => DifferentiatesBack(integrand);
+    }
+}

--- a/Sources/Tests/UnitTests/Calculus/SymbolicFactorsPartialFractionsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/SymbolicFactorsPartialFractionsTest.cs
@@ -119,9 +119,34 @@ namespace AngouriMath.Tests.Calculus
         }
 
         /// <summary>
-        /// A repeated factor is not this rule's — there is nothing for a symbolic repeated
-        /// quadratic to land on — and a denominator not written as a product is left to the
-        /// other splits.
+        /// A repeated <b>linear</b> factor is one block, <c>P/(a + b u)^k</c>, which the rule for
+        /// a polynomial over a power of a linear reads; Welz's <c>1/(a + b e^(p x))^2</c> is
+        /// this under <c>u = e^(p x)</c>.
+        /// </summary>
+        [Theory]
+        [InlineData("1/(u*(a + b*u)^2)")]
+        [InlineData("1/(u*(a + b*u)^3)")]
+        [InlineData("1/((u + a)^2*(u^2 + b))")]
+        [InlineData("1/(a + e^(p*u)*b)^2")]
+        public void ARepeatedSymbolicLinearFactor(string integrand)
+            => DifferentiatesBack(integrand, "u", ("a", 1.7), ("b", 2.3), ("p", 0.6));
+
+        /// <summary>
+        /// The rule the block above lands on: a polynomial over a power of a linear with a
+        /// symbol in it, under <c>t = a + b x</c>. <c>1/(a + b x)^2</c> was answered before as
+        /// a piecewise on a discriminant identically zero, through the quadratic rule; that
+        /// still runs first and this is what the split hands on.
+        /// </summary>
+        [Theory]
+        [InlineData("(c + d*x)/(a + b*x)^2")]
+        [InlineData("x/(a + b*x)^2")]
+        [InlineData("x^2/(a + b*x)^3")]
+        [InlineData("(1 + x + x^2)/(a + b*x)^4")]
+        public void APolynomialOverASymbolicLinearPower(string integrand)
+            => DifferentiatesBack(integrand, "x", ("a", 1.7), ("b", 2.3), ("c", 0.4), ("d", 1.1));
+
+        /// <summary>
+        /// A repeated symbolic quadratic has nothing to land on and is declined.
         /// </summary>
         [Theory]
         [InlineData("1/((x^2 + a)^2*(x + 1))")]


### PR DESCRIPTION
Four families the Rubi sample was declining, each answered by one rule or one bound,
with the two runaway declines each opened measured and closed before it shipped.

## Different multiples of one argument

`sin(x)/cos(2x)`, `(cos(x) + sin(x))/sin(2x)`, `cos(x)/(sin(x) tan(x/2))` had no
antiderivative, while each with the double or half angle written out by hand came
out. Every trigonometric rule reads one argument. The new rule rewrites the
integrand to one: down to the greatest common divisor of the slopes through the
Chebyshev recurrences `cos(nt) = T_n(cos t)`, `sin(nt) = sin(t) U_(n-1)(cos t)`; or --
when only an argument and its double are present and the integrand is *even* in the
smaller, every monomial `sin^p cos^q` having `p + q` even -- up to the double, at
half the degree. Moses's `sec(2t)/(1 + sec(t)^2 + 3 tan(t))` is answered in a third
of a second the second way and declined after five the first.

What it hands on is one quotient with the common factors cancelled, because
`tan(x)/tan(2x)` becomes `(s/c) / (2sc/(2c^2 - 1))` and on that shape, or on the
single quotient with the `s` still in it, the search ran twenty-five seconds to
decline `1 - 1/(2c^2)`. `Simplify` is not the tool: it folds `2sc` back into
`sin(2x)` and hands the rule its own input.

Two bounds, both from the corpus rather than from caution. Rational in the
trigonometric functions only -- a radical or fractional power of one is a different
integrand, and `sqrt(cos(x) sin(x)^3)` beside `sin(2x)` and `(2 - 3 sin^2)^(3/5) sin(4x)`
were each a five-second timeout for a decline that took a tenth of that before. And
a cap on the degree the rewriting produces: `1/(cos(x) + cos(3x))^5` is degree
fifteen in the sine and cosine, and went the same way.

## `(a + b sin(cx + d))^n` for `a^2 = b^2`

`sqrt(1 + sin(x))` had no antiderivative. It is `-2 cos(x)/sqrt(1 + sin(x))`, and the
cancellation `cos^2 = (1 - sin)(1 + sin)` that checks it is what `a^2 = b^2` buys.
Above the base case, one step of parts lowers `n` by one -- Rubi's rule for the same
case -- so `(1 - sin(2x/3))^(5/2)` is two steps and the base. The cosine is the same
rule with `sin` replaced by `-cos` in the boundary term. `a^2 = b^2` is decided, not
assumed; `sqrt(1 + 2 sin(x))` is elliptic and is declined.

## A power of an inverse tangent, by two rounds of parts

`x arctan(x)^2` leaves `x^2 arctan(x)/(1 + x^2)` after one step, which has more
nodes and needs one more step to finish; on nodes alone the second step was refused.
The power fell from two to one, and that is the descent the step made. The measure
is now the pair, power first: a step that lowers the power may grow the expression,
and one that keeps it must shrink it, so the pair is well-founded.

Two things were measured on the way. A remainder whose power has fallen to *zero* is
whatever the derivative and the integral made together -- for `asec(x)^2` times a
radical, a hundred-node radical expression -- and admitting it on the power opened
a by-parts search at every level: thirty seconds to decline, one without. So the
power admits a remainder only while a factor is left for the next round. And the
remainder is re-spelled as the product its next step reads, since `Simplify` writes
it as a quotient and parts runs on a product -- but only where what stands beside
the factor is rational in the variable, for the same measured reason.

## A repeated linear factor with a symbol in it

`1/(a + b e^(px))^2` is `1/(p u (a + b u)^2)` under `u = e^(px)`. The symbolic
partial-fraction split (#1284) read `(a + b u)^2` as a quadratic; it is a repeated
linear factor, and is now one block `P/(a + b u)^2` with `P` of degree one -- which
is then a shape nothing read: `(c + d x)/(a + b x)^2` came out with numbers and not
with symbols, the rational-root split being the only thing that ever answered it.
Under `t = a + b x` it is a sum of powers of `t`, and that rule is here too. A
repeated symbolic quadratic has nothing to land on and stays declined.

## Measured

Every answer differentiated back, with parameters pinned.

Rubi corpus, 463-problem sample, against #1284's branch it was cut from, both timed
on the same afternoon:

    #1284       290/463, 0 wrong, 0 timeouts, 95 s
    with this   300/463, 0 wrong, 0 timeouts, 95 s

Ten more and nothing lost: `sin(x)/cos(2x)`, `(cos(x) + sin(x))/sin(2x)`,
`cos(x)/(sin(x) tan(x/2))`, `sec(2t)/(1 + sec(t)^2 + 3 tan(t))`, `sqrt(1 + sin(x))`,
`(1 - sin(2x/3))^(5/2)`, `x arctan(x)^2`, `arctan(x)^2/x^3`, `1/(a + b e^(px))^2`, and
`ln(sin(x))/(1 + sin(x))`, which the by-parts measure reached on its own. The sum of
per-problem time over the sample is 94 s on both sides.

`ExpandedPowerIntegralTest.APowerInsideAQuotientIsNotReached` pinned
`(a - b x^2)^3/x^7` as declined and said it would move rather than be deleted when
something answered it; `x^7` is a power of a linear, and it moved.

The five test suites are green.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
