### PR TITLE
A substitution whose variable may be negative is answered for it positive and extended by parity, and the complement of a written sine or cosine is a candidate

### DIFF
--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -424,5 +424,8 @@ file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed
 [Tests/UnitTests/Calculus/CubeRootLogarithmAnsatzTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
 
+[Tests/UnitTests/Calculus/ParityUnderASubstitutionTest.cs]
+file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n
+
 [Tests/UnitTests/Calculus/ReciprocalSubstitutionTest.cs]
 file_header_template=\nCopyright (c) 2019-2026 Angouri.\nAngouriMath is licensed under MIT.\nDetails: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.\nWebsite: https://am.angouri.org.\n

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -4741,13 +4741,28 @@ namespace AngouriMath.Functions.Algebra
                     return forPositiveX;
 
                 // Extended to x < 0 by parity, or not at all.
-                var reflected = expr.Substitute(x, -x);
-                if (Functions.PartialFractions.HoldsAtSampledPoints(reflected, -expr, x))
-                    return forPositiveX.Substitute(x, MathS.Abs(x));
-                if (Functions.PartialFractions.HoldsAtSampledPoints(reflected, expr, x))
-                    return MathS.Signum(x) * forPositiveX.Substitute(x, MathS.Abs(x));
-                return null;
+                return ExtendedByParity(expr, forPositiveX, x);
             }
+            return null;
+        }
+
+        /// <summary>
+        /// <paramref name="forPositive"/>, an antiderivative of <paramref name="integrand"/> for
+        /// <paramref name="x"/> positive, extended to the other side by parity, which is exact:
+        /// an odd integrand has an even antiderivative, so <c>F(|x|)</c> serves on both sides,
+        /// and an even one has an odd antiderivative, <c>sgn(x) F(|x|)</c>. An integrand of
+        /// neither parity is declined rather than answered on half the line.
+        /// </summary>
+        private static Entity? ExtendedByParity(Entity integrand, Entity forPositive, Entity.Variable x)
+        {
+            // In the generic case, as every rule answers: the conditions a simplification
+            // attached on the way -- each denominator nonzero -- are not part of the answer.
+            forPositive = Functions.PartialFractions.Bare(forPositive);
+            var reflected = integrand.Substitute(x, -x);
+            if (Functions.PartialFractions.HoldsAtSampledPoints(reflected, -integrand, x))
+                return forPositive.Substitute(x, MathS.Abs(x));
+            if (Functions.PartialFractions.HoldsAtSampledPoints(reflected, integrand, x))
+                return MathS.Signum(x) * forPositive.Substitute(x, MathS.Abs(x));
             return null;
         }
 
