### PR TITLE
Two roots that share a factor are read over their irreducible factors, with the sign placed where the split is exact

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -5216,6 +5216,21 @@ namespace AngouriMath.Functions.Algebra
                     gathered = true;
                 }
             }
+            // **Over the irreducible factors**, where that cancels something: `sqrt(1 - x^4)`
+            // over `sqrt(1 - x^2)` -- what by parts leaves from `x^3 arcsin(x)/sqrt(1 - x^4)` --
+            // is `sqrt(1 + x^2)`, and the two roots as written share nothing. Each base with
+            // an odd exponent is factored over the rationals, with the constant folded into
+            // the first factor so that no `sqrt(-1)` is set free, and the root split over the
+            // factors where that is exact -- at most one of them negative anywhere on the
+            // reals; the whole polynomial factors beside them are factored the same way. The
+            // refinement is kept only where it leaves fewer roots than it found, since
+            // otherwise it only respells the integrand.
+            if (TryRefineOverIrreducibleFactors(halves, others, x) is var (refinedHalves, refinedOthers))
+            {
+                halves = refinedHalves;
+                others = refinedOthers;
+                gathered = true;
+            }
             foreach (var (factor, isBelow) in others)
                 if (isBelow) below = below * factor;
                 else above = above * factor;
@@ -5257,6 +5272,90 @@ namespace AngouriMath.Functions.Algebra
             }
             var rewritten = ((above * radical).InnerSimplified / below.InnerSimplified).InnerSimplified;
             return rewritten is Providedf(var inner, _) ? inner : rewritten;
+        }
+
+        /// <summary>
+        /// The bases with an odd exponent in halves, and the whole polynomial factors beside
+        /// them, taken into their irreducible factors over the rationals and gathered again
+        /// by factor; <see langword="null"/> where that leaves no fewer roots than it found.
+        /// </summary>
+        private static (Dictionary<Entity, int> Halves, List<(Entity Factor, bool Below)> Others)? TryRefineOverIrreducibleFactors(
+            Dictionary<Entity, int> halves, List<(Entity Factor, bool Below)> others, Entity.Variable x)
+        {
+            if (!halves.Values.Any(n => n % 2 != 0))
+                return null;
+            var refined = new Dictionary<Entity, int>();
+            var keptOthers = new List<(Entity Factor, bool Below)>();
+            void Add(Entity factor, int n) => refined[factor] = refined.TryGetValue(factor, out var so) ? so + n : n;
+            foreach (var pair in halves)
+            {
+                // The constant goes into whichever factor lets the split be exact: `1 - x^4` is
+                // `-(x + 1)(x - 1)(x^2 + 1)`, and with the sign on `x + 1` two factors are
+                // negative inside the unit interval, where with it on `x - 1` -- `(1 - x)` --
+                // at most one is anywhere.
+                var placements = IrreducibleFactorsWithTheSignPlaced(pair.Key, x);
+                List<Entity>? parts = null;
+                if (placements is not null && placements.Count > 0 && placements[0].Count > 1)
+                    parts = pair.Value % 2 == 0
+                        ? placements[0]
+                        : placements.FirstOrDefault(candidate => AtMostOneIsNegativeOnTheReals(candidate, x));
+                if (parts is null)
+                {
+                    Add(pair.Key, pair.Value);
+                    continue;
+                }
+                foreach (var part in parts)
+                    Add(part, pair.Value);
+            }
+            foreach (var (factor, isBelow) in others)
+            {
+                var (@base, power) = factor is Powf(var b, Number.Integer e) && e.EInteger.CanFitInInt32() && e.EInteger.Sign > 0
+                    ? (b, e.EInteger.ToInt32Unchecked()) : (factor, 1);
+                // A whole factor splits freely; the sign goes where it meets a root already read.
+                var placements = @base.ContainsNode(x) ? IrreducibleFactorsWithTheSignPlaced(@base, x) : null;
+                var parts = placements?.FirstOrDefault(candidate => candidate.Count(refined.ContainsKey) == candidate.Count)
+                            ?? placements?.FirstOrDefault(candidate => candidate.Any(refined.ContainsKey));
+                if (parts is null)
+                {
+                    keptOthers.Add((factor, isBelow));
+                    continue;
+                }
+                foreach (var part in parts)
+                    Add(part, (isBelow ? -2 : 2) * power);
+            }
+            var rootsBefore = halves.Values.Count(n => n % 2 != 0);
+            var rootsAfter = refined.Values.Count(n => n % 2 != 0);
+            return rootsAfter < rootsBefore ? (refined, keptOthers) : null;
+        }
+
+        /// <summary>
+        /// The irreducible factors over the rationals of the polynomial <paramref name="polynomial"/>
+        /// in <paramref name="x"/>, each repeated by its multiplicity, with the constant of the
+        /// factorization multiplied into one of them -- one list per choice of which, so that
+        /// the product is the polynomial exactly and a negative constant is never a factor of
+        /// its own. <see langword="null"/> where it is not such a polynomial.
+        /// </summary>
+        private static List<List<Entity>>? IrreducibleFactorsWithTheSignPlaced(Entity polynomial, Entity.Variable x)
+        {
+            if (polynomial.Vars.Any(v => v != x))
+                return null;
+            if (Functions.PolynomialFactorization.FactorComplete(polynomial, x) is not { } factorization || factorization.Parts.Count == 0)
+                return null;
+            var parts = new List<Entity>();
+            foreach (var part in factorization.Parts)
+                for (var i = 0; i < part.Multiplicity; i++)
+                    parts.Add(part.Factor.ToEntity(x));
+            if (factorization.Constant.CompareTo(ERational.One) == 0)
+                return new List<List<Entity>> { parts };
+            var constant = Number.Rational.Create(factorization.Constant);
+            var placements = new List<List<Entity>>();
+            for (var i = 0; i < parts.Count; i++)
+            {
+                var placed = new List<Entity>(parts);
+                placed[i] = (constant * parts[i]).InnerSimplified;
+                placements.Add(placed);
+            }
+            return placements;
         }
 
         /// <summary>

