### PR TITLE
Euler's substitution reads a power of itself: (x + sqrt(Q))^b is t^b, for any b

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -4241,8 +4241,11 @@ namespace AngouriMath.Functions.Algebra
         internal static Entity? SolveByEulerSubstitution(Entity expr, Entity.Variable x)
         {
 
-            // One square root of a quadratic in x, and otherwise a rational function of x.
+            // One square root of a quadratic in x, and otherwise a rational function of x --
+            // or, besides those, powers of `x + sqrt(Q)` and `sqrt(Q) - x` to any exponent,
+            // which the first substitution makes powers of `t`: see below.
             Entity? radicand = null;
+            var powersOfTheSubstitution = new List<Powf>();
             foreach (var node in expr.Nodes)
             {
                 if (!node.ContainsNode(x))
@@ -4253,16 +4256,29 @@ namespace AngouriMath.Functions.Algebra
                         break;
                     case Powf(_, Number.Integer):
                         break;
-                    case Powf(var radicalBase, Number.Rational half) when half.ERational.Denominator.Equals(EInteger.FromInt32(2)):
+                    case Powf(var radicalBase, Number.Rational half) when half.ERational.Denominator.Equals(EInteger.FromInt32(2))
+                            && radicalBase.Nodes.All(inner => inner is not Powf(_, Number.Rational r) || r is Number.Integer):
                         if (radicand is null)
                             radicand = radicalBase;
                         else if (radicand != radicalBase)
                             return null;
                         break;
+                    case Powf(var @base, var exponent) when !exponent.ContainsNode(x) && @base.Nodes.Any(inner => inner is Powf(_, Number.Rational)):
+                        powersOfTheSubstitution.Add((Powf)node);
+                        break;
                     default:
                         return null;
                 }
             }
+            // The radical inside such a power is the radical: `(x + sqrt(1 + x^2))^b` holds it.
+            if (radicand is null)
+                foreach (var power in powersOfTheSubstitution)
+                    foreach (var inner in power.Base.Nodes)
+                        if (inner is Powf(var innerBase, Number.Rational innerHalf) && innerHalf.ERational.Denominator.Equals(EInteger.FromInt32(2)) && innerBase.ContainsNode(x))
+                        {
+                            if (radicand is null) radicand = innerBase;
+                            else if (radicand != innerBase) return null;
+                        }
             if (radicand is null
                 || !TreeAnalyzer.TryGetPolyQuadratic(radicand, x, out var a, out var b, out var c)
                 || a.Evaled is Number.Complex { IsZero: true })
@@ -4323,12 +4339,81 @@ namespace AngouriMath.Functions.Algebra
                     break;
             }
 
+            // **A power of the substitution itself.** With `t = sqrt(Q) + sqrt(a) x`, a factor
+            // `(x + sqrt(Q))^b` is `t^b` for `a = 1`, exactly and for any `b`, and `sqrt(Q) - x`
+            // is `c/t`, since `(sqrt(Q) + x)(sqrt(Q) - x) = Q - x^2 = b x + c` -- `c/t` when the
+            // linear term is absent. Welz's `(x + sqrt(b + x^2))^a` and Bondarenko's
+            // `1/(1 + sqrt(x + sqrt(1 + x^2)))` are both this: the first becomes Laurent
+            // monomials in `t` to the power `a`, the second a rational function of `sqrt(t)`,
+            // and each is handed to the chain in `t` rather than to the rational integrator,
+            // since neither is a quotient of polynomials.
+            var powered = false;
+            if (powersOfTheSubstitution.Count > 0)
+            {
+                if (which != 1 || !(a.Evaled is Number.Integer { IsZero: false } aOne && aOne.EInteger.Equals(EInteger.One)))
+                    return null;
+                // `x - sqrt(Q)` is the same substitution with the root's sign flipped:
+                // `t = x - sqrt(Q)` gives the same `x(t)`, `sqrt(Q) = x - t` in place of `t - x`,
+                // and `t = x - sqrt(Q)` on the way back. Both signs in one integrand is neither.
+                var root = MathS.Pow(radicand, Number.Rational.Create(1, 2));
+                var flipped = (bool?)null;
+                foreach (var power in powersOfTheSubstitution)
+                {
+                    var plus = (power.Base - (x + root)).Simplify().Evaled is Number.Complex { IsZero: true };
+                    var minus = (power.Base - (x - root)).Simplify().Evaled is Number.Complex { IsZero: true };
+                    if (!plus && !minus)
+                        return null;
+                    if (flipped is null)
+                        flipped = minus;
+                    else if (flipped != minus)
+                        return null;
+                    expr = expr.Substitute(power, MathS.Pow(t, power.Exponent));
+                }
+                if (flipped == true)
+                {
+                    rootInT = xInT - t;
+                    backSubstitution = x - root;
+                }
+                powered = true;
+            }
+
             var dxdt = xInT.Differentiate(t);
             var rewritten = expr.Replace(node =>
                 node is Powf(var @base, Number.Rational half) && @base == radicand
                     ? MathS.Pow(rootInT, Number.Integer.Create(half.ERational.Numerator))
                     : node)
                 .Substitute(x, xInT) * dxdt;