@@ -5315,14 +5330,27 @@ namespace AngouriMath.Functions.Algebra
         /// </remarks>
         internal static Entity? SolveByCombiningRadicals(Entity expr, Entity.Variable x, bool integrateByParts)
         {
+            // A secant or cosecant under a root is the reciprocal of a cosine or sine there:
+            // `sqrt(sec(x)^4 - 1)` is a root of `(1 - cos(x)^4)/cos(x)^4`, a quotient whose
+            // denominator is an even power, and comes apart as `sqrt(1 - cos(x)^4)/cos(x)^2`;
+            // as written it is a root of a sum of secants that no rule reads.
+            if (expr.Nodes.Any(node => node is Powf(var radicalBase, Number.Rational r) && r is not Number.Integer
+                    && radicalBase.Nodes.Any(inner => inner is Secantf or Cosecantf)))
+                expr = expr.Replace(node => node switch
+                {
+                    Secantf(var argument) => 1 / MathS.Cos(argument),
+                    Cosecantf(var argument) => 1 / MathS.Sin(argument),
+                    _ => node,
+                });
             // Two square roots holding the variable, or there is nothing to combine; counted
             // before any of the rewriting below is paid for, since this runs on every
             // sub-integrand of the chain.
-            // A root of a quotient counts as the two roots it splits into.
+            // A root of a quotient counts as the two roots it splits into -- a sum with a
+            // quotient in it, `1/cos(x)^4 - 1`, being a quotient once combined.
             if (expr.Nodes.Sum(node => node is Powf(var @base, Number.Rational half)
                     && half is not Number.Integer && half.ERational.Denominator.Equals(EInteger.FromInt32(2))
                     && @base.ContainsNode(x)
-                        ? (@base is Divf || Functions.SingleQuotient.Of(@base).Denominator != Number.Integer.One ? 2 : 1)
+                        ? (@base is Divf || Functions.SingleQuotient.Of(AsOneQuotient(@base)).Denominator != Number.Integer.One ? 2 : 1)
                         : 0) < 2)
                 return null;
             var rewritten = CombineRadicalsIn(expr, x);
@@ -5362,9 +5390,38 @@ namespace AngouriMath.Functions.Algebra
                 if (node is not Powf(var @base, Number.Rational power) || power is Number.Integer
                     || !power.ERational.Denominator.Equals(EInteger.FromInt32(2)) || !@base.ContainsNode(x))
                     return node;
-                var (above, below) = Functions.SingleQuotient.Of(@base);
+                var (above, below) = Functions.SingleQuotient.Of(AsOneQuotient(@base));
                 if (below == Number.Integer.One || !below.ContainsNode(x))
                     return node;
+                // A denominator that is an even power of anything real is not negative, so the
+                // split is exact whatever the numerator, and the root of the denominator is a
+                // whole power where the exponents allow: `sqrt(N/cos(x)^4)` is `sqrt(N)/cos(x)^2`.
+                if (Mulf.LinearChildren(below).All(factor => !factor.ContainsNode(x)
+                        || factor is Powf(_, Number.Integer even) && even.EInteger.IsEven && even.EInteger.Sign > 0)
+                    && power.ERational.Numerator.CanFitInInt32())
+                {
+                    var p = power.ERational.Numerator.ToInt32Unchecked();
+                    Entity rootOfBelow = Number.Integer.One;
+                    var whole = true;
+                    foreach (var factor in Mulf.LinearChildren(below))
+                    {
+                        if (!factor.ContainsNode(x))
+                        {
+                            rootOfBelow *= MathS.Pow(factor, power);
+                            continue;
+                        }
+                        var (f, twoK) = ((Powf)factor).DirectChildren is var children ? (children[0], ((Number.Integer)children[1]).EInteger.ToInt32Unchecked()) : default;
+                        // (f^(2k))^(p/2) = |f|^(k p), and f^(k p) only for an even k p.
+                        if ((twoK / 2 * p) % 2 != 0)
+                        {
+                            whole = false;
+                            break;
+                        }
+                        rootOfBelow *= MathS.Pow(f, twoK / 2 * p);
+                    }
+                    if (whole)
+                        return MathS.Pow(above, power) / rootOfBelow;
+                }
                 if (!TreeAnalyzer.TryGetPolynomial(above, x, out var aboveRead) || !TreeAnalyzer.TryGetPolynomial(below, x, out var belowRead)
                     || above.Vars.Any(v => v != x) || below.Vars.Any(v => v != x))
                     return node;
@@ -5381,6 +5438,16 @@ namespace AngouriMath.Functions.Algebra
                     return node;
                 return MathS.Pow(above, power) / MathS.Pow(below, power);
             });
+
+        /// <summary>
+        /// <paramref name="expr"/> as one quotient where it is a sum with a quotient among its
+        /// terms -- <c>1/cos(x)^4 - 1</c> is <c>(1 - cos(x)^4)/cos(x)^4</c> -- and as it is
+        /// otherwise, so that the combining is paid for only where it changes anything.
+        /// </summary>
+        private static Entity AsOneQuotient(Entity expr)
+            => expr is Sumf or Minusf && Sumf.LinearChildren(expr).Any(term => term is Divf || term is Powf(_, Number.Integer { IsNegative: true }))
+                ? Functions.SingleQuotient.Combine(expr)
+                : expr;
 
         /// <summary>
         /// A factor of a product that is a small power of a sum holding a square root of a
@@ -5828,7 +5895,10 @@ namespace AngouriMath.Functions.Algebra
                 Entity term = degree == 0 ? pair.Value : degree == 1 ? pair.Value * u : pair.Value * MathS.Pow(u, degree);
                 rest = rest == Number.Integer.Zero ? term : rest + term;
             }
-            return k == 0 ? MathS.Pow(rest.InnerSimplified, exponent) : MathS.Pow(u, k * p) * MathS.Pow(rest.InnerSimplified, exponent);
+            // `u` rather than `u^1`, which the substitution rule's power rewriting does not read
+            // as a power of u: `1/(u^1 sqrt(3 - 3u^2 + u^4))` was refused the candidate `u^2`.
+            Entity taken = k * p == 1 ? u : MathS.Pow(u, k * p);
+            return k == 0 ? MathS.Pow(rest.InnerSimplified, exponent) : taken * MathS.Pow(rest.InnerSimplified, exponent);
         }
 
         /// <summary>
