### PR TITLE
A root of a quotient of two linears is a substitution of its own, and a whole power below the bar is read with its exponent evaluated

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -475,12 +475,21 @@ namespace AngouriMath.Functions.Algebra
 
         private static bool TryReadAsQuotient(Entity expr, out Entity numerator, out Entity denominator)
         {
+            // An exponent read evaluated: the normalisation writes `(u^2 - 1)^5` below the bar
+            // as `(u^2 - 1)^(5 * (-1))`, a power whose exponent is a product of two numbers and
+            // not a number, and `1/((1 - x)^(7/2) x^5)` was declined for it one level down.
             switch (expr)
             {
                 case Entity.Divf(var dividend, var divisor):
                     (numerator, denominator) = (dividend, divisor);
                     return true;
-                case Entity.Powf(var @base, Number.Integer power) when power.EInteger.Sign < 0:
+                // A whole power of a quotient is the quotient of the powers: `(u/(1 - 2u^2))^2`,
+                // which is how the simplifier writes the image of `sqrt((1 + x)/(3 + 2x))`
+                // under the root as the variable, read as nothing before.
+                case Entity.Powf(Entity.Divf(var dividend, var divisor), var exponent) when exponent.Evaled is Number.Integer { EInteger.Sign: > 0 } power && power != Number.Integer.One:
+                    (numerator, denominator) = (MathS.Pow(dividend, power), MathS.Pow(divisor, power));
+                    return true;
+                case Entity.Powf(var @base, var exponent) when exponent.Evaled is Number.Integer { EInteger.Sign: < 0 } power:
                     // Written out rather than as base^1 when the power is -1, since everything
                     // downstream reads the denominator as a polynomial and a redundant power of
                     // one is a shape it would have to see through.
@@ -494,9 +503,13 @@ namespace AngouriMath.Functions.Algebra
                     foreach (var factor in Entity.Mulf.LinearChildren(expr))
                         switch (factor)
                         {
-                            case Entity.Powf(var @base, Number.Integer power) when power.EInteger.Sign < 0:
+                            case Entity.Powf(var @base, var exponent) when exponent.Evaled is Number.Integer { EInteger.Sign: < 0 } power:
                                 var positive = -power;
                                 below *= positive == Number.Integer.One ? @base : MathS.Pow(@base, positive);
+                                break;
+                            case Entity.Powf(Entity.Divf(var dividend, var divisor), var exponent) when exponent.Evaled is Number.Integer { EInteger.Sign: > 0 } power:
+                                above *= MathS.Pow(dividend, power);
+                                below *= MathS.Pow(divisor, power);
                                 break;
                             case Entity.Divf(var dividend, var divisor):
                                 above *= dividend;
@@ -3206,8 +3219,22 @@ namespace AngouriMath.Functions.Algebra
                 // and the integrand becomes `2u sqrt(u^2 + u - 1)`, which the quadratic radical
                 // rule answers. The check that no `x` survives, below, is what makes skipping safe
                 // rather than a guess. https://github.com/asc-community/AngouriMath/issues/718
+                // A quotient of two linears is a base of its own kind: `sqrt((1 + x)/(3 + 2x))`
+                // under `u = sqrt((1 + x)/(3 + 2x))` has `x = (3u^2 - 1)/(1 - 2u^2)`, rational,
+                // and the answer holds wherever the root is real -- below `-3/2` too, where
+                // both linears are negative and the root of each is not. Split into a root
+                // over a root it is declined for that, and rightly.
                 if (!TreeAnalyzer.TryGetPolyLinear(@base, x, out var slope, out _) || slope.Evaled == 0)
+                {
+                    if (radicalBase is null && IsAQuotientOfLinears(@base, x))
+                    {
+                        radicalBase = @base;
+                        if (!exponent.ERational.Denominator.CanFitInInt32())
+                            return null;
+                        denominators.Add(exponent.ERational.Denominator.ToInt32Checked());
+                    }
                     continue;
+                }
                 if (radicalBase is null)
                     radicalBase = @base;
                 else if (radicalBase != @base)
@@ -3233,13 +3260,27 @@ namespace AngouriMath.Functions.Algebra
             var q = denominators.Aggregate(1, Lcm);
             if (q < 2 || q > 12)   // beyond this the rewritten polynomial is not worth building
                 return null;
-            if (!TreeAnalyzer.TryGetPolyLinear(radicalBase, x, out var a, out var b))
-                return null;
 
             var u = Variable.CreateUnique(expr, "u_rad");
-            // x = (u^q - b) / a, and dx = (q/a) u^(q-1) du.
-            var xInU = (MathS.Pow(u, q) - b) / a;
-            var dx = Number.Integer.Create(q) / a * MathS.Pow(u, q - 1);
+            Entity xInU;
+            Entity dx;
+            if (TreeAnalyzer.TryGetPolyLinear(radicalBase, x, out var a, out var b))
+            {
+                // x = (u^q - b) / a, and dx = (q/a) u^(q-1) du.
+                xInU = (MathS.Pow(u, q) - b) / a;
+                dx = Number.Integer.Create(q) / a * MathS.Pow(u, q - 1);
+            }
+            else
+            {
+                if (otherBase is not null)
+                    return null;
+                // u^q = (a x + b)/(c x + d), so x = (d u^q - b)/(a - c u^q).
+                var (above, below) = Functions.SingleQuotient.Of(radicalBase);
+                if (!TreeAnalyzer.TryGetPolyLinear(above, x, out a, out b) || !TreeAnalyzer.TryGetPolyLinear(below, x, out var c, out var d))
+                    return null;
+                xInU = ((d * MathS.Pow(u, q) - b) / (a - c * MathS.Pow(u, q))).InnerSimplified;
+                dx = xInU.Differentiate(u).InnerSimplified;
+            }
 
             // Each radical becomes its power of u **by construction** rather than by substituting
             // and then simplifying. Substituting alone turns (x + 1)^(1/2) into ((u^6))^(1/2), and
@@ -3272,6 +3313,19 @@ namespace AngouriMath.Functions.Algebra
             return Integration.ComputeIndefiniteIntegral(integrand, u, integrateByParts) is { } result
                 ? result.Substitute(u, MathS.Pow(radicalBase, Number.Rational.Create(1, q)))
                 : null;
+        }
+
+        /// <summary>
+        /// Whether <paramref name="expr"/> is a quotient of two polynomials linear in
+        /// <paramref name="x"/>, the one below with a slope.
+        /// </summary>
+        private static bool IsAQuotientOfLinears(Entity expr, Entity.Variable x)
+        {
+            var (above, below) = Functions.SingleQuotient.Of(expr);
+            return below != Number.Integer.One
+                && TreeAnalyzer.TryGetPolyLinear(above, x, out _, out _)
+                && TreeAnalyzer.TryGetPolyLinear(below, x, out var slope, out _)
+                && slope.Evaled is not Number.Complex { IsZero: true };
         }
 
         /// <summary>
@@ -6116,6 +6170,19 @@ namespace AngouriMath.Functions.Algebra
                         : expr / duDx;
                     integrandInU = InTermsOf(quotient, u, uSub, x).Simplify(1);
                     if (integrandInU is Providedf(var innerExpr, _)) integrandInU = innerExpr; // TODO: singularities ignored but not handled properly
+                    // A factor written on both sides of the bar cancelled, where x survived:
+                    // the one-level simplification leaves `u/((a w + b)^2 p u)` as it is, and
+                    // the candidate was refused for the u it did not cancel.
+                    if (integrandInU.ContainsNode(x))
+                    {
+                        var (top, bottom) = Functions.SingleQuotient.Of(Functions.SingleQuotient.Combine(integrandInU));
+                        var cancelled = CancelCommonFactors(top, bottom);
+                        if (cancelled != integrandInU && !cancelled.ContainsNode(x))
+                        {
+                            integrandInU = cancelled.Simplify(1);
+                            if (integrandInU is Providedf(var innerCancelled, _)) integrandInU = innerCancelled;
+                        }
+                    }
                     if (u is Sinf or Cosf && integrandInU.ContainsNode(x))
                         firstPass[u] = integrandInU;
                 }

--- a/Sources/AngouriMath/Functions/Continuous/Integration/IntegralPatterns.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IntegralPatterns.cs
@@ -540,8 +540,15 @@ namespace AngouriMath.Functions.Algebra
                 : numerator * AntiderivativeLog(b * x + c) / b;
 
 
-            // For true quadratics (a ≠ 0), discriminant Δ = 4ac - b^2 determines the form
-            var discriminant = 4 * a * c - b * b;
+            // For true quadratics (a ≠ 0), discriminant Δ = 4ac - b^2 determines the form --
+            // expanded, so that a square of a symbolic linear is seen for one: `(a w + b)^2`
+            // is `a^2 w^2 + 2ab w + b^2`, whose discriminant `4a^2 b^2 - (2ab)^2` is zero only
+            // once it is written out, and unwritten it was a piecewise of three arms, two of
+            // them dividing by that zero, that nothing downstream could read.
+            var discriminant = (4 * a * c - b * b).Expand().InnerSimplified;
+            if (TreeAnalyzer.IsZero(discriminant))
+                // The perfect square, in the generic case as every rule answers: -2k/(2ax + b).
+                return (-2 * numerator / (2 * a * x + b)).InnerSimplified;
             
             // Case 1: Δ > 0 (no real roots, use arctan)
             // Result: (2k/√Δ) * arctan((2ax + b)/√Δ)

--- a/Sources/Tests/UnitTests/Calculus/LinearRadicalSubstitutionIntegralTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/LinearRadicalSubstitutionIntegralTest.cs
@@ -129,6 +129,44 @@ namespace AngouriMath.Tests.Calculus
         /// measured by quadrature at <c>-3.66</c> against an answer's <c>-4.68</c>. Should any
         /// later be answered by something else, these move rather than being deleted.
         /// </summary>
+        /// <summary>
+        /// A root of a quotient of two linears is a base of its own kind: under
+        /// <c>u = sqrt((1 + x)/(3 + 2x))</c>, <c>x = (3u^2 - 1)/(1 - 2u^2)</c> is rational, and
+        /// the answer holds wherever the root is real -- below <c>-3/2</c> too, where both
+        /// linears are negative and the root of each is not, which is why the split into a
+        /// root over a root is declined for it and rightly. Differentiated back on both sides.
+        /// </summary>
+        [Theory]
+        [InlineData("sqrt((1 + x)/(3 + 2*x))", new[] { -4.0, -2.5, -1.8, -0.5, 0.7, 2.1 })]
+        [InlineData("sqrt((x - 1)/(x + 1))/x", new[] { -4.0, -2.5, -1.8, 1.4, 2.6, 5.0 })]
+        [InlineData("((2*x + 1)/(x - 3))^(1/3)", new[] { -4.0, -2.5, -1.8, 4.0, 5.5, 9.0 })]
+        public void ARootOfAQuotientOfLinears(string integrand, double[] points)
+        {
+            var integral = integrand.ToEntity().Integrate("x");
+            Assert.DoesNotContain("integral(", integral.Stringize());
+            var derivative = integral.Substitute("C", 0).Differentiate("x");
+            var original = integrand.ToEntity();
+            foreach (var at in points)
+            {
+                var got = derivative.Substitute("x", at).EvalNumerical();
+                var want = original.Substitute("x", at).EvalNumerical();
+                var difference = Math.Abs((double)(got - want).RealPart) + Math.Abs((double)(got - want).ImaginaryPart);
+                var scale = Math.Max(1.0, Math.Abs((double)want.RealPart));
+                Assert.True(difference / scale < 1e-9,
+                    $"d/dx of the antiderivative of {integrand} is {got} at x = {at}, where the integrand is {want}");
+            }
+        }
+
+        /// <summary>
+        /// A whole power below the bar one level down: under <c>u = sqrt(1 - x)</c> this is
+        /// <c>2u/(u^7 (u^2 - 1)^5)</c>, and the normalisation writes the power below as
+        /// <c>(u^2 - 1)^(5 * (-1))</c>, an exponent that is a product of numbers and not a
+        /// number, which the rational readers read evaluated now and read as nothing before.
+        /// </summary>
+        [Theory]
+        [InlineData("1/((1 - x)^(7/2)*x^5)")]
+        public void AWholePowerBelowTheBarOneLevelDown(string integrand) => DifferentiatesBack(integrand);
+
         [Theory]
         [InlineData("1/(sqrt(x) + sqrt(x + 1) + sqrt(x + 2))")]
         [InlineData("x^(1/3)/sqrt(x + 1)")]

--- a/Sources/Tests/UnitTests/Calculus/SymbolicCoefficientIntegralsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/SymbolicCoefficientIntegralsTest.cs
@@ -81,6 +81,22 @@ namespace AngouriMath.Tests.Calculus
             string integrand, string coefficients, double[] points) =>
             AssertIsAntiderivative(integrand, coefficients, points);
 
