### PR TITLE
An exponential times a rational function by Liouville's ansatz, the Hermite reduction first for a repeated factor, and a cache that had been remembering a scoped decline

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -390,3 +390,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/InverseTangentPowerByPartsTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/ExponentialAnsatzTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/ScopedDeclineIsNotCachedTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Algebra/Polynomials/PartialFractions.cs
+++ b/Sources/AngouriMath/Functions/Algebra/Polynomials/PartialFractions.cs
@@ -536,48 +536,83 @@ namespace AngouriMath.Functions
             var size = rhs.Length;
             if (size == 0 || matrix.Any(row => row.Length != size))
                 return false;
+            return TrySolveLinear(matrix, rhs, out values);
+        }
 
-            for (var column = 0; column < size; column++)
+        /// <summary>
+        /// Gaussian elimination on a system of any shape whose entries may be symbols: a row
+        /// that reduces to <c>0 = c</c> with <c>c</c> not decidably zero declines the system,
+        /// and an unknown no row pivots on is set to zero. A pivot is a number that is not zero
+        /// where a column has one, and otherwise an entry that does not simplify to zero — a
+        /// judgement, which is why every caller checks what it builds from the answer.
+        /// </summary>
+        internal static bool TrySolveLinear(Entity[][] matrix, Entity[] rhs, [NotNullWhen(true)] out Entity[]? values)
+        {
+            values = null;
+            var rows = rhs.Length;
+            if (rows == 0 || matrix.Length != rows)
+                return false;
+            var width = matrix[0].Length;
+            if (width == 0 || matrix.Any(row => row.Length != width))
+                return false;
+
+            var pivotColumnOfRow = new int[rows];
+            for (var row = 0; row < rows; row++)
+                pivotColumnOfRow[row] = -1;
+            var rank = 0;
+            for (var column = 0; column < width && rank < rows; column++)
             {
                 var pivot = -1;
-                for (var row = column; row < size; row++)
+                for (var row = rank; row < rows; row++)
                     if (matrix[row][column].Evaled is Complex { IsExact: true, IsZero: false })
                     {
                         pivot = row;
                         break;
                     }
                 if (pivot < 0)
-                    for (var row = column; row < size; row++)
+                    for (var row = rank; row < rows; row++)
                         if (matrix[row][column] != Integer.Zero && matrix[row][column].Evaled is not Complex { IsZero: true })
                         {
                             pivot = row;
                             break;
                         }
                 if (pivot < 0)
-                    return false;
-                if (pivot != column)
+                    continue;
+                if (pivot != rank)
                 {
-                    (matrix[pivot], matrix[column]) = (matrix[column], matrix[pivot]);
-                    (rhs[pivot], rhs[column]) = (rhs[column], rhs[pivot]);
+                    (matrix[pivot], matrix[rank]) = (matrix[rank], matrix[pivot]);
+                    (rhs[pivot], rhs[rank]) = (rhs[rank], rhs[pivot]);
                 }
-                for (var row = column + 1; row < size; row++)
+                for (var row = rank + 1; row < rows; row++)
                 {
                     if (matrix[row][column] == Integer.Zero)
                         continue;
-                    var factor = Bare(matrix[row][column] / matrix[column][column]);
-                    for (var k = column; k < size; k++)
-                        matrix[row][k] = Bare(matrix[row][k] - factor * matrix[column][k]);
-                    rhs[row] = Bare(rhs[row] - factor * rhs[column]);
+                    var factor = Bare(matrix[row][column] / matrix[rank][column]);
+                    for (var k = column; k < width; k++)
+                        matrix[row][k] = Bare(matrix[row][k] - factor * matrix[rank][k]);
+                    rhs[row] = Bare(rhs[row] - factor * rhs[rank]);
                 }
+                pivotColumnOfRow[rank] = column;
+                rank++;
             }
 
-            values = new Entity[size];
-            for (var row = size - 1; row >= 0; row--)
+            // A row with no pivot says 0 = rhs; the system is consistent only where that is
+            // decidably so.
+            for (var row = rank; row < rows; row++)
+                if (rhs[row] != Integer.Zero && rhs[row].Evaled is not Complex { IsZero: true })
+                    return false;
+
+            values = new Entity[width];
+            for (var column = 0; column < width; column++)
+                values[column] = Integer.Zero;
+            for (var row = rank - 1; row >= 0; row--)
             {
+                var column = pivotColumnOfRow[row];
                 var accumulated = rhs[row];
-                for (var k = row + 1; k < size; k++)
-                    accumulated -= matrix[row][k] * values[k];
-                values[row] = Bare(accumulated / matrix[row][row]);
+                for (var k = column + 1; k < width; k++)
+                    if (matrix[row][k] != Integer.Zero)
+                        accumulated -= matrix[row][k] * values[k];
+                values[column] = Bare(accumulated / matrix[row][column]);
             }
             return true;
         }
@@ -587,7 +622,7 @@ namespace AngouriMath.Functions
         /// acquires on the way: that condition is the generic case this decomposition is
         /// answering in, and left on it makes a term nothing downstream reads.
         /// </summary>
-        private static Entity Bare(Entity e)
+        internal static Entity Bare(Entity e)
             => e.InnerSimplified is Providedf(var inner, _) ? inner : e.InnerSimplified;
 
         /// <summary>
@@ -595,7 +630,7 @@ namespace AngouriMath.Functions
         /// few points in <paramref name="x"/> with every other symbol pinned to a fixed value.
         /// A point where either is undefined is skipped, and at least two must compare.
         /// </summary>
