### PR TITLE
The Rothstein-Trager resultant stands behind the splits Euler hands to, and a split term has a root over the same root cancelled before the chain collects it into nothing

### DIFF
--- a/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
+++ b/Sources/AngouriMath/Functions/Continuous/Integration/IndefiniteIntegralSolver.cs
@@ -40,7 +40,16 @@ namespace AngouriMath.Functions.Algebra
             }
             var splitted = TreeAnalyzer.GatherLinearChildrenOverSumAndExpand(expr, e => e.ContainsNode(x));
             if (splitted is null || splitted.Count < 2) return null; // nothing to do, let other solvers do the work
-            return Integrated(splitted);
+            // Each expanded term with a factor written on both sides of its bar cancelled:
+            // `x sqrt(1 - x^2)/(sqrt(1 - x^2)(2 + 2x sqrt(1 - x^2)))` is what the expansion makes
+            // of one term of the by-parts remainder of `arctan(x + sqrt(1 - x^2))`, and the
+            // chain's own normalisation collects that root over itself into `(1 - x^2)^0`, a
+            // factor no rule that reads a root of a quadratic sees through.
+            return Integrated(splitted.Select(term =>
+            {
+                var (above, below) = Functions.SingleQuotient.Of(term);
+                return below == Number.Integer.One ? term : CancelCommonFactors(above, below);
+            }).ToList());
 
             Entity? Integrated(List<Entity> terms)
                 => terms.Select(e => Integration.ComputeAsAQuestionOfItsOwn(e, x, integrateByParts)).Aggregate((e1, e2) => (e1, e2) switch {
@@ -4624,8 +4633,12 @@ namespace AngouriMath.Functions.Algebra
                 return null;
             var rational = cleanNumerator / cleanDenominator;
 
+            // The Rothstein-Trager resultant behind the splits, for a denominator they cannot
+            // take apart: `1/(1 + x sqrt(1 - x^2))` is one over a quartic in t irreducible over
+            // the rationals, whose residues are in a quadratic field.
             var inT = SolveByPartialFractions(rational, t, integrateByParts: false)
-                   ?? IntegralPatterns.TryStandardIntegrals(rational, t);
+                   ?? IntegralPatterns.TryStandardIntegrals(rational, t)
+                   ?? SolveByRothsteinTrager(rational, t);
             if (inT is null)
                 return null;
             var answer = inT.Substitute(t, backSubstitution).InnerSimplified;

--- a/Sources/Tests/UnitTests/Calculus/ABareInverseFunctionByPartsTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/ABareInverseFunctionByPartsTest.cs
@@ -68,9 +68,20 @@ namespace AngouriMath.Tests.Calculus
         /// <c>arcsin(x^2)</c>, whose remainder <c>2x^2/sqrt(1 - x^4)</c> is elliptic: declined or
         /// answered, never wrong, and not slowly.
         /// </summary>
+        /// <summary>
+        /// Charlwood's <c>arctan(x + sqrt(1 - x^2))</c>, whose remainder is a sum whose expanded
+        /// terms carry a root over the same root -- cancelled as written now, before the
+        /// chain's normalisation collects it into a zero power nothing reads -- and each of
+        /// which is Euler's, one of them through the Rothstein-Trager resultant behind the
+        /// splits. And its companion with the root below the bar.
+        /// </summary>
+        [Theory]
+        [InlineData("atan(x + sqrt(1 - x^2))")]
+        [InlineData("x*atan(x + sqrt(1 - x^2))/sqrt(1 - x^2)")]
+        public void TheRemainderIsEulersThroughTheResultant(string integrand) => DifferentiatesBack(integrand);
+
         [Theory]
         [InlineData("asin(x^2)")]
-        [InlineData("atan(x + sqrt(1 - x^2))")]
         [InlineData("ln(1 + x*sqrt(1 + x^2))")]
         [InlineData("asin(x/sqrt(1 - x^2))")]
         [InlineData("asin(sqrt(1 + x) - sqrt(x))")]

--- a/Sources/Tests/UnitTests/Calculus/EulerSubstitutionTest.cs
+++ b/Sources/Tests/UnitTests/Calculus/EulerSubstitutionTest.cs
@@ -126,6 +126,18 @@ namespace AngouriMath.Tests.Calculus
         public void CancelledByTheGcdWhereTheSpellingsDiffer(string integrand, double[] points) => DifferentiatesBack(integrand, points);
 
         /// <summary>
+        /// The Rothstein-Trager resultant behind the splits, for a rational function in
+        /// <c>t</c> whose denominator they cannot take apart: <c>x/(1 + x sqrt(1 - x^2))</c> is
+        /// one over a quartic in <c>t</c> irreducible over the rationals, with its residues in
+        /// a quadratic field. It is the by-parts remainder of Charlwood's
+        /// <c>arctan(x + sqrt(1 - x^2))</c>, which is answered through it.
+        /// </summary>
+        [Theory]
+        [InlineData("x/(1 + x*sqrt(1 - x^2))", new[] { -0.8, -0.4, 0.3, 0.6, 0.9 })]
+        [InlineData("x/(2 + 2*x*sqrt(1 - x^2))", new[] { -0.8, -0.4, 0.3, 0.6, 0.9 })]
+        public void TheResultantBehindTheSplits(string integrand, double[] points) => DifferentiatesBack(integrand, points);
+
+        /// <summary>
         /// A power of the substitution itself. With <c>t = sqrt(Q) + x</c>, a factor
         /// <c>(x + sqrt(Q))^b</c> is <c>t^b</c> exactly and for any <c>b</c>, and with the root's
         /// sign flipped, <c>t = x - sqrt(Q)</c>, so is <c>(x - sqrt(Q))^b</c>: Welz's


### PR DESCRIPTION
Charlwood's `arctan(x + sqrt(1 - x^2))` and `x arctan(x + sqrt(1 - x^2))/sqrt(1 - x^2)`
had no antiderivative. By parts against one leaves
`x (sqrt(1 - x^2) - x)/(sqrt(1 - x^2) (2 + 2x sqrt(1 - x^2)))`, a rational function of
`x` and one root of a quadratic, and Euler's substitution declined it. Two things
stood in the way.

Split over its expanded terms, the first is `x sqrt(1 - x^2)/(sqrt(1 - x^2) (...))`,
and the chain's own normalisation collects the root over itself into `(1 - x^2)^0`,
a factor no rule that reads a root of a quadratic sees through; the split cancels
a factor written on both sides of a term's bar now, before the term is asked.
The term is then `x/(2 + 2x sqrt(1 - x^2))`, which Euler's substitution turns into a
rational function of `t` over a quartic irreducible over the rationals -- with
its residues in a quadratic field, which is the Rothstein-Trager resultant's
case, and Euler handed only to the splits and the table. The resultant stands
behind them now, as it does behind the binomial differential.

## Measured

Every answer differentiated back on both sides of zero, and both of Charlwood's
by quadrature over `[-0.9, 0.9]`.

Rubi corpus, 463-problem sample, on the same afternoon:

    master at #1306     394/463, 0 wrong, 0 timeouts
    with this           396/463, 0 wrong, 0 timeouts, 98 s

Two more, nothing lost: Charlwood 41 and 44, rated by Rubi as the two worst
answers of its own in the sample.

The five test suites are green.

Part of #718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sonx8iAspMiwRwokT1Ura
