### PR TITLE
Euler's substitution cancels by the polynomial gcd where the written factors differ, and a rational function offers only the powers of x its exponents allow

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -4146,6 +4146,22 @@ namespace AngouriMath.Functions.Algebra
             var (numerator, denominator) = Functions.SingleQuotient.Of(rewritten.InnerSimplified);
             var cancelled = CancelCommonFactors(numerator, denominator);
             (numerator, denominator) = Functions.SingleQuotient.Of(cancelled);
+            // And by the polynomial gcd where the written factors do not match: the third
+            // substitution leaves `(2t)^2 - 2(t^2 + 1)` above and `2t^2 - (t^2 + 1)` below for
+            // `1/((1 + x^2)^2 sqrt(x^2 - 1))`, one factor twice the other, and the degree read
+            // off the uncancelled quotient was ten where the bound is eight. Only where the
+            // bound would otherwise refuse it, since the gcd hands back expanded sides and the
+            // rational integrator does better with the written ones.
+            // ...and only where the uncancelled degree is within twice the bound: the gcd of
+            // two polynomials of degree thirty with the coefficients a power eleven over two
+            // produces did not return in ninety seconds for `1/((3 - 2x + x^2)^(11/2) (1 + x + 2x^2)^5)`,
+            // which the bound alone declined in a moment.
+            if (TreeAnalyzer.TryGetPolynomial(numerator, t, out var beforeAbove) && TreeAnalyzer.TryGetPolynomial(denominator, t, out var beforeBelow)
+                && System.Math.Max(beforeAbove.Count == 0 ? 0 : (int)beforeAbove.Keys.Max()!.ToInt32Checked(),
+                                   beforeBelow.Count == 0 ? 0 : (int)beforeBelow.Keys.Max()!.ToInt32Checked()) is var uncancelled
+                && uncancelled > MaximumEulerDegree && uncancelled <= 2 * MaximumEulerDegree
+                && Functions.PolynomialGcd.TryCancel(numerator, denominator, out var byGcd) && byGcd is not null)
+                (numerator, denominator) = Functions.SingleQuotient.Of(Functions.PartialFractions.Bare(byGcd));
             // Each side rebuilt as a polynomial from its coefficients, so that a factor which has
             // collapsed to a constant -- `-1 - t^2 + 2 t t - 1 - t^2` is `-2` -- is one before
             // the rational readers see it: one of them divided by that factor's zero leading
@@ -5435,10 +5451,31 @@ namespace AngouriMath.Functions.Algebra
             // candidate costs one simplification of the quotient -- which, with an irrational
             // constant in the coefficients, is where `(1 + t^2)/((sqrt(2) - 1) t^2 + 2t + 1 + sqrt(2))`
             // spent eight seconds being declined by this rule before the rational integrator
-            // answered it in a few milliseconds. The base of a written power stays a candidate,
-            // since `x (x^2 + 1)^3` is answered as a power that way and as a degree-eight
-            // polynomial otherwise.
+            // answered it in a few milliseconds. The base of a written power stays a candidate
+            // for a *polynomial*, since `x (x^2 + 1)^3` is answered as a power that way and as
+            // a degree-eight polynomial otherwise; for a quotient it goes the way of the sums --
+            // `(t^2 + t + 1)^2` below the bar is one more simplification of a rational function
+            // for nothing, and Timofeev's `(1 + x^4)/((1 + x + x^2) sqrt(2 + x + x^2))` spent
+            // thirteen of its fourteen seconds on those, over the rational functions Euler's
+            // substitution and by parts handed down.
             var rational = IsRationalIn(expr, x);
