### PR TITLE
Chebyshev's other two cases for a binomial differential, a term of a top-level sum asked at the top, and a bare inverse function by parts

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -396,3 +396,9 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 
 [Tests/UnitTests/Calculus/ScopedDeclineIsNotCachedTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/ATermOfATopLevelSumIsAskedAtTheTopTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
+[Tests/UnitTests/Calculus/ABareInverseFunctionByPartsTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -18,7 +18,7 @@ namespace AngouriMath.Functions.Algebra
         {
             var splitted = TreeAnalyzer.GatherLinearChildrenOverSumAndExpand(expr, e => e.ContainsNode(x));
             if (splitted is null || splitted.Count < 2) return null; // nothing to do, let other solvers do the work
-            return splitted.Select(e => Integration.ComputeIndefiniteIntegral(e, x, integrateByParts)).Aggregate((e1, e2) => (e1, e2) switch {
+            return splitted.Select(e => Integration.ComputeAsAQuestionOfItsOwn(e, x, integrateByParts)).Aggregate((e1, e2) => (e1, e2) switch {
                 (null, _) or (_, null) => null,
                 (var int1, var int2) => int1 + int2
             });
@@ -761,6 +761,20 @@ namespace AngouriMath.Functions.Algebra
                 && TrySplit(differentiated, others) is { } byLiate)
                 return byLiate;
 
+            // **A bare logarithm or inverse function of something that is not linear**, by
+            // parts against 1: `int f(g) dx = x f(g) - int x g' f'(g) dx`, and the remainder is
+            // algebraic. A linear argument is the table's; anything else reached no rule at all,
+            // since this one runs on a product and the integrand is a single node.
+            // `arctan(x sqrt(1 - x^2))` had no antiderivative and is one step of this.
+            // Asked, not volunteered, like the regrouping above: the remainder can be a radical
+            // the search spends seconds on, and a rule that produced this shape on its way
+            // somewhere is not owed that search.
+            if (Integration.AnsweringTheQuestionAsked && IsDifferentiatedBeforeAPolynomial(expr)
+                && expr is not Powf
+                && !(expr.DirectChildren.LastOrDefault() is { } argument && TreeAnalyzer.TryGetPolyLinear(argument, x, out _, out _))
+                && TryIntegrateByPartsOnce(expr, Integer.One, x, wholeSize, wholePower) is { } againstOne)
+                return againstOne;
+
             // Special case for powers of integrable functions, try integration by parts on base × base
             // e.g., ln(abs(x))^2 = ln(abs(x)) × ln(abs(x))
             if (expr is Powf(var @base, Integer(2)) && TryIntegrateByPartsOnce(@base, @base, x, wholeSize, wholePower) is { } result) return result;
@@ -1329,8 +1343,9 @@ namespace AngouriMath.Functions.Algebra
         }
 
         /// <summary>
-        /// A <b>binomial differential</b> <c>x^m (a + b x^n)^(p/q)</c>, in the case Chebyshev's
-        /// criterion makes a polynomial: where <c>(m + 1)/n</c> is a whole number of at least one.
+        /// A <b>binomial differential</b> <c>x^m (a + b x^n)^(p/q)</c>, in the two of Chebyshev's
+        /// three cases that are not a whole power: <c>(m + 1)/n</c> whole, or
+        /// <c>(m + 1)/n + p/q</c> whole.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -1348,18 +1363,22 @@ namespace AngouriMath.Functions.Algebra
         ///     int x^m (a + b x^n)^(p/q) dx = (q/(n b)) int ((u^q - a)/b)^(s-1) u^(p+q-1) du
         /// </code>
         /// <para>
-        /// which is a polynomial in <c>u</c> exactly when <c>s</c> is a whole number of at least
-        /// one — the first of Chebyshev's three cases. Expanded by the binomial theorem and
-        /// integrated term by term, so the rule is <b>closed</b> and asks the integrator nothing.
+        /// which is a polynomial in <c>u</c> when <c>s</c> is a whole number of at least one,
+        /// expanded by the binomial theorem and integrated term by term; and a <b>rational
+        /// function</b> of <c>u</c> when <c>s</c> is a whole number of at most zero, which the
+        /// rational integrator answers — <c>sqrt(1 + x^3)/x</c> is <c>(2/3) int u^2/(u^2 - 1) du</c>,
+        /// and <c>1/(x sqrt(1 - x^3))</c> is <c>(2/3) int 1/(u^2 - 1) du</c>. Both were declined
+        /// for <c>s = 0</c>, which the rule read as "not a polynomial" and left at that.
         /// </para>
         /// <para>
-        /// <b>The other two cases are not here.</b> <c>p/q</c> whole is a whole power of a
-        /// polynomial, which expanding already answers; and <c>s + p/q</c> whole wants
-        /// <c>u = ((a + b x^n)/x^n)^(1/q)</c>, which leaves a polynomial over a power of
-        /// <c>u^q - b</c> — a rational function rather than a polynomial, so a search rather than
-        /// a closed answer. Chebyshev also proved there is no fourth case: outside those three the
-        /// integrand has no elementary antiderivative at all, which is worth knowing before
-        /// anyone goes looking.
+        /// <b>The third case comes down to the second.</b> Where <c>s + p/q</c> is whole instead,
+        /// <c>x = 1/y</c> turns <c>x^m (a + b x^n)^(p/q) dx</c> into
+        /// <c>-y^m' (b + a y^n)^(p/q) dy</c> with <c>m' = -m - 2 - n p/q</c>, a whole number, and
+        /// <c>(m' + 1)/n = -(s + p/q)</c>, whole — so it is the second case in <c>y</c>, with the
+        /// roles of <c>a</c> and <c>b</c> exchanged, and <c>y = 1/x</c> put back afterwards.
+        /// <c>x^6 (3 + 4x^4)^(1/4)</c> and <c>(x^3 - 1)/(2 + x^3)^(1/3)</c> are this. Chebyshev
+        /// proved there is no fourth case: outside these the integrand has no elementary
+        /// antiderivative at all, which is worth knowing before anyone goes looking.
         /// </para>
         /// <para>
         /// <b>Asked, not volunteered</b>:
@@ -1375,22 +1394,63 @@ namespace AngouriMath.Functions.Algebra
                     out var inner, out var free, out var leading, out var factor))
                 return null;
 
-            // s = (m + 1)/n, whole and at least one, which is what makes the expansion finite.
+            // The second case: s = (m + 1)/n whole.
+            if ((power + 1) % inner == 0)
+                return IntegrateABinomialDifferentialInTheSecondCase(
+                    power, inner, exponent, free, leading, x, factor);
+
+            // The third: s + p/q whole, taken to the second by x = 1/y.
+            var sPlusP = ERational.Create(power + 1, inner).Add(exponent);
+            if (!sPlusP.IsInteger())
+                return null;
+            var nTimesP = exponent.Multiply(EInteger.FromInt32(inner));
+            if (!nTimesP.IsInteger() || !nTimesP.Numerator.CanFitInInt32())
+                return null;
+            var reflectedPower = -power - 2 - nTimesP.ToLowestTerms().Numerator.ToInt32Unchecked();
+            var y = Variable.CreateUnique(expr, "y_binom");
+            if (IntegrateABinomialDifferentialInTheSecondCase(
+                    reflectedPower, inner, exponent, leading, free, y, Number.Integer.MinusOne) is not { } inY)
+                return null;
+            return (factor * inY.Substitute(y, 1 / x)).InnerSimplified;
+        }
+
+        /// <summary>
+        /// <c>int factor * v^m (a + b v^n)^(p/q) dv</c> with <c>(m + 1)/n</c> whole: a polynomial
+        /// in <c>u = (a + b v^n)^(1/q)</c> expanded term by term for <c>s >= 1</c>, and a rational
+        /// function of <c>u</c> handed to the rational integrator for <c>s &lt;= 0</c>.
+        /// </summary>
+        private static Entity? IntegrateABinomialDifferentialInTheSecondCase(
+            int power, int inner, ERational exponent, ERational free, ERational leading,
+            Entity.Variable v, Entity factor)
+        {
             if ((power + 1) % inner != 0)
                 return null;
             var s = (power + 1) / inner;
-            if (s < 1)
-                return null;
-
             var q = exponent.Denominator.ToInt32Checked();
             var p = exponent.Numerator.ToInt32Checked();
             var a = Number.Rational.Create(free);
             var b = Number.Rational.Create(leading);
+            var u = Variable.CreateUnique(v + factor, "u_binom");
+            var outside = Number.Integer.Create(q)
+                        / (Number.Integer.Create(inner) * MathS.Pow(b, Number.Integer.Create(s)));
+            var bracket = (a + b * MathS.Pow(v, Number.Integer.Create(inner))).InnerSimplified;
+            var back = MathS.Pow(bracket, Number.Rational.Create(EInteger.One, exponent.Denominator));
+
+            if (s < 1)
+            {
+                // (q/(n b^s)) int u^(p+q-1) / (u^q - a)^(1-s) du: a rational function of u.
+                var overPower = 1 - s;
+                Entity denominator = overPower == 1 ? MathS.Pow(u, q) - a : MathS.Pow(MathS.Pow(u, q) - a, overPower);
+                Entity numerator = p + q - 1 == 0 ? Number.Integer.One : MathS.Pow(u, p + q - 1);
+                var rational = (numerator / denominator).InnerSimplified;
+                if (Integration.ComputeIndefiniteIntegral(rational, u, integrateByParts: false) is not { } inU)
+                    return null;
+                return (factor * outside * inU.Substitute(u, back)).InnerSimplified;
+            }
 
             // (q/(n b^s)) * int (u^q - a)^(s-1) u^(p+q-1) du, the binomial expanded.
             Entity total = 0;
             var binomial = EInteger.One;
-            var u = Variable.CreateUnique(expr, "u_binom");
             for (var i = 0; i <= s - 1; i++)
             {
                 // Term i of (u^q - a)^(s-1) is C(s-1, i) u^(q i) (-a)^(s-1-i).
@@ -1402,11 +1462,6 @@ namespace AngouriMath.Functions.Algebra
                        * MathS.Pow(u, Number.Integer.Create(raised)) / Number.Integer.Create(raised);
                 binomial = binomial * (s - 1 - i) / (i + 1);
             }
-
-            var outside = Number.Integer.Create(q)
-                        / (Number.Integer.Create(inner) * MathS.Pow(b, Number.Integer.Create(s)));
-            var bracket = (a + b * MathS.Pow(x, Number.Integer.Create(inner))).InnerSimplified;
-            var back = MathS.Pow(bracket, Number.Rational.Create(EInteger.One, exponent.Denominator));
             return (factor * outside * total.Substitute(u, back)).InnerSimplified;
         }
 