@@ -5979,9 +6049,17 @@ namespace AngouriMath.Functions.Algebra
         {
             // Try to find a suitable substitution u = g(x)
             // We need to identify a composite function and check if du/dx appears in the integrand
-            var candidates = FindSubstitutionCandidates(expr, x);
+            var candidates = FindSubstitutionCandidates(expr, x).ToList();
+            // Every candidate as written first, and only then the sines and cosines again
+            // with the even powers of their complement written in u: `cos(x)/sin(x)` under
+            // `u = cos(x)` that way is `ln(1 - cos(x)^2)/2`, and under the sine it is written
+            // with, `ln(sin(x))`, which is the answer to give.
+            var firstPass = new Dictionary<Entity, Entity>();
+            foreach (var complementEvenPowers in new[] { false, true })
             foreach (var u in candidates)
             {
+                if (complementEvenPowers && !firstPass.ContainsKey(u))
+                    continue;
                 var duDx = u.Differentiate(x).InnerSimplified;
 
                 // A candidate that does not vary with x is no substitution at all, and its
@@ -5998,8 +6076,39 @@ namespace AngouriMath.Functions.Algebra
 
                 // Try to divide expr by duDx and check if result is independent of x
                 // Replace all occurrences of u's expression with a temporary variable
-                var integrandInU = InTermsOf(expr / duDx, u, uSub, x).Simplify(1);
-                if (integrandInU is Providedf(var innerExpr, _)) integrandInU = innerExpr; // TODO: singularities ignored but not handled properly
+                // For a power of x, the quotient is collected before the powers of x are
+                // rewritten: the rewriting reads written powers, and `1/(x sqrt(P))` over `2x`
+                // holds two bare x's that are `x^2` only once collected -- and a bare x is not
+                // a power of x^2, so the candidate was refused.
+                // Under u = cos(a), an even power of sin(a) is a power of 1 - u^2, and the odd
+                // ones are a sine times one; the same the other way round. Written so after the
+                // division by du/dx has taken one sine out of `sin(x)/sqrt(1 - sin(x)^6)`, since
+                // that is where the sixth power becomes a polynomial in u.
+                Entity integrandInU;
+                if (complementEvenPowers)
+                {
+                    // From what the first pass computed, not computed again.
+                    var complemented = WithTheComplementInEvenPowers(firstPass[u], u, uSub);
+                    if (complemented == firstPass[u])
+                        continue;   // nothing the first pass did not see
+                    integrandInU = complemented.Simplify(1);
+                    if (integrandInU is Providedf(var innerComplemented, _)) integrandInU = innerComplemented;
+                }
+                else
+                {
+                    // For a power of x of a numeric integrand of modest size, from the
+                    // quotient written as one with its powers of x collected. Numeric and
+                    // modest only: a symbolic partial fraction written as one quotient is a
+                    // page, and its simplification took twelve minutes of one test.
+                    var quotient = u is Powf(var powerOfX, Number.Rational) && powerOfX == x
+                        && expr.Complexity <= LargestIntegrandOfferedSums && !expr.Vars.Any(v => v != x)
+                        ? WithThePowersOfXCollected(Functions.SingleQuotient.Combine(expr / duDx), x)
+                        : expr / duDx;
+                    integrandInU = InTermsOf(quotient, u, uSub, x).Simplify(1);
+                    if (integrandInU is Providedf(var innerExpr, _)) integrandInU = innerExpr; // TODO: singularities ignored but not handled properly
+                    if (u is Sinf or Cosf && integrandInU.ContainsNode(x))
+                        firstPass[u] = integrandInU;
+                }
 
                 // If the result doesn't contain x anymore, we found a valid substitution
                 // and we can integrate with respect to u (treating u as a variable)
@@ -6014,12 +6123,109 @@ namespace AngouriMath.Functions.Algebra
                 if (integrandInU.Nodes.Any(node => node == MathS.NaN))
                     continue;
 
-                if (!integrandInU.ContainsNode(x) && Integration.ComputeIndefiniteIntegral(integrandInU, uSub, integrateByParts) is { } resultInU)
+                if (integrandInU.ContainsNode(x))
+                    continue;
+                if (Integration.ComputeIndefiniteIntegral(integrandInU, uSub, integrateByParts) is { } resultInU)
                     // Substitute back: replace u with g(x)
                     return resultInU.Substitute(uSub, u);
+
+                // A power of u under a root -- `1/sqrt(u^2 (3 - 3u^2 + u^4))`, which is
+                // `sin(x)/sqrt(1 - sin(x)^6)` under `u = cos(x)` -- comes out of the root as
+                // `|u|`, and the rule for that takes `|u| = u`: what it answers holds for
+                // `u > 0`, and is extended to `u < 0` by parity where the integrand has one, as
+                // the reciprocal substitution extends its own. Nothing is known of the sign
+                // of a cosine, and this is what makes that not matter.
+                var factored = FactorANonnegativeVariableOutOfRadicals(integrandInU, uSub);
+                if (factored != integrandInU && !factored.ContainsNode(x)
+                    && Integration.ComputeIndefiniteIntegral(factored, uSub, integrateByParts) is { } forPositiveU
+                    && !forPositiveU.Nodes.Any(node => node == MathS.NaN))
+                {
+                    // An even root is not negative, and what holds for u > 0 is the answer as
+                    // it stands; `sqrt(x^(1/3))` under `1/(sqrt(x) - x^(-1/3))` was extended by
+                    // parity it did not need, to an answer with a sign function in it.
+                    if (u is Powf(_, Number.Rational root) && root.ERational.Denominator.IsEven)
+                        return Functions.PartialFractions.Bare(forPositiveU).Substitute(uSub, u);
+                    if (ExtendedByParity(integrandInU, forPositiveU, uSub) is { } onBothSides)
+                        return onBothSides.Substitute(uSub, u);
+                }
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Every product in <paramref name="expr"/> with its powers of <paramref name="x"/>
+        /// gathered into one: <c>x sqrt(P) 2 x</c> is <c>2 x^2 sqrt(P)</c>. The power rewriting
+        /// of a substitution <c>u = x^r</c> reads written powers, and the quotient of an
+        /// integrand by <c>du/dx</c> writes the differential's power beside the integrand's,
+        /// where neither alone is a power of <c>u</c>.
+        /// </summary>
+        private static Entity WithThePowersOfXCollected(Entity expr, Entity.Variable x)
+            => expr.Replace(node =>
+            {
+                if (node is not Mulf)
+                    return node;
+                var factors = Mulf.LinearChildren(node).ToList();
+                Entity total = Number.Integer.Zero;
+                var powers = 0;
+                var rest = new List<Entity>();
+                foreach (var factor in factors)
+                {
+                    if (factor == x)
+                    {
+                        total += 1;
+                        powers++;
+                    }
+                    else if (factor is Powf(var @base, Number.Rational exponent) && @base == x)
+                    {
+                        total += exponent;
+                        powers++;
+                    }
+                    else
+                        rest.Add(factor);
+                }
+                if (powers < 2)
+                    return node;
+                var collected = total.InnerSimplified;
+                Entity product = collected == Number.Integer.One ? x : MathS.Pow(x, collected);
+                foreach (var factor in rest)
+                    product *= factor;
+                return product;
+            });
+
+        /// <summary>
+        /// For <paramref name="u"/> a sine or a cosine, every even power of the other function
+        /// of the same argument in <paramref name="expr"/> written as a power of
+        /// <c>1 - uSub^2</c>, and every odd one as the function times such a power; the
+        /// expression itself where there is nothing to write.
+        /// </summary>
+        private static Entity WithTheComplementInEvenPowers(Entity expr, Entity u, Entity.Variable uSub)
+        {
+            Entity argument;
+            Entity complement;
+            switch (u)
+            {
+                case Sinf(var a):
+                    argument = a;
+                    complement = MathS.Cos(a);
+                    break;
+                case Cosf(var a):
+                    argument = a;
+                    complement = MathS.Sin(a);
+                    break;
+                default:
+                    return expr;
+            }
+            var oneMinusSquare = 1 - MathS.Sqr(uSub);
+            return expr.Replace(node =>
+            {
+                if (node is not Powf(var @base, Number.Integer power) || @base != complement
+                    || !power.EInteger.CanFitInInt32() || power.EInteger.ToInt32Unchecked() is var n && n < 2)
+                    return node;
+                var half = n / 2;
+                Entity even = half == 1 ? oneMinusSquare : MathS.Pow(oneMinusSquare, half);
+                return n % 2 == 0 ? even : complement * even;
+            });
         }
 
         /// <summary>
@@ -6123,6 +6329,7 @@ namespace AngouriMath.Functions.Algebra
         private static IEnumerable<Entity> FindSubstitutionCandidates(Entity expr, Entity.Variable x)
         {
             var candidates = new List<Entity>();
+            var complements = new List<Entity>();
             // A sum is no candidate for a rational function: whatever `u = g(x)` with `g` a
             // polynomial would find in one, partial fractions find without it, and each
             // candidate costs one simplification of the quotient -- which, with an irrational
@@ -6182,6 +6389,17 @@ namespace AngouriMath.Functions.Algebra
                         candidates.Add(node); // Trigonometric function itself (for cases like sin(x)*cos(x))
                         if (node.DirectChildren[0] != x && node.DirectChildren[0].ContainsNode(x))
                             candidates.Add(node.DirectChildren[0]); // Trigonometric functions with non-trivial arguments
+                        // And the other of the pair, which need not be written to be the
+                        // substitution: `sin(x)/sqrt(1 - sin(x)^6)` wants `u = cos(x)`, under
+                        // which the sine that is left is the differential and the even powers
+                        // of it are `1 - u^2`. Only for a sine or cosine, whose complement is
+                        // reached through even powers alone; and after everything written,
+                        // since `cos(x)/sin(x)` under `u = cos(x)` is `ln(1 - cos(x)^2)/2`, and
+                        // under the sine it is written with, `ln(sin(x))`.
+                        if (node is Sinf(var sineArgument) && sineArgument.ContainsNode(x))
+                            complements.Add(MathS.Cos(sineArgument));
+                        else if (node is Cosf(var cosineArgument) && cosineArgument.ContainsNode(x))
+                            complements.Add(MathS.Sin(cosineArgument));
                         break;
                     case Powf(var @base, var exp):
                         if (@base == x && (exp is not Number.Integer whole || !whole.EInteger.CanFitInInt32() || APowerCanBeExact(whole.EInteger.ToInt32Unchecked())))
@@ -6213,7 +6431,11 @@ namespace AngouriMath.Functions.Algebra
                         break;
                 }
             // Sort by complexity - try simpler substitutions first
-            return candidates.OrderBy(c => c.Complexity).Distinct();
+            var ordered = candidates.OrderBy(c => c.Complexity).Distinct().ToList();
+            foreach (var complement in complements)
+                if (!ordered.Contains(complement))
+                    ordered.Add(complement);
+            return ordered;
         }
     }
 }

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -5356,7 +5356,14 @@ namespace AngouriMath.Functions.Algebra
             var rewritten = CombineRadicalsIn(expr, x);
             if (rewritten == expr)
                 return null;