-        private static bool HoldsAtSampledPoints(Entity left, Entity right, Variable x)
+        internal static bool HoldsAtSampledPoints(Entity left, Entity right, Variable x)
         {
             var parameters = left.Vars.Concat(right.Vars).Where(v => v != x).Distinct().ToList();
             var pinned = 0;

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -79,6 +79,15 @@ namespace AngouriMath.Functions.Algebra
                 && Integration.ComputeIndefiniteIntegral(properPart, x, integrateByParts) is { } fractionPart)
                 return wholePart + fractionPart;
 
+            // A denominator with a written repeated factor takes the Hermite reduction first:
+            // the rational part of the answer in one linear solve, and what is left is a proper
+            // fraction over a squarefree denominator for the splits below. `(1 + x^2)/(x (1 + x^3)^2)`
+            // reached the same answer through them after seventeen seconds of peeling and
+            // re-factoring; this way it is under a second.
+            if (Mulf.LinearChildren(denominator).Any(f => f.ContainsNode(x) && f is Powf(_, Number.Integer { EInteger.Sign: > 0 } e) && e != Number.Integer.One)
+                && IntegrateByAnsatz(null, numerator / denominator, x) is { } byHermite)
+                return byHermite;
+
             // Splitting into coprime blocks comes before peeling one root off, and the order is
             // load-bearing rather than a preference.
             //
@@ -456,8 +465,12 @@ namespace AngouriMath.Functions.Algebra
                 TakeConstantFactorOutOfDenominator(div, over, x, integrateByParts) is { } withoutIt ?
                     withoutIt :
                 !div.ContainsNode(x) ?
+                    // The exponent negated as a number rather than as a tree: `-power` on the
+                    // node `2` is `2 * (-1)`, and `sin(x)^(2 * (-1))` is a shape the closed rule
+                    // for a power of the sine does not read, so `c/sin(x)^2` went to the
+                    // half-angle substitution for what is `-c cot(x)`.
                     over is Entity.Powf(var @base, var power) ?
-                        Integration.ComputeIndefiniteIntegral(MathS.Pow(@base, -power), x, integrateByParts)?.Pipe(i => div * i) :
+                        Integration.ComputeIndefiniteIntegral(MathS.Pow(@base, (-power).InnerSimplified), x, integrateByParts)?.Pipe(i => div * i) :
                         Integration.ComputeIndefiniteIntegral(MathS.Pow(over, -1), x, integrateByParts)?.Pipe(i => div * i) :
                 !over.ContainsNode(x) ?
                     Integration.ComputeIndefiniteIntegral(div, x, integrateByParts)?.Pipe(i => i / over) :
@@ -675,6 +688,20 @@ namespace AngouriMath.Functions.Algebra
                 // Case 2: Neither is polynomial - try single-step integration by parts
                 // This handles cases like ln(abs(x)) × ln(abs(x))
                 // Try both orderings: f as v, g as u OR g as v, f as u
+                //
+                // **Only with a factor worth differentiating** -- a logarithm or an inverse
+                // function, whose derivative is algebraic, or an exponential, whose integral
+                // is itself and which the cyclic cases need. With neither, the step trades one
+                // product of transcendental factors for another of the same kind with a
+                // derivative in it, and searching that is where a decline went to spend thirty
+                // seconds: `-3 tan(x)/(4 sec(x)^2 + 5 tan(x)^2)` against `1/sin(x)^2`, both
+                // integrable, neither the right thing to differentiate. Measured on the Rubi
+                // sample with the restriction and without: the same answers, eight seconds less.
+                bool IsAnExponential(Entity factor)
+                    => factor is Powf(var @base, var power) && !@base.ContainsNode(x) && power.ContainsNode(x);
+                if (!IsDifferentiatedBeforeAPolynomial(f) && !IsDifferentiatedBeforeAPolynomial(g)
+                    && !IsAnExponential(f) && !IsAnExponential(g))
+                    return null;
                 if (TryIntegrateByPartsOnce(f, g, x, wholeSize, wholePower) is { } result1) return result1;
                 if (TryIntegrateByPartsOnce(g, f, x, wholeSize, wholePower) is { } result2) return result2;
                 return null;
@@ -3003,6 +3030,304 @@ namespace AngouriMath.Functions.Algebra
         }
 
         /// <summary>