--- a/Sources/Tests/UnitTests/Calculus/CombinedRadicalsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/CombinedRadicalsTest.cs
@@ -123,6 +123,37 @@ namespace AngouriMath.Tests.Calculus
         }
 
         /// <summary>
+        /// Over the irreducible factors, where that cancels something: <c>sqrt(1 - x^4)</c> over
+        /// <c>sqrt(1 - x^2)</c> -- what by parts leaves from Charlwood's <c>x^3 arcsin(x)/sqrt(1 - x^4)</c>
+        /// -- is <c>sqrt(1 + x^2)</c>, and the two roots as written share nothing. The sign of
+        /// the factorization goes into whichever factor lets the split be exact: <c>1 - x^4</c>
+        /// is <c>-(x + 1)(x - 1)(x^2 + 1)</c>, and with the sign on <c>x + 1</c> two factors are
+        /// negative inside the unit interval, where with it on <c>x - 1</c> at most one is
+        /// anywhere.
+        /// </summary>
+        [Theory]
+        [InlineData("x^3*arcsin(x)/sqrt(1 - x^4)")]
+        [InlineData("sqrt(1 - x^4)/sqrt(1 - x^2)")]
+        public void OverTheIrreducibleFactors(string integrand) => DifferentiatesBack(integrand, InsideTheUnitInterval);
+
+        /// <summary>
+        /// <c>sqrt(x^4 - 1)/sqrt(x^2 - 1)</c> does not split: <c>x^4 - 1</c> is <c>(x - 1)(x + 1)(x^2 + 1)</c>
+        /// and below <c>-1</c> two of those are negative whichever carries the sign, where the
+        /// integrand is real. Either verdict but a wrong answer, on both sides.
+        /// </summary>
+        [Theory]
+        [InlineData("sqrt(x^4 - 1)/sqrt(x^2 - 1)")]
+        [InlineData("x^3*arcsec(x)/sqrt(x^4 - 1)")]
+        public void WhereNoPlacementOfTheSignSplitsExactly(string integrand)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("NaN", integral.Stringize());
+            if (integral.Stringize().Contains("integral("))
+                return;
+            DifferentiatesBack(integrand, new[] { -3.1, -2.2, -1.4, 1.3, 2.1, 3.4 });
+        }
+
+        /// <summary>
         /// A small power of a sum of radicals, as a factor, is written out first:
         /// Bondarenko's <c>1/(sqrt(1 - x) + sqrt(1 + x))^2</c> is <c>1/(2 + 2 sqrt(1 - x^2))</c>,
         /// which Euler's substitution answers.


### PR DESCRIPTION
Charlwood's `x^3 arcsin(x)/sqrt(1 - x^4)` had no antiderivative. By parts against the
arcsine leaves `sqrt(1 - x^4)/sqrt(1 - x^2)`, which is `sqrt(1 + x^2)` -- and the two
roots as written share nothing, so the combining rule saw a quartic radical over a
quadratic one and did what it could, which was nothing. Each base with an odd
exponent is now factored over the rationals and the root split over the factors
where that is exact -- at most one factor negative anywhere on the reals -- and the
whole polynomial factors beside them are factored the same way; gathered again by
factor, `(1 - x)(1 + x)` cancels between the two and `sqrt(1 + x^2)` is what is left.

The sign of the factorization is the part that needed care. `1 - x^4` is
`-(x + 1)(x - 1)(x^2 + 1)`, and with the constant folded into `x + 1` two of the factors
are negative inside the unit interval -- exactly where the integrand is real -- so
that split is not exact there; folded into `x - 1`, as `1 - x`, at most one factor is
negative anywhere, and it is. So every placement is tried and the first exact one
taken, and a base with none stays whole: `sqrt(x^4 - 1)/sqrt(x^2 - 1)` has two negative
factors below `-1` whichever carries the sign, and is declined rather than answered
there with the wrong sign. The refinement is kept only where it leaves fewer roots
than it found, since otherwise it only respells the integrand.

## Measured

Every answer differentiated back on both sides of zero.

Rubi corpus, 463-problem sample, on the same evening:

    master at #1298     364/463, 0 wrong, 0 timeouts, 77 s   (measured)
    master at #1300     365/463                              (#1300's +1)
    with this           366/463, 0 wrong, 0 timeouts, 78 s

One more, nothing lost: Charlwood's `x^3 arcsin(x)/sqrt(1 - x^4)`.

The five test suites are green.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