-            return Integration.ComputeIndefiniteIntegral(rewritten, x, integrateByParts);
+            // The rewriting is exact and the rewritten integrand is the question asked in
+            // another spelling, so at the top it is asked as one: the rules scoped to the
+            // question -- the parity extension under a substitution, for one, which
+            // `sec(x)/sqrt(sec(x)^4 - 1)` needs after the secant is written as a cosine here --
+            // answer it then and not one level down.
+            return Integration.AnsweringTheQuestionAsked
+                ? Integration.ComputeAsAQuestionOfItsOwn(rewritten, x, integrateByParts)
+                : Integration.ComputeIndefiniteIntegral(rewritten, x, integrateByParts);
         }
 
         /// <summary>
@@ -6096,11 +6103,14 @@ namespace AngouriMath.Functions.Algebra
                 }
                 else
                 {
-                    // For a power of x of a numeric integrand of modest size, from the
+                    // For a whole power of x of a numeric integrand of modest size, from the
                     // quotient written as one with its powers of x collected. Numeric and
                     // modest only: a symbolic partial fraction written as one quotient is a
-                    // page, and its simplification took twelve minutes of one test.
-                    var quotient = u is Powf(var powerOfX, Number.Rational) && powerOfX == x
+                    // page, and its simplification took twelve minutes of one test. Whole
+                    // only: `x^(-1/2)` collected the same way admitted a substitution the
+                    // by-parts remainder of `arcsin(sqrt(1 + x) - sqrt(x))` was refused before,
+                    // and a minute of search below it.
+                    var quotient = u is Powf(var powerOfX, Number.Integer { EInteger.Sign: > 0 } wholePower) && powerOfX == x && wholePower != Number.Integer.One
                         && expr.Complexity <= LargestIntegrandOfferedSums && !expr.Vars.Any(v => v != x)
                         ? WithThePowersOfXCollected(Functions.SingleQuotient.Combine(expr / duDx), x)
                         : expr / duDx;
@@ -6135,6 +6145,11 @@ namespace AngouriMath.Functions.Algebra
                 // `u > 0`, and is extended to `u < 0` by parity where the integrand has one, as
                 // the reciprocal substitution extends its own. Nothing is known of the sign
                 // of a cosine, and this is what makes that not matter.
+                // Asked, not volunteered: the factored form is a second search per candidate,
+                // and one level down the by-parts remainder of `arcsin(sqrt(1 + x) - sqrt(x))`
+                // spent a minute in them.
+                if (!Integration.AnsweringTheQuestionAsked)
+                    continue;
                 var factored = FactorANonnegativeVariableOutOfRadicals(integrandInU, uSub);
                 if (factored != integrandInU && !factored.ContainsNode(x)
                     && Integration.ComputeIndefiniteIntegral(factored, uSub, integrateByParts) is { } forPositiveU

--- a/Sources/Tests/UnitTests/Calculus/ParityUnderASubstitutionTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ParityUnderASubstitutionTest.cs
@@ -1,0 +1,105 @@
+//
+// Copyright (c) 2019-2026 Angouri.
+// AngouriMath is licensed under MIT.
+// Details: https://github.com/asc-community/AngouriMath/blob/master/LICENSE.md.
+// Website: https://am.angouri.org.
+//
+
+using System;
+using AngouriMath.Extensions;
+using Xunit;
+
+namespace AngouriMath.Tests.Calculus
+{
+    /// <summary>
+    /// A substitution whose variable may be negative, with an even power of it under a root:
+    /// answered for the variable positive and extended to the other side by parity.
+    /// <a href="https://github.com/asc-community/AngouriMath/issues/718">#718</a>
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Charlwood's <c>sin(x)/sqrt(1 - sin(x)^6)</c> had no antiderivative. Under
+    /// <c>u = cos(x)</c> -- a candidate now whenever a sine of the argument is written, since
+    /// the sine that is left is the differential and its even powers are <c>1 - u^2</c> -- it
+    /// is <c>-1/sqrt(u^2 (3 - 3u^2 + u^4))</c>, and <c>u</c> comes out of the root as
+    /// <c>|u|</c>. The rule takes <c>|u| = u</c>, which is an antiderivative for <c>u &gt; 0</c>,
+    /// and extends it by parity: the integrand is even in <c>u</c>, so the antiderivative is
+    /// <c>sgn(u) F(|u|)</c>. Nothing is known of the sign of a cosine, and that is what makes
+    /// it not matter.
+    /// </para>
+    /// <para>
+    /// Every answer is differentiated back on both sides of zero, where the sine and the
+    /// cosine take both signs.
+    /// </para>
+    /// </remarks>
+    [Trait("Area", "Calculus")]
+    public sealed class ParityUnderASubstitutionTest
+    {
+        private static void DifferentiatesBack(string integrand, double[] points)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+            Assert.DoesNotContain("NaN", integral.Stringize());
+
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            var compared = 0;
+            foreach (var at in points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                if (got.IsNaN || want.IsNaN)
+                    continue;
+                compared++;
+                var difference = Math.Abs((double)(got - want).RealPart)
+                               + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-8,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, "
+                    + $"where the integrand is {want}");
+            }
+            Assert.True(compared >= 5,
+                $"only {compared} of {points.Length} points were comparable for {integrand}");
+        }
+
+        /// <summary>Away from the zeros of the sine and the cosine, on both sides of zero.</summary>
+        private static readonly double[] BothSigns = { -2.5, -1.1, -0.4, 0.4, 1.1, 2.0 };
+
+        /// <summary>
+        /// Charlwood's pair, and the cosine version: the complement of the written function
+        /// is the substitution, and the even power of the variable under the root is what
+        /// the parity extension is for. The secant is written as the reciprocal of the cosine
+        /// under its root first, where <c>sec(x)^4 - 1</c> is <c>(1 - cos(x)^4)/cos(x)^4</c> and
+        /// the even power below comes out of the root whole.
+        /// </summary>
+        [Theory]
+        [InlineData("sin(x)/sqrt(1 - sin(x)^6)")]
+        [InlineData("cos(x)/sqrt(1 - cos(x)^4)")]
+        [InlineData("sec(x)/sqrt(sec(x)^4 - 1)")]
+        public void TheComplementOfTheWrittenFunction(string integrand) => DifferentiatesBack(integrand, BothSigns);
+
+        /// <summary>
+        /// The same collecting of powers, for a power of <c>x</c> itself: under <c>u = x^8</c>
+        /// the quotient by <c>du/dx</c> writes <c>x^7</c> beside the integrand's <c>x</c>, and
+        /// only collected is it <c>x^8</c>. Bronstein's, on both sides of zero.
+        /// </summary>
+        [Theory]
+        [InlineData("(1 + 2*x^8)*sqrt(1 + x^8)/(x + 2*x^9 + x^17)")]
+        public void ThePowersOfTheVariableAreCollectedFirst(string integrand)
+            => DifferentiatesBack(integrand, new[] { -1.3, -0.9, -0.5, 0.4, 0.8, 1.2 });
+
+        /// <summary>
+        /// An even root is not negative, and what holds for it positive is the answer as it
+        /// stands: <c>sqrt(x^(1/3))</c> here was extended by a parity it did not need, to an
+        /// answer with a sign function in it that nothing could differentiate.
+        /// </summary>
+        [Fact]
+        public void AnEvenRootIsNotExtended()
+        {
+            var integral = "1/(sqrt(x) - x^(-1/3))".ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+            Assert.DoesNotContain("sgn(", integral.Stringize());
+            DifferentiatesBack("1/(sqrt(x) - x^(-1/3))", new[] { 1.3, 1.9, 2.7, 3.6, 5.2 });
+        }
+    }
+}