+        /// An integrand <c>e^h R</c>, with <c>R</c> rational in <c>x</c> and <c>h</c> rational
+        /// in <c>x</c> or absent, integrated by the ansatz <c>F = e^h N/D</c>: <c>D</c> read
+        /// off the denominator of <c>R</c>, <c>N</c> a polynomial of unknown coefficients, and
+        /// <c>F' = e^h R</c> a linear system in them.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <c>e^x x/(1 + x)^2</c> is <c>(e^x/(1 + x))'</c>; <c>e^(x^2)(1 + 2x^2)</c> is
+        /// <c>(x e^(x^2))'</c>; <c>(4x^5 - 1)/(1 + x + x^5)^2</c> is <c>(-x/(1 + x + x^5))'</c>.
+        /// None had an antiderivative: the first two are not a polynomial times an exponential,
+        /// which is the shape by parts reads, and the third has a denominator nothing factors.
+        /// Each is the derivative of something of the same shape, and that is what is looked
+        /// for -- Liouville's theorem says the elementary antiderivative of <c>e^h R</c>, where
+        /// there is one, is <c>e^h</c> times a rational function, so an ansatz that fails here
+        /// fails because there is no such antiderivative and not because the shape was wrong.
+        /// For <c>h = 0</c> this is the rational part of the Hermite reduction, with the
+        /// logarithmic part required to vanish; a denominator with a repeated factor and a
+        /// logarithmic part beside it is left to the splits, as before.
+        /// </para>
+        /// <para>
+        /// <b>Which <c>D</c>.</b> Differentiating raises the multiplicity of every factor of the
+        /// denominator by one, so <c>D</c> is the denominator of <c>R</c> with each factor's
+        /// written power lowered by one, and then the denominator itself, and <c>1</c> where the
+        /// denominator is <c>1</c>. With <c>h = p/q</c> the identity is
+        /// </para>
+        /// <code>
+        ///     ((N' D - N D') q^2 + (p' q - p q') N D) D_R  =  N_R D^2 q^2
+        /// </code>
+        /// <para>
+        /// a polynomial identity in <c>x</c>, linear in the coefficients of <c>N</c>, solved by
+        /// the same elimination the symbolic partial-fraction split uses and checked the same way
+        /// before anything is returned: at sampled points with every symbol pinned. The degree
+        /// of <c>N</c> is bounded by the degrees in that identity, with a little to spare;
+        /// an unknown the system does not need is zero.
+        /// </para>
+        /// https://github.com/asc-community/AngouriMath/issues/718
+        /// </remarks>
+        internal static Entity? SolveByExponentialAnsatz(Entity expr, Entity.Variable x)
+        {
+            // A sum whose terms share one exponential is read whole -- `e^(x^2) + 2x^2 e^(x^2)`
+            // is `(x e^(x^2))'` and neither term is elementary on its own, so splitting the sum
+            // first, which linearity does, loses it.
+            Entity? exponent = null;
+            Entity rest = 0;
+            foreach (var term in Sumf.LinearChildren(expr))
+            {
+                if (ReadOneExponentialTimesTheRest(term, x) is not var (h, r) || h is null)
+                    return null;
+                if (exponent is null)
+                    exponent = h;
+                else if (exponent != h)
+                    return null;
+                rest += r;
+            }
+            return exponent is null ? null : IntegrateByAnsatz(exponent, rest, x);
+        }
+
+        /// <summary>
+        /// <paramref name="term"/> as one exponential of something in <paramref name="x"/> times
+        /// everything else, or a <see langword="null"/> exponent where there is not exactly one.
+        /// </summary>
+        private static (Entity? Exponent, Entity Remainder)? ReadOneExponentialTimesTheRest(Entity term, Entity.Variable x)
+        {
+            Entity? exponent = null;
+            Entity rest = Number.Integer.One;
+            foreach (var (factor, underneath) in FactorsOfTheIntegrand(term))
+            {
+                if (factor is Powf(var @base, var power) && !@base.ContainsNode(x) && power.ContainsNode(x)
+                    && power is not Number)
+                {
+                    if (exponent is not null)
+                        return null;
+                    var h = @base == MathS.e ? power : power * MathS.Ln(@base);
+                    exponent = (underneath ? -h : h).InnerSimplified;
+                    continue;
+                }
+                rest = underneath ? rest / factor : rest * factor;
+            }
+            return (exponent, rest);
+        }
+
+        /// <summary>
+        /// The ansatz of <see cref="SolveByExponentialAnsatz"/> for <c>e^h R</c>, or for
+        /// <c>R</c> alone when <paramref name="h"/> is <see langword="null"/>.
+        /// </summary>
+        internal static Entity? IntegrateByAnsatz(Entity? h, Entity rational, Entity.Variable x)
+        {
+            var (above, below) = Functions.SingleQuotient.Of(rational.InnerSimplified);
+            if (!TreeAnalyzer.TryGetPolynomial(above, x, out var numeratorRead)
+                || !TreeAnalyzer.TryGetPolynomial(below, x, out var denominatorRead)
+                || numeratorRead.Count == 0 || denominatorRead.Count == 0)
+                return null;
+            foreach (var pair in numeratorRead.Concat(denominatorRead))
+                if (pair.Key.Sign < 0 || pair.Value.ContainsNode(x))
+                    return null;
+
+            Entity p = 0, q = 1;
+            if (h is not null)
+            {
+                (p, q) = Functions.SingleQuotient.Of(h.InnerSimplified);
+                if (!TreeAnalyzer.TryGetPolynomial(p, x, out var pRead) || !TreeAnalyzer.TryGetPolynomial(q, x, out var qRead))
+                    return null;
+                foreach (var pair in pRead.Concat(qRead))
+                    if (pair.Key.Sign < 0 || pair.Value.ContainsNode(x))
+                        return null;
+            }
+
+            var degreeAbove = (int)numeratorRead.Keys.Max()!.ToInt32Checked();
+            var degreeBelow = (int)denominatorRead.Keys.Max()!.ToInt32Checked();
+            if (degreeAbove > MaximumAnsatzDegree || degreeBelow > MaximumAnsatzDegree)
+                return null;
+
+            foreach (var d in CandidateDenominators(below, x))
+            {
+                if (IntegrateByAnsatzOver(h, p, q, above, below, d, x, degreeAbove, degreeBelow) is { } answer)
+                    return answer;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// The denominators the ansatz tries, in order: the denominator with every written power
+        /// lowered by one, and the denominator as it is.
+        /// </summary>
+        private static IEnumerable<Entity> CandidateDenominators(Entity denominator, Entity.Variable x)
+        {
+            var variableFactors = Mulf.LinearChildren(denominator).Where(f => f.ContainsNode(x)).ToList();
+            // One written power on its own is tried at every level below it: with an exponential
+            // in front the antiderivative's denominator need not be one below the integrand's --
+            // `e^(1/x)(1 + x)/x^4` is `(-e^(1/x)(1 - x + x^2)/x^2)'`, two below.
+            if (variableFactors.Count == 1
+                && variableFactors[0] is Powf(var only, Number.Integer onlyPower)
+                && onlyPower.EInteger.Sign > 0 && onlyPower.EInteger.CanFitInInt32())
+            {
+                for (var level = onlyPower.EInteger.ToInt32Unchecked() - 1; level >= 0; level--)
+                    yield return level == 0 ? Number.Integer.One : level == 1 ? only : MathS.Pow(only, level);
+                yield return denominator;
+                yield break;
+            }
+            Entity lowered = Number.Integer.One;
+            foreach (var factor in variableFactors)
+                if (factor is Powf(var @base, Number.Integer power) && power.EInteger.Sign > 0)
+                {
+                    var one = power.EInteger.Subtract(EInteger.One);
+                    if (one.IsZero)
+                        continue;
+                    lowered *= one.Equals(EInteger.One) ? @base : MathS.Pow(@base, Number.Integer.Create(one));
+                }
+            yield return lowered;
+            if (denominator.ContainsNode(x))
+                yield return denominator;
+        }
+
+        /// <summary>
+        /// The product of the distinct written factors of <paramref name="denominator"/>, each
+        /// to the first power: the denominator of the logarithmic part of a Hermite reduction.
+        /// </summary>
+        private static Entity SquarefreePartAsWritten(Entity denominator, Entity.Variable x)
+        {
+            Entity product = Number.Integer.One;
+            foreach (var factor in Mulf.LinearChildren(denominator))
+            {
+                if (!factor.ContainsNode(x))
+                    continue;
+                var @base = factor is Powf(var b, Number.Integer power) && power.EInteger.Sign > 0 ? b : factor;
+                product = product == Number.Integer.One ? @base : product * @base;
+            }
+            return product;
+        }
+
+        private static Entity? IntegrateByAnsatzOver(
+            Entity? h, Entity p, Entity q, Entity above, Entity below, Entity d, Entity.Variable x,
+            int degreeAbove, int degreeBelow)
+        {
+            var degreeD = TreeAnalyzer.TryGetPolynomial(d, x, out var dRead) && dRead.Count > 0
+                ? (int)dRead.Keys.Max()!.ToInt32Checked() : 0;
+            var degreeQ = TreeAnalyzer.TryGetPolynomial(q, x, out var qRead) && qRead.Count > 0
+                ? (int)qRead.Keys.Max()!.ToInt32Checked() : 0;
+            // Hermite's bound is `deg N < deg D`; with an exponential in front the numerator can
+            // run past it by as much as the integrand's own excess and the exponent's
+            // denominator -- `e^(x^2)(1 + 2x^2)` has `N = x` over `D = 1`. Two to spare either
+            // way, since an unknown the system does not need is set to zero and costs nothing.
+            var degreeN = System.Math.Max(degreeD - 1,
+                degreeD + System.Math.Max(degreeAbove - degreeBelow, 0) + degreeQ + 2);
+            if (degreeN > MaximumAnsatzDegree)
+                return null;
+
+            // With no exponential this is the Hermite reduction in full: `R = (N/D)' + M/D_1`,
+            // with `D_1` the product of the distinct factors and `M` a second unknown
+            // polynomial, so that a logarithmic part beside the rational one does not defeat
+            // the ansatz -- `(1 + x^2 + x^4)/((1 + x^2)(4 + x^2)^2)` has both. What is left,
+            // `M/D_1`, is a proper fraction over a squarefree denominator, which the splits
+            // answer. With an exponential there is no logarithmic part to look for.
+            Entity? squarefree = null;
+            var degreeM = -1;
+            if (h is null)
+            {
+                squarefree = SquarefreePartAsWritten(below, x);
+                var degreeSquarefree = TreeAnalyzer.TryGetPolynomial(squarefree, x, out var sRead) && sRead.Count > 0
+                    ? (int)sRead.Keys.Max()!.ToInt32Checked() : 0;
+                if (degreeSquarefree > 0 && squarefree != below)
+                    degreeM = degreeSquarefree - 1;
+                else
+                    squarefree = null;
+            }
+
+            // The identity, linear in the unknown coefficients, is built **one column at a
+            // time** as a numeric polynomial rather than once with the unknowns in it: with
+            // fourteen unknowns over a degree-eleven denominator the single symbolic expansion
+            // did not return, and the same fourteen numeric ones take a moment. The identity is
+            //
+            //     [(N' D - N D') q^2 + (p' q - p q') N D] D_R  =  N_R D^2 q^2            (exponential)
+            //     (N' D - N D') D_1 D_R + M D^2 D_R           =  N_R D^2 D_1            (Hermite)
+            //
+            // so the column for the k-th coefficient of N is the left side with N = x^k, the
+            // column for the j-th of M is x^j D^2 D_R, and the right side is the constant.
+            var dPrime = d.Differentiate(x);
+            var scale = squarefree is null ? below : squarefree * below;
+            var columns = new List<Dictionary<EInteger, Entity>>();
+            for (var k = 0; k <= degreeN; k++)
+            {
+                Entity xk = k == 0 ? Number.Integer.One : k == 1 ? x : MathS.Pow(x, k);
+                Entity xkPrime = k == 0 ? Number.Integer.Zero : k == 1 ? Number.Integer.One : k * MathS.Pow(x, k - 1);
+                Entity term = (xkPrime * d - xk * dPrime) * MathS.Sqr(q);
+                if (h is not null)
+                    term += (p.Differentiate(x) * q - p * q.Differentiate(x)) * xk * d;
+                if (!TreeAnalyzer.TryGetPolynomial(term * scale, x, out var column))
+                    return null;
+                columns.Add(column);
+            }
+            for (var j = 0; j <= degreeM; j++)
+            {
+                Entity xj = j == 0 ? Number.Integer.One : j == 1 ? x : MathS.Pow(x, j);
+                if (!TreeAnalyzer.TryGetPolynomial(xj * MathS.Sqr(d) * below, x, out var column))
+                    return null;
+                columns.Add(column);
+            }
+            var target = squarefree is null ? above * MathS.Sqr(d) * MathS.Sqr(q) : above * MathS.Sqr(d) * squarefree;
+            if (!TreeAnalyzer.TryGetPolynomial(target, x, out var targetRead))
+                return null;
+
+            var powers = columns.SelectMany(c => c.Keys).Concat(targetRead.Keys).Distinct().ToList();
+            var width = columns.Count;
+            var matrix = new Entity[powers.Count][];
+            var rhs = new Entity[powers.Count];
+            for (var row = 0; row < powers.Count; row++)
+            {
+                matrix[row] = new Entity[width];
+                for (var column = 0; column < width; column++)
+                    matrix[row][column] = columns[column].TryGetValue(powers[row], out var entry) ? entry.InnerSimplified : Number.Integer.Zero;
+                rhs[row] = targetRead.TryGetValue(powers[row], out var wanted) ? wanted.InnerSimplified : Number.Integer.Zero;
+            }
+            if (!Functions.PartialFractions.TrySolveLinear(matrix, rhs, out var values))
+                return null;
+
+            Entity solvedN = 0;
+            for (var k = 0; k <= degreeN; k++)
+                if (values[k] != Number.Integer.Zero)
+                    solvedN += values[k] * (k == 0 ? Number.Integer.One : k == 1 ? x : MathS.Pow(x, k));
+            Entity solvedM = 0;
+            for (var j = 0; j <= degreeM; j++)
+                if (values[degreeN + 1 + j] != Number.Integer.Zero)
+                    solvedM += values[degreeN + 1 + j] * (j == 0 ? Number.Integer.One : j == 1 ? x : MathS.Pow(x, j));
+            solvedN = Functions.PartialFractions.Bare(solvedN);
+            solvedM = Functions.PartialFractions.Bare(solvedM);
+
+            Entity exponential = h is null ? Number.Integer.One : MathS.Pow(MathS.e, h);
+            var rationalPart = exponential * solvedN / d;
+            var integrand = exponential * above / below;
+            if (squarefree is null)
+            {
+                if (!Functions.PartialFractions.HoldsAtSampledPoints(rationalPart.Differentiate(x), integrand, x))
+                    return null;
+                return rationalPart.InnerSimplified;
+            }
+
+            var logarithmicPart = solvedM / squarefree;
+            if (!Functions.PartialFractions.HoldsAtSampledPoints(rationalPart.Differentiate(x) + logarithmicPart, integrand, x))
+                return null;
+            if (solvedM == Number.Integer.Zero || solvedM.Evaled is Number.Complex { IsZero: true })
+                return rationalPart.InnerSimplified;
+            // The logarithmic part is a proper rational function over a squarefree denominator,
+            // and the splits are what answer that; handing it to the whole integrator instead
+            // sent one of them through every substitution and by-parts attempt there is, thirty
+            // seconds to decline what the splits decline in a few milliseconds.
+            return SolveByPartialFractions(logarithmicPart.InnerSimplified, x, integrateByParts: false) is { } rest
+                ? (rationalPart + rest).InnerSimplified
+                : null;
+        }
+
+        /// <summary>
+        /// The largest degree, of the numerator, the denominator or the ansatz polynomial, that
+        /// <see cref="SolveByExponentialAnsatz"/> takes on. The system is square in the degree,
+        /// and past this the elimination is longer than any answer.
+        /// </summary>
+        private const int MaximumAnsatzDegree = 12;
+
+        /// <summary>
         /// A product of sines and cosines of <b>different</b> arguments, rewritten as a sum by the
         /// product-to-sum identities and then integrated term by term.
         /// </summary>
@@ -3169,7 +3494,7 @@ namespace AngouriMath.Functions.Algebra
                 return null;
 
             return Integration.ComputeIndefiniteIntegral(
-                numerator * MathS.Pow(@base, -power), x, integrateByParts);
+                numerator * MathS.Pow(@base, (-power).InnerSimplified), x, integrateByParts);
         }
 
         internal static Entity? SolveByExponentialSubstitution(Entity expr, Entity.Variable x, bool integrateByParts)