+        /// <summary>
+        /// The square of a symbolic linear is a quadratic whose discriminant is zero only once
+        /// it is written out, and it was answered as a piecewise of three arms, two of them
+        /// dividing by that zero, that nothing downstream could read: the exponential
+        /// substitution's image of Welz's <c>x/(a e^(px) + b e^(-px))^2</c> is one. The
+        /// perfect square is answered as such, in the generic case.
+        /// </summary>
+        [Theory]
+        [InlineData("1 / (a * x + b) ^ 2", "a = 2, b = 3", new[] { 0.3, 1.7, -0.6 })]
+        [InlineData("1 / (2 * (a * x + b) ^ 2)", "a = 2, b = 3", new[] { 0.3, 1.7, -0.6 })]
+        public void ASquareOfASymbolicLinear(string integrand, string coefficients, double[] points)
+        {
+            Assert.DoesNotContain("piecewise", integrand.ToEntity().Integrate("x").Stringize());
+            AssertIsAntiderivative(integrand, coefficients, points);
+        }
+
         // A linear numerator over the same shape goes through the same arm, one rewrite later.
         [Theory]
         [InlineData("x / (a ^ 2 + b ^ 2 * x ^ 2)", "a = 2, b = 3", new[] { 0.3, 1.7, -0.6 })]