### PR DESCRIPTION
Charlwood's `sin(x)/sqrt(1 - sin(x)^6)` and `sec(x)/sqrt(sec(x)^4 - 1)` had no
antiderivative. The first wants `u = cos(x)`, which was no candidate -- only what
is written is -- and under which the sine that is left is the differential and
the sixth power is `(1 - u^2)^3`: the complement of a written sine or cosine is
offered now, and in a second pass over the sines and cosines, after every
candidate as written has been tried, the even powers of the function that is
left are written in `u` -- second, because `cos(x)/sin(x)` that way under the
cosine is `ln(1 - cos(x)^2)/2`, and under the sine it is written with,
`ln(sin(x))`, which is the answer to give. What that leaves for Charlwood's is
`-1/sqrt(u^2 (3 - 3u^2 + u^4))`,
and `u` comes out of the root as `|u|`; the rule for that takes `|u| = u`, an
antiderivative for `u > 0`, and the substitution rule extends it by parity as
the reciprocal substitution extends its own -- the integrand is even in `u`, so
the antiderivative is `sgn(u) F(|u|)` -- through one helper both now share.
Nothing is known of the sign of a cosine, and this is what makes it not matter.
An even root is not negative and is not extended: `sqrt(x^(1/3))` under
`1/(sqrt(x) - x^(-1/3))` was, to an answer with a sign function in it that
nothing could differentiate, and is pinned.