--- a/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
@@ -152,8 +152,18 @@ namespace AngouriMath.Functions.Algebra
         /// which matters, because the library opens and closes thousands of balanced scopes while
         /// simplifying and a change count is therefore never still.
         /// </para>
+        /// <para>
+        /// <b>A decline is held with the scope it was made in.</b> Five rules answer only the
+        /// question asked (<see cref="AnsweringTheQuestionAsked"/>) and decline the same
+        /// integrand one level down, so a <see langword="null"/> computed at depth two says
+        /// nothing about depth one — and once held without the scope it was served to the
+        /// top-level ask: <c>sec(x)^3</c>, tried and declined inside another rule's search, then
+        /// asked for directly and declined from the cache in two milliseconds. The key carries
+        /// the scope, and a lookup takes a decline only from its own scope and an answer from
+        /// either, since an antiderivative that was found is right wherever it is asked for.
+        /// </para>
         /// </remarks>
-        [System.ThreadStatic] private static Dictionary<(Entity, Entity.Variable, bool), Entity?>? answered;
+        [System.ThreadStatic] private static Dictionary<(Entity, Entity.Variable, bool, bool), Entity?>? answered;
 
         /// <summary>The settings <see cref="answered"/> was filled under.</summary>
         [System.ThreadStatic] private static object?[]? answeredUnder;