--- a/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/Integration.Definition.cs
@@ -250,6 +250,35 @@ namespace AngouriMath.Functions.Algebra
         internal static bool AnsweringTheQuestionAsked => descentDepth == 1;
 
         /// <summary>
+        /// <paramref name="expr"/> integrated as a question in its own right rather than as a
+        /// step in the search for the current one: the term of a sum asked at the top is asked at
+        /// the top.
+        /// </summary>
+        /// <remarks>
+        /// Linearity splits the integrand before anything else, and every term it produced was
+        /// one level down — where the five scoped rules decline. So <c>(x^3 - 1)/(2 + x^3)^(1/3)</c>
+        /// was declined although each of its two terms is a binomial differential the rule
+        /// answers when asked directly. A term of a top-level sum is strictly smaller than the
+        /// sum and is not a continuation of any rule's search, which is what the scope exists to
+        /// stop; taken at the top it costs nothing the scope was measured to save. Only from the
+        /// top: one level down the terms stay one level down, as before.
+        /// </remarks>
+        internal static Entity? ComputeAsAQuestionOfItsOwn(Entity expr, Entity.Variable x, bool integrateByParts)
+        {
+            if (!AnsweringTheQuestionAsked)
+                return ComputeIndefiniteIntegral(expr, x, integrateByParts);
+            descentDepth--;
+            try
+            {
+                return ComputeIndefiniteIntegral(expr, x, integrateByParts);
+            }
+            finally
+            {
+                descentDepth++;
+            }
+        }
+
+        /// <summary>
         /// Whether anything in the current top-level call gave up on <see cref="DeepestDescent"/>
         /// rather than on the mathematics. A <c>null</c> produced that way must not be cached as
         /// "this cannot be integrated", because the same key may well be answerable when it is