+            if (powered)
+            {
+                if (rewritten.ContainsNode(x))
+                    return null;
+                // With the written factors cancelled first: `1/sqrt(Q)` brings `(t^2 + c)` below
+                // the bar and `dx/dt` brings it above, and beside a symbolic power of `t`
+                // nothing later cancels them.
+                var (poweredAbove, poweredBelow) = Functions.SingleQuotient.Of(rewritten.InnerSimplified);
+                // The powers of t with an exponent that is not a whole number are set aside,
+                // and what is left -- two polynomials in t -- is cancelled by their gcd, since
+                // the two spellings of `t^2 + c` the substitution produces are not equal as
+                // written; then they are put back.
+                Entity setAside = Number.Integer.One;
+                Entity polynomialAbove = Number.Integer.One;
+                foreach (var factor in Mulf.LinearChildren(poweredAbove))
+                    if (factor is Powf(var pb, var pe) && pb == t && pe is not Number.Integer)
+                        setAside = setAside * factor;
+                    else
+                        polynomialAbove = polynomialAbove * factor;
+                Entity cancelledPowered = polynomialAbove / poweredBelow;
+                if (Functions.PolynomialGcd.TryCancel(polynomialAbove.InnerSimplified, poweredBelow.InnerSimplified, out var poweredByGcd) && poweredByGcd is not null)
+                    cancelledPowered = Functions.PartialFractions.Bare(poweredByGcd);
+                var poweredInT = Functions.SingleQuotient.Combine(setAside * cancelledPowered).Simplify();
+                if (poweredInT is Providedf(var bareInT, _))
+                    poweredInT = bareInT;
+                var inTByTheChain = Integration.ComputeIndefiniteIntegral(poweredInT, t, integrateByParts: true);
+                if (inTByTheChain is null)
+                    return null;
+                var poweredAnswer = inTByTheChain.Substitute(t, backSubstitution).InnerSimplified;
+                return poweredAnswer.Nodes.Any(n => n is Number.Complex { IsNaN: true }) ? null : poweredAnswer;
+            }
             var (numerator, denominator) = Functions.SingleQuotient.Of(rewritten.InnerSimplified);
             var cancelled = CancelCommonFactors(numerator, denominator);
             (numerator, denominator) = Functions.SingleQuotient.Of(cancelled);

--- a/Sources/Tests/UnitTests/Calculus/EulerSubstitutionTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/EulerSubstitutionTest.cs
@@ -126,6 +126,28 @@ namespace AngouriMath.Tests.Calculus
         public void CancelledByTheGcdWhereTheSpellingsDiffer(string integrand, double[] points) => DifferentiatesBack(integrand, points);
 
         /// <summary>