+            var polynomial = rational && TreeAnalyzer.TryGetPolynomial(expr, x, out _);
+            // For a rational function `u = x^k` is exact only when every exponent below the bar
+            // is a multiple of k and every one above is k - 1 more than one -- the x^(k-1) of
+            // du -- so the candidate is read off the exponents before the quotient is
+            // simplified for it. Each simplification it saves is one to two seconds on the
+            // degree-eight rational functions Euler's substitution hands down.
+            HashSet<int>? exponentsAbove = null, exponentsBelow = null;
+            if (rational && TryReadAsQuotient(expr, out var aboveForPowers, out var belowForPowers)
+                && TreeAnalyzer.TryGetPolynomial(aboveForPowers, x, out var aboveRead)
+                && TreeAnalyzer.TryGetPolynomial(belowForPowers, x, out var belowRead))
+            {
+                exponentsAbove = new HashSet<int>(aboveRead.Keys.Where(k => k.CanFitInInt32()).Select(k => k.ToInt32Unchecked()));
+                exponentsBelow = new HashSet<int>(belowRead.Keys.Where(k => k.CanFitInInt32()).Select(k => k.ToInt32Unchecked()));
+            }
+            bool APowerCanBeExact(int k)
+                => exponentsAbove is null || exponentsBelow is null
+                   || (exponentsBelow.All(e => e % k == 0) && exponentsAbove.All(e => e % k == k - 1));
             foreach (var node in expr.Nodes) // Look for composite functions (functions of functions)
                 switch (node)
                 {
@@ -5448,7 +5485,8 @@ namespace AngouriMath.Functions.Algebra
                             candidates.Add(node.DirectChildren[0]); // Trigonometric functions with non-trivial arguments
                         break;
                     case Powf(var @base, var exp):
-                        if (@base == x) candidates.Add(node); // Power expressions x^n
+                        if (@base == x && (exp is not Number.Integer whole || !whole.EInteger.CanFitInInt32() || APowerCanBeExact(whole.EInteger.ToInt32Unchecked())))
+                            candidates.Add(node); // Power expressions x^n
                         // And the roots of that power, which need not occur anywhere to be the
                         // right substitution: `int x / (x^4 + 1)` wants u = x^2, and x^2 appears
                         // nowhere in it. A divisor of the exponent is the condition for the
@@ -5461,10 +5499,10 @@ namespace AngouriMath.Functions.Algebra
                             && power.EInteger.ToInt32Checked() is var n
                             && n > 2)
                             for (var divisor = 2; divisor + divisor <= n; divisor++)
-                                if (n % divisor == 0)
+                                if (n % divisor == 0 && APowerCanBeExact(divisor))
                                     candidates.Add(MathS.Pow(x, divisor));
                         // Exponential with non-trivial argument
-                        if (@base != x && @base.ContainsNode(x)) candidates.Add(@base);
+                        if (@base != x && @base.ContainsNode(x) && (!rational || polynomial)) candidates.Add(@base);
                         if (exp != x && exp.ContainsNode(x)) candidates.Add(exp);
                         break;
                     case Logf(_, var antilog):

--- a/Sources/Tests/UnitTests/Calculus/EulerSubstitutionTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/EulerSubstitutionTest.cs
@@ -110,6 +110,22 @@ namespace AngouriMath.Tests.Calculus
         public void ReachedOneLevelDown(string integrand, double[] points) => DifferentiatesBack(integrand, points);
 
         /// <summary>
+        /// The rational function in <c>t</c> cancelled by the polynomial gcd where its written
+        /// factors do not match: the first substitution leaves <c>(2t)^2 - 2(t^2 + 1)</c> above
+        /// and <c>2t^2 - (t^2 + 1)</c> below for Welz's <c>1/((1 + x^2)^2 sqrt(x^2 - 1))</c>, one
+        /// twice the other, and the degree read off the uncancelled quotient was ten where the
+        /// bound is eight. Only where the bound would otherwise refuse it, and only up to twice
+        /// the bound: the gcd of two degree-thirty polynomials did not return, where the bound
+        /// alone declined `1/((3 - 2x + x^2)^(11/2) (1 + x + 2x^2)^5)` in a moment.
+        /// </summary>
+        [Theory]
+        [InlineData("1/((1 + x^2)^2*sqrt(x^2 - 1))", new[] { 1.3, 1.9, 2.7, 3.6 })]
+        [InlineData("1/((3*x^2 - 4)^2*sqrt(x^2 - 1))", new[] { 1.3, 1.9, 2.7, 3.6 })]
+        [InlineData("1/((x^2 + 2)^2*sqrt(x^2 + 1))", new[] { 0.3, 0.9, 1.7, 2.6 })]
+        [InlineData("(1 + x^4)/((1 + x + x^2)*sqrt(2 + x + x^2))", new[] { 0.3, 0.9, 1.7, 2.6 })]
+        public void CancelledByTheGcdWhereTheSpellingsDiffer(string integrand, double[] points) => DifferentiatesBack(integrand, points);
+
+        /// <summary>
         /// A complex constant under the root is none of the three substitutions', and taking
         /// <c>-i</c> for a symbol once answered <c>NaN</c>; a rational function of the root
         /// whose Euler form is past the degree the splits can factor is declined too, and not
@@ -118,6 +134,7 @@ namespace AngouriMath.Tests.Calculus
         [Theory]
         [InlineData("1/((1 + x)^2*sqrt(2)*sqrt(-i + x^2))")]
         [InlineData("ln(x^2 + sqrt(1 - x^2))")]