@@ -329,9 +339,12 @@ namespace AngouriMath.Functions.Algebra
             var into = answered;
             var stamp = answeredUnder;
 
-            var key = (expr, x, integrateByParts);
+            var key = (expr, x, integrateByParts, AnsweringTheQuestionAsked);
             if (into.TryGetValue(key, out var already))
                 return already;
+            var otherScope = (expr, x, integrateByParts, !AnsweringTheQuestionAsked);
+            if (into.TryGetValue(otherScope, out var elsewhere) && elsewhere is not null)
+                return elsewhere;
 
             var computed = ComputeIndefiniteIntegralUncached(expr, x, integrateByParts);
 
@@ -478,6 +491,11 @@ namespace AngouriMath.Functions.Algebra
             // before it, since a quotient that is rational in e^(k x) is that rule's to answer
             // whole and comes out in better shape for it.
             if ((answer = IndefiniteIntegralSolver.SolveByDividingByAnExponential(expr, x, integrateByParts)) is { }) return answer;
+            // An exponential of something rational times something rational, as the derivative
+            // of `e^h N/D`: Liouville says that is the only elementary shape it can have, and
+            // an ansatz finds it or nothing does. After the substitutions, which answer the
+            // linear-exponent cases in their own terms.
+            if ((answer = IndefiniteIntegralSolver.SolveByExponentialAnsatz(expr, x)) is { }) return answer;
             // Last of the rewrites, because it is the only one that fires on an integrand nothing
             // is wrong with -- it clears a parameter rather than a shape -- so everything that
             // can answer the problem as written gets to try first.