### PR DESCRIPTION
Moses's `sqrt((1 + x)/(3 + 2x))` had no antiderivative. The combining rule splits it
into a root over a root, and that is declined -- rightly: below `-3/2` both
linears are negative, the root of the quotient is real, and the root of each is
not, so an answer built through the split does not hold there. Under
`u = sqrt((1 + x)/(3 + 2x))` itself, `x = (3u^2 - 1)/(1 - 2u^2)` is rational, and
so is the integrand; the linear-radical substitution reads a quotient of two
linears as a base of its own now, with `x = (d u^q - b)/(a - c u^q)`, and the
answer holds wherever the root is real, checked by quadrature over `[-4, -2]`.

Timofeev's `1/((1 - x)^(7/2) x^5)` had none either, and under `u = sqrt(1 - x)` it
is `2u/(u^7 (u^2 - 1)^5)`, a rational function. The normalisation writes the
power below the bar as `(u^2 - 1)^(5 * (-1))`, an exponent that is a product of
two numbers and not a number, and the quotient reader matched a number: the
exponent is read evaluated now, and a whole power of a quotient, `(u/(1 - 2u^2))^2`,
which is how the simplifier writes the image of Moses's integrand, is read as
the quotient of the powers. The substitution rule cancels a factor written on
both sides of the bar where the one-level simplification leaves it --
`u/((a w + b)^2 p u)` -- since with the reader seeing more integrands as rational,
and a rational integrand offered no sums as candidates, the power candidate has
to carry what the sum used to.

And the square of a symbolic linear, `(a w + b)^2`, is a quadratic whose
discriminant is zero only once it is written out; unwritten, the table answered
it as a piecewise of three arms, two of them dividing by that zero, that
nothing downstream could read. The discriminant is expanded, and a perfect
square is answered as one, `-2k/(2ax + b)`, in the generic case as every rule
answers.

## Measured

Every answer differentiated back on both sides of zero, and Moses's by
quadrature over the interval where both linears are negative.

Rubi corpus, 463-problem sample, on the same afternoon:

    master at #1306     394/463, 0 wrong, 0 timeouts
    with this           396/463, 0 wrong, 0 timeouts, 95 s

Two more, nothing lost: Moses 55 and Timofeev 305. The reader change first cost
Welz's `x/(a e^(px) + b e^(-px))^2`, whose exponential image went to the power
candidate instead of the sum and hit the piecewise above; both halves of that
are fixed here and it is pinned.

The five test suites are green.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