The secant is written as the reciprocal of the cosine under its root, where
`sec(x)^4 - 1` is `(1 - cos(x)^4)/cos(x)^4`, a root of a quotient whose denominator
is an even power: not negative whatever it is a power of, so the split is exact,
and the root of the denominator is the whole power `cos(x)^2`. A sum with a
quotient among its terms is combined into one before either the counting or
the splitting reads it.

And a power substitution reads written powers, so the quotient of the
integrand by `du/dx` is written as one quotient with its powers of `x` collected
first: `1/(x sqrt(P))` over `2x` is `x^2` only once collected, and a bare `x` is not
a power of `x^2`. Bronstein's `(1 + 2x^8) sqrt(1 + x^8)/(x + 2x^9 + x^17)` is
answered by that alone. For the power candidates of a numeric integrand of
modest size only: a half-angle image with a quartic under its root, written as
one quotient, is a page whose simplification did not return, and Charlwood's
`cos(x)^2/sqrt(1 + cos(x)^2 + cos(x)^4)` was a timeout for one corpus run; and a
symbolic partial fraction written as one quotient took twelve minutes of one
test where it takes six seconds as written.

## Measured

Every answer differentiated back on both sides of zero.

Rubi corpus, 463-problem sample, on the same morning:

    master at #1304     380/463, 0 wrong, 0 timeouts, 79 s

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