--- a/Sources/Tests/UnitTests/Calculus/BinomialDenominatorIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/BinomialDenominatorIntegralTest.cs
@@ -129,14 +129,23 @@ namespace AngouriMath.Tests.Calculus
 
         /// <summary>
         /// What is not this shape and must stay declined by it rather than mis-answered: a
-        /// trinomial, a repeated binomial, a degree below three, and an improper fraction —
-        /// the last of which the division in front takes, so it is answered and not by this.
+        /// trinomial with no rational root, which no rule reads and
+        /// <a href="https://github.com/asc-community/AngouriMath/issues/1285">#1285</a> is about.
         /// </summary>
         [Theory]
         [InlineData("1/(x^3 + x + 1)")]
-        [InlineData("1/(x^3 + 2)^2")]
         public void OutsideTheShapeNothingIsClaimed(string integrand)
             => Assert.Contains("integral(", integrand.ToEntity().Integrate("x").Stringize());
+
+        /// <summary>
+        /// A repeated binomial is the Hermite reduction's first, and what that leaves over the
+        /// binomial itself is this rule's: <c>1/(x^3 + 2)^2</c> is <c>x/(6(x^3 + 2))</c> plus a
+        /// third of <c>int 1/(x^3 + 2)</c>.
+        /// </summary>
+        [Theory]
+        [InlineData("1/(x^3 + 2)^2")]
+        [InlineData("x/(x^5 + 1)^2")]
+        public void ARepeatedBinomialIsHermitesThenThis(string integrand) => DifferentiatesBack(integrand);
 
         [Theory]
         [InlineData("x^4/(x^3 + 2)")]

