### PR TITLE
A substitution whose variable is not negative takes its powers out of the radicals, the half-angle rule divides its common factor out, and a rational function stops offering its sums as substitutions

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -79,6 +79,17 @@ namespace AngouriMath.Functions.Algebra
                 && Integration.ComputeIndefiniteIntegral(properPart, x, integrateByParts) is { } fractionPart)
                 return wholePart + fractionPart;
 
+            // A numerator that is a constant multiple of the denominator's derivative is the
+            // logarithm of the denominator, whatever the denominator is: Welz's
+            // `(3 - 3x + 30x^2 + 160x^3)/(9 + 24x - 12x^2 + 80x^3 + 320x^4)` is `ln(D)/8`, and
+            // the substitution rule found it as `u = D` while sums were still its candidates.
+            if (denominator.ContainsNode(x)
+                && TreeAnalyzer.PolynomialLongDivision(numerator, denominator.Differentiate(x).InnerSimplified, genericCase: true, inTermsOf: x)
+                    is var (multiple, leftover)
+                && !multiple.ContainsNode(x)
+                && (leftover is Divf(var leftoverTop, _) ? leftoverTop : leftover).InnerSimplified.Evaled is Number.Complex { IsZero: true })
+                return (multiple * MathS.Ln(denominator)).InnerSimplified;
+
             // Every rule below reads the denominator **as written**: the Hermite reduction wants
             // its repeated factor written as a power, the coprime split wants two written blocks.
             // A denominator whose written factors hide either -- `(1 + t^2)(1 - 2t - 2t^3 - t^4)`
@@ -2980,18 +2991,38 @@ namespace AngouriMath.Functions.Algebra
         /// </para>
         /// https://github.com/asc-community/AngouriMath/issues/718
         /// </remarks>