+        /// A power of the substitution itself. With <c>t = sqrt(Q) + x</c>, a factor
+        /// <c>(x + sqrt(Q))^b</c> is <c>t^b</c> exactly and for any <c>b</c>, and with the root's
+        /// sign flipped, <c>t = x - sqrt(Q)</c>, so is <c>(x - sqrt(Q))^b</c>: Welz's
+        /// <c>(x + sqrt(b + x^2))^a</c> becomes Laurent monomials in <c>t</c> to the power <c>a</c>,
+        /// and Bondarenko's <c>1/(1 + sqrt(x + sqrt(1 + x^2)))</c> a rational function of
+        /// <c>sqrt(t)</c>; each is handed to the chain in <c>t</c>, since neither is a quotient
+        /// of polynomials. The parameters are pinned only when differentiating back; the
+        /// flipped-sign answers are complex at real points and are compared as such.
+        /// </summary>
+        [Theory]
+        [InlineData("(x + sqrt(1 + x^2))^3", new[] { 0.3, 0.9, 1.7, 2.6 })]
+        [InlineData("(x + sqrt(b + x^2))^a", new[] { 0.3, 0.9, 1.7, 2.6 })]
+        [InlineData("(x - sqrt(a + x^2))^b", new[] { 0.3, 0.9, 1.7, 2.6 })]
+        [InlineData("(x - sqrt(a + x^2))^b/sqrt(a + x^2)", new[] { 0.3, 0.9, 1.7, 2.6 })]
+        [InlineData("sqrt(x + sqrt(a^2 + x^2))/sqrt(a^2 + x^2)", new[] { 0.3, 0.9, 1.7, 2.6 })]
+        [InlineData("sqrt(x + sqrt(a^2 + x^2))/x", new[] { 0.3, 0.9, 1.7, 2.6 })]
+        [InlineData("1/(x*sqrt(a^2 + x^2)*sqrt(x + sqrt(a^2 + x^2)))", new[] { 0.3, 0.9, 1.7, 2.6 })]
+        [InlineData("1/(1 + sqrt(x + sqrt(1 + x^2)))", new[] { 0.3, 0.9, 1.7, 2.6 })]
+        public void APowerOfTheSubstitutionItself(string integrand, double[] points)
+            => DifferentiatesBack(integrand, points, ("a", 1.7), ("b", 0.7));
+
+        /// <summary>
         /// A complex constant under the root is none of the three substitutions', and taking
         /// <c>-i</c> for a symbol once answered <c>NaN</c>; a rational function of the root
         /// whose Euler form is past the degree the splits can factor is declined too, and not


### PR DESCRIPTION
Welz's `(x + sqrt(b + x^2))^a` had no antiderivative, and neither had `sqrt(x + sqrt(a^2 + x^2))/x`
or Bondarenko's `1/(1 + sqrt(x + sqrt(1 + x^2)))`: a power, symbolic or fractional, of
`x + sqrt(Q)` is neither a rational function of the root nor a radical any substitution
reads. But `x + sqrt(Q)` is Euler's first substitution variable itself, `t = sqrt(Q) + x`,
so the power is `t^b` exactly and for any `b`; and `x - sqrt(Q)` is the same
substitution with the root's sign flipped -- the same `x(t)`, `sqrt(Q) = x - t` in place
of `t - x`, `t = x - sqrt(Q)` on the way back -- so `(x - sqrt(Q))^b` is `t^b` too. Both
signs in one integrand are neither, and are declined.

What the substitution leaves is not a quotient of polynomials, so it goes to the
chain in `t` rather than to the rational integrator: `t^a` times Laurent monomials for
Welz's, which the power rule answers term by term, and a rational function of
`sqrt(t)` for Bondarenko's, which the linear-radical substitution answers. Before it
goes, the powers of `t` with an exponent that is not a whole number are set aside
and the two polynomials left are cancelled by their gcd -- `1/sqrt(Q)` brings `t^2 + c`
below the bar and `dx/dt` brings it above, in two spellings nothing later cancels;
`(x - sqrt(a + x^2))^b/sqrt(a + x^2)` is `-t^(b-1)` after that and was declined before it.

## Measured

Every answer differentiated back with the parameters pinned; the flipped-sign
answers are complex at real points and compared as such.

Rubi corpus, 463-problem sample, on the same evening:

    master at #1294     353/463, 0 wrong, 0 timeouts, 85 s   (measured)
    master at #1296     357/463                              (#1295's +3, #1296's +1)
    with this           362/463, 0 wrong, 0 timeouts, 92 s

Seven more, nothing lost: Welz's `(x + sqrt(b + x^2))^a`, `(x - sqrt(a + x^2))^b`,
`(x - sqrt(a + x^2))^b/sqrt(a + x^2)`, `sqrt(x + sqrt(a^2 + x^2))/sqrt(a^2 + x^2)`,
`sqrt(x + sqrt(a^2 + x^2))/x` and `1/(x sqrt(a^2 + x^2) sqrt(x + sqrt(a^2 + x^2)))`, and
Bondarenko's `1/(1 + sqrt(x + sqrt(1 + x^2)))`. The harness counts five of them and
lists the two flipped-sign ones as "not checkable on the reals", which is what they
are: complex at every real sample point, with the parameters it pins. The probe,
which compares complex values, verifies both.

The five test suites are green.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
