### PR TITLE
The exponential substitution reads a fractional slope, and takes the sign of its base from the radicals

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -3554,29 +3554,49 @@ namespace AngouriMath.Functions.Algebra
 
         internal static Entity? SolveByExponentialSubstitution(Entity expr, Entity.Variable x, bool integrateByParts)
         {
-            var slopes = new List<EInteger>();
-            var offsets = new Dictionary<Entity, (EInteger Slope, Entity Offset)>();
+            // Rational slopes, so that `e^(x/2)` beside `e^x` is read: the base is `e^(k x)` with
+            // `k` the greatest common divisor of the slopes, and every exponential is a whole
+            // power of it. `e^(x/2)/sqrt(e^x - 1)` is `2/sqrt(u^2 - 1)` that way, and was declined
+            // for the half.
+            var slopes = new List<ERational>();
+            var offsets = new Dictionary<Entity, (ERational Slope, Entity Offset)>();
+            var underARadical = new HashSet<Entity>();
             foreach (var node in expr.Nodes)
             {
+                if (node is Powf(_, Number.Rational fractional) && fractional is not Number.Integer)
+                    foreach (var inside in node.Nodes)
+                        underARadical.Add(inside);
                 if (node is not Powf(var @base, var exponent) || @base != MathS.e)
                     continue;
                 if (!exponent.ContainsNode(x))
                     continue;
                 if (!TreeAnalyzer.TryGetPolyLinear(exponent, x, out var slope, out var offset))
                     return null;   // not linear in x, so not a power of one exponential
-                if (slope.Evaled is not Number.Integer whole || whole.EInteger.IsZero)
+                if (slope.Evaled is not Number.Rational rational || rational.ERational.IsZero)
                     return null;
-                slopes.Add(whole.EInteger);
-                offsets[node] = (whole.EInteger, offset);
+                slopes.Add(rational.ERational);
+                offsets[node] = (rational.ERational, offset);
             }
             if (slopes.Count == 0)
                 return null;
 
-            var k = slopes[0].Abs();
+            var numerators = EInteger.Zero;
+            var denominators = EInteger.One;
             foreach (var slope in slopes)
-                k = k.Gcd(slope.Abs());
-            if (k.IsZero)
+            {
+                numerators = numerators.Gcd(slope.Numerator.Abs());
+                denominators = denominators.Multiply(slope.Denominator).Divide(denominators.Gcd(slope.Denominator));
+            }
+            if (numerators.IsZero)
                 return null;
+            var k = ERational.Create(numerators, denominators);
+            // The sign of the base is chosen for the radicals: with every exponential under a
+            // root of negative slope, `u = e^(-x)` makes `sqrt(1 + e^(-x))` into `sqrt(1 + u)`,
+            // where `u = e^x` would make it `sqrt(1 + 1/u)`, a root of a quotient that nothing
+            // rationalises. `u` is positive either way, since it is an exponential.
+            var slopesUnderRoots = offsets.Where(pair => underARadical.Contains(pair.Key)).Select(pair => pair.Value.Slope).ToList();
+            if (slopesUnderRoots.Count > 0 && slopesUnderRoots.All(slope => slope.Sign < 0))
+                k = k.Negate();
 
             var u = Variable.CreateUnique(expr, "u_exp");
 
@@ -3587,7 +3607,7 @@ namespace AngouriMath.Functions.Algebra
             var rewritten = expr.Replace(node =>
                 offsets.TryGetValue(node, out var found)
                     ? MathS.Pow(MathS.e, found.Offset)
-                      * MathS.Pow(u, Number.Integer.Create(found.Slope / k))
+                      * MathS.Pow(u, Number.Integer.Create(found.Slope.Divide(k).ToLowestTerms().Numerator))
                     : node);
 
             if (rewritten.ContainsNode(x))
@@ -3599,14 +3619,14 @@ namespace AngouriMath.Functions.Algebra
             // 1/(u^2 + 1) at once. Simplifying first instead leaves the nesting for Combine to
             // flatten and the common factor never meets a cancellation.
             var integrand = Functions.SingleQuotient.Combine(
-                rewritten / (Number.Integer.Create(k) * u)).Simplify();
+                rewritten / (Number.Rational.Create(k) * u)).Simplify();
             if (integrand is Providedf(var inner, _))
                 integrand = inner;
 
             if (Integration.ComputeIndefiniteIntegral(integrand, u, integrateByParts) is not { } result)
                 return null;
 