--- a/Sources/Tests/UnitTests/Calculus/ABareInverseFunctionByPartsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ABareInverseFunctionByPartsTest.cs
@@ -1,0 +1,86 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// A bare logarithm or inverse function of something that is not linear, by parts against
+    /// <c>1</c>: <c>int f(g) dx = x f(g) - int x g' f'(g) dx</c>.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// The by-parts rule runs on a product, and a single node is not one; a linear argument is
+    /// the table's, and anything else reached no rule at all. <c>arctan(x sqrt(1 - x^2))</c>
+    /// had no antiderivative and is one step of this. The remainder is algebraic and is
+    /// answered where the radical rules reach it — three of Charlwood's and Bondarenko's do,
+    /// and the rest of that family, whose remainders want an Euler substitution, decline in
+    /// about a second and are pinned below as declined or correct.
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class ABareInverseFunctionByPartsTest
+    {
+        private static readonly double[] Points = { 0.2, 0.45, 0.7, 0.9 };
+
+        private static void DifferentiatesBack(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+            Assert.DoesNotContain("NaN", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in Points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 3,
+                $"only {compared} of {Points.Length} points were comparable for {integrand}");
+        }
+
+        [Theory]
+        [InlineData("atan(x*sqrt(1 - x^2))")]
+        [InlineData("atan(x*sqrt(1 + x^2))")]
+        [InlineData("ln(1/x^4 + x^4)")]
+        [InlineData("ln(1 + x^2)")]
+        public void AnInverseFunctionOfANonLinearArgument(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// The rest of Charlwood's family, whose remainders the radical rules do not reach, and
+        /// <c>arcsin(x^2)</c>, whose remainder <c>2x^2/sqrt(1 - x^4)</c> is elliptic: declined or
+        /// answered, never wrong, and not slowly.
+        /// </summary>
+        [Theory]
+        [InlineData("asin(x^2)")]
+        [InlineData("atan(x + sqrt(1 - x^2))")]
+        [InlineData("ln(1 + x*sqrt(1 + x^2))")]
+        [InlineData("asin(x/sqrt(1 - x^2))")]
+        [InlineData("asin(sqrt(1 + x) - sqrt(x))")]
+        public void TheRemainderMayBeOutOfReach(string integrand)
+        {
+            var watch = System.Diagnostics.Stopwatch.StartNew();
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.True(watch.Elapsed < TimeSpan.FromSeconds(20), $"took {watch.Elapsed}");
+            if (!integral.Stringize().Contains("integral("))
+                DifferentiatesBack(integrand);
+        }
+    }
+}