-        internal static Entity? SolveByLinearRadicalSubstitution(Entity expr, Entity.Variable x, bool integrateByParts)
+        internal static Entity? SolveByLinearRadicalSubstitution(Entity expr, Entity.Variable x, bool integrateByParts, bool variableIsNonnegative = false)
         {
             // Every fractional power in the tree whose base is linear in x, collected with the
             // base it is over so that radicals over different bases are told apart.
+            //
+            // **Two bases, when both are square roots.** `sqrt(u)/(u sqrt(1 + u))` -- what
+            // `sqrt(1 + tanh(4x))` becomes under `u = e^(8x)` -- was declined here for the second
+            // base, and it is one substitution: with `s = sqrt(u)` the other root is
+            // `sqrt(1 + s^2)`, a root of a quadratic, which the rules for those answer. So a
+            // second base is admitted where every radical is a square root; its radicals are
+            // substituted rather than built, and what they become is the next rule's. A third
+            // base, or a cube root beside a second base, is declined as before.
+            //
+            // And only where the two bases are not both negative anywhere on the reals, unless
+            // the caller knows its variable to be non-negative. Where both are, the integrand
+            // is real -- `sqrt(x - 1) sqrt(x - 2)` below 1 is `-sqrt((1 - x)(2 - x))` -- and the
+            // answer, built through an imaginary `u`, is not its antiderivative there: measured
+            // by quadrature over [-1.5, 0.3], -3.66 against the answer's -4.68, with the two
+            // agreeing to twelve digits above 2. The exponential substitution's `u = e^(k x)`
+            // never is negative, and it says so.
             Entity? radicalBase = null;
+            Entity? otherBase = null;
             var denominators = new List<int>();
+            var allSquareRoots = true;
             foreach (var node in expr.Nodes)
             {
                 if (node is not Powf(var @base, Number.Rational exponent) || exponent is Number.Integer)
                     continue;
                 if (!@base.ContainsNode(x))
                     continue;
+                if (!exponent.ERational.Denominator.Equals(EInteger.FromInt32(2)))
+                    allSquareRoots = false;
                 // A radical over something that is not linear is **skipped rather than refused**,
                 // and that is where the nested ones come from. `sqrt(x + sqrt(1 + x))` holds two:
                 // the inner one is over something linear and is what the substitution is for, and
@@ -3006,12 +3037,23 @@ namespace AngouriMath.Functions.Algebra
                 if (radicalBase is null)
                     radicalBase = @base;
                 else if (radicalBase != @base)
-                    return null;   // two different bases at once
+                {
+                    if (otherBase is null)
+                        otherBase = @base;
+                    else if (otherBase != @base)
+                        return null;   // three different bases at once
+                    continue;
+                }
                 if (!exponent.ERational.Denominator.CanFitInInt32())
                     return null;
                 denominators.Add(exponent.ERational.Denominator.ToInt32Checked());
             }
             if (radicalBase is null || denominators.Count == 0)
+                return null;
+            if (otherBase is not null && !allSquareRoots)
+                return null;
+            if (otherBase is not null && !variableIsNonnegative
+                && !AtMostOneIsNegativeOnTheReals(new List<Entity> { radicalBase, otherBase }, x))
                 return null;
 
             var q = denominators.Aggregate(1, Lcm);
@@ -3047,6 +3089,11 @@ namespace AngouriMath.Functions.Algebra
             var integrand = Functions.SingleQuotient.Combine((rewritten * dx).Simplify());
             if (integrand is Providedf(var inner, _))
                 integrand = inner;
+            // For an even q the principal root is not negative wherever it is real, and a root
+            // holding a power of u gives that power up: `1/sqrt(t + t^(3/2))` under `u = sqrt(t)`
+            // is `2u/sqrt(u^2 + u^3)`, a root of a cubic, and is `2/sqrt(1 + u)`.
+            if (q % 2 == 0)
+                integrand = FactorANonnegativeVariableOutOfRadicals(integrand, u);
 
             return Integration.ComputeIndefiniteIntegral(integrand, u, integrateByParts) is { } result
                 ? result.Substitute(u, MathS.Pow(radicalBase, Number.Rational.Create(1, q)))
@@ -4265,12 +4312,26 @@ namespace AngouriMath.Functions.Algebra
                 rewritten / (Number.Rational.Create(k) * u)).Simplify();
             if (integrand is Providedf(var inner, _))
                 integrand = inner;
+            // u is an exponential, so it is positive, and a root holding a power of it gives
+            // that power up: `sqrt(1 + tanh(4x))` is a root of `2u/(1 + u)` here and nothing
+            // rationalises that; as `sqrt(2) sqrt(u)/sqrt(1 + u)` it is one substitution more.
+            integrand = FactorANonnegativeVariableOutOfRadicals(integrand, u);
 
+            // What that leaves can be two square roots of linears in u -- `sqrt(u)/(u sqrt(1 + u))`
+            // for `sqrt(1 + tanh(4x))` -- which the linear-radical substitution answers only
+            // when told that u is not negative, as an exponential is; asked directly, so that
+            // it is told.
+            if (SolveByLinearRadicalSubstitution(integrand, u, integrateByParts, variableIsNonnegative: true) is { } byARoot)
+                return Finished(byARoot);
             if (Integration.ComputeIndefiniteIntegral(integrand, u, integrateByParts) is not { } result)
                 return null;
+            return Finished(result);
 
-            var answer = result.Substitute(u, MathS.Pow(MathS.e, (Number.Rational.Create(k) * x).InnerSimplified));
-            return answer.Nodes.Any(node => node == MathS.NaN) ? null : answer;
+            Entity? Finished(Entity result)
+            {
+                var answer = result.Substitute(u, MathS.Pow(MathS.e, (Number.Rational.Create(k) * x).InnerSimplified));
+                return answer.Nodes.Any(node => node == MathS.NaN) ? null : answer;
+            }
         }
 
         /// <summary>
@@ -4666,6 +4727,93 @@ namespace AngouriMath.Functions.Algebra
             return true;
         }
 