+        [InlineData("1/((3 - 2*x + x^2)^(11/2)*(1 + x + 2*x^2)^5)")]
         public void DeclinedRatherThanWrongOrSlow(string integrand)
         {
             var watch = System.Diagnostics.Stopwatch.StartNew();

--- a/Sources/Tests/UnitTests/Calculus/RationalIntegralsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/RationalIntegralsTest.cs
@@ -108,12 +108,19 @@ namespace AngouriMath.Tests.Calculus
         public void TheLogarithmicDerivative(string integrand, double[] points) =>
             AssertIsAntiderivative(integrand, points);
 
-        // The candidate the substitution rule no longer offers for a rational function, answered
-        // all the same, and the case the restriction is for.
+        // The candidates the substitution rule no longer offers for a rational function --
+        // a sum, the base of a written power below the bar, and a power of x that the
+        // exponents say cannot be exact -- answered all the same, and the cases the
+        // restriction is for. `x/(x^6 + 1)` and `x^2/(x^6 + 1)` are the powers that are exact,
+        // u = x^2 and u = x^3, and stay candidates.
         [Theory]
         [InlineData("(1 + x^2)/((sqrt(2) - 1)*x^2 + 2*x + 1 + sqrt(2))", new[] { 0.3, 1.7, 3.2 })]
         [InlineData("x*(x^2 + 1)^3", new[] { 0.3, 1.7, -0.6 })]
         [InlineData("(2*x + 1)/(x^2 + x + 1)^3", new[] { 0.3, 1.7, -0.6 })]
+        [InlineData("x/(x^6 + 1)", new[] { 0.3, 1.7, -0.6 })]
+        [InlineData("x^2/(x^6 + 1)", new[] { 0.3, 1.7, -0.6 })]
+        [InlineData("x^5/(x^4 + 1)", new[] { 0.3, 1.7, -0.6 })]
+        [InlineData("x^3/(x^4 + 1)", new[] { 0.3, 1.7, -0.6 })]
         public void ARationalFunctionWithoutSumCandidates(string integrand, double[] points) =>
             AssertIsAntiderivative(integrand, points);
 


### PR DESCRIPTION
Welz's `1/((1 + x^2)^2 sqrt(x^2 - 1))` had no antiderivative. Euler's first substitution
turns it into `16 t^3 (t^2 - 1)/((t^4 + 6t^2 + 1)^2 (t^2 - 1))` -- with the common factor
written `(2t)^2 - 2(t^2 + 1)` above and `2t^2 - (t^2 + 1)` below, one twice the other,
which the cancellation by written factors cannot see. The degree read off the
uncancelled quotient was ten, the bound is eight, and the rule declined. The gcd of
the two sides as polynomials cancels it; taken only where the bound would otherwise
refuse the quotient, since the gcd hands back expanded sides and the rational
integrator does better with the written ones, and only where the uncancelled degree
is within twice the bound -- the gcd of two degree-thirty polynomials with the
coefficients `(3 - 2x + x^2)^(11/2)` produces did not return in ninety seconds, where
the bound alone had declined that integrand in a moment. That last one was the
first draft's timeout.

What the cancellation lets through then met the substitution rule, at every level
below: a degree-eight rational function in `t` has `t^3`, `t^4`, `t^5`, `t^6`, `t^7` as
candidates for `u = x^k`, each one simplification of the quotient, one to two seconds
apiece, and Timofeev's `(1 + x^4)/((1 + x + x^2) sqrt(2 + x + x^2))` spent thirteen of
its fourteen seconds that way. For a rational function `u = x^k` is exact only when
every exponent below the bar is a multiple of `k` and every one above is `k - 1`
more than one, the `x^(k-1)` of `du`; the candidate is read off the exponents first,
and the base of a written power is offered only for a polynomial, where
`x (x^2 + 1)^3` wants it, and not below the bar of a quotient, where partial fractions
have it anyway. Timofeev's takes one second.

## Measured

Every answer differentiated back.

Rubi corpus, 463-problem sample, on the same evening:

    master at #1294     353/463, 0 wrong, 0 timeouts, 85 s   (measured)
    master at #1295     356/463                              (#1295's own +3)
    with this           361/463, 0 wrong, 0 timeouts, 76 s

Five more, nothing lost, and the wall clock nine seconds shorter: Welz's `1/((1 + x^2)^2 sqrt(x^2 - 1))`
and `1/((3x^2 - 4)^2 sqrt(x^2 - 1))`, Timofeev's `(1 + x^4)/((1 + x + x^2) sqrt(2 + x + x^2))`,
and Charlwood's `ln(1 + x sqrt(1 + x^2))` and `arctan(sqrt(1 + x) - sqrt(x))`, whose
by-parts remainders the cancellation reaches.

The five test suites are green.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