--- a/Sources/Tests/UnitTests/Calculus/ATermOfATopLevelSumIsAskedAtTheTopTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ATermOfATopLevelSumIsAskedAtTheTopTest.cs
@@ -1,0 +1,49 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// A term of a sum asked at the top is asked at the top: the rules scoped to the question
+    /// asked answer it, where one level down they decline.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/1265">#1265</a>
+    /// </summary>
+    /// <remarks>
+    /// Linearity splits the integrand before anything else, and every term it produced sat one
+    /// level down, where the five scoped rules decline. So <c>(x^3 - 1)/(2 + x^3)^(1/3)</c> was
+    /// declined although each of its two terms is a binomial differential the rule answers when
+    /// asked directly, and <c>sec(x)^3 + x</c> although the secant reduction answers the first
+    /// term. A term of a top-level sum is not a continuation of any rule's search, which is what
+    /// the scope was measured to stop.
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class ATermOfATopLevelSumIsAskedAtTheTopTest
+    {
+        [Theory]
+        [InlineData("(x^3 - 1)/(2 + x^3)^(1/3)")]
+        [InlineData("sec(x)^3 + x")]
+        [InlineData("x^5*sqrt(1 + x^3) + sec(x)^3")]
+        public void TheTermsAreAnsweredByTheScopedRules(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+        }
+
+        /// <summary>
+        /// Each term alone is answered, which is what makes the sum's decline a defect of the
+        /// split and not of the rules.
+        /// </summary>
+        [Theory]
+        [InlineData("x^3/(2 + x^3)^(1/3)")]
+        [InlineData("sec(x)^3")]
+        public void EachTermAloneIsAnswered(string integrand)
+            => Assert.DoesNotContain("integral(", integrand.ToEntity().Integrate("x").Stringize());
+    }
+}