--- a/Sources/Tests/UnitTests/Calculus/ExponentialAnsatzTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ExponentialAnsatzTest.cs
@@ -1,0 +1,133 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// <c>e^h R</c>, with <c>h</c> and <c>R</c> rational in the variable, integrated by the
+    /// ansatz <c>F = e^h N/D</c>; and with no exponential, the Hermite reduction
+    /// <c>R = (N/D)' + M/D_1</c> for a denominator with a repeated factor.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Liouville's theorem says the elementary antiderivative of <c>e^h R</c>, where there is
+    /// one, is <c>e^h</c> times a rational function; so an ansatz of that shape, solved as a
+    /// linear system in the coefficients of <c>N</c>, finds the antiderivative or shows there
+    /// is none of that shape. <c>e^x x/(1 + x)^2</c>, <c>e^(x^2)(1 + 2x^2)</c> and
+    /// <c>(4x^5 - 1)/(1 + x + x^5)^2</c> had no antiderivative; each is the derivative of
+    /// something of its own shape.
+    /// </para>
+    /// <para>
+    /// Every answer is differentiated back and compared to the integrand numerically; the
+    /// non-elementary neighbours — <c>e^x/x</c>, <c>e^(x^2)</c> — are pinned as declined, since
+    /// answering them would be a wrong answer and not a missing one.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class ExponentialAnsatzTest
+    {
+        private static readonly double[] Points = { 0.3, 0.9, 1.7, 2.6 };
+
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+            Assert.DoesNotContain("NaN", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 3,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}");
+        }
+
+        /// <summary>
+        /// An exponential of the variable, of its square, of its reciprocal and of a rational
+        /// function, each times a rational function: Moses's, Hearn's and Hebisch's from the
+        /// Rubi suite. The sum is Moses's too, and is read whole.
+        /// </summary>
+        [Theory]
+        [InlineData("e^x*x/(1 + x)^2")]
+        [InlineData("e^x*(x^2 + 1)/(x + 1)^2")]
+        [InlineData("e^(x^2)*(1 + 2*x^2)")]
+        [InlineData("e^(x^2) + 2*e^(x^2)*x^2")]
+        [InlineData("e^(1/x)*(1 + x)/x^4")]
+        [InlineData("(1 - 3*x - x^2 + x^3)*e^(1/(x^2 - 1))/(1 - x - x^2 + x^3)")]
+        [InlineData("e^(-x)/(1 - x)^2 - e^(-x)/(1 - x)")]
+        public void AnExponentialTimesARationalFunction(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// The exact forms, so that the ansatz is seen to find the short answer and not a
+        /// longer equivalent.
+        /// </summary>
+        [Theory]
+        [InlineData("e^x*x/(1 + x)^2", "e ^ x / (1 + x) + C")]
+        [InlineData("(-1 + 4*x^5)/(1 + x + x^5)^2", "-x / (1 + x + x ^ 5) + C")]
+        public void TheAnswerIsTheShortOne(string integrand, string expected)
+            => Assert.Equal(expected, integrand.ToEntity().Integrate("x").Stringize());
+
+        /// <summary>
+        /// No exponential: the Hermite reduction for a repeated factor, whose logarithmic part
+        /// is then the splits' to answer. Apostol's, Stewart's and two of Timofeev's; the last
+        /// took seventeen seconds of peeling and re-factoring to reach the same answer before.
+        /// </summary>
+        [Theory]
+        [InlineData("(-1 + 4*x^5)/(1 + x + x^5)^2")]
+        [InlineData("(1 + x^2 + x^4)/((1 + x^2)*(4 + x^2)^2)")]
+        [InlineData("x^5/(1 + x^4)^3")]
+        [InlineData("(1 + x^2)/(x*(1 + x^3)^2)")]
+        [InlineData("1/((x + 1)^3*(x + 2)^4)")]
+        public void TheHermiteReduction(string integrand) => DifferentiatesBack(integrand);
+
+        [Fact]
+        public void TheHermiteReductionIsQuick()
+        {
+            var watch = System.Diagnostics.Stopwatch.StartNew();
+            DifferentiatesBack("(1 + x^2)/(x*(1 + x^3)^2)");
+            Assert.True(watch.Elapsed < TimeSpan.FromSeconds(10), $"took {watch.Elapsed}");
+        }
+
+        /// <summary>
+        /// What has no elementary antiderivative is declined, not answered: the ansatz finds
+        /// no <c>N</c>, which by Liouville is the proof.
+        /// </summary>
+        [Theory]
+        [InlineData("e^x/x")]
+        [InlineData("e^(x^2)")]
+        [InlineData("e^x/(1 + x)")]
+        [InlineData("e^(1/x)")]
+        public void ANonElementaryOneIsDeclined(string integrand)
+            => Assert.Contains("integral(", integrand.ToEntity().Integrate("x").Stringize());
+
+        /// <summary>
+        /// What by parts answered before keeps its form: a polynomial times an exponential is
+        /// still integrated by parts, since the ansatz runs after it.
+        /// </summary>
+        [Fact]
+        public void APolynomialTimesAnExponentialKeepsItsForm()
+            => Assert.Equal("x * e ^ x + -e ^ x + C", "x*e^x".ToEntity().Integrate("x").Stringize());
+    }
+}

--- a/Sources/Tests/UnitTests/Calculus/ScopedDeclineIsNotCachedTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ScopedDeclineIsNotCachedTest.cs
@@ -1,0 +1,48 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// A decline made one level down, by a rule that answers only the question asked, must not
+    /// be served from the cache to the question when it is asked.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Five rules are scoped to the top-level integrand
+    /// (<see href="https://github.com/asc-community/AngouriMath/issues/1265"/>) and decline the
+    /// same integrand inside another rule's search. The integrator's cache held that
+    /// <see langword="null"/> without the scope it was made in, so <c>cos(x)^(-3)</c> — tried
+    /// inside the search for <c>1/cos(x)^3</c> and declined there by the scoped secant
+    /// reduction — was then declined from the cache in two milliseconds when asked for
+    /// directly. It went unseen because integration by parts used to answer it at depth two
+    /// regardless; when that path was narrowed the cache's mistake surfaced.
+    /// </para>
+    /// <para>
+    /// The two integrals are asked in that order in one test, on one thread, so the cache is
+    /// exercised exactly as it was.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class ScopedDeclineIsNotCachedTest
+    {
+        [Fact]
+        public void AnIntegrandDeclinedInsideAnotherSearchIsStillAnsweredWhenAsked()
+        {
+            // The first search tries cos(x)^(-3) one level down, where the reduction declines it.
+            var viaQuotient = "1/cos(x)^3".ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", viaQuotient.Stringize());
+
+            var asked = "cos(x)^(-3)".ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", asked.Stringize());
+        }
+    }
+}