+        /// <summary>
+        /// The radicals of <paramref name="expr"/> with every power of <paramref name="u"/>
+        /// that a radical can hold taken out of it, for a <paramref name="u"/> that is not
+        /// negative: <c>(u^2 (1 + u))^(1/2)</c> is <c>u sqrt(1 + u)</c>, and
+        /// <c>(2u/(1 + u))^(1/2)</c> is <c>sqrt(2u)/sqrt(1 + u)</c>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// For the substitutions whose variable is one by construction -- <c>u = e^(k x)</c>,
+        /// <c>u = (a x + b)^(1/q)</c> with <c>q</c> even, <c>u = x^(1/q)</c> likewise -- and
+        /// for no one else: the simplifier is right not to call <c>sqrt(u^2 (1 + u))</c>
+        /// <c>u sqrt(1 + u)</c> for a <c>u</c> it knows nothing about, and the substitution
+        /// knows exactly this about its own. Two identities, each exact for <c>u &gt;= 0</c>:
+        /// <c>(a b)^r = a^r b^r</c> whenever <c>a</c> is a non-negative real, since then
+        /// <c>arg(a b) = arg(b)</c>; and <c>(P/Q)^r = P^r/Q^r</c> whenever <c>Q</c> is a positive
+        /// real, for the same reason -- which a polynomial in <c>u</c> with non-negative
+        /// coefficients and a positive constant term is, at every <c>u &gt;= 0</c>.
+        /// </para>
+        /// <para>
+        /// Without it <c>1/sqrt(t + t^(3/2))</c> under <c>u = sqrt(t)</c> is
+        /// <c>2u/sqrt(u^2 + u^3)</c>, a root of a cubic, and with it <c>2/sqrt(1 + u)</c>;
+        /// <c>sqrt(1 + tanh(4x))</c> under <c>u = e^(8x)</c> is a root of <c>2u/(1 + u)</c>,
+        /// which nothing rationalises, and with it <c>sqrt(2) sqrt(u)/sqrt(1 + u)</c>.
+        /// </para>
+        /// </remarks>
+        private static Entity FactorANonnegativeVariableOutOfRadicals(Entity expr, Entity.Variable u)
+            => expr.Replace(node =>
+            {
+                if (node is not Powf(var @base, Number.Rational exponent) || exponent is Number.Integer
+                    || !@base.ContainsNode(u)
+                    || !exponent.ERational.Denominator.CanFitInInt32() || !exponent.ERational.Numerator.CanFitInInt32())
+                    return node;
+                var p = exponent.ERational.Numerator.ToInt32Unchecked();
+                var q = exponent.ERational.Denominator.ToInt32Unchecked();
+
+                // A quotient whose denominator is positive at every u >= 0 comes apart first.
+                var (above, below) = Functions.SingleQuotient.Of(@base);
+                Entity result;
+                if (below != Number.Integer.One && below.ContainsNode(u) && IsPositiveForNonnegative(below, u))
+                    result = Factored(above, u, p, q) / Factored(below, u, p, q);
+                else if (below == Number.Integer.One)
+                    result = Factored(above, u, p, q);
+                else
+                    return node;
+                return result;
+            });
+
+        /// <summary>
+        /// <c>P^(p/q)</c> with the largest <c>u^(k q)</c> dividing the polynomial <c>P</c> taken
+        /// out as <c>u^(k p)</c>; <c>P^(p/q)</c> as it is where <c>P</c> is not a polynomial in
+        /// <paramref name="u"/> or holds no such power.
+        /// </summary>
+        private static Entity Factored(Entity polynomial, Entity.Variable u, int p, int q)
+        {
+            var exponent = Number.Rational.Create(p, q);
+            if (!polynomial.ContainsNode(u) || !TreeAnalyzer.TryGetPolynomial(polynomial, u, out var monomials) || monomials.Count == 0)
+                return MathS.Pow(polynomial, exponent);
+            var lowest = monomials.Keys.Min()!;
+            if (!lowest.CanFitInInt32())
+                return MathS.Pow(polynomial, exponent);
+            // Rebuilt from its monomials even where nothing comes out, so that a numerator a
+            // quotient split left as `2(u + 1) - 2` is the `2u` the next rule reads.
+            var k = System.Math.Max(0, lowest.ToInt32Unchecked() / q);
+            Entity rest = Number.Integer.Zero;
+            foreach (var pair in monomials.OrderBy(pair => pair.Key))
+            {
+                var degree = pair.Key.ToInt32Unchecked() - k * q;
+                Entity term = degree == 0 ? pair.Value : degree == 1 ? pair.Value * u : pair.Value * MathS.Pow(u, degree);
+                rest = rest == Number.Integer.Zero ? term : rest + term;
+            }
+            return k == 0 ? MathS.Pow(rest.InnerSimplified, exponent) : MathS.Pow(u, k * p) * MathS.Pow(rest.InnerSimplified, exponent);
+        }
+
+        /// <summary>
+        /// Whether the polynomial <paramref name="expr"/> in <paramref name="u"/> is positive at
+        /// every <c>u &gt;= 0</c> for the plain reason that every coefficient is a positive
+        /// number and the constant term is among them.
+        /// </summary>
+        private static bool IsPositiveForNonnegative(Entity expr, Entity.Variable u)
+        {
+            if (!TreeAnalyzer.TryGetPolynomial(expr, u, out var monomials) || monomials.Count == 0)
+                return false;
+            if (!monomials.TryGetValue(EInteger.Zero, out var constant) || constant.Evaled is not Number.Real { IsPositive: true })
+                return false;
+            return monomials.Values.All(coefficient => coefficient.Evaled is Number.Real { IsPositive: true });
+        }
+
         private static int Lcm(int a, int b)
         {
             var (x, y) = (a, b);
@@ -4763,6 +4911,29 @@ namespace AngouriMath.Functions.Algebra
             // standing caveat on this substitution and is recorded in the summary above.
             if (integrand is Providedf(var inner, _))
                 integrand = inner;
+
+            // Every sine and cosine brought its own `1 + t^2` below the bar, and clearing them
+            // puts the same power of it above and below -- where the simplifier does not see
+            // it once the denominator is a sum, `(1 + t^2)(1 - t^2 + 2t) + sqrt(2)(1 + t^2)^2`
+            // for `1/(cos(x) + sin(x) + sqrt(2))`. Divided out by long division, as many times
+            // as both sides allow: what is left is `2/((sqrt(2) - 1)t^2 + 2t + 1 + sqrt(2))`, a
+            // quadratic below the bar, which was a quartic nothing split.
+            var (numerator, denominator) = Functions.SingleQuotient.Of(integrand);
+            var divided = false;
+            // The remainder comes back over the divisor, `0/(1 + t^2)` when there is none.
+            static bool NoRemainder(Entity rest)
+                => rest is Divf(var top, _) ? NoRemainder(top) : rest.Evaled is Number.Complex { IsZero: true };
+            while (TreeAnalyzer.PolynomialLongDivision(numerator, 1 + tSquared, inTermsOf: t) is var (aboveQuotient, aboveRest)
+                   && NoRemainder(aboveRest)
+                   && TreeAnalyzer.PolynomialLongDivision(denominator, 1 + tSquared, inTermsOf: t) is var (belowQuotient, belowRest)
+                   && NoRemainder(belowRest))
+            {
+                numerator = aboveQuotient.InnerSimplified;
+                denominator = belowQuotient.InnerSimplified;
+                divided = true;
+            }
+            if (divided)
+                integrand = (numerator / denominator).InnerSimplified;
 
             return Integration.ComputeIndefiniteIntegral(integrand, t, integrateByParts) is { } result
                 ? result.Substitute(t, MathS.Tan(x / 2))
@@ -4915,6 +5086,15 @@ namespace AngouriMath.Functions.Algebra
         private static IEnumerable<Entity> FindSubstitutionCandidates(Entity expr, Entity.Variable x)
         {
             var candidates = new List<Entity>();
+            // A sum is no candidate for a rational function: whatever `u = g(x)` with `g` a
+            // polynomial would find in one, partial fractions find without it, and each
+            // candidate costs one simplification of the quotient -- which, with an irrational
+            // constant in the coefficients, is where `(1 + t^2)/((sqrt(2) - 1) t^2 + 2t + 1 + sqrt(2))`
+            // spent eight seconds being declined by this rule before the rational integrator
+            // answered it in a few milliseconds. The base of a written power stays a candidate,
+            // since `x (x^2 + 1)^3` is answered as a power that way and as a degree-eight
+            // polynomial otherwise.
+            var rational = IsRationalIn(expr, x);
             foreach (var node in expr.Nodes) // Look for composite functions (functions of functions)
                 switch (node)
                 {
@@ -4947,7 +5127,7 @@ namespace AngouriMath.Functions.Algebra
                         candidates.Add(node); // Logarithm itself (for cases like 1/(x*ln(x)))
                         if (antilog != x && antilog.ContainsNode(x)) candidates.Add(antilog); // Also add the argument if it's not just x
                         break;
-                    case Sumf(var aug, var add):
+                    case Sumf(var aug, var add) when !rational:
                         if (aug.ContainsNode(x) || add.ContainsNode(x)) candidates.Add(node); // Linear expressions ax + b
                         break;
                 }

--- a/Sources/Tests/UnitTests/Calculus/ExponentialSubstitutionIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ExponentialSubstitutionIntegralTest.cs
@@ -127,6 +127,20 @@ namespace AngouriMath.Tests.Calculus
         public void TheBaseTakesTheSignOfTheRadicand(string integrand) => DifferentiatesBack(integrand);
 
         /// <summary>
+        /// <c>u = e^(k x)</c> is positive, and a root holding a power of it gives that power up:
+        /// <c>sqrt(e^(2x) + e^(3x))</c> is <c>sqrt(u^2 (1 + u))</c> under <c>u = e^x</c>, and the
+        /// simplifier is right not to call that <c>u sqrt(1 + u)</c> for a <c>u</c> it knows
+        /// nothing about -- the substitution knows exactly this about its own. The identity
+        /// <c>(a b)^r = a^r b^r</c> is exact whenever <c>a</c> is a non-negative real.
+        /// </summary>
+        [Theory]
+        [InlineData("sqrt(e^(2*x) + e^(3*x))")]
+        [InlineData("e^x/sqrt(e^(2*x) - e^x)")]
+        [InlineData("e^(2*x)/sqrt(e^(4*x) + e^(2*x))")]
+        [InlineData("sqrt(1 + tanh(4*x))")]
+        public void APowerOfThePositiveBaseLeavesTheRoot(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
         /// What the rule must not disturb: exponentials the other rules already answer, and which
         /// are not rational in <c>e^(k x)</c> at all.
         /// </summary>

--- a/Sources/Tests/UnitTests/Calculus/HalfAngleSubstitutionIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/HalfAngleSubstitutionIntegralTest.cs
@@ -110,6 +110,19 @@ namespace AngouriMath.Tests.Calculus
         public void ADenominatorLinearInEither(string integrand) => DifferentiatesBack(integrand);
 
         /// <summary>
+        /// Every sine and cosine brings its own <c>1 + t^2</c> below the bar, and clearing them
+        /// leaves the same power of it above and below -- where the simplifier does not see
+        /// it once the denominator is a sum. Bondarenko's <c>1/(cos(x) + sin(x) + sqrt(2))</c>
+        /// came out as a quartic below the bar that nothing split, and is a quadratic once the
+        /// common <c>1 + t^2</c> is divided out.
+        /// </summary>
+        [Theory]
+        [InlineData("1/(cos(x) + sin(x) + sqrt(2))")]
+        [InlineData("1/(cos(x) + sin(x) + 2)")]
+        [InlineData("(1 + sin(x))/(cos(x) + sin(x) + 2)")]
+        public void TheCommonFactorIsDividedOut(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
         /// A numerator that mentions the sine too, so the rewrite produces an <b>improper</b>
         /// rational function and the long division in front of partial fractions has to run
         /// before anything else can. The answer carries an <c>x</c> term from the whole part.

--- a/Sources/Tests/UnitTests/Calculus/LinearRadicalSubstitutionIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/LinearRadicalSubstitutionIntegralTest.cs
@@ -65,6 +65,19 @@ namespace AngouriMath.Tests.Calculus
         }
 
         /// <summary>
+        /// For an even <c>q</c> the principal root <c>u = (a x + b)^(1/q)</c> is not negative
+        /// wherever it is real, and a root holding a power of <c>u</c> gives that power up:
+        /// <c>1/sqrt(x + x^(3/2))</c> under <c>u = sqrt(x)</c> is <c>2u/sqrt(u^2 + u^3)</c>, a
+        /// root of a cubic that nothing reads, and is <c>2/sqrt(1 + u)</c>. Apostol's
+        /// <c>x/sqrt(1 + x^2 + (1 + x^2)^(3/2))</c> is the same one step further in.
+        /// </summary>
+        [Theory]
+        [InlineData("1/sqrt(x + x^(3/2))")]
+        [InlineData("sqrt(x)/sqrt(x + x^2)")]
+        [InlineData("x/sqrt(1 + x^2 + (1 + x^2)^(3/2))")]
+        public void APowerOfTheRootLeavesTheRadical(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
         /// A polynomial over a square root of something linear. None of these had an
         /// antiderivative, and each is a first-year exercise.
         /// </summary>
@@ -90,17 +103,37 @@ namespace AngouriMath.Tests.Calculus
         public void TwoRootsOverOneBase(string integrand) => DifferentiatesBack(integrand);
 
         /// <summary>
-        /// Declined, so the boundary is recorded rather than assumed.
+        /// Two bases, when every radical is a square root: <c>sqrt(x)/(x sqrt(1 + x))</c> is what
+        /// <c>sqrt(1 + tanh(4x))</c> becomes under <c>u = e^(8x)</c>, and with <c>s = sqrt(x)</c>
+        /// the other root is <c>sqrt(1 + s^2)</c>, a root of a quadratic, which the rules for
+        /// those answer. <c>sqrt(1 - x) + sqrt(1 + x)</c> was pinned here as declined for the
+        /// second base; it is answered now, by linearity before this rule and by this rule
+        /// when the sum is not at the top. What the rule hands on still has to be answered:
+        /// <c>1/(sqrt(1 - x) + sqrt(1 + x))</c> becomes a root of <c>2 - u^2</c>, whose Euler
+        /// form has <c>sqrt(2)</c> in its coefficients, and the rational integrator stops at
+        /// those; <c>3 + x</c> beside <c>1 - x</c> becomes a root of <c>4 - u^2</c> and comes out.
         /// </summary>
-        /// <remarks>
-        /// A radical over a <em>quadratic</em> is a different substitution and is not this rule's;
-        /// two radicals over <em>different</em> linear bases would need two substitutions at once,
-        /// and half-rewriting is worse than declining. Should either later be answered by
-        /// something else, these move rather than being deleted.
-        /// </remarks>
         [Theory]
-        [InlineData("sqrt(1 - x) + sqrt(1 + x)")]
-        public void DifferentBasesAreDeclined(string integrand)
+        [InlineData("sqrt(x)/(x*sqrt(1 + x))")]
+        [InlineData("sqrt(x)/sqrt(1 + x)")]
+        [InlineData("1/(sqrt(x) + sqrt(x + 1))")]
+        [InlineData("1/(sqrt(1 - x) + sqrt(3 + x))")]
+        public void ASecondBaseUnderASquareRoot(string integrand) => DifferentiatesBack(integrand);
+
+        /// <summary>
+        /// Declined, so the boundary is recorded rather than assumed: three bases, or a cube
+        /// root beside a second base, would need more than the one substitution and the
+        /// quadratic-radical rules behind it; and two bases that are both negative somewhere
+        /// on the reals, where the integrand is real and the answer built through an imaginary
+        /// <c>u</c> is not its antiderivative -- <c>sqrt(x - 1) sqrt(x - 2)</c> below <c>1</c>,
+        /// measured by quadrature at <c>-3.66</c> against an answer's <c>-4.68</c>. Should any
+        /// later be answered by something else, these move rather than being deleted.
+        /// </summary>
+        [Theory]
+        [InlineData("1/(sqrt(x) + sqrt(x + 1) + sqrt(x + 2))")]
+        [InlineData("x^(1/3)/sqrt(x + 1)")]
+        [InlineData("x/(sqrt(x - 1)*sqrt(x - 2))")]
+        public void ThreeBasesOrACubeRootBesideASecondAreDeclined(string integrand)
         {
             var integral = integrand.ToEntity().Integrate("x");
             Assert.DoesNotContain("u_rad", integral.Stringize());

--- a/Sources/Tests/UnitTests/Calculus/RationalIntegralsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/RationalIntegralsTest.cs
@@ -95,6 +95,28 @@ namespace AngouriMath.Tests.Calculus
         public void ARepeatedRationalRootDecomposesToo(string integrand, double[] points) =>
             AssertIsAntiderivative(integrand, points);
 
+        // A numerator that is a constant multiple of the denominator's derivative is the
+        // logarithm of the denominator whatever the denominator is. Welz's quartic was answered
+        // by the substitution rule with u the denominator, until sums stopped being that rule's
+        // candidates for a rational function -- each cost a simplification of the quotient, and
+        // (1 + t^2)/((sqrt(2) - 1)t^2 + 2t + 1 + sqrt(2)) spent eight seconds on them -- so
+        // the case is read here, where it is one division.
+        [Theory]
+        [InlineData("(3 - 3*x + 30*x^2 + 160*x^3)/(9 + 24*x - 12*x^2 + 80*x^3 + 320*x^4)", new[] { 0.3, 1.7, 3.2 })]
+        [InlineData("(x^3 + 1)/(x^4 + 4*x + 2)", new[] { 0.3, 1.7, 3.2 })]
+        [InlineData("(2*x + 1)/(x^2 + x + 1)", new[] { 0.3, 1.7, -0.6 })]
+        public void TheLogarithmicDerivative(string integrand, double[] points) =>
+            AssertIsAntiderivative(integrand, points);
+
+        // The candidate the substitution rule no longer offers for a rational function, answered
+        // all the same, and the case the restriction is for.
+        [Theory]
+        [InlineData("(1 + x^2)/((sqrt(2) - 1)*x^2 + 2*x + 1 + sqrt(2))", new[] { 0.3, 1.7, 3.2 })]
+        [InlineData("x*(x^2 + 1)^3", new[] { 0.3, 1.7, -0.6 })]
+        [InlineData("(2*x + 1)/(x^2 + x + 1)^3", new[] { 0.3, 1.7, -0.6 })]
+        public void ARationalFunctionWithoutSumCandidates(string integrand, double[] points) =>
+            AssertIsAntiderivative(integrand, points);
+
         // A denominator that factors over Q with no rational root anywhere in it, which the
         // split at a root cannot get a foothold on. x^4 + 3x^2 + 2 is (x^2 + 1)(x^2 + 2) and
         // x^4 + 4 is (x^2 - 2x + 2)(x^2 + 2x + 2); the split at a coprime pair of factors


### PR DESCRIPTION
Four small things, each one answer or one second on the Rubi sample, in one batch.

`x/sqrt(1 + x^2 + (1 + x^2)^(3/2))` had no antiderivative. Under `u = sqrt(1 + x^2)`
it is a root of `u^2 + u^3`, and the simplifier is right not to call that
`u sqrt(1 + u)` for a `u` it knows nothing about -- it is `|u| sqrt(1 + u)` on the
reals. The substitution knows exactly this about its own variable: `e^(k x)` is
positive, and the principal `q`-th root of a linear is not negative for an even `q`
wherever it is real. So those two substitutions now take every power of `u` a
radical holds out of it before handing on, by two identities each exact for
`u >= 0`: `(a b)^r = a^r b^r` whenever `a` is a non-negative real, since then
`arg(a b) = arg(b)`, and `(P/Q)^r = P^r/Q^r` whenever `Q` is a positive real, which
a polynomial in `u` with positive coefficients and a positive constant term is at
every `u >= 0`. `1/sqrt(x + x^(3/2))` is `2/sqrt(1 + u)` that way, and Apostol's
integrand is the same one step further in.

`sqrt(1 + tanh(4x))` is the same one step further: under `u = e^(8x)` it is a root of
`2u/(1 + u)`, which nothing rationalises, and with the quotient taken apart it is
`sqrt(2) sqrt(u)/(8u sqrt(1 + u))` -- two square roots of two different linears, which
the linear-radical substitution declined for the second base. It takes a second base
now, when every radical is a square root: with `s = sqrt(u)` the other root is
`sqrt(1 + s^2)`, a root of a quadratic, which the rules for those answer. Two things
kept that honest. A first draft combined the two roots into `sqrt(u(1 + u))` instead
and let Euler's third substitution finish; the answer was correct and its
derivative could not be evaluated at `x = 1.77`, the form being a logarithm of
`sqrt(u^2 + u)/u - 1`, two quantities agreeing to fifteen digits at `u = e^14` --
checked by quadrature before anything was changed. And the second base is admitted
only where the two bases are not both negative anywhere on the reals, or where the
caller knows its variable to be non-negative, as the exponential substitution does:
`sqrt(x - 1) sqrt(x - 2)` below `1` is a real integrand whose answer built through
an imaginary `u` is not its antiderivative there, `-3.66` by quadrature against the
answer's `-4.68`, with the two agreeing to twelve digits above `2`.

`1/(cos(x) + sin(x) + sqrt(2))` had no antiderivative. The half-angle substitution
rewrote it correctly and handed on `2(1 + t^2)/((1 + t^2)(1 - t^2 + 2t) + sqrt(2)(1 + t^2)^2)`:
every sine and cosine brings its own `1 + t^2` below the bar, and clearing them
leaves the same power of it above and below, where the simplifier does not see it
once the denominator is a sum. Divided out by long division, as many times as both
sides allow, it is `2/((sqrt(2) - 1)t^2 + 2t + 1 + sqrt(2))` -- a quadratic below the
bar, which was a quartic nothing split.

And that quadratic took eight seconds to be *declined* by the substitution rule
before the rational integrator answered it in a few milliseconds. The rule offers
every sum in the integrand as a candidate `u`, and each candidate costs one
simplification of the quotient, which with an irrational constant in the
coefficients is the slow kind. For a rational function a sum is no candidate:
whatever `u = g(x)` with `g` a polynomial would find in one, partial fractions find
without it -- except the logarithm of the denominator, which Welz's
`(3 - 3x + 30x^2 + 160x^3)/(9 + 24x - 12x^2 + 80x^3 + 320x^4)` needed and the
substitution had been finding as `u = D`. That case is read in partial fractions
now, as one division of the numerator by the denominator's derivative. The base
of a written power stays a candidate, since `x (x^2 + 1)^3` is answered as a power
that way and as a degree-eight polynomial otherwise.

## Measured


Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