--- a/Sources/Tests/UnitTests/Calculus/BinomialDifferentialTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/BinomialDifferentialTest.cs
@@ -12,8 +12,9 @@ using Xunit;
 namespace AngouriMath.Tests.Calculus
 {
     /// <summary>
-    /// The binomial differential <c>x^m (a + b x^n)^(p/q)</c>, in the case Chebyshev's criterion
-    /// makes a polynomial.
+    /// The binomial differential <c>x^m (a + b x^n)^(p/q)</c>, in the two of Chebyshev's three
+    /// cases that are not a whole power: where the substitution leaves a polynomial or a
+    /// rational function of <c>u</c>, and the third case taken to those through <c>x = 1/y</c>.
     /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
     /// </summary>
     /// <remarks>
@@ -101,16 +102,43 @@ namespace AngouriMath.Tests.Calculus
         public void AFactorAndACoefficient(string integrand) => DifferentiatesBack(integrand);
 
         /// <summary>
-        /// Outside Chebyshev's first case. <c>s</c> not whole is either his second or third case
-        /// or — and this is the part worth knowing before anyone goes looking — no elementary
-        /// antiderivative at all, which he proved. These must be declined or answered by another
-        /// rule, never wrong.
+        /// <c>s = (m + 1)/n</c> whole and at most zero, where the substitution leaves a rational
+        /// function of <c>u</c> rather than a polynomial: <c>sqrt(1 + x^3)/x</c> is
+        /// <c>(2/3) int u^2/(u^2 - 1) du</c>. Charlwood's, Bronstein's and four of Welz's.
+        /// </summary>
+        [Theory]
+        [InlineData("sqrt(1 + x^3)/x")]
+        [InlineData("1/(x*sqrt(1 - x^3))")]
+        [InlineData("sqrt(1 + x^4)/(x*(1 + x^4))")]
+        [InlineData("(1 - x^3)^(1/3)/x")]
+        [InlineData("(1 - x^3)^(2/3)/x")]
+        [InlineData("1/(x*(1 - x^2)^(1/3))")]
+        [InlineData("1/(x*(1 + x^3)^(1/3))")]
+        [InlineData("sqrt(1 + x^2)/x^3")]
+        public void WhereTheSubstitutionLeavesARationalFunction(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// Chebyshev's third case, <c>s + p/q</c> whole, taken to the second by <c>x = 1/y</c>:
+        /// <c>x^6 (3 + 4x^4)^(1/4)</c> and <c>(x^3 - 1)/(2 + x^3)^(1/3)</c> are Timofeev's, and the
+        /// second is a sum whose terms are each this shape.
+        /// </summary>
+        [Theory]
+        [InlineData("x^6*(3 + 4*x^4)^(1/4)")]
+        [InlineData("x^3/(2 + x^3)^(1/3)")]
+        [InlineData("1/(2 + x^3)^(1/3)")]
+        [InlineData("(x^3 - 1)/(2 + x^3)^(1/3)")]
+        [InlineData("x^2*(1 + x^2)^(-3/2)")]
+        public void TheThirdCaseThroughTheReciprocal(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// Outside all three of Chebyshev's cases there is — and this is the part worth knowing
+        /// before anyone goes looking — no elementary antiderivative at all, which he proved.
+        /// These must be declined or answered by another rule, never wrong.
         /// </summary>
         [Theory]
         [InlineData("sqrt(1 + x^3)")]
         [InlineData("x*sqrt(1 + x^3)")]
         [InlineData("x^3*sqrt(1 + x^3)")]
-        [InlineData("1/(x*(1 + x^3)^(1/3))")]
         public void OutsideTheFirstCase(string integrand)
         {
             var integral = integrand.ToEntity().Integrate("x");


### PR DESCRIPTION
`sqrt(1 + x^3)/x` had no antiderivative. `x^2 sqrt(1 + x^3)` and `x^5 sqrt(1 + x^3)`
did, by the same substitution, and the rule for it (#1275) stopped where Chebyshev's
first case does.

## The second case, with a rational function left over

Under `u = (a + b x^n)^(1/q)`, with `s = (m + 1)/n`:

    int x^m (a + b x^n)^(p/q) dx = (q/(n b^s)) int u^(p+q-1) (u^q - a)^(s-1) du

which is a polynomial in `u` when `s >= 1` -- what the rule expanded -- and a
**rational function** of `u` when `s <= 0`, which it read as "not a polynomial" and
declined. `sqrt(1 + x^3)/x` is `(2/3) int u^2/(u^2 - 1) du`; `1/(x sqrt(1 - x^3))` is
`(2/3) int 1/(u^2 - 1) du`. The rational integrator answers those, and the rule now
hands them to it.

## The third case, through the reciprocal

Where `s + p/q` is whole instead, `x = 1/y` turns `x^m (a + b x^n)^(p/q) dx` into
`-y^m' (b + a y^n)^(p/q) dy` with `m' = -m - 2 - n p/q`, a whole number, and
`(m' + 1)/n = -(s + p/q)`, whole -- the second case in `y`, with `a` and `b`
exchanged, and `y = 1/x` put back afterwards. `x^6 (3 + 4x^4)^(1/4)` is
`-9 int u^4/(u^4 - 4)^3 du` that way, which is the Hermite reduction's (#1287) and
the binomial rule's. Chebyshev proved there is no fourth case, so a binomial
differential outside these two is declined for a reason.

## A term of a top-level sum is asked at the top

`(x^3 - 1)/(2 + x^3)^(1/3)` is two binomial differentials, and was declined although
each term alone is answered. Linearity splits the integrand before anything else,
and every term it produced sat one level down -- where the five rules scoped to the
question asked (#1265, #1280) decline. A term of a top-level sum is strictly smaller
than the sum and is not a continuation of any rule's search, which is what the
scope was measured to stop; it is asked at the top now. Only from the top: one level
down the terms stay one level down, as before. `sec(x)^3 + x` is the same story with
the secant reduction.

## A bare inverse function, by parts against 1

`arctan(x sqrt(1 - x^2))` had no antiderivative. It is one step of parts against `1`
-- `x f(g) - int x g' f'(g) dx`, with an algebraic remainder -- and that step was never
taken: the by-parts rule runs on a product, a single node is not one, and a linear
argument is the table's. The remainder is answered where the radical rules reach it,
which is three of Charlwood's and Bondarenko's `ln(1/x^4 + x^4)`; the rest of that
family wants an Euler substitution the library does not have, and declines in about a
second, which a test pins. Asked, not volunteered, like the regrouping beside it.

## Measured

Every answer differentiated back.

Rubi corpus, 463-problem sample, against #1287's branch it was cut from, both timed
on the same evening:

    #1287       312/463, 0 wrong, 0 timeouts, 76 s
    with this   325/463, 0 wrong, 0 timeouts, 80 s

Thirteen more and nothing lost: `arctan(x sqrt(1 - x^2))`, `arctan(x sqrt(1 + x^2))`
(Charlwood) and `ln(1/x^4 + x^4)` (Bondarenko) by parts against 1; and by the binomial
rule `sqrt(1 + x^3)/x` (Charlwood), `1/(x sqrt(1 - x^3))` and
`sqrt(1 + x^8)/(x (1 + x^8))` (Bronstein), `x^6 (3 + 4x^4)^(1/4)` and
`(x^3 - 1)/(2 + x^3)^(1/3)` (Timofeev), and five of Welz's: `(1 - x^3)^(1/3)/x`,
`(1 - x^3)^(2/3)/x`, `1/(x (1 - x^2)^(1/3))`, `1/(x (1 - x^2)^(2/3))`,
`1/(x (1 - x^3)^(1/3))`. The sum of per-problem time over the sample is 75 s to 79 s,
which is the answers.

`BinomialDifferentialTest.OutsideTheFirstCase` had `1/(x (1 + x^3)^(1/3))` as a case
that may be declined; it is the second case with `s = 0` and moved to the answered
theory, with the three that Chebyshev says have no antiderivative kept where they
were.

The five test suites are green.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