-            var answer = result.Substitute(u, MathS.Pow(MathS.e, Number.Integer.Create(k) * x));
+            var answer = result.Substitute(u, MathS.Pow(MathS.e, (Number.Rational.Create(k) * x).InnerSimplified));
             return answer.Nodes.Any(node => node == MathS.NaN) ? null : answer;
         }
 

--- a/Sources/Tests/UnitTests/Calculus/ExponentialSubstitutionIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ExponentialSubstitutionIntegralTest.cs
@@ -103,6 +103,30 @@ namespace AngouriMath.Tests.Calculus
         public void SlopesTakenTogether(string integrand) => DifferentiatesBack(integrand);
 
         /// <summary>
+        /// A fractional slope: the base is <c>e^(k x)</c> with <c>k</c> the greatest common
+        /// divisor of the slopes as rationals, so <c>e^(x/2)</c> beside <c>e^x</c> is read as
+        /// <c>u</c> beside <c>u^2</c>. Timofeev's <c>e^(x/2)/sqrt(e^x - 1)</c> is
+        /// <c>2/sqrt(u^2 - 1)</c> that way, and was declined for the half.
+        /// </summary>
+        [Theory]
+        [InlineData("e^(x/2)/sqrt(e^x - 1)")]
+        [InlineData("e^(x/3)/(1 + e^x)")]
+        [InlineData("1/(e^(x/2) + e^(x/3))")]
+        public void AFractionalSlope(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// The sign of the base is chosen for the radicals: with every exponential under a root
+        /// of negative slope, <c>u = e^(-x)</c> makes <c>sqrt(1 + e^(-x))</c> a root of something
+        /// linear in <c>u</c>, where <c>u = e^x</c> would make it a root of a quotient that
+        /// nothing rationalises. Bondarenko's two.
+        /// </summary>
+        [Theory]
+        [InlineData("sqrt(1 + e^(-x))/(e^x - e^(-x))")]
+        [InlineData("sqrt(1 + e^(-x))/sinh(x)")]
+        [InlineData("sqrt(1 + e^x)")]
+        public void TheBaseTakesTheSignOfTheRadicand(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
         /// What the rule must not disturb: exponentials the other rules already answer, and which
         /// are not rational in <c>e^(k x)</c> at all.
         /// </summary>


### PR DESCRIPTION
`e^(x/2)/sqrt(e^x - 1)` had no antiderivative. It is `2/sqrt(u^2 - 1)` under
`u = e^(x/2)`, and the exponential substitution refused the half: a slope had to be a
whole number. The base is now `e^(k x)` with `k` the greatest common divisor of the
slopes as rationals -- numerators' gcd over denominators' lcm -- so every exponential
in the integrand is a whole power of it, and `e^(x/2)` beside `e^x` is `u` beside
`u^2`.

The sign of `k` is chosen for the radicals. `sqrt(1 + e^(-x))/sinh(x)` under `u = e^x`
is a root of `1 + 1/u`, a quotient, which nothing rationalises; under `u = e^(-x)` it is
`sqrt(1 + u)`, a root of something linear, which the linear-radical substitution
answers. So where every exponential under a root has a negative slope the base is
`e^(-k x)`; `u` is positive either way, being an exponential, and nothing about the
substitution changes but the spelling of what comes out.

## Measured

Every answer differentiated back.

Rubi corpus, 463-problem sample, against the master it was cut from (#1288), timed on
the same evening:

    master      325/463, 0 wrong, 0 timeouts, 80 s
    with this   328/463, 0 wrong, 0 timeouts, 81 s

Three more, nothing lost: Timofeev's `e^(x/2)/sqrt(e^x - 1)`, and Bondarenko's
`sqrt(1 + e^(-x))/(e^x - e^(-x))` and `sqrt(1 + e^(-x))/sinh(x)`. `sqrt(1 + tanh(4x))`,
the fourth of that family, becomes `sqrt(2u^2/(u^2 + 1))` and wants `sqrt(u^2) = u`
for a `u` the rule knows to be positive; that is a rewrite this rule could make and
the simplifier rightly will not, and it is not here yet.

The five test suites are green.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
