### PR TITLE
A sum is split over its terms as written before it is expanded, and the reciprocal is a substitution where it sits under a root

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -5790,9 +5790,16 @@ namespace AngouriMath.Functions.Algebra
             // linear, and `1/x` is written as a quotient that no power candidate reads. Under a
             // root only -- offered for every `/x`, it opened a search on `(x^2 - 10)^(5/2)/x` and
             // `x ln(x)/sqrt(1 + x^2)` that did not return, where each is a second's work
-            // without it.
+            // without it. And not beside a root of a polynomial in the variable: under the
+            // reciprocal that root becomes a root of a reciprocal, which offers the reciprocal
+            // back, and `x^(-1/2)` is a candidate of its own that leads the same way -- on the
+            // by-parts remainder of `arcsin(sqrt(1 + x) - sqrt(x))` the two alternated to the
+            // depth limit, forty seconds where declining takes three.
             if (!rational && expr.Nodes.Any(node => node is Powf(var radicalBase, Number.Rational radicalPower) && radicalPower is not Number.Integer
-                    && radicalBase.Nodes.Any(inner => inner is Divf(_, var divisor) && (divisor == x || divisor is Powf(var pb, Number.Integer) && pb == x))))
+                    && radicalBase.Nodes.Any(inner => inner is Divf(_, var divisor) && (divisor == x || divisor is Powf(var pb, Number.Integer) && pb == x)))
+                && !expr.Nodes.Any(node => node is Powf(var polynomialBase, Number.Rational rootPower) && rootPower is not Number.Integer
+                    && polynomialBase.ContainsNode(x) && TreeAnalyzer.TryGetPolynomial(polynomialBase, x, out var radicand)
+                    && radicand.Keys.Any(degree => degree.Sign > 0)))
                 candidates.Add(MathS.Pow(x, -1));
             foreach (var node in expr.Nodes) // Look for composite functions (functions of functions)
                 switch (node)

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -16,13 +16,41 @@ namespace AngouriMath.Functions.Algebra
     {
         internal static Entity? SolveBySplittingSum(Entity expr, Entity.Variable x, bool integrateByParts)
         {
+            // The terms as written first, and expanded only if one of those fails: expanding
+            // `(1 + 1/x)/(x + ln(x))^(3/2)` writes it as two terms, neither of which is the
+            // substitution `u = x + ln(x)` the unexpanded one is, and Bronstein's
+            // `1/x + (1 + 1/x)/(x + ln(x))^(3/2)` was declined for that while each of its two
+            // terms alone was answered.
+            if (expr is Sumf or Minusf)
+            {
+                // In the order the expanding gather uses -- the terms in the variable, then
+                // what is free of it as one term -- so that the answer reads the same either way.
+                // And only for terms of modest size: a partial-fraction term whose coefficient
+                // is a page of unsimplified symbols took sixty seconds of every rule
+                // simplifying the page for itself, where the expanding gather below tidies
+                // its terms as it goes and takes half a second on the same sum.
+                var inTheVariable = Sumf.LinearChildren(expr).Where(term => term.ContainsNode(x)).ToList();
+                var free = Sumf.LinearChildren(expr).Where(term => !term.ContainsNode(x)).ToList();
+                var asWritten = new List<Entity>(inTheVariable);
+                if (free.Count > 0)
+                    asWritten.Add(free.Aggregate((l, r) => l + r));
+                if (asWritten.Count >= 2 && asWritten.All(term => term.Complexity <= LargestTermTakenAsWritten)
+                    && Integrated(asWritten) is { } termByTerm)
+                    return termByTerm;
+            }
             var splitted = TreeAnalyzer.GatherLinearChildrenOverSumAndExpand(expr, e => e.ContainsNode(x));
             if (splitted is null || splitted.Count < 2) return null; // nothing to do, let other solvers do the work
-            return splitted.Select(e => Integration.ComputeAsAQuestionOfItsOwn(e, x, integrateByParts)).Aggregate((e1, e2) => (e1, e2) switch {
-                (null, _) or (_, null) => null,
-                (var int1, var int2) => int1 + int2
-            });
+            return Integrated(splitted);
+
+            Entity? Integrated(List<Entity> terms)
+                => terms.Select(e => Integration.ComputeAsAQuestionOfItsOwn(e, x, integrateByParts)).Aggregate((e1, e2) => (e1, e2) switch {
+                    (null, _) or (_, null) => null,
+                    (var int1, var int2) => int1 + int2
+                });
         }
+
+        /// <summary>The largest term a sum is split over as written, before the expanding gather.</summary>
+        private const int LargestTermTakenAsWritten = 60;
 
         /// <summary>
         /// A quotient of polynomials, split into two smaller quotients and integrated in two
@@ -5757,6 +5785,15 @@ namespace AngouriMath.Functions.Algebra
             bool APowerCanBeExact(int k)
                 => exponentsAbove is null || exponentsBelow is null
                    || (exponentsBelow.All(e => e % k == 0) && exponentsAbove.All(e => e % k == k - 1));
+            // The reciprocal, where it is under a root: `sqrt(1/x + sqrt(1 + 1/x))` is
+            // `sqrt(u + sqrt(1 + u))` over `-u^2` under `u = 1/x`, a nested radical of something
+            // linear, and `1/x` is written as a quotient that no power candidate reads. Under a
+            // root only -- offered for every `/x`, it opened a search on `(x^2 - 10)^(5/2)/x` and
+            // `x ln(x)/sqrt(1 + x^2)` that did not return, where each is a second's work
+            // without it.
+            if (!rational && expr.Nodes.Any(node => node is Powf(var radicalBase, Number.Rational radicalPower) && radicalPower is not Number.Integer
+                    && radicalBase.Nodes.Any(inner => inner is Divf(_, var divisor) && (divisor == x || divisor is Powf(var pb, Number.Integer) && pb == x))))
+                candidates.Add(MathS.Pow(x, -1));
             foreach (var node in expr.Nodes) // Look for composite functions (functions of functions)
                 switch (node)
                 {

--- a/Sources/Tests/UnitTests/Calculus/ATermOfATopLevelSumIsAskedAtTheTopTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ATermOfATopLevelSumIsAskedAtTheTopTest.cs
@@ -37,6 +37,31 @@ namespace AngouriMath.Tests.Calculus
         }
 
         /// <summary>
+        /// The terms as written first, and expanded only if one of those fails: expanding
+        /// <c>(1 + 1/x)/(x + ln(x))^(3/2)</c> writes it as two terms, neither of which is the
+        /// substitution <c>u = x + ln(x)</c> the unexpanded one is, and Bronstein's
+        /// <c>1/x + (1 + 1/x)/(x + ln(x))^(3/2)</c> was declined for that while each of its two
+        /// terms alone was answered.
+        /// </summary>
+        [Theory]
+        [InlineData("1/x + (1 + 1/x)/(x + ln(x))^(3/2)")]
+        [InlineData("(1 + 1/x)/(x + ln(x))^(3/2) - 1/x^2")]
+        public void TheTermsAsWrittenBeforeExpanded(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            foreach (var at in new[] { 0.7, 1.3, 2.4 })
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                var difference = System.Math.Abs((double)(got - want).RealPart);
+                Assert.True(difference < 1e-8, $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, where the integrand is {want}");
+            }
+        }
+
+        /// <summary>
         /// Each term alone is answered, which is what makes the sum's decline a defect of the
         /// split and not of the rules.
         /// </summary>

--- a/Sources/Tests/UnitTests/Calculus/NestedRadicalIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/NestedRadicalIntegralTest.cs
@@ -117,6 +117,22 @@ namespace AngouriMath.Tests.Calculus
             => DifferentiatesBack(integrand, points);
 
         /// <summary>
+        /// The same shape in <c>1/x</c>: Bondarenko's <c>sqrt(1/x + sqrt(1 + 1/x))</c> is
+        /// <c>sqrt(u + sqrt(1 + u))</c> over <c>-u^2</c> under <c>u = 1/x</c>, and <c>1/x</c> is
+        /// written as a quotient that no power candidate of the substitution rule read. The
+        /// reciprocal is offered only where it sits under a root: offered for every <c>/x</c>
+        /// it opened searches on <c>(x^2 - 10)^(5/2)/x</c> and <c>x ln(x)/sqrt(1 + x^2)</c> that
+        /// did not return, and those two are pinned here as still quick.
+        /// </summary>
+        [Theory]
+        [InlineData("sqrt(1/x + sqrt(1 + 1/x))", new[] { 0.3, 0.9, 1.7 })]
+        [InlineData("sqrt(1 + 1/x)/x^2", new[] { 0.3, 0.9, 1.7 })]
+        [InlineData("(x^2 - 10)^(5/2)/x", new[] { 3.3, 3.9, 4.7 })]
+        [InlineData("x*ln(x)/sqrt(1 + x^2)", new[] { 0.3, 0.9, 1.7 })]
+        public void TheReciprocalUnderARoot(string integrand, double[] points)
+            => DifferentiatesBack(integrand, points);
+
+        /// <summary>
         /// What the substitution answered before, and must keep answering: one radical over a
         /// linear base, and a radical over a radical of the variable itself.
         /// </summary>

--- a/Sources/Tests/UnitTests/Calculus/NestedRadicalIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/NestedRadicalIntegralTest.cs
@@ -122,7 +122,13 @@ namespace AngouriMath.Tests.Calculus
         /// written as a quotient that no power candidate of the substitution rule read. The
         /// reciprocal is offered only where it sits under a root: offered for every <c>/x</c>
         /// it opened searches on <c>(x^2 - 10)^(5/2)/x</c> and <c>x ln(x)/sqrt(1 + x^2)</c> that
-        /// did not return, and those two are pinned here as still quick.
+        /// did not return, and those two are pinned here as still quick. And not beside a root
+        /// of a polynomial in the variable: under the reciprocal that root becomes a root of a
+        /// reciprocal, which offers the reciprocal back, and <c>x^(-1/2)</c> is a candidate of
+        /// its own that leads the same way -- on the by-parts remainder of
+        /// <c>arcsin(sqrt(1 + x) - sqrt(x))</c> the two alternated to the depth limit, forty
+        /// seconds here and three and a half minutes on the CI runner, where declining takes
+        /// three seconds. That one is pinned in <see cref="ABareInverseFunctionByPartsTest"/>.
         /// </summary>
         [Theory]
         [InlineData("sqrt(1/x + sqrt(1 + 1/x))", new[] { 0.3, 0.9, 1.7 })]

--- a/Sources/Tests/UnitTests/Calculus/TangentSubstitutionIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/TangentSubstitutionIntegralTest.cs
@@ -114,14 +114,17 @@ namespace AngouriMath.Tests.Calculus
             => Assert.Equal(expected.ToEntity(), integrand.ToEntity().Integrate("x"));
 
         /// <summary>
-        /// What is still declined, recorded so the boundary is visible rather than inferred from
-        /// an absence. Each is declined by what the rewrite hands on, not by the rewrite itself:
+        /// What was declined, recorded so the boundary is visible rather than inferred from
+        /// an absence, and moved here as it is answered. Each was declined by what the rewrite
+        /// hands on, not by the rewrite itself:
         /// </summary>
         /// <remarks>
         /// <list type="bullet">
-        /// <item><c>sqrt(cotan(x))</c> — the cotangent is written as <c>1/tan</c> on the way in
-        /// now, so this does start; what stops it is the fractional power, which leaves a
-        /// radical in <c>u</c> rather than a rational function.</item>
+        /// <item><c>sqrt(cotan(x))</c> — the cotangent is written as <c>1/tan</c> on the way in,
+        /// so this does start; what stopped it was the fractional power, which leaves
+        /// <c>sqrt(1/u)/(1 + u^2)</c>, a radical of a reciprocal. The substitution rule offers
+        /// <c>1/u</c> where it sits under a root now, and that is <c>sqrt(v)/(1 + v^2)</c> over
+        /// <c>v^2</c>, the same shape as <c>sqrt(tan(x))</c> itself.</item>
         /// </list>
         /// <c>tan(x)^2</c> and <c>tan(x)^3</c> were on this list, for becoming improper rational
         /// functions that nothing divided out; they are answered above now that the rational
@@ -133,8 +136,7 @@ namespace AngouriMath.Tests.Calculus
         /// </remarks>
         [Theory]
         [InlineData("sqrt(cotan(x))")]
-        public void WhatIsStillDeclined(string integrand)
-            => Assert.Contains("integral(", integrand.ToEntity().Integrate("x").Stringize());
+        public void WhatWasDeclinedAndIsAnswered(string integrand) => DifferentiatesBack(integrand);
 
         /// <summary>
         /// <c>1/(1 + tan(x)^2)</c> is <c>cos(x)^2</c>, and it used to be declined for becoming


### PR DESCRIPTION
Bronstein's `1/x + (1 + 1/x)/(x + ln(x))^(3/2)` had no antiderivative, while each of
its two terms alone was answered. Linearity splits a sum, and split it by
expanding: `(1 + 1/x)/(x + ln(x))^(3/2)` written out is `1/(x + ln(x))^(3/2)` and
`1/(x (x + ln(x))^(3/2))`, and neither of those is the substitution `u = x + ln(x)`
the unexpanded term is, so the split failed and nothing else read the sum. The
terms are tried as written first now, in the order the expanding gather uses --
the terms in the variable, then what is free of it as one term, so that an answer
reads the same either way -- and expanded only if one of them fails. Only for
terms of modest size: a partial-fraction term whose coefficient is a page of
unsimplified symbols took sixty seconds of every rule simplifying the page for
itself, where the expanding gather tidies its terms as it goes and takes half a
second on the same sum.

Bondarenko's `sqrt(1/x + sqrt(1 + 1/x))` had none either. Under `u = 1/x` it is
`sqrt(u + sqrt(1 + u))` over `-u^2`, a nested radical of something linear, which is
answered; and `1/x` is written as a quotient that no power candidate of the
substitution rule reads. The reciprocal is offered where it sits under a root, and
only there: offered for every `/x`, it opened searches on `(x^2 - 10)^(5/2)/x` and
`x ln(x)/sqrt(1 + x^2)` that did not return, where each is a second's work without
it. `sqrt(cot(x))` was pinned as declined, for becoming a radical of a reciprocal
under the tangent; it is `sqrt(v)/(1 + v^2)` over `v^2` now, the same shape as
`sqrt(tan(x))`, and the pin moved into an answered theory.

## Measured

Every answer differentiated back.

Rubi corpus, 463-problem sample, on the same evening:

    master at #1298     364/463, 0 wrong, 0 timeouts, 77 s   (measured)
    with this           367/463, 0 wrong, 0 timeouts, 79 s

Three more, nothing lost: Bronstein's and Bondarenko's above, and Charlwood's
`arcsin(x/sqrt(1 - x^2))`, whose by-parts remainder is a sum that splits as
written. The first draft offered the reciprocal for every `/x` and was measured at
three timeouts; the second took the written terms of every sum and was measured
at seventy seconds on one symbolic partial fraction. Both bounds are what those
measurements asked for.

The five test suites are green.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