### PR DESCRIPTION
`e^x x/(1 + x)^2` is `(e^x/(1 + x))'`. `e^(x^2)(1 + 2x^2)` is `(x e^(x^2))'`.
`(4x^5 - 1)/(1 + x + x^5)^2` is `(-x/(1 + x + x^5))'`. None had an antiderivative:
the first two are not a polynomial times an exponential, which is the shape by parts
reads, and the third has a denominator nothing factors.

## The ansatz

Liouville's theorem says the elementary antiderivative of `e^h R`, with `h` and `R`
rational, is `e^h` times a rational function where it exists at all. So the rule
writes `F = e^h N/D`, with `D` read off the denominator of `R` -- every written power
lowered by one, then the denominator itself, and every level of a single written
power, since with an exponential in front the antiderivative's denominator need not
be one below the integrand's (`e^(1/x)(1 + x)/x^4` has `x^2` under it) -- and `N` a
polynomial of unknown coefficients. `F' = e^h R` is then a polynomial identity linear
in those coefficients, solved by the elimination the symbolic partial-fraction split
uses and **checked at sampled points with every symbol pinned before anything is
returned**. An ansatz that finds no `N` has, by Liouville, shown there is no
elementary antiderivative of that shape: `e^x/x`, `e^(x^2)` and `e^x/(1 + x)` are
declined in a millisecond each, and a test pins that they stay declined.

A sum whose terms share one exponential is read whole: `e^(x^2) + 2x^2 e^(x^2)` is
`(x e^(x^2))'`, and neither term is elementary on its own, so splitting it first --
which linearity does -- loses it.

The identity is built **one column at a time** as a numeric polynomial rather than
once with the unknowns in it. With fourteen unknowns over a degree-eleven denominator
the single symbolic expansion did not return; the fourteen numeric ones take a moment.

## The Hermite reduction, and first

With no exponential the same ansatz is the rational part of the Hermite reduction,
and the full form is taken: `R = (N/D)' + M/D_1`, with `D_1` the product of the
distinct factors and `M` a second unknown polynomial, so that a logarithmic part
beside the rational one does not defeat it. `(1 + x^2 + x^4)/((1 + x^2)(4 + x^2)^2)`
has both. What is left, `M/D_1`, is a proper fraction over a squarefree denominator,
and it is handed to the splits and not to the whole integrator: handing it to the
whole integrator sent one such remainder through every substitution and by-parts
attempt there is, thirty seconds to decline what the splits decline in milliseconds.

A denominator with a written repeated factor takes this **first**, ahead of the
coprime split and the root peeling. `(1 + x^2)/(x (1 + x^3)^2)` reached the same
answer through those after seventeen seconds of peeling and re-factoring; this way
it is under a tenth of one. `x^7`, `(x^3 + 2)^2` and `(1 + x^4)^3` are the same story.

## Integration by parts with neither factor worth differentiating

The classic "neither is a polynomial, try both orderings" case of by parts ran on any
product. Once the Hermite reduction answered `∫u` for a small rational piece of a
radical trigonometric integrand, by parts carried on with `v' ∫u`, three hundred
nodes of mixed arguments against forty, and every substitution below was tried on it:
thirty seconds to decline where it had taken a tenth of one. The case now runs only
with a factor worth differentiating -- a logarithm or an inverse function, whose
derivative is algebraic, or an exponential, whose integral is itself and which the
cyclic cases need. Measured on the Rubi sample with the restriction and without: the
same answers, eight seconds less.

## The cache

That restriction surfaced a defect that by parts had been hiding. Five rules answer
only the question asked (#1265) and decline the same integrand one level down, and
the integrator's cache held such a `null` without the scope it was made in.
`cos(x)^(-3)`, tried inside the search for `1/cos(x)^3` and declined there by the
scoped secant reduction, was then declined *from the cache* in two milliseconds when
asked for directly -- unseen until now because by parts used to answer it at depth
two regardless. The key carries the scope; a lookup takes a decline only from its own
scope and an answer from either, since an antiderivative that was found is right
wherever it is asked for. A test asks the two integrals in that order.

## Measured

Every answer differentiated back, with parameters pinned.

Rubi corpus, 463-problem sample, against the master it was cut from (#1286), both
timed on the same evening:

    master      300/463, 0 wrong, 0 timeouts, 102 s
    with this   312/463, 0 wrong, 0 timeouts,  76 s

Twelve more and nothing lost: `e^x x/(1 + x)^2`, `e^(x^2)(1 + 2x^2)` twice and once as
a sum (Moses), `e^(1/x)(1 + x)/x^4` (Hearn), Hebisch's `e^(1/(x^2 - 1))` times a
rational function, `(4x^5 - 1)/(1 + x + x^5)^2` (Apostol), Stewart's
`(1 + x^2 + x^4)/((1 + x^2)(4 + x^2)^2)`, Timofeev's `x^5/(1 + x^4)^3` and
`(1 + x^2)/(x (1 + x^3)^2)`, and two the reduction reached on its own:
`ln(x)/(1 + ln(x))^2` and `(3x - 1)^(4/3)/x^2`. The sum of per-problem time over the
sample is 100 s to 75 s.

Two pinned declines moved as their tests said they would:
`BinomialDenominatorIntegralTest` had `1/(x^3 + 2)^2` as outside the binomial rule's
shape, and it is the reduction's first and then the rule's;
`ExpandedPowerIntegralTest` had `(a - b x^2)^3/x^7` as unreached, and `x^7` is a power
of a linear.

The five test suites are green.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
